### PR TITLE
Add unrecognized enum value

### DIFF
--- a/integration/simple-long-string/simple.ts
+++ b/integration/simple-long-string/simple.ts
@@ -286,6 +286,7 @@ export const StateEnum = {
   UNKNOWN: 0 as StateEnum,
   ON: 2 as StateEnum,
   OFF: 3 as StateEnum,
+  UNRECOGNIZED: -1 as StateEnum,
   fromJSON(object: any): StateEnum {
     switch (object) {
       case 0:
@@ -297,8 +298,10 @@ export const StateEnum = {
       case 3:
       case "OFF":
         return StateEnum.OFF;
+      case -1:
+      case "UNRECOGNIZED":
       default:
-        throw new global.Error(`Invalid value ${object}`);
+        return StateEnum.UNRECOGNIZED;
     }
   },
   toJSON(object: StateEnum): string {
@@ -321,6 +324,7 @@ export const Child_Type = {
   UNKNOWN: 0 as Child_Type,
   GOOD: 1 as Child_Type,
   BAD: 2 as Child_Type,
+  UNRECOGNIZED: -1 as Child_Type,
   fromJSON(object: any): Child_Type {
     switch (object) {
       case 0:
@@ -332,8 +336,10 @@ export const Child_Type = {
       case 2:
       case "BAD":
         return Child_Type.BAD;
+      case -1:
+      case "UNRECOGNIZED":
       default:
-        throw new global.Error(`Invalid value ${object}`);
+        return Child_Type.UNRECOGNIZED;
     }
   },
   toJSON(object: Child_Type): string {
@@ -356,6 +362,7 @@ export const Nested_InnerEnum = {
   UNKNOWN_INNER: 0 as Nested_InnerEnum,
   GOOD: 100 as Nested_InnerEnum,
   BAD: 1000 as Nested_InnerEnum,
+  UNRECOGNIZED: -1 as Nested_InnerEnum,
   fromJSON(object: any): Nested_InnerEnum {
     switch (object) {
       case 0:
@@ -367,8 +374,10 @@ export const Nested_InnerEnum = {
       case 1000:
       case "BAD":
         return Nested_InnerEnum.BAD;
+      case -1:
+      case "UNRECOGNIZED":
       default:
-        throw new global.Error(`Invalid value ${object}`);
+        return Nested_InnerEnum.UNRECOGNIZED;
     }
   },
   toJSON(object: Nested_InnerEnum): string {

--- a/integration/simple-long-string/simple.ts
+++ b/integration/simple-long-string/simple.ts
@@ -318,7 +318,7 @@ export const StateEnum = {
   },
 }
 
-export type StateEnum = 0 | 2 | 3;
+export type StateEnum = 0 | 2 | 3 | -1;
 
 export const Child_Type = {
   UNKNOWN: 0 as Child_Type,
@@ -356,7 +356,7 @@ export const Child_Type = {
   },
 }
 
-export type Child_Type = 0 | 1 | 2;
+export type Child_Type = 0 | 1 | 2 | -1;
 
 export const Nested_InnerEnum = {
   UNKNOWN_INNER: 0 as Nested_InnerEnum,
@@ -394,7 +394,7 @@ export const Nested_InnerEnum = {
   },
 }
 
-export type Nested_InnerEnum = 0 | 100 | 1000;
+export type Nested_InnerEnum = 0 | 100 | 1000 | -1;
 
 export const Simple = {
   encode(message: Simple, writer: Writer = Writer.create()): Writer {

--- a/integration/simple-long/simple.ts
+++ b/integration/simple-long/simple.ts
@@ -286,6 +286,7 @@ export const StateEnum = {
   UNKNOWN: 0 as StateEnum,
   ON: 2 as StateEnum,
   OFF: 3 as StateEnum,
+  UNRECOGNIZED: -1 as StateEnum,
   fromJSON(object: any): StateEnum {
     switch (object) {
       case 0:
@@ -297,8 +298,10 @@ export const StateEnum = {
       case 3:
       case "OFF":
         return StateEnum.OFF;
+      case -1:
+      case "UNRECOGNIZED":
       default:
-        throw new global.Error(`Invalid value ${object}`);
+        return StateEnum.UNRECOGNIZED;
     }
   },
   toJSON(object: StateEnum): string {
@@ -321,6 +324,7 @@ export const Child_Type = {
   UNKNOWN: 0 as Child_Type,
   GOOD: 1 as Child_Type,
   BAD: 2 as Child_Type,
+  UNRECOGNIZED: -1 as Child_Type,
   fromJSON(object: any): Child_Type {
     switch (object) {
       case 0:
@@ -332,8 +336,10 @@ export const Child_Type = {
       case 2:
       case "BAD":
         return Child_Type.BAD;
+      case -1:
+      case "UNRECOGNIZED":
       default:
-        throw new global.Error(`Invalid value ${object}`);
+        return Child_Type.UNRECOGNIZED;
     }
   },
   toJSON(object: Child_Type): string {
@@ -356,6 +362,7 @@ export const Nested_InnerEnum = {
   UNKNOWN_INNER: 0 as Nested_InnerEnum,
   GOOD: 100 as Nested_InnerEnum,
   BAD: 1000 as Nested_InnerEnum,
+  UNRECOGNIZED: -1 as Nested_InnerEnum,
   fromJSON(object: any): Nested_InnerEnum {
     switch (object) {
       case 0:
@@ -367,8 +374,10 @@ export const Nested_InnerEnum = {
       case 1000:
       case "BAD":
         return Nested_InnerEnum.BAD;
+      case -1:
+      case "UNRECOGNIZED":
       default:
-        throw new global.Error(`Invalid value ${object}`);
+        return Nested_InnerEnum.UNRECOGNIZED;
     }
   },
   toJSON(object: Nested_InnerEnum): string {

--- a/integration/simple-long/simple.ts
+++ b/integration/simple-long/simple.ts
@@ -318,7 +318,7 @@ export const StateEnum = {
   },
 }
 
-export type StateEnum = 0 | 2 | 3;
+export type StateEnum = 0 | 2 | 3 | -1;
 
 export const Child_Type = {
   UNKNOWN: 0 as Child_Type,
@@ -356,7 +356,7 @@ export const Child_Type = {
   },
 }
 
-export type Child_Type = 0 | 1 | 2;
+export type Child_Type = 0 | 1 | 2 | -1;
 
 export const Nested_InnerEnum = {
   UNKNOWN_INNER: 0 as Nested_InnerEnum,
@@ -394,7 +394,7 @@ export const Nested_InnerEnum = {
   },
 }
 
-export type Nested_InnerEnum = 0 | 100 | 1000;
+export type Nested_InnerEnum = 0 | 100 | 1000 | -1;
 
 export const Simple = {
   encode(message: Simple, writer: Writer = Writer.create()): Writer {

--- a/integration/simple-snake/simple.ts
+++ b/integration/simple-snake/simple.ts
@@ -321,7 +321,7 @@ export const StateEnum = {
   },
 }
 
-export type StateEnum = 0 | 2 | 3;
+export type StateEnum = 0 | 2 | 3 | -1;
 
 export const Child_Type = {
   UNKNOWN: 0 as Child_Type,
@@ -359,7 +359,7 @@ export const Child_Type = {
   },
 }
 
-export type Child_Type = 0 | 1 | 2;
+export type Child_Type = 0 | 1 | 2 | -1;
 
 export const Nested_InnerEnum = {
   UNKNOWN_INNER: 0 as Nested_InnerEnum,
@@ -397,7 +397,7 @@ export const Nested_InnerEnum = {
   },
 }
 
-export type Nested_InnerEnum = 0 | 100 | 1000;
+export type Nested_InnerEnum = 0 | 100 | 1000 | -1;
 
 export const Simple = {
   encode(message: Simple, writer: Writer = Writer.create()): Writer {

--- a/integration/simple-snake/simple.ts
+++ b/integration/simple-snake/simple.ts
@@ -289,6 +289,7 @@ export const StateEnum = {
   UNKNOWN: 0 as StateEnum,
   ON: 2 as StateEnum,
   OFF: 3 as StateEnum,
+  UNRECOGNIZED: -1 as StateEnum,
   fromJSON(object: any): StateEnum {
     switch (object) {
       case 0:
@@ -300,8 +301,10 @@ export const StateEnum = {
       case 3:
       case "OFF":
         return StateEnum.OFF;
+      case -1:
+      case "UNRECOGNIZED":
       default:
-        throw new global.Error(`Invalid value ${object}`);
+        return StateEnum.UNRECOGNIZED;
     }
   },
   toJSON(object: StateEnum): string {
@@ -324,6 +327,7 @@ export const Child_Type = {
   UNKNOWN: 0 as Child_Type,
   GOOD: 1 as Child_Type,
   BAD: 2 as Child_Type,
+  UNRECOGNIZED: -1 as Child_Type,
   fromJSON(object: any): Child_Type {
     switch (object) {
       case 0:
@@ -335,8 +339,10 @@ export const Child_Type = {
       case 2:
       case "BAD":
         return Child_Type.BAD;
+      case -1:
+      case "UNRECOGNIZED":
       default:
-        throw new global.Error(`Invalid value ${object}`);
+        return Child_Type.UNRECOGNIZED;
     }
   },
   toJSON(object: Child_Type): string {
@@ -359,6 +365,7 @@ export const Nested_InnerEnum = {
   UNKNOWN_INNER: 0 as Nested_InnerEnum,
   GOOD: 100 as Nested_InnerEnum,
   BAD: 1000 as Nested_InnerEnum,
+  UNRECOGNIZED: -1 as Nested_InnerEnum,
   fromJSON(object: any): Nested_InnerEnum {
     switch (object) {
       case 0:
@@ -370,8 +377,10 @@ export const Nested_InnerEnum = {
       case 1000:
       case "BAD":
         return Nested_InnerEnum.BAD;
+      case -1:
+      case "UNRECOGNIZED":
       default:
-        throw new global.Error(`Invalid value ${object}`);
+        return Nested_InnerEnum.UNRECOGNIZED;
     }
   },
   toJSON(object: Nested_InnerEnum): string {

--- a/integration/simple/simple-json-test.ts
+++ b/integration/simple/simple-json-test.ts
@@ -45,18 +45,18 @@ describe('simple json', () => {
     expect(s2.state).toEqual(StateEnum.ON);
   });
 
-  it('fails decode json with invalid numeric enum values', () => {
+  it('can decode json with unrecognized numeric enum values', () => {
     // given state is mapped as 1, which is not a valid numeric value
     const s1 = { state: 1 };
-    // then we fail fast
-    expect(() => Simple.fromJSON(s1)).toThrow('Invalid value 1');
+    // then we decode to UNRECOGNIZED
+    expect(Simple.fromJSON(s1).state).toEqual(StateEnum.UNRECOGNIZED);
   });
 
-  it('fails decode json with invalid string enum values', () => {
+  it('can decode json with unrecognized string enum values', () => {
     // given state is mapped as an invalid string
     const s1 = { state: 'INVALID' };
     // then we fail fast
-    expect(() => Simple.fromJSON(s1)).toThrow('Invalid value INVALID');
+    expect(Simple.fromJSON(s1).state).toEqual(StateEnum.UNRECOGNIZED);
   });
 
   it('can decode nested enums', () => {

--- a/integration/simple/simple.ts
+++ b/integration/simple/simple.ts
@@ -321,7 +321,7 @@ export const StateEnum = {
   },
 }
 
-export type StateEnum = 0 | 2 | 3;
+export type StateEnum = 0 | 2 | 3 | -1;
 
 export const Child_Type = {
   UNKNOWN: 0 as Child_Type,
@@ -359,7 +359,7 @@ export const Child_Type = {
   },
 }
 
-export type Child_Type = 0 | 1 | 2;
+export type Child_Type = 0 | 1 | 2 | -1;
 
 export const Nested_InnerEnum = {
   UNKNOWN_INNER: 0 as Nested_InnerEnum,
@@ -397,7 +397,7 @@ export const Nested_InnerEnum = {
   },
 }
 
-export type Nested_InnerEnum = 0 | 100 | 1000;
+export type Nested_InnerEnum = 0 | 100 | 1000 | -1;
 
 export const Simple = {
   encode(message: Simple, writer: Writer = Writer.create()): Writer {

--- a/integration/simple/simple.ts
+++ b/integration/simple/simple.ts
@@ -289,6 +289,7 @@ export const StateEnum = {
   UNKNOWN: 0 as StateEnum,
   ON: 2 as StateEnum,
   OFF: 3 as StateEnum,
+  UNRECOGNIZED: -1 as StateEnum,
   fromJSON(object: any): StateEnum {
     switch (object) {
       case 0:
@@ -300,8 +301,10 @@ export const StateEnum = {
       case 3:
       case "OFF":
         return StateEnum.OFF;
+      case -1:
+      case "UNRECOGNIZED":
       default:
-        throw new global.Error(`Invalid value ${object}`);
+        return StateEnum.UNRECOGNIZED;
     }
   },
   toJSON(object: StateEnum): string {
@@ -324,6 +327,7 @@ export const Child_Type = {
   UNKNOWN: 0 as Child_Type,
   GOOD: 1 as Child_Type,
   BAD: 2 as Child_Type,
+  UNRECOGNIZED: -1 as Child_Type,
   fromJSON(object: any): Child_Type {
     switch (object) {
       case 0:
@@ -335,8 +339,10 @@ export const Child_Type = {
       case 2:
       case "BAD":
         return Child_Type.BAD;
+      case -1:
+      case "UNRECOGNIZED":
       default:
-        throw new global.Error(`Invalid value ${object}`);
+        return Child_Type.UNRECOGNIZED;
     }
   },
   toJSON(object: Child_Type): string {
@@ -359,6 +365,7 @@ export const Nested_InnerEnum = {
   UNKNOWN_INNER: 0 as Nested_InnerEnum,
   GOOD: 100 as Nested_InnerEnum,
   BAD: 1000 as Nested_InnerEnum,
+  UNRECOGNIZED: -1 as Nested_InnerEnum,
   fromJSON(object: any): Nested_InnerEnum {
     switch (object) {
       case 0:
@@ -370,8 +377,10 @@ export const Nested_InnerEnum = {
       case 1000:
       case "BAD":
         return Nested_InnerEnum.BAD;
+      case -1:
+      case "UNRECOGNIZED":
       default:
-        throw new global.Error(`Invalid value ${object}`);
+        return Nested_InnerEnum.UNRECOGNIZED;
     }
   },
   toJSON(object: Nested_InnerEnum): string {

--- a/integration/vector-tile/__snapshots__/vector-tile-test.ts.snap
+++ b/integration/vector-tile/__snapshots__/vector-tile-test.ts.snap
@@ -114,7 +114,7 @@ export const Tile_GeomType = {
   },
 }
 
-export type Tile_GeomType = 0 | 1 | 2 | 3;
+export type Tile_GeomType = 0 | 1 | 2 | 3 | -1;
 
 export const Tile = {
   encode(message: Tile, writer: Writer = Writer.create()): Writer {

--- a/integration/vector-tile/__snapshots__/vector-tile-test.ts.snap
+++ b/integration/vector-tile/__snapshots__/vector-tile-test.ts.snap
@@ -77,6 +77,7 @@ export const Tile_GeomType = {
   POINT: 1 as Tile_GeomType,
   LINESTRING: 2 as Tile_GeomType,
   POLYGON: 3 as Tile_GeomType,
+  UNRECOGNIZED: -1 as Tile_GeomType,
   fromJSON(object: any): Tile_GeomType {
     switch (object) {
       case 0:
@@ -91,8 +92,10 @@ export const Tile_GeomType = {
       case 3:
       case \\"POLYGON\\":
         return Tile_GeomType.POLYGON;
+      case -1:
+      case \\"UNRECOGNIZED\\":
       default:
-        throw new global.Error(\`Invalid value \${object}\`);
+        return Tile_GeomType.UNRECOGNIZED;
     }
   },
   toJSON(object: Tile_GeomType): string {

--- a/integration/vector-tile/vector_tile.ts
+++ b/integration/vector-tile/vector_tile.ts
@@ -74,6 +74,7 @@ export const Tile_GeomType = {
   POINT: 1 as Tile_GeomType,
   LINESTRING: 2 as Tile_GeomType,
   POLYGON: 3 as Tile_GeomType,
+  UNRECOGNIZED: -1 as Tile_GeomType,
   fromJSON(object: any): Tile_GeomType {
     switch (object) {
       case 0:
@@ -88,8 +89,10 @@ export const Tile_GeomType = {
       case 3:
       case "POLYGON":
         return Tile_GeomType.POLYGON;
+      case -1:
+      case "UNRECOGNIZED":
       default:
-        throw new global.Error(`Invalid value ${object}`);
+        return Tile_GeomType.UNRECOGNIZED;
     }
   },
   toJSON(object: Tile_GeomType): string {

--- a/integration/vector-tile/vector_tile.ts
+++ b/integration/vector-tile/vector_tile.ts
@@ -111,7 +111,7 @@ export const Tile_GeomType = {
   },
 }
 
-export type Tile_GeomType = 0 | 1 | 2 | 3;
+export type Tile_GeomType = 0 | 1 | 2 | 3 | -1;
 
 export const Tile = {
   encode(message: Tile, writer: Writer = Writer.create()): Writer {

--- a/src/main.ts
+++ b/src/main.ts
@@ -276,6 +276,9 @@ function addTimestampMethods(file: FileSpec, options: Options): FileSpec {
     );
 }
 
+const UNRECOGNIZED_ENUM_NAME = "UNRECOGNIZED";
+const UNRECOGNIZED_ENUM_VALUE = -1;
+
 function generateEnum(
   options: Options,
   fullName: string,
@@ -292,6 +295,7 @@ function generateEnum(
     maybeAddComment(info, text => (code = code.add(`/** ${valueDesc.name} - ${text} */\n`)));
     code = code.add('%L: %L as %L,\n', valueDesc.name, valueDesc.number.toString(), fullName);
   }
+  code = code.add('%L: %L as %L,\n', UNRECOGNIZED_ENUM_NAME, UNRECOGNIZED_ENUM_VALUE.toString(), fullName);
 
   if (options.outputJsonMethods) {
     code = code.addHashEntry(generateEnumFromJson(fullName, enumDesc));
@@ -319,8 +323,10 @@ function generateEnumFromJson(fullName: string, enumDesc: EnumDescriptorProto): 
       .addStatement('return %L.%L%<', fullName, valueDesc.name);
   }
   body = body
+    .add('case %L:\n', UNRECOGNIZED_ENUM_VALUE)
+    .add('case %S:\n', UNRECOGNIZED_ENUM_NAME)
     .add('default:%>\n')
-    .addStatement('throw new global.Error(`Invalid value ${object}`)%<')
+    .addStatement('return %L.%L%<', fullName, UNRECOGNIZED_ENUM_NAME)
     .endControlFlow();
   return func.addCodeBlock(body);
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -305,7 +305,8 @@ function generateEnum(
   code = code.endControlFlow();
   code = code.add('\n');
 
-  code = code.add('export type %L = %L;', fullName, enumDesc.value.map(v => v.number.toString()).join(' | '));
+  const enumTypes = [...enumDesc.value.map(v => v.number.toString()), UNRECOGNIZED_ENUM_VALUE.toString()];
+  code = code.add('export type %L = %L;', fullName, enumTypes.join(' | '));
   code = code.add('\n');
 
   return code;


### PR DESCRIPTION
Fixes https://github.com/stephenh/ts-proto/issues/41

Update enum default to be `UNRECOGNIZED` / `-1` to be consistent with how java generates enums.

e.g.
```java
public enum ChangeType implements ProtocolMessageEnum {
    ADDED(0),
    REMOVED(1),
    MODIFIED(2),
    UNRECOGNIZED(-1);
```