### PR TITLE
Add use enum names option

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -147,7 +147,8 @@ Supported options:
 * If you pass `--ts_proto_opt=forceLong=true`, all 64 bit numbers will be parsed as instances of `Long` (using the [long](https://www.npmjs.com/package/long) library).
 * If you pass `--ts_proto_opt=outputEncodeMethods=false`, the `Message.encode` and `Message.decode` methods for working with protobuff-encoded data will not be output.
 * If you pass `--ts_proto_opt=outputJsonMethods=false`, the `Message.fromJSON` and `Message.toJSON` methods for working with JSON-coded data will not be output.
-* If you pass `--ts_proto_opt=outputClientImpl=false`, the `FooServiceClientImpl` classes that implement the client-side (currently Twirp-only) RPC interfaces will not be output. 
+* If you pass `--ts_proto_opt=outputClientImpl=false`, the `FooServiceClientImpl` classes that implement the client-side (currently Twirp-only) RPC interfaces will not be output.
+* If you pass `--useEnumNames=true`, enum names will be used as values in the generated typescript interfaces instead of the integer values.
 
 (I.e. you want only interface declarations for your Protobuf types, then pass all three of `outputEncodeMethods`, `outputJsonMethods`, and `outputClientImpl` as `false`, i.e. `--ts_proto_opt=outputEncodeMethods=false,outputJsonMethods=false,outputClientImpl=false`.)
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -53,6 +53,7 @@ export type Options = {
   outputEncodeMethods: boolean;
   outputJsonMethods: boolean;
   outputClientImpl: boolean;
+  useEnumNames: boolean;
 };
 
 export function generateFile(typeMap: TypeMap, fileDesc: FileDescriptorProto, parameter: string): FileSpec {
@@ -87,7 +88,7 @@ export function generateFile(typeMap: TypeMap, fileDesc: FileDescriptorProto, pa
     },
     options,
     (fullName, enumDesc, sInfo) => {
-      file = file.addEnum(generateEnum(fullName, enumDesc, sInfo));
+      file = file.addEnum(generateEnum(fullName, enumDesc, sInfo, options));
     }
   );
 
@@ -266,7 +267,7 @@ function addTimestampMethods(file: FileSpec, options: Options): FileSpec {
     );
 }
 
-function generateEnum(fullName: string, enumDesc: EnumDescriptorProto, sourceInfo: SourceInfo): EnumSpec {
+function generateEnum(fullName: string, enumDesc: EnumDescriptorProto, sourceInfo: SourceInfo, options: Options): EnumSpec {
   let spec = EnumSpec.create(fullName).addModifiers(Modifier.EXPORT);
   maybeAddComment(sourceInfo, text => (spec = spec.addJavadoc(text)));
 
@@ -274,7 +275,7 @@ function generateEnum(fullName: string, enumDesc: EnumDescriptorProto, sourceInf
   for (const valueDesc of enumDesc.value) {
     const info = sourceInfo.lookup(Fields.enum.value, index++);
     maybeAddComment(info, text => (spec = spec.addJavadoc(`${valueDesc.name} - ${text}\n`)));
-    spec = spec.addConstant(valueDesc.name, valueDesc.number.toString());
+    spec = spec.addConstant(valueDesc.name, options.useEnumNames ? `"${valueDesc.name}"` : valueDesc.number.toString());
   }
   return spec;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -43,6 +43,7 @@ export function optionsFromParameter(parameter: string): Options {
     outputEncodeMethods: true,
     outputJsonMethods: true,
     outputClientImpl: true,
+    useEnumNames: false,
   };
 
   if (parameter) {
@@ -63,6 +64,9 @@ export function optionsFromParameter(parameter: string): Options {
     }
     if (parameter.includes('outputClientImpl=false')) {
       options.outputClientImpl = false;
+    }
+    if (parameter.includes('useEnumNames=true')) {
+      options.useEnumNames = true;
     }
   }
   return options;


### PR DESCRIPTION
Adds option to generate enums in typescript with string values rather than integer.
example:
```ts
export enum Animals {
  CAT = "CAT",
  DOG = "DOG",
}
```