### PR TITLE
Fix DataLoader interface not being added

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -184,9 +184,6 @@ export function generateFile(typeMap: TypeMap, fileDesc: FileDescriptorProto, pa
 
   if (options.outputClientImpl && fileDesc.service.length > 0) {
     file = file.addInterface(generateRpcType(options));
-    if (options.useContext) {
-      file = file.addInterface(generateDataLoadersType());
-    }
   }
 
   if (options.useContext) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -189,6 +189,10 @@ export function generateFile(typeMap: TypeMap, fileDesc: FileDescriptorProto, pa
     }
   }
 
+  if (options.useContext) {
+    file = file.addInterface(generateDataLoadersType());
+  }
+
   let hasAnyTimestamps = false;
   visit(
     fileDesc,


### PR DESCRIPTION
As per #94 which is closed. `useContext` didn't seem to work properly because it was not adding DataLoader interface. This makes sure that if flag is passed it will properly generate and insert interface into generated output.