### PR TITLE
repeated google.protobuf.FoobarValue fields should translate to Foobar[], not Array<Foobar | undefined>

### DIFF
--- a/integration/simple-long-string/simple.ts
+++ b/integration/simple-long-string/simple.ts
@@ -66,8 +66,8 @@ export interface SimpleWithWrappers {
   name: string | undefined;
   age: number | undefined;
   enabled: boolean | undefined;
-  coins: Array<number | undefined>;
-  snacks: Array<string | undefined>;
+  coins: number[];
+  snacks: string[];
 }
 
 export interface Entity {

--- a/integration/simple-long/simple.ts
+++ b/integration/simple-long/simple.ts
@@ -66,8 +66,8 @@ export interface SimpleWithWrappers {
   name: string | undefined;
   age: number | undefined;
   enabled: boolean | undefined;
-  coins: Array<number | undefined>;
-  snacks: Array<string | undefined>;
+  coins: number[];
+  snacks: string[];
 }
 
 export interface Entity {

--- a/integration/simple-snake/simple.ts
+++ b/integration/simple-snake/simple.ts
@@ -66,8 +66,8 @@ export interface SimpleWithWrappers {
   name: string | undefined;
   age: number | undefined;
   enabled: boolean | undefined;
-  coins: Array<number | undefined>;
-  snacks: Array<string | undefined>;
+  coins: number[];
+  snacks: string[];
 }
 
 export interface Entity {

--- a/integration/simple/simple.ts
+++ b/integration/simple/simple.ts
@@ -67,8 +67,8 @@ export interface SimpleWithWrappers {
   name: string | undefined;
   age: number | undefined;
   enabled: boolean | undefined;
-  coins: Array<number | undefined>;
-  snacks: Array<string | undefined>;
+  coins: number[];
+  snacks: string[];
 }
 
 export interface Entity {

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,7 +33,8 @@ import {
   toReaderCall,
   toTypeName,
   TypeMap,
-  isEmptyType
+  isEmptyType,
+  valueTypeName,
 } from './types';
 import { asSequence } from 'sequency';
 import SourceInfo, { Fields } from './sourceInfo';
@@ -760,8 +761,7 @@ function generateFromJson(
       } else if (isTimestamp(field)) {
         return CodeBlock.of('fromJsonTimestamp(%L)', from);
       } else if (isValueType(field)) {
-        const cstr = capitalize((basicTypeName(typeMap, field, options, false) as Union).typeChoices[0].toString());
-        return CodeBlock.of('%L(%L)', cstr, from);
+        return CodeBlock.of('%L(%L)', capitalize(valueTypeName(field).toString()), from);
       } else if (isMessage(field)) {
         if (isRepeated(field) && isMapType(typeMap, messageDesc, field, options)) {
           const valueType = (typeMap.get(field.typeName)![2] as DescriptorProto).field[1];


### PR DESCRIPTION
addresses https://github.com/stephenh/ts-proto/issues/80