### PR TITLE
Allow Uint8Arrays / Buffers to be passed to decode() directly

### DIFF
--- a/integration/batching-with-context/batching.ts
+++ b/integration/batching-with-context/batching.ts
@@ -190,7 +190,8 @@ export const BatchQueryRequest = {
     }
     return writer;
   },
-  decode(reader: Reader, length?: number): BatchQueryRequest {
+  decode(input: Uint8Array | Reader, length?: number): BatchQueryRequest {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseBatchQueryRequest) as BatchQueryRequest;
     message.ids = [];
@@ -245,7 +246,8 @@ export const BatchQueryResponse = {
     }
     return writer;
   },
-  decode(reader: Reader, length?: number): BatchQueryResponse {
+  decode(input: Uint8Array | Reader, length?: number): BatchQueryResponse {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseBatchQueryResponse) as BatchQueryResponse;
     message.entities = [];
@@ -300,7 +302,8 @@ export const BatchMapQueryRequest = {
     }
     return writer;
   },
-  decode(reader: Reader, length?: number): BatchMapQueryRequest {
+  decode(input: Uint8Array | Reader, length?: number): BatchMapQueryRequest {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseBatchMapQueryRequest) as BatchMapQueryRequest;
     message.ids = [];
@@ -355,7 +358,8 @@ export const BatchMapQueryResponse = {
     })
     return writer;
   },
-  decode(reader: Reader, length?: number): BatchMapQueryResponse {
+  decode(input: Uint8Array | Reader, length?: number): BatchMapQueryResponse {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseBatchMapQueryResponse) as BatchMapQueryResponse;
     message.entities = {};
@@ -412,7 +416,8 @@ export const BatchMapQueryResponse_EntitiesEntry = {
     }
     return writer;
   },
-  decode(reader: Reader, length?: number): BatchMapQueryResponse_EntitiesEntry {
+  decode(input: Uint8Array | Reader, length?: number): BatchMapQueryResponse_EntitiesEntry {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseBatchMapQueryResponse_EntitiesEntry) as BatchMapQueryResponse_EntitiesEntry;
     while (reader.pos < end) {
@@ -472,7 +477,8 @@ export const GetOnlyMethodRequest = {
     writer.uint32(10).string(message.id);
     return writer;
   },
-  decode(reader: Reader, length?: number): GetOnlyMethodRequest {
+  decode(input: Uint8Array | Reader, length?: number): GetOnlyMethodRequest {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseGetOnlyMethodRequest) as GetOnlyMethodRequest;
     while (reader.pos < end) {
@@ -520,7 +526,8 @@ export const GetOnlyMethodResponse = {
     }
     return writer;
   },
-  decode(reader: Reader, length?: number): GetOnlyMethodResponse {
+  decode(input: Uint8Array | Reader, length?: number): GetOnlyMethodResponse {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseGetOnlyMethodResponse) as GetOnlyMethodResponse;
     while (reader.pos < end) {
@@ -566,7 +573,8 @@ export const WriteMethodRequest = {
     writer.uint32(10).string(message.id);
     return writer;
   },
-  decode(reader: Reader, length?: number): WriteMethodRequest {
+  decode(input: Uint8Array | Reader, length?: number): WriteMethodRequest {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseWriteMethodRequest) as WriteMethodRequest;
     while (reader.pos < end) {
@@ -611,7 +619,8 @@ export const WriteMethodResponse = {
   encode(_: WriteMethodResponse, writer: Writer = Writer.create()): Writer {
     return writer;
   },
-  decode(reader: Reader, length?: number): WriteMethodResponse {
+  decode(input: Uint8Array | Reader, length?: number): WriteMethodResponse {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseWriteMethodResponse) as WriteMethodResponse;
     while (reader.pos < end) {
@@ -644,7 +653,8 @@ export const Entity = {
     writer.uint32(18).string(message.name);
     return writer;
   },
-  decode(reader: Reader, length?: number): Entity {
+  decode(input: Uint8Array | Reader, length?: number): Entity {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseEntity) as Entity;
     while (reader.pos < end) {

--- a/integration/batching/batching.ts
+++ b/integration/batching/batching.ts
@@ -148,7 +148,8 @@ export const BatchQueryRequest = {
     }
     return writer;
   },
-  decode(reader: Reader, length?: number): BatchQueryRequest {
+  decode(input: Uint8Array | Reader, length?: number): BatchQueryRequest {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseBatchQueryRequest) as BatchQueryRequest;
     message.ids = [];
@@ -203,7 +204,8 @@ export const BatchQueryResponse = {
     }
     return writer;
   },
-  decode(reader: Reader, length?: number): BatchQueryResponse {
+  decode(input: Uint8Array | Reader, length?: number): BatchQueryResponse {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseBatchQueryResponse) as BatchQueryResponse;
     message.entities = [];
@@ -258,7 +260,8 @@ export const BatchMapQueryRequest = {
     }
     return writer;
   },
-  decode(reader: Reader, length?: number): BatchMapQueryRequest {
+  decode(input: Uint8Array | Reader, length?: number): BatchMapQueryRequest {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseBatchMapQueryRequest) as BatchMapQueryRequest;
     message.ids = [];
@@ -313,7 +316,8 @@ export const BatchMapQueryResponse = {
     })
     return writer;
   },
-  decode(reader: Reader, length?: number): BatchMapQueryResponse {
+  decode(input: Uint8Array | Reader, length?: number): BatchMapQueryResponse {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseBatchMapQueryResponse) as BatchMapQueryResponse;
     message.entities = {};
@@ -370,7 +374,8 @@ export const BatchMapQueryResponse_EntitiesEntry = {
     }
     return writer;
   },
-  decode(reader: Reader, length?: number): BatchMapQueryResponse_EntitiesEntry {
+  decode(input: Uint8Array | Reader, length?: number): BatchMapQueryResponse_EntitiesEntry {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseBatchMapQueryResponse_EntitiesEntry) as BatchMapQueryResponse_EntitiesEntry;
     while (reader.pos < end) {
@@ -430,7 +435,8 @@ export const GetOnlyMethodRequest = {
     writer.uint32(10).string(message.id);
     return writer;
   },
-  decode(reader: Reader, length?: number): GetOnlyMethodRequest {
+  decode(input: Uint8Array | Reader, length?: number): GetOnlyMethodRequest {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseGetOnlyMethodRequest) as GetOnlyMethodRequest;
     while (reader.pos < end) {
@@ -478,7 +484,8 @@ export const GetOnlyMethodResponse = {
     }
     return writer;
   },
-  decode(reader: Reader, length?: number): GetOnlyMethodResponse {
+  decode(input: Uint8Array | Reader, length?: number): GetOnlyMethodResponse {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseGetOnlyMethodResponse) as GetOnlyMethodResponse;
     while (reader.pos < end) {
@@ -524,7 +531,8 @@ export const WriteMethodRequest = {
     writer.uint32(10).string(message.id);
     return writer;
   },
-  decode(reader: Reader, length?: number): WriteMethodRequest {
+  decode(input: Uint8Array | Reader, length?: number): WriteMethodRequest {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseWriteMethodRequest) as WriteMethodRequest;
     while (reader.pos < end) {
@@ -569,7 +577,8 @@ export const WriteMethodResponse = {
   encode(_: WriteMethodResponse, writer: Writer = Writer.create()): Writer {
     return writer;
   },
-  decode(reader: Reader, length?: number): WriteMethodResponse {
+  decode(input: Uint8Array | Reader, length?: number): WriteMethodResponse {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseWriteMethodResponse) as WriteMethodResponse;
     while (reader.pos < end) {
@@ -602,7 +611,8 @@ export const Entity = {
     writer.uint32(18).string(message.name);
     return writer;
   },
-  decode(reader: Reader, length?: number): Entity {
+  decode(input: Uint8Array | Reader, length?: number): Entity {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseEntity) as Entity;
     while (reader.pos < end) {

--- a/integration/point/point.ts
+++ b/integration/point/point.ts
@@ -27,7 +27,8 @@ export const Point = {
     writer.uint32(17).double(message.lng);
     return writer;
   },
-  decode(reader: Reader, length?: number): Point {
+  decode(input: Uint8Array | Reader, length?: number): Point {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(basePoint) as Point;
     while (reader.pos < end) {
@@ -92,7 +93,8 @@ export const Area = {
     }
     return writer;
   },
-  decode(reader: Reader, length?: number): Area {
+  decode(input: Uint8Array | Reader, length?: number): Area {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseArea) as Area;
     while (reader.pos < end) {

--- a/integration/simple-long-string/google/protobuf/timestamp.ts
+++ b/integration/simple-long-string/google/protobuf/timestamp.ts
@@ -119,7 +119,8 @@ export const Timestamp = {
     writer.uint32(16).int32(message.nanos);
     return writer;
   },
-  decode(reader: Reader, length?: number): Timestamp {
+  decode(input: Uint8Array | Reader, length?: number): Timestamp {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseTimestamp) as Timestamp;
     while (reader.pos < end) {

--- a/integration/simple-long-string/google/protobuf/wrappers.ts
+++ b/integration/simple-long-string/google/protobuf/wrappers.ts
@@ -155,7 +155,8 @@ export const DoubleValue = {
     writer.uint32(9).double(message.value);
     return writer;
   },
-  decode(reader: Reader, length?: number): DoubleValue {
+  decode(input: Uint8Array | Reader, length?: number): DoubleValue {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseDoubleValue) as DoubleValue;
     while (reader.pos < end) {
@@ -201,7 +202,8 @@ export const FloatValue = {
     writer.uint32(13).float(message.value);
     return writer;
   },
-  decode(reader: Reader, length?: number): FloatValue {
+  decode(input: Uint8Array | Reader, length?: number): FloatValue {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseFloatValue) as FloatValue;
     while (reader.pos < end) {
@@ -247,7 +249,8 @@ export const Int64Value = {
     writer.uint32(8).int64(message.value);
     return writer;
   },
-  decode(reader: Reader, length?: number): Int64Value {
+  decode(input: Uint8Array | Reader, length?: number): Int64Value {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseInt64Value) as Int64Value;
     while (reader.pos < end) {
@@ -293,7 +296,8 @@ export const UInt64Value = {
     writer.uint32(8).uint64(message.value);
     return writer;
   },
-  decode(reader: Reader, length?: number): UInt64Value {
+  decode(input: Uint8Array | Reader, length?: number): UInt64Value {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseUInt64Value) as UInt64Value;
     while (reader.pos < end) {
@@ -339,7 +343,8 @@ export const Int32Value = {
     writer.uint32(8).int32(message.value);
     return writer;
   },
-  decode(reader: Reader, length?: number): Int32Value {
+  decode(input: Uint8Array | Reader, length?: number): Int32Value {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseInt32Value) as Int32Value;
     while (reader.pos < end) {
@@ -385,7 +390,8 @@ export const UInt32Value = {
     writer.uint32(8).uint32(message.value);
     return writer;
   },
-  decode(reader: Reader, length?: number): UInt32Value {
+  decode(input: Uint8Array | Reader, length?: number): UInt32Value {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseUInt32Value) as UInt32Value;
     while (reader.pos < end) {
@@ -431,7 +437,8 @@ export const BoolValue = {
     writer.uint32(8).bool(message.value);
     return writer;
   },
-  decode(reader: Reader, length?: number): BoolValue {
+  decode(input: Uint8Array | Reader, length?: number): BoolValue {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseBoolValue) as BoolValue;
     while (reader.pos < end) {
@@ -477,7 +484,8 @@ export const StringValue = {
     writer.uint32(10).string(message.value);
     return writer;
   },
-  decode(reader: Reader, length?: number): StringValue {
+  decode(input: Uint8Array | Reader, length?: number): StringValue {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseStringValue) as StringValue;
     while (reader.pos < end) {
@@ -523,7 +531,8 @@ export const BytesValue = {
     writer.uint32(10).bytes(message.value);
     return writer;
   },
-  decode(reader: Reader, length?: number): BytesValue {
+  decode(input: Uint8Array | Reader, length?: number): BytesValue {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseBytesValue) as BytesValue;
     while (reader.pos < end) {

--- a/integration/simple-long-string/import_dir/thing.ts
+++ b/integration/simple-long-string/import_dir/thing.ts
@@ -39,7 +39,8 @@ export const ImportedThing = {
     }
     return writer;
   },
-  decode(reader: Reader, length?: number): ImportedThing {
+  decode(input: Uint8Array | Reader, length?: number): ImportedThing {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseImportedThing) as ImportedThing;
     while (reader.pos < end) {

--- a/integration/simple-long-string/simple.ts
+++ b/integration/simple-long-string/simple.ts
@@ -428,7 +428,8 @@ export const Simple = {
     }
     return writer;
   },
-  decode(reader: Reader, length?: number): Simple {
+  decode(input: Uint8Array | Reader, length?: number): Simple {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseSimple) as Simple;
     message.grandChildren = [];
@@ -643,7 +644,8 @@ export const Child = {
     writer.uint32(16).int32(message.type);
     return writer;
   },
-  decode(reader: Reader, length?: number): Child {
+  decode(input: Uint8Array | Reader, length?: number): Child {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseChild) as Child;
     while (reader.pos < end) {
@@ -707,7 +709,8 @@ export const Nested = {
     writer.uint32(24).int32(message.state);
     return writer;
   },
-  decode(reader: Reader, length?: number): Nested {
+  decode(input: Uint8Array | Reader, length?: number): Nested {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseNested) as Nested;
     while (reader.pos < end) {
@@ -784,7 +787,8 @@ export const Nested_InnerMessage = {
     }
     return writer;
   },
-  decode(reader: Reader, length?: number): Nested_InnerMessage {
+  decode(input: Uint8Array | Reader, length?: number): Nested_InnerMessage {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseNested_InnerMessage) as Nested_InnerMessage;
     while (reader.pos < end) {
@@ -844,7 +848,8 @@ export const Nested_InnerMessage_DeepMessage = {
     writer.uint32(10).string(message.name);
     return writer;
   },
-  decode(reader: Reader, length?: number): Nested_InnerMessage_DeepMessage {
+  decode(input: Uint8Array | Reader, length?: number): Nested_InnerMessage_DeepMessage {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseNested_InnerMessage_DeepMessage) as Nested_InnerMessage_DeepMessage;
     while (reader.pos < end) {
@@ -895,7 +900,8 @@ export const OneOfMessage = {
     }
     return writer;
   },
-  decode(reader: Reader, length?: number): OneOfMessage {
+  decode(input: Uint8Array | Reader, length?: number): OneOfMessage {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseOneOfMessage) as OneOfMessage;
     while (reader.pos < end) {
@@ -969,7 +975,8 @@ export const SimpleWithWrappers = {
     }
     return writer;
   },
-  decode(reader: Reader, length?: number): SimpleWithWrappers {
+  decode(input: Uint8Array | Reader, length?: number): SimpleWithWrappers {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseSimpleWithWrappers) as SimpleWithWrappers;
     message.coins = [];
@@ -1085,7 +1092,8 @@ export const Entity = {
     writer.uint32(8).int32(message.id);
     return writer;
   },
-  decode(reader: Reader, length?: number): Entity {
+  decode(input: Uint8Array | Reader, length?: number): Entity {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseEntity) as Entity;
     while (reader.pos < end) {
@@ -1139,7 +1147,8 @@ export const SimpleWithMap = {
     })
     return writer;
   },
-  decode(reader: Reader, length?: number): SimpleWithMap {
+  decode(input: Uint8Array | Reader, length?: number): SimpleWithMap {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseSimpleWithMap) as SimpleWithMap;
     message.entitiesById = {};
@@ -1240,7 +1249,8 @@ export const SimpleWithMap_EntitiesByIdEntry = {
     }
     return writer;
   },
-  decode(reader: Reader, length?: number): SimpleWithMap_EntitiesByIdEntry {
+  decode(input: Uint8Array | Reader, length?: number): SimpleWithMap_EntitiesByIdEntry {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseSimpleWithMap_EntitiesByIdEntry) as SimpleWithMap_EntitiesByIdEntry;
     while (reader.pos < end) {
@@ -1301,7 +1311,8 @@ export const SimpleWithMap_NameLookupEntry = {
     writer.uint32(18).string(message.value);
     return writer;
   },
-  decode(reader: Reader, length?: number): SimpleWithMap_NameLookupEntry {
+  decode(input: Uint8Array | Reader, length?: number): SimpleWithMap_NameLookupEntry {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseSimpleWithMap_NameLookupEntry) as SimpleWithMap_NameLookupEntry;
     while (reader.pos < end) {
@@ -1362,7 +1373,8 @@ export const SimpleWithMap_IntLookupEntry = {
     writer.uint32(16).int32(message.value);
     return writer;
   },
-  decode(reader: Reader, length?: number): SimpleWithMap_IntLookupEntry {
+  decode(input: Uint8Array | Reader, length?: number): SimpleWithMap_IntLookupEntry {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseSimpleWithMap_IntLookupEntry) as SimpleWithMap_IntLookupEntry;
     while (reader.pos < end) {
@@ -1424,7 +1436,8 @@ export const SimpleWithSnakeCaseMap = {
     })
     return writer;
   },
-  decode(reader: Reader, length?: number): SimpleWithSnakeCaseMap {
+  decode(input: Uint8Array | Reader, length?: number): SimpleWithSnakeCaseMap {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseSimpleWithSnakeCaseMap) as SimpleWithSnakeCaseMap;
     message.entitiesById = {};
@@ -1481,7 +1494,8 @@ export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
     }
     return writer;
   },
-  decode(reader: Reader, length?: number): SimpleWithSnakeCaseMap_EntitiesByIdEntry {
+  decode(input: Uint8Array | Reader, length?: number): SimpleWithSnakeCaseMap_EntitiesByIdEntry {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseSimpleWithSnakeCaseMap_EntitiesByIdEntry) as SimpleWithSnakeCaseMap_EntitiesByIdEntry;
     while (reader.pos < end) {
@@ -1541,7 +1555,8 @@ export const PingRequest = {
     writer.uint32(10).string(message.input);
     return writer;
   },
-  decode(reader: Reader, length?: number): PingRequest {
+  decode(input: Uint8Array | Reader, length?: number): PingRequest {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(basePingRequest) as PingRequest;
     while (reader.pos < end) {
@@ -1587,7 +1602,8 @@ export const PingResponse = {
     writer.uint32(10).string(message.output);
     return writer;
   },
-  decode(reader: Reader, length?: number): PingResponse {
+  decode(input: Uint8Array | Reader, length?: number): PingResponse {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(basePingResponse) as PingResponse;
     while (reader.pos < end) {
@@ -1644,7 +1660,8 @@ export const Numbers = {
     writer.uint32(97).sfixed64(message.sfixed64);
     return writer;
   },
-  decode(reader: Reader, length?: number): Numbers {
+  decode(input: Uint8Array | Reader, length?: number): Numbers {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseNumbers) as Numbers;
     while (reader.pos < end) {

--- a/integration/simple-long/google/protobuf/timestamp.ts
+++ b/integration/simple-long/google/protobuf/timestamp.ts
@@ -115,7 +115,8 @@ export const Timestamp = {
     writer.uint32(16).int32(message.nanos);
     return writer;
   },
-  decode(reader: Reader, length?: number): Timestamp {
+  decode(input: Uint8Array | Reader, length?: number): Timestamp {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseTimestamp) as Timestamp;
     while (reader.pos < end) {

--- a/integration/simple-long/google/protobuf/wrappers.ts
+++ b/integration/simple-long/google/protobuf/wrappers.ts
@@ -151,7 +151,8 @@ export const DoubleValue = {
     writer.uint32(9).double(message.value);
     return writer;
   },
-  decode(reader: Reader, length?: number): DoubleValue {
+  decode(input: Uint8Array | Reader, length?: number): DoubleValue {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseDoubleValue) as DoubleValue;
     while (reader.pos < end) {
@@ -197,7 +198,8 @@ export const FloatValue = {
     writer.uint32(13).float(message.value);
     return writer;
   },
-  decode(reader: Reader, length?: number): FloatValue {
+  decode(input: Uint8Array | Reader, length?: number): FloatValue {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseFloatValue) as FloatValue;
     while (reader.pos < end) {
@@ -243,7 +245,8 @@ export const Int64Value = {
     writer.uint32(8).int64(message.value);
     return writer;
   },
-  decode(reader: Reader, length?: number): Int64Value {
+  decode(input: Uint8Array | Reader, length?: number): Int64Value {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseInt64Value) as Int64Value;
     while (reader.pos < end) {
@@ -289,7 +292,8 @@ export const UInt64Value = {
     writer.uint32(8).uint64(message.value);
     return writer;
   },
-  decode(reader: Reader, length?: number): UInt64Value {
+  decode(input: Uint8Array | Reader, length?: number): UInt64Value {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseUInt64Value) as UInt64Value;
     while (reader.pos < end) {
@@ -335,7 +339,8 @@ export const Int32Value = {
     writer.uint32(8).int32(message.value);
     return writer;
   },
-  decode(reader: Reader, length?: number): Int32Value {
+  decode(input: Uint8Array | Reader, length?: number): Int32Value {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseInt32Value) as Int32Value;
     while (reader.pos < end) {
@@ -381,7 +386,8 @@ export const UInt32Value = {
     writer.uint32(8).uint32(message.value);
     return writer;
   },
-  decode(reader: Reader, length?: number): UInt32Value {
+  decode(input: Uint8Array | Reader, length?: number): UInt32Value {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseUInt32Value) as UInt32Value;
     while (reader.pos < end) {
@@ -427,7 +433,8 @@ export const BoolValue = {
     writer.uint32(8).bool(message.value);
     return writer;
   },
-  decode(reader: Reader, length?: number): BoolValue {
+  decode(input: Uint8Array | Reader, length?: number): BoolValue {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseBoolValue) as BoolValue;
     while (reader.pos < end) {
@@ -473,7 +480,8 @@ export const StringValue = {
     writer.uint32(10).string(message.value);
     return writer;
   },
-  decode(reader: Reader, length?: number): StringValue {
+  decode(input: Uint8Array | Reader, length?: number): StringValue {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseStringValue) as StringValue;
     while (reader.pos < end) {
@@ -519,7 +527,8 @@ export const BytesValue = {
     writer.uint32(10).bytes(message.value);
     return writer;
   },
-  decode(reader: Reader, length?: number): BytesValue {
+  decode(input: Uint8Array | Reader, length?: number): BytesValue {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseBytesValue) as BytesValue;
     while (reader.pos < end) {

--- a/integration/simple-long/import_dir/thing.ts
+++ b/integration/simple-long/import_dir/thing.ts
@@ -44,7 +44,8 @@ export const ImportedThing = {
     }
     return writer;
   },
-  decode(reader: Reader, length?: number): ImportedThing {
+  decode(input: Uint8Array | Reader, length?: number): ImportedThing {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseImportedThing) as ImportedThing;
     while (reader.pos < end) {

--- a/integration/simple-long/simple.ts
+++ b/integration/simple-long/simple.ts
@@ -428,7 +428,8 @@ export const Simple = {
     }
     return writer;
   },
-  decode(reader: Reader, length?: number): Simple {
+  decode(input: Uint8Array | Reader, length?: number): Simple {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseSimple) as Simple;
     message.grandChildren = [];
@@ -643,7 +644,8 @@ export const Child = {
     writer.uint32(16).int32(message.type);
     return writer;
   },
-  decode(reader: Reader, length?: number): Child {
+  decode(input: Uint8Array | Reader, length?: number): Child {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseChild) as Child;
     while (reader.pos < end) {
@@ -707,7 +709,8 @@ export const Nested = {
     writer.uint32(24).int32(message.state);
     return writer;
   },
-  decode(reader: Reader, length?: number): Nested {
+  decode(input: Uint8Array | Reader, length?: number): Nested {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseNested) as Nested;
     while (reader.pos < end) {
@@ -784,7 +787,8 @@ export const Nested_InnerMessage = {
     }
     return writer;
   },
-  decode(reader: Reader, length?: number): Nested_InnerMessage {
+  decode(input: Uint8Array | Reader, length?: number): Nested_InnerMessage {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseNested_InnerMessage) as Nested_InnerMessage;
     while (reader.pos < end) {
@@ -844,7 +848,8 @@ export const Nested_InnerMessage_DeepMessage = {
     writer.uint32(10).string(message.name);
     return writer;
   },
-  decode(reader: Reader, length?: number): Nested_InnerMessage_DeepMessage {
+  decode(input: Uint8Array | Reader, length?: number): Nested_InnerMessage_DeepMessage {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseNested_InnerMessage_DeepMessage) as Nested_InnerMessage_DeepMessage;
     while (reader.pos < end) {
@@ -895,7 +900,8 @@ export const OneOfMessage = {
     }
     return writer;
   },
-  decode(reader: Reader, length?: number): OneOfMessage {
+  decode(input: Uint8Array | Reader, length?: number): OneOfMessage {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseOneOfMessage) as OneOfMessage;
     while (reader.pos < end) {
@@ -969,7 +975,8 @@ export const SimpleWithWrappers = {
     }
     return writer;
   },
-  decode(reader: Reader, length?: number): SimpleWithWrappers {
+  decode(input: Uint8Array | Reader, length?: number): SimpleWithWrappers {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseSimpleWithWrappers) as SimpleWithWrappers;
     message.coins = [];
@@ -1085,7 +1092,8 @@ export const Entity = {
     writer.uint32(8).int32(message.id);
     return writer;
   },
-  decode(reader: Reader, length?: number): Entity {
+  decode(input: Uint8Array | Reader, length?: number): Entity {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseEntity) as Entity;
     while (reader.pos < end) {
@@ -1139,7 +1147,8 @@ export const SimpleWithMap = {
     })
     return writer;
   },
-  decode(reader: Reader, length?: number): SimpleWithMap {
+  decode(input: Uint8Array | Reader, length?: number): SimpleWithMap {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseSimpleWithMap) as SimpleWithMap;
     message.entitiesById = {};
@@ -1240,7 +1249,8 @@ export const SimpleWithMap_EntitiesByIdEntry = {
     }
     return writer;
   },
-  decode(reader: Reader, length?: number): SimpleWithMap_EntitiesByIdEntry {
+  decode(input: Uint8Array | Reader, length?: number): SimpleWithMap_EntitiesByIdEntry {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseSimpleWithMap_EntitiesByIdEntry) as SimpleWithMap_EntitiesByIdEntry;
     while (reader.pos < end) {
@@ -1301,7 +1311,8 @@ export const SimpleWithMap_NameLookupEntry = {
     writer.uint32(18).string(message.value);
     return writer;
   },
-  decode(reader: Reader, length?: number): SimpleWithMap_NameLookupEntry {
+  decode(input: Uint8Array | Reader, length?: number): SimpleWithMap_NameLookupEntry {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseSimpleWithMap_NameLookupEntry) as SimpleWithMap_NameLookupEntry;
     while (reader.pos < end) {
@@ -1362,7 +1373,8 @@ export const SimpleWithMap_IntLookupEntry = {
     writer.uint32(16).int32(message.value);
     return writer;
   },
-  decode(reader: Reader, length?: number): SimpleWithMap_IntLookupEntry {
+  decode(input: Uint8Array | Reader, length?: number): SimpleWithMap_IntLookupEntry {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseSimpleWithMap_IntLookupEntry) as SimpleWithMap_IntLookupEntry;
     while (reader.pos < end) {
@@ -1424,7 +1436,8 @@ export const SimpleWithSnakeCaseMap = {
     })
     return writer;
   },
-  decode(reader: Reader, length?: number): SimpleWithSnakeCaseMap {
+  decode(input: Uint8Array | Reader, length?: number): SimpleWithSnakeCaseMap {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseSimpleWithSnakeCaseMap) as SimpleWithSnakeCaseMap;
     message.entitiesById = {};
@@ -1481,7 +1494,8 @@ export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
     }
     return writer;
   },
-  decode(reader: Reader, length?: number): SimpleWithSnakeCaseMap_EntitiesByIdEntry {
+  decode(input: Uint8Array | Reader, length?: number): SimpleWithSnakeCaseMap_EntitiesByIdEntry {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseSimpleWithSnakeCaseMap_EntitiesByIdEntry) as SimpleWithSnakeCaseMap_EntitiesByIdEntry;
     while (reader.pos < end) {
@@ -1541,7 +1555,8 @@ export const PingRequest = {
     writer.uint32(10).string(message.input);
     return writer;
   },
-  decode(reader: Reader, length?: number): PingRequest {
+  decode(input: Uint8Array | Reader, length?: number): PingRequest {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(basePingRequest) as PingRequest;
     while (reader.pos < end) {
@@ -1587,7 +1602,8 @@ export const PingResponse = {
     writer.uint32(10).string(message.output);
     return writer;
   },
-  decode(reader: Reader, length?: number): PingResponse {
+  decode(input: Uint8Array | Reader, length?: number): PingResponse {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(basePingResponse) as PingResponse;
     while (reader.pos < end) {
@@ -1644,7 +1660,8 @@ export const Numbers = {
     writer.uint32(97).sfixed64(message.sfixed64);
     return writer;
   },
-  decode(reader: Reader, length?: number): Numbers {
+  decode(input: Uint8Array | Reader, length?: number): Numbers {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseNumbers) as Numbers;
     while (reader.pos < end) {

--- a/integration/simple-proto2/simple.ts
+++ b/integration/simple-proto2/simple.ts
@@ -46,7 +46,8 @@ export const Issue56 = {
     writer.uint32(8).int32(message.test);
     return writer;
   },
-  decode(reader: Reader, length?: number): Issue56 {
+  decode(input: Uint8Array | Reader, length?: number): Issue56 {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseIssue56) as Issue56;
     while (reader.pos < end) {

--- a/integration/simple-snake/google/protobuf/timestamp.ts
+++ b/integration/simple-snake/google/protobuf/timestamp.ts
@@ -122,7 +122,8 @@ export const Timestamp = {
     writer.uint32(16).int32(message.nanos);
     return writer;
   },
-  decode(reader: Reader, length?: number): Timestamp {
+  decode(input: Uint8Array | Reader, length?: number): Timestamp {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseTimestamp) as Timestamp;
     while (reader.pos < end) {

--- a/integration/simple-snake/google/protobuf/wrappers.ts
+++ b/integration/simple-snake/google/protobuf/wrappers.ts
@@ -158,7 +158,8 @@ export const DoubleValue = {
     writer.uint32(9).double(message.value);
     return writer;
   },
-  decode(reader: Reader, length?: number): DoubleValue {
+  decode(input: Uint8Array | Reader, length?: number): DoubleValue {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseDoubleValue) as DoubleValue;
     while (reader.pos < end) {
@@ -204,7 +205,8 @@ export const FloatValue = {
     writer.uint32(13).float(message.value);
     return writer;
   },
-  decode(reader: Reader, length?: number): FloatValue {
+  decode(input: Uint8Array | Reader, length?: number): FloatValue {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseFloatValue) as FloatValue;
     while (reader.pos < end) {
@@ -250,7 +252,8 @@ export const Int64Value = {
     writer.uint32(8).int64(message.value);
     return writer;
   },
-  decode(reader: Reader, length?: number): Int64Value {
+  decode(input: Uint8Array | Reader, length?: number): Int64Value {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseInt64Value) as Int64Value;
     while (reader.pos < end) {
@@ -296,7 +299,8 @@ export const UInt64Value = {
     writer.uint32(8).uint64(message.value);
     return writer;
   },
-  decode(reader: Reader, length?: number): UInt64Value {
+  decode(input: Uint8Array | Reader, length?: number): UInt64Value {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseUInt64Value) as UInt64Value;
     while (reader.pos < end) {
@@ -342,7 +346,8 @@ export const Int32Value = {
     writer.uint32(8).int32(message.value);
     return writer;
   },
-  decode(reader: Reader, length?: number): Int32Value {
+  decode(input: Uint8Array | Reader, length?: number): Int32Value {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseInt32Value) as Int32Value;
     while (reader.pos < end) {
@@ -388,7 +393,8 @@ export const UInt32Value = {
     writer.uint32(8).uint32(message.value);
     return writer;
   },
-  decode(reader: Reader, length?: number): UInt32Value {
+  decode(input: Uint8Array | Reader, length?: number): UInt32Value {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseUInt32Value) as UInt32Value;
     while (reader.pos < end) {
@@ -434,7 +440,8 @@ export const BoolValue = {
     writer.uint32(8).bool(message.value);
     return writer;
   },
-  decode(reader: Reader, length?: number): BoolValue {
+  decode(input: Uint8Array | Reader, length?: number): BoolValue {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseBoolValue) as BoolValue;
     while (reader.pos < end) {
@@ -480,7 +487,8 @@ export const StringValue = {
     writer.uint32(10).string(message.value);
     return writer;
   },
-  decode(reader: Reader, length?: number): StringValue {
+  decode(input: Uint8Array | Reader, length?: number): StringValue {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseStringValue) as StringValue;
     while (reader.pos < end) {
@@ -526,7 +534,8 @@ export const BytesValue = {
     writer.uint32(10).bytes(message.value);
     return writer;
   },
-  decode(reader: Reader, length?: number): BytesValue {
+  decode(input: Uint8Array | Reader, length?: number): BytesValue {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseBytesValue) as BytesValue;
     while (reader.pos < end) {

--- a/integration/simple-snake/import_dir/thing.ts
+++ b/integration/simple-snake/import_dir/thing.ts
@@ -39,7 +39,8 @@ export const ImportedThing = {
     }
     return writer;
   },
-  decode(reader: Reader, length?: number): ImportedThing {
+  decode(input: Uint8Array | Reader, length?: number): ImportedThing {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseImportedThing) as ImportedThing;
     while (reader.pos < end) {

--- a/integration/simple-snake/simple.ts
+++ b/integration/simple-snake/simple.ts
@@ -431,7 +431,8 @@ export const Simple = {
     }
     return writer;
   },
-  decode(reader: Reader, length?: number): Simple {
+  decode(input: Uint8Array | Reader, length?: number): Simple {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseSimple) as Simple;
     message.grand_children = [];
@@ -646,7 +647,8 @@ export const Child = {
     writer.uint32(16).int32(message.type);
     return writer;
   },
-  decode(reader: Reader, length?: number): Child {
+  decode(input: Uint8Array | Reader, length?: number): Child {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseChild) as Child;
     while (reader.pos < end) {
@@ -710,7 +712,8 @@ export const Nested = {
     writer.uint32(24).int32(message.state);
     return writer;
   },
-  decode(reader: Reader, length?: number): Nested {
+  decode(input: Uint8Array | Reader, length?: number): Nested {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseNested) as Nested;
     while (reader.pos < end) {
@@ -787,7 +790,8 @@ export const Nested_InnerMessage = {
     }
     return writer;
   },
-  decode(reader: Reader, length?: number): Nested_InnerMessage {
+  decode(input: Uint8Array | Reader, length?: number): Nested_InnerMessage {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseNested_InnerMessage) as Nested_InnerMessage;
     while (reader.pos < end) {
@@ -847,7 +851,8 @@ export const Nested_InnerMessage_DeepMessage = {
     writer.uint32(10).string(message.name);
     return writer;
   },
-  decode(reader: Reader, length?: number): Nested_InnerMessage_DeepMessage {
+  decode(input: Uint8Array | Reader, length?: number): Nested_InnerMessage_DeepMessage {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseNested_InnerMessage_DeepMessage) as Nested_InnerMessage_DeepMessage;
     while (reader.pos < end) {
@@ -898,7 +903,8 @@ export const OneOfMessage = {
     }
     return writer;
   },
-  decode(reader: Reader, length?: number): OneOfMessage {
+  decode(input: Uint8Array | Reader, length?: number): OneOfMessage {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseOneOfMessage) as OneOfMessage;
     while (reader.pos < end) {
@@ -972,7 +978,8 @@ export const SimpleWithWrappers = {
     }
     return writer;
   },
-  decode(reader: Reader, length?: number): SimpleWithWrappers {
+  decode(input: Uint8Array | Reader, length?: number): SimpleWithWrappers {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseSimpleWithWrappers) as SimpleWithWrappers;
     message.coins = [];
@@ -1088,7 +1095,8 @@ export const Entity = {
     writer.uint32(8).int32(message.id);
     return writer;
   },
-  decode(reader: Reader, length?: number): Entity {
+  decode(input: Uint8Array | Reader, length?: number): Entity {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseEntity) as Entity;
     while (reader.pos < end) {
@@ -1142,7 +1150,8 @@ export const SimpleWithMap = {
     })
     return writer;
   },
-  decode(reader: Reader, length?: number): SimpleWithMap {
+  decode(input: Uint8Array | Reader, length?: number): SimpleWithMap {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseSimpleWithMap) as SimpleWithMap;
     message.entitiesById = {};
@@ -1243,7 +1252,8 @@ export const SimpleWithMap_EntitiesByIdEntry = {
     }
     return writer;
   },
-  decode(reader: Reader, length?: number): SimpleWithMap_EntitiesByIdEntry {
+  decode(input: Uint8Array | Reader, length?: number): SimpleWithMap_EntitiesByIdEntry {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseSimpleWithMap_EntitiesByIdEntry) as SimpleWithMap_EntitiesByIdEntry;
     while (reader.pos < end) {
@@ -1304,7 +1314,8 @@ export const SimpleWithMap_NameLookupEntry = {
     writer.uint32(18).string(message.value);
     return writer;
   },
-  decode(reader: Reader, length?: number): SimpleWithMap_NameLookupEntry {
+  decode(input: Uint8Array | Reader, length?: number): SimpleWithMap_NameLookupEntry {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseSimpleWithMap_NameLookupEntry) as SimpleWithMap_NameLookupEntry;
     while (reader.pos < end) {
@@ -1365,7 +1376,8 @@ export const SimpleWithMap_IntLookupEntry = {
     writer.uint32(16).int32(message.value);
     return writer;
   },
-  decode(reader: Reader, length?: number): SimpleWithMap_IntLookupEntry {
+  decode(input: Uint8Array | Reader, length?: number): SimpleWithMap_IntLookupEntry {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseSimpleWithMap_IntLookupEntry) as SimpleWithMap_IntLookupEntry;
     while (reader.pos < end) {
@@ -1427,7 +1439,8 @@ export const SimpleWithSnakeCaseMap = {
     })
     return writer;
   },
-  decode(reader: Reader, length?: number): SimpleWithSnakeCaseMap {
+  decode(input: Uint8Array | Reader, length?: number): SimpleWithSnakeCaseMap {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseSimpleWithSnakeCaseMap) as SimpleWithSnakeCaseMap;
     message.entities_by_id = {};
@@ -1484,7 +1497,8 @@ export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
     }
     return writer;
   },
-  decode(reader: Reader, length?: number): SimpleWithSnakeCaseMap_EntitiesByIdEntry {
+  decode(input: Uint8Array | Reader, length?: number): SimpleWithSnakeCaseMap_EntitiesByIdEntry {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseSimpleWithSnakeCaseMap_EntitiesByIdEntry) as SimpleWithSnakeCaseMap_EntitiesByIdEntry;
     while (reader.pos < end) {
@@ -1544,7 +1558,8 @@ export const PingRequest = {
     writer.uint32(10).string(message.input);
     return writer;
   },
-  decode(reader: Reader, length?: number): PingRequest {
+  decode(input: Uint8Array | Reader, length?: number): PingRequest {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(basePingRequest) as PingRequest;
     while (reader.pos < end) {
@@ -1590,7 +1605,8 @@ export const PingResponse = {
     writer.uint32(10).string(message.output);
     return writer;
   },
-  decode(reader: Reader, length?: number): PingResponse {
+  decode(input: Uint8Array | Reader, length?: number): PingResponse {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(basePingResponse) as PingResponse;
     while (reader.pos < end) {
@@ -1647,7 +1663,8 @@ export const Numbers = {
     writer.uint32(97).sfixed64(message.sfixed64);
     return writer;
   },
-  decode(reader: Reader, length?: number): Numbers {
+  decode(input: Uint8Array | Reader, length?: number): Numbers {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseNumbers) as Numbers;
     while (reader.pos < end) {

--- a/integration/simple/google/protobuf/timestamp.ts
+++ b/integration/simple/google/protobuf/timestamp.ts
@@ -122,7 +122,8 @@ export const Timestamp = {
     writer.uint32(16).int32(message.nanos);
     return writer;
   },
-  decode(reader: Reader, length?: number): Timestamp {
+  decode(input: Uint8Array | Reader, length?: number): Timestamp {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseTimestamp) as Timestamp;
     while (reader.pos < end) {

--- a/integration/simple/google/protobuf/wrappers.ts
+++ b/integration/simple/google/protobuf/wrappers.ts
@@ -158,7 +158,8 @@ export const DoubleValue = {
     writer.uint32(9).double(message.value);
     return writer;
   },
-  decode(reader: Reader, length?: number): DoubleValue {
+  decode(input: Uint8Array | Reader, length?: number): DoubleValue {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseDoubleValue) as DoubleValue;
     while (reader.pos < end) {
@@ -204,7 +205,8 @@ export const FloatValue = {
     writer.uint32(13).float(message.value);
     return writer;
   },
-  decode(reader: Reader, length?: number): FloatValue {
+  decode(input: Uint8Array | Reader, length?: number): FloatValue {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseFloatValue) as FloatValue;
     while (reader.pos < end) {
@@ -250,7 +252,8 @@ export const Int64Value = {
     writer.uint32(8).int64(message.value);
     return writer;
   },
-  decode(reader: Reader, length?: number): Int64Value {
+  decode(input: Uint8Array | Reader, length?: number): Int64Value {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseInt64Value) as Int64Value;
     while (reader.pos < end) {
@@ -296,7 +299,8 @@ export const UInt64Value = {
     writer.uint32(8).uint64(message.value);
     return writer;
   },
-  decode(reader: Reader, length?: number): UInt64Value {
+  decode(input: Uint8Array | Reader, length?: number): UInt64Value {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseUInt64Value) as UInt64Value;
     while (reader.pos < end) {
@@ -342,7 +346,8 @@ export const Int32Value = {
     writer.uint32(8).int32(message.value);
     return writer;
   },
-  decode(reader: Reader, length?: number): Int32Value {
+  decode(input: Uint8Array | Reader, length?: number): Int32Value {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseInt32Value) as Int32Value;
     while (reader.pos < end) {
@@ -388,7 +393,8 @@ export const UInt32Value = {
     writer.uint32(8).uint32(message.value);
     return writer;
   },
-  decode(reader: Reader, length?: number): UInt32Value {
+  decode(input: Uint8Array | Reader, length?: number): UInt32Value {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseUInt32Value) as UInt32Value;
     while (reader.pos < end) {
@@ -434,7 +440,8 @@ export const BoolValue = {
     writer.uint32(8).bool(message.value);
     return writer;
   },
-  decode(reader: Reader, length?: number): BoolValue {
+  decode(input: Uint8Array | Reader, length?: number): BoolValue {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseBoolValue) as BoolValue;
     while (reader.pos < end) {
@@ -480,7 +487,8 @@ export const StringValue = {
     writer.uint32(10).string(message.value);
     return writer;
   },
-  decode(reader: Reader, length?: number): StringValue {
+  decode(input: Uint8Array | Reader, length?: number): StringValue {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseStringValue) as StringValue;
     while (reader.pos < end) {
@@ -526,7 +534,8 @@ export const BytesValue = {
     writer.uint32(10).bytes(message.value);
     return writer;
   },
-  decode(reader: Reader, length?: number): BytesValue {
+  decode(input: Uint8Array | Reader, length?: number): BytesValue {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseBytesValue) as BytesValue;
     while (reader.pos < end) {

--- a/integration/simple/import_dir/thing.ts
+++ b/integration/simple/import_dir/thing.ts
@@ -39,7 +39,8 @@ export const ImportedThing = {
     }
     return writer;
   },
-  decode(reader: Reader, length?: number): ImportedThing {
+  decode(input: Uint8Array | Reader, length?: number): ImportedThing {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseImportedThing) as ImportedThing;
     while (reader.pos < end) {

--- a/integration/simple/simple.ts
+++ b/integration/simple/simple.ts
@@ -442,7 +442,8 @@ export const Simple = {
     }
     return writer;
   },
-  decode(reader: Reader, length?: number): Simple {
+  decode(input: Uint8Array | Reader, length?: number): Simple {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseSimple) as Simple;
     message.grandChildren = [];
@@ -678,7 +679,8 @@ export const Child = {
     writer.uint32(16).int32(message.type);
     return writer;
   },
-  decode(reader: Reader, length?: number): Child {
+  decode(input: Uint8Array | Reader, length?: number): Child {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseChild) as Child;
     while (reader.pos < end) {
@@ -742,7 +744,8 @@ export const Nested = {
     writer.uint32(24).int32(message.state);
     return writer;
   },
-  decode(reader: Reader, length?: number): Nested {
+  decode(input: Uint8Array | Reader, length?: number): Nested {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseNested) as Nested;
     while (reader.pos < end) {
@@ -819,7 +822,8 @@ export const Nested_InnerMessage = {
     }
     return writer;
   },
-  decode(reader: Reader, length?: number): Nested_InnerMessage {
+  decode(input: Uint8Array | Reader, length?: number): Nested_InnerMessage {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseNested_InnerMessage) as Nested_InnerMessage;
     while (reader.pos < end) {
@@ -879,7 +883,8 @@ export const Nested_InnerMessage_DeepMessage = {
     writer.uint32(10).string(message.name);
     return writer;
   },
-  decode(reader: Reader, length?: number): Nested_InnerMessage_DeepMessage {
+  decode(input: Uint8Array | Reader, length?: number): Nested_InnerMessage_DeepMessage {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseNested_InnerMessage_DeepMessage) as Nested_InnerMessage_DeepMessage;
     while (reader.pos < end) {
@@ -930,7 +935,8 @@ export const OneOfMessage = {
     }
     return writer;
   },
-  decode(reader: Reader, length?: number): OneOfMessage {
+  decode(input: Uint8Array | Reader, length?: number): OneOfMessage {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseOneOfMessage) as OneOfMessage;
     while (reader.pos < end) {
@@ -1004,7 +1010,8 @@ export const SimpleWithWrappers = {
     }
     return writer;
   },
-  decode(reader: Reader, length?: number): SimpleWithWrappers {
+  decode(input: Uint8Array | Reader, length?: number): SimpleWithWrappers {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseSimpleWithWrappers) as SimpleWithWrappers;
     message.coins = [];
@@ -1120,7 +1127,8 @@ export const Entity = {
     writer.uint32(8).int32(message.id);
     return writer;
   },
-  decode(reader: Reader, length?: number): Entity {
+  decode(input: Uint8Array | Reader, length?: number): Entity {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseEntity) as Entity;
     while (reader.pos < end) {
@@ -1174,7 +1182,8 @@ export const SimpleWithMap = {
     })
     return writer;
   },
-  decode(reader: Reader, length?: number): SimpleWithMap {
+  decode(input: Uint8Array | Reader, length?: number): SimpleWithMap {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseSimpleWithMap) as SimpleWithMap;
     message.entitiesById = {};
@@ -1275,7 +1284,8 @@ export const SimpleWithMap_EntitiesByIdEntry = {
     }
     return writer;
   },
-  decode(reader: Reader, length?: number): SimpleWithMap_EntitiesByIdEntry {
+  decode(input: Uint8Array | Reader, length?: number): SimpleWithMap_EntitiesByIdEntry {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseSimpleWithMap_EntitiesByIdEntry) as SimpleWithMap_EntitiesByIdEntry;
     while (reader.pos < end) {
@@ -1336,7 +1346,8 @@ export const SimpleWithMap_NameLookupEntry = {
     writer.uint32(18).string(message.value);
     return writer;
   },
-  decode(reader: Reader, length?: number): SimpleWithMap_NameLookupEntry {
+  decode(input: Uint8Array | Reader, length?: number): SimpleWithMap_NameLookupEntry {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseSimpleWithMap_NameLookupEntry) as SimpleWithMap_NameLookupEntry;
     while (reader.pos < end) {
@@ -1397,7 +1408,8 @@ export const SimpleWithMap_IntLookupEntry = {
     writer.uint32(16).int32(message.value);
     return writer;
   },
-  decode(reader: Reader, length?: number): SimpleWithMap_IntLookupEntry {
+  decode(input: Uint8Array | Reader, length?: number): SimpleWithMap_IntLookupEntry {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseSimpleWithMap_IntLookupEntry) as SimpleWithMap_IntLookupEntry;
     while (reader.pos < end) {
@@ -1459,7 +1471,8 @@ export const SimpleWithSnakeCaseMap = {
     })
     return writer;
   },
-  decode(reader: Reader, length?: number): SimpleWithSnakeCaseMap {
+  decode(input: Uint8Array | Reader, length?: number): SimpleWithSnakeCaseMap {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseSimpleWithSnakeCaseMap) as SimpleWithSnakeCaseMap;
     message.entitiesById = {};
@@ -1516,7 +1529,8 @@ export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
     }
     return writer;
   },
-  decode(reader: Reader, length?: number): SimpleWithSnakeCaseMap_EntitiesByIdEntry {
+  decode(input: Uint8Array | Reader, length?: number): SimpleWithSnakeCaseMap_EntitiesByIdEntry {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseSimpleWithSnakeCaseMap_EntitiesByIdEntry) as SimpleWithSnakeCaseMap_EntitiesByIdEntry;
     while (reader.pos < end) {
@@ -1576,7 +1590,8 @@ export const PingRequest = {
     writer.uint32(10).string(message.input);
     return writer;
   },
-  decode(reader: Reader, length?: number): PingRequest {
+  decode(input: Uint8Array | Reader, length?: number): PingRequest {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(basePingRequest) as PingRequest;
     while (reader.pos < end) {
@@ -1622,7 +1637,8 @@ export const PingResponse = {
     writer.uint32(10).string(message.output);
     return writer;
   },
-  decode(reader: Reader, length?: number): PingResponse {
+  decode(input: Uint8Array | Reader, length?: number): PingResponse {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(basePingResponse) as PingResponse;
     while (reader.pos < end) {
@@ -1679,7 +1695,8 @@ export const Numbers = {
     writer.uint32(97).sfixed64(message.sfixed64);
     return writer;
   },
-  decode(reader: Reader, length?: number): Numbers {
+  decode(input: Uint8Array | Reader, length?: number): Numbers {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseNumbers) as Numbers;
     while (reader.pos < end) {
@@ -1878,7 +1895,8 @@ export const Empty = {
   encode(_: Empty, writer: Writer = Writer.create()): Writer {
     return writer;
   },
-  decode(reader: Reader, length?: number): Empty {
+  decode(input: Uint8Array | Reader, length?: number): Empty {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseEmpty) as Empty;
     while (reader.pos < end) {

--- a/integration/types-with-underscores/file.ts
+++ b/integration/types-with-underscores/file.ts
@@ -21,7 +21,8 @@ export const Baz = {
     }
     return writer;
   },
-  decode(reader: Reader, length?: number): Baz {
+  decode(input: Uint8Array | Reader, length?: number): Baz {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseBaz) as Baz;
     while (reader.pos < end) {
@@ -66,7 +67,8 @@ export const FooBar = {
   encode(_: FooBar, writer: Writer = Writer.create()): Writer {
     return writer;
   },
-  decode(reader: Reader, length?: number): FooBar {
+  decode(input: Uint8Array | Reader, length?: number): FooBar {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseFooBar) as FooBar;
     while (reader.pos < end) {

--- a/integration/vector-tile/__snapshots__/vector-tile-test.ts.snap
+++ b/integration/vector-tile/__snapshots__/vector-tile-test.ts.snap
@@ -123,7 +123,8 @@ export const Tile = {
     }
     return writer;
   },
-  decode(reader: Reader, length?: number): Tile {
+  decode(input: Uint8Array | Reader, length?: number): Tile {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseTile) as Tile;
     message.layers = [];
@@ -182,7 +183,8 @@ export const Tile_Value = {
     writer.uint32(56).bool(message.boolValue);
     return writer;
   },
-  decode(reader: Reader, length?: number): Tile_Value {
+  decode(input: Uint8Array | Reader, length?: number): Tile_Value {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseTile_Value) as Tile_Value;
     while (reader.pos < end) {
@@ -323,7 +325,8 @@ export const Tile_Feature = {
     writer.ldelim();
     return writer;
   },
-  decode(reader: Reader, length?: number): Tile_Feature {
+  decode(input: Uint8Array | Reader, length?: number): Tile_Feature {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseTile_Feature) as Tile_Feature;
     message.tags = [];
@@ -450,7 +453,8 @@ export const Tile_Layer = {
     writer.uint32(40).uint32(message.extent);
     return writer;
   },
-  decode(reader: Reader, length?: number): Tile_Layer {
+  decode(input: Uint8Array | Reader, length?: number): Tile_Layer {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseTile_Layer) as Tile_Layer;
     message.features = [];

--- a/integration/vector-tile/vector-tile-test.ts
+++ b/integration/vector-tile/vector-tile-test.ts
@@ -33,6 +33,27 @@ describe('vector-tile', () => {
     expect(v2).toEqual(v1);
   });
 
+  it('can decode Uint8Array input directly', () => {
+    const v1: IValue = {
+      intValue: 1_000,
+      uintValue: 2_000
+    };
+    const bytes = PbValue.encode(PbValue.fromObject(v1)).finish()
+    const v2 = Tile_Value.decode(bytes);
+    expect(v2).toEqual(v1);
+  });
+
+  it('can decode Buffer input', () => {
+    const v1: IValue = {
+      intValue: 1_000,
+      uintValue: 2_000
+    };
+    const bytes = PbValue.encode(PbValue.fromObject(v1)).finish()
+    const buffer = Buffer.from(bytes)
+    const v2 = Tile_Value.decode(buffer);
+    expect(v2).toEqual(v1);
+  });
+
   it('decodes numbers', () => {
     const tile = {
       intValue: 1,

--- a/integration/vector-tile/vector_tile.ts
+++ b/integration/vector-tile/vector_tile.ts
@@ -120,7 +120,8 @@ export const Tile = {
     }
     return writer;
   },
-  decode(reader: Reader, length?: number): Tile {
+  decode(input: Uint8Array | Reader, length?: number): Tile {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseTile) as Tile;
     message.layers = [];
@@ -179,7 +180,8 @@ export const Tile_Value = {
     writer.uint32(56).bool(message.boolValue);
     return writer;
   },
-  decode(reader: Reader, length?: number): Tile_Value {
+  decode(input: Uint8Array | Reader, length?: number): Tile_Value {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseTile_Value) as Tile_Value;
     while (reader.pos < end) {
@@ -320,7 +322,8 @@ export const Tile_Feature = {
     writer.ldelim();
     return writer;
   },
-  decode(reader: Reader, length?: number): Tile_Feature {
+  decode(input: Uint8Array | Reader, length?: number): Tile_Feature {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseTile_Feature) as Tile_Feature;
     message.tags = [];
@@ -447,7 +450,8 @@ export const Tile_Layer = {
     writer.uint32(40).uint32(message.extent);
     return writer;
   },
-  decode(reader: Reader, length?: number): Tile_Layer {
+  decode(input: Uint8Array | Reader, length?: number): Tile_Layer {
+    const reader = input instanceof Uint8Array ? new Reader(input) : input;
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = Object.create(baseTile_Layer) as Tile_Layer;
     message.features = [];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-proto",
-  "version": "1.20.2",
+  "version": "1.21.0",
   "description": "",
   "main": "build/plugin.js",
   "repository": "github:stephenh/ts-proto",

--- a/src/main.ts
+++ b/src/main.ts
@@ -521,12 +521,13 @@ function generateDecode(
 ): FunctionSpec {
   // create the basic function declaration
   let func = FunctionSpec.create('decode')
-    .addParameter('reader', 'Reader@protobufjs/minimal')
+    .addParameter('input', TypeNames.unionType('Uint8Array', 'Reader@protobufjs/minimal'))
     .addParameter('length?', 'number')
     .returns(fullName);
 
   // add the initial end/message
   func = func
+    .addStatement('const reader = input instanceof Uint8Array ? new Reader(input) : input')
     .addStatement('let end = length === undefined ? reader.len : reader.pos + length')
     .addStatement('const message = Object.create(base%L) as %L', fullName, fullName);
 


### PR DESCRIPTION
This PR makes a small tweak to the `decode()` method so that it can accept an input type of `Uint8Array | Reader` (vs just `Reader` previously). 

You'll want to view this PR by commit. The 1st commit contains the actual changes. And the 2nd contains all the jitter caused by integration tests updating themselves to reflect the new method signature.

Also, I wasn't sure if your build process / CI auto ticks the package version, so I included a version bump in the PR as well. 