### PR TITLE
fix map type detection when field name is not camelCase

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 import { google } from '../build/pbjs';
 import { Member, TypeName, TypeNames } from 'ts-poet';
 import { visit } from './main';
-import { fail, upperFirst } from './utils';
+import { fail } from './utils';
 import { asSequence } from 'sequency';
 import FieldDescriptorProto = google.protobuf.FieldDescriptorProto;
 import CodeGeneratorRequest = google.protobuf.compiler.CodeGeneratorRequest;
@@ -298,19 +298,12 @@ export function detectMapType(
     fieldDesc.label === FieldDescriptorProto.Label.LABEL_REPEATED &&
     fieldDesc.type === FieldDescriptorProto.Type.TYPE_MESSAGE
   ) {
-    return messageDesc.nestedType
-      .filter(
-        t =>
-          t.name === `${upperFirst(fieldDesc.name)}Entry` &&
-          (t.options !== undefined && t.options != null && t.options.mapEntry)
-      )
-      .map(mapType => {
-        const keyType = toTypeName(typeMap, messageDesc, mapType.field[0]);
-        // use basicTypeName because we don't need the '| undefined'
-        const valueType = basicTypeName(typeMap, mapType.field[1]);
-        return { messageDesc: mapType, keyType, valueType };
-      })
-      .find(_ => true);
+    const mapType = typeMap.get(fieldDesc.typeName)![2] as DescriptorProto;
+    if (!mapType.options?.mapEntry) return undefined;
+    const keyType = toTypeName(typeMap, messageDesc, mapType.field[0]);
+    // use basicTypeName because we don't need the '| undefined'
+    const valueType = basicTypeName(typeMap, mapType.field[1]);
+    return { messageDesc: mapType, keyType, valueType };
   }
   return undefined;
 }


### PR DESCRIPTION
First of all, thanks for ts-proto, I really appreciate finally having a protoc plugin that generates typescript interfaces instead of classes!

When a field in a .proto file has a map type and a non-camelCase name (e.g. `map<string, TraceSourceInfo> trace_source_info = 10;`), the generated code for this field was typed to an array instead of an index-signature object. Instead of relying on the string comparison of type and field name (which fails when the field name is snake_case), the relevant types can be looked up from the type map.

I didn't fully understand the test infrastructure, so I couldn't add any unit tests unfortunately.