### PR TITLE
support bytes as Buffer by Env option

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -54,6 +54,11 @@ export enum LongOption {
   STRING = 'string'
 }
 
+export enum EnvOption {
+  NODE = 'node',
+  BROWSER = 'browser'
+}
+
 export type Options = {
   useContext: boolean;
   snakeToCamel: boolean;
@@ -65,6 +70,7 @@ export type Options = {
   returnObservable: boolean;
   lowerCaseServiceMethods: boolean;
   nestJs: boolean;
+  env: EnvOption;
 };
 
 export function generateFile(typeMap: TypeMap, fileDesc: FileDescriptorProto, parameter: string): FileSpec {
@@ -1273,17 +1279,17 @@ function generateNestjsGrpcServiceMethodsDecorator(
   const grpcStreamMethodType = TypeNames.importedType('GrpcStreamMethod@@nestjs/microservices');
 
   let decoratorFunction = FunctionSpec.createCallable().addParameter('constructor', TypeNames.typeVariable('Function'))
-  
+
   // add loop for applying @GrpcMethod decorators to functions
   decoratorFunction = generateGrpcMethodDecoratorLoop(decoratorFunction, serviceDesc, 'grpcMethods', grpcMethods, grpcMethodType);
-  
+
   // add loop for applying @GrpcStreamMethod decorators to functions
   decoratorFunction = generateGrpcMethodDecoratorLoop(decoratorFunction, serviceDesc, 'grpcStreamMethods', grpcStreamMethods, grpcStreamMethodType);
-  
+
   const body = CodeBlock.empty().add('return function %F', decoratorFunction);
-  
+
   grpcServiceDecorator = grpcServiceDecorator.addCodeBlock(body);
-  
+
   return grpcServiceDecorator;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 import { google } from '../build/pbjs';
 import { CodeBlock, Member, TypeName, TypeNames } from 'ts-poet';
-import { Options, visit, LongOption } from './main';
+import { Options, visit, LongOption, EnvOption } from './main';
 import { fail } from './utils';
 import { asSequence } from 'sequency';
 import FieldDescriptorProto = google.protobuf.FieldDescriptorProto;
@@ -84,7 +84,11 @@ export function basicTypeName(typeMap: TypeMap, field: FieldDescriptorProto, opt
     case FieldDescriptorProto.Type.TYPE_STRING:
       return TypeNames.STRING;
     case FieldDescriptorProto.Type.TYPE_BYTES:
-      return TypeNames.anyType('Uint8Array');
+      if (options.env === EnvOption.NODE) {
+        return TypeNames.BUFFER;
+      } else {
+        return TypeNames.anyType('Uint8Array');
+      }
     case FieldDescriptorProto.Type.TYPE_MESSAGE:
     case FieldDescriptorProto.Type.TYPE_ENUM:
       return messageToTypeName(typeMap, field.typeName, keepValueType);
@@ -190,13 +194,13 @@ export function defaultValue(typeMap: TypeMap, field: FieldDescriptorProto, opti
     case FieldDescriptorProto.Type.TYPE_INT64:
     case FieldDescriptorProto.Type.TYPE_SINT64:
     case FieldDescriptorProto.Type.TYPE_SFIXED64:
-        if (options.forceLong === LongOption.LONG) {
-          return CodeBlock.of('%T.ZERO', 'Long*long');
-        } else if (options.forceLong === LongOption.STRING) {
-          return '"0"';
-        } else {
-          return 0;
-        }
+      if (options.forceLong === LongOption.LONG) {
+        return CodeBlock.of('%T.ZERO', 'Long*long');
+      } else if (options.forceLong === LongOption.STRING) {
+        return '"0"';
+      } else {
+        return 0;
+      }
     case FieldDescriptorProto.Type.TYPE_BOOL:
       return false;
     case FieldDescriptorProto.Type.TYPE_STRING:

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 import ReadStream = NodeJS.ReadStream;
-import { Options, LongOption } from './main';
+import { Options, LongOption, EnvOption } from './main';
 import { SourceDescription } from './sourceInfo';
 
 export function readToBuffer(stream: ReadStream): Promise<Buffer> {
@@ -47,6 +47,7 @@ export function optionsFromParameter(parameter: string): Options {
     returnObservable: false,
     addGrpcMetadata: false,
     nestJs: false,
+    env: EnvOption.BROWSER,
   };
 
   if (parameter) {
@@ -91,6 +92,12 @@ export function optionsFromParameter(parameter: string): Options {
       }
     }
 
+    if (parameter.includes('env=node')) {
+      options.env = EnvOption.NODE;
+    }
+    if (parameter.includes('env=browser')) {
+      options.env = EnvOption.BROWSER;
+    }
   }
   return options;
 }


### PR DESCRIPTION
it resolves #65.

- added options.env (browser | node)
- protobuf `bytes` is `Buffer` on node or `Uint8Array` on browsers.

We need to discuss which of 'browser' and 'node' is proper to the default value for options.env.
