### PR TITLE
fix(nestjs): fixes grpc controller decorator

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "protoc-gen-ts_proto": "./protoc-gen-ts_proto"
   },
   "scripts": {
-    "prepare": "yarn setup && yarn build && yarn test",
+    "prepare": "yarn build && yarn test",
     "build": "yarn tsc",
     "setup": "./pbjs.sh && ./integration/pbjs.sh && ./integration/update-bins.sh && ./integration/codegen.sh",
     "test": "yarn jest -c jest.config.js"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "protoc-gen-ts_proto": "./protoc-gen-ts_proto"
   },
   "scripts": {
-    "prepare": "yarn build && yarn test",
+    "prepare": "yarn setup && yarn build && yarn test",
     "build": "yarn tsc",
     "setup": "./pbjs.sh && ./integration/pbjs.sh && ./integration/update-bins.sh && ./integration/codegen.sh",
     "test": "yarn jest -c jest.config.js"

--- a/src/main.ts
+++ b/src/main.ts
@@ -1261,12 +1261,12 @@ function generateNestjsGrpcServiceMethodsDecorator(
   let grpcServiceDecorator = FunctionSpec.create(`${serviceDesc.name}ControllerMethods`).addModifiers(Modifier.EXPORT);
 
   const grpcMethods = serviceDesc.method
-    .filter(m => !m.serverStreaming && !m.clientStreaming)
+    .filter(m => !m.clientStreaming)
     .map(m => `'${options.lowerCaseServiceMethods ? camelCase(m.name) : m.name}'`)
     .join(', ');
 
   const grpcStreamMethods = serviceDesc.method
-    .filter(m => m.serverStreaming || m.clientStreaming)
+    .filter(m => m.clientStreaming)
     .map(m => `'${options.lowerCaseServiceMethods ? camelCase(m.name) : m.name}'`)
     .join(', ');
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
     "strict": true,
     "outDir": "build",
     "skipLibCheck": true,
-    "experimentalDecorators": true
+    "experimentalDecorators": true,
+    "noImplicitAny": false
   },
   "include": ["src"]
 }


### PR DESCRIPTION
First off let me say I am very grateful to see NestJS support here, so thanks! I've been doing similar things in a custom tool alongside your ts-proto package but glad to see it in here now.

This fixes the controller methods decorator. Prior to this fix it was using the wrong decorator for certain types of methods.

Given the following proto that demonstrates all possible combinations of rpcs:
```proto
service GreeterService {
    rpc SayHello (HelloRequest) returns (HelloReply) {}
    rpc SayHelloToAll (stream HelloRequest) returns (stream HelloReplyMessage) {}
    rpc MonitorHellos (MonitorHelloRequest) returns (stream MonitorHelloResponse) {}
    rpc MonitorHellosWithSnapshot (MonitorHelloRequest) returns (stream MonitorHelloResponseOrSnapshot) {}
    rpc BroadcastHellos (stream HelloRequest) returns (HelloCounter) {}
}
```

rpc calls that take in a regular request, regardless of if they return a stream, need to be decorated with `GrpcMethod()` in Nest. 

rpc calls that take in a stream, regardless of what they return should be decorated with `GrpcStreamMethod()`

## Note

There was no yarn.lock in this repository which i believe caused some issues when trying to initialize this repository and i've seen some tests fail as a result of that, probably. I also had to add a tsconfig rule to remove some TS errors I was seeing.