### PR TITLE
Adds remaining wrapper types to valueType map

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -232,7 +232,13 @@ export function isMapType(typeMap: TypeMap, messageDesc: DescriptorProto, field:
 const valueTypes: { [key: string]: TypeName } = {
   '.google.protobuf.StringValue': TypeNames.unionType(TypeNames.STRING, TypeNames.UNDEFINED),
   '.google.protobuf.Int32Value': TypeNames.unionType(TypeNames.NUMBER, TypeNames.UNDEFINED),
-  '.google.protobuf.BoolValue': TypeNames.unionType(TypeNames.BOOLEAN, TypeNames.UNDEFINED)
+  '.google.protobuf.Int64Value': TypeNames.unionType(TypeNames.NUMBER, TypeNames.UNDEFINED),
+  '.google.protobuf.UInt32Value': TypeNames.unionType(TypeNames.NUMBER, TypeNames.UNDEFINED),
+  '.google.protobuf.UInt64Value': TypeNames.unionType(TypeNames.NUMBER, TypeNames.UNDEFINED),
+  '.google.protobuf.BoolValue': TypeNames.unionType(TypeNames.BOOLEAN, TypeNames.UNDEFINED),
+  '.google.protobuf.DoubleValue': TypeNames.unionType(TypeNames.NUMBER, TypeNames.UNDEFINED),
+  '.google.protobuf.FloatValue': TypeNames.unionType(TypeNames.NUMBER, TypeNames.UNDEFINED),
+  '.google.protobuf.BytesValue': TypeNames.unionType(TypeNames.anyType('Uint8Array'), TypeNames.UNDEFINED)
 };
 
 const mappedTypes: { [key: string]: TypeName } = {


### PR DESCRIPTION
Adds remaining types to typeMap handle simplifying full list of wrapper types found at: https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/wrappers.proto