### PR TITLE
Go back to use `enum` keyword for enums.

### DIFF
--- a/integration/codegen.sh
+++ b/integration/codegen.sh
@@ -1,10 +1,25 @@
 #!/usr/bin/env bash
 shopt -s globstar
 
-# Runs the local code generator for each of our .bin test files (as created/kept
+# Runs the local code generator for the .bin test files (as created/kept
 # up-to-date by ./update-bins.sh). Good for local iteration of WIP changes.
+#
+# Usage:
+#
+# ./codegen.sh
+#
+#    Updates generated output for all integration tests.
+#
+# ./codegen.sh simple
+#
+#    Updates generated output only for the 'simple' integration test.
+#
+# Each integration test can optionally have a `parameters.txt` file that will
+# be used as the ts-proto_opt... args for generating that test's code.
 
-for file in **/*.bin; do
+dir=${1:-*}
+
+for file in ${dir}/*.bin; do
   echo "${file}"
   # Strip the longest suffix starting at the 1st slash
   dir="${file%%/*}"

--- a/integration/oneof-properties/oneof.ts
+++ b/integration/oneof-properties/oneof.ts
@@ -40,43 +40,43 @@ const basePleaseChoose_Submessage: object = {
   name: "",
 };
 
-export const PleaseChoose_StateEnum = {
-  UNKNOWN: 0 as const,
-  ON: 2 as const,
-  OFF: 3 as const,
-  UNRECOGNIZED: -1 as const,
-  fromJSON(object: any): PleaseChoose_StateEnum {
-    switch (object) {
-      case 0:
-      case "UNKNOWN":
-        return PleaseChoose_StateEnum.UNKNOWN;
-      case 2:
-      case "ON":
-        return PleaseChoose_StateEnum.ON;
-      case 3:
-      case "OFF":
-        return PleaseChoose_StateEnum.OFF;
-      case -1:
-      case "UNRECOGNIZED":
-      default:
-        return PleaseChoose_StateEnum.UNRECOGNIZED;
-    }
-  },
-  toJSON(object: PleaseChoose_StateEnum): string {
-    switch (object) {
-      case PleaseChoose_StateEnum.UNKNOWN:
-        return "UNKNOWN";
-      case PleaseChoose_StateEnum.ON:
-        return "ON";
-      case PleaseChoose_StateEnum.OFF:
-        return "OFF";
-      default:
-        return "UNKNOWN";
-    }
-  },
+export enum PleaseChoose_StateEnum {
+  UNKNOWN = 0,
+  ON = 2,
+  OFF = 3,
+  UNRECOGNIZED = -1,
 }
 
-export type PleaseChoose_StateEnum = 0 | 2 | 3 | -1;
+export function pleaseChoose_StateEnumFromJSON(object: any): PleaseChoose_StateEnum {
+  switch (object) {
+    case 0:
+    case "UNKNOWN":
+      return PleaseChoose_StateEnum.UNKNOWN;
+    case 2:
+    case "ON":
+      return PleaseChoose_StateEnum.ON;
+    case 3:
+    case "OFF":
+      return PleaseChoose_StateEnum.OFF;
+    case -1:
+    case "UNRECOGNIZED":
+    default:
+      return PleaseChoose_StateEnum.UNRECOGNIZED;
+  }
+}
+
+export function pleaseChoose_StateEnumToJSON(object: PleaseChoose_StateEnum): string {
+  switch (object) {
+    case PleaseChoose_StateEnum.UNKNOWN:
+      return "UNKNOWN";
+    case PleaseChoose_StateEnum.ON:
+      return "ON";
+    case PleaseChoose_StateEnum.OFF:
+      return "OFF";
+    default:
+      return "UNKNOWN";
+  }
+}
 
 export const PleaseChoose = {
   encode(message: PleaseChoose, writer: Writer = Writer.create()): Writer {
@@ -189,7 +189,7 @@ export const PleaseChoose = {
       message.bunchaBytes = bytesFromBase64(object.bunchaBytes);
     }
     if (object.anEnum !== undefined && object.anEnum !== null) {
-      message.anEnum = PleaseChoose_StateEnum.fromJSON(object.anEnum);
+      message.anEnum = pleaseChoose_StateEnumFromJSON(object.anEnum);
     } else {
       message.anEnum = undefined;
     }
@@ -280,7 +280,7 @@ export const PleaseChoose = {
     obj.aMessage = message.aMessage ? PleaseChoose_Submessage.toJSON(message.aMessage) : undefined;
     obj.aBool = message.aBool || undefined;
     obj.bunchaBytes = message.bunchaBytes !== undefined ? base64FromBytes(message.bunchaBytes) : undefined;
-    obj.anEnum = message.anEnum !== undefined ? PleaseChoose_StateEnum.toJSON(message.anEnum) : undefined;
+    obj.anEnum = message.anEnum !== undefined ? pleaseChoose_StateEnumToJSON(message.anEnum) : undefined;
     obj.age = message.age || 0;
     obj.either = message.either || undefined;
     obj.or = message.or || undefined;

--- a/integration/oneof-unions/oneof.ts
+++ b/integration/oneof-unions/oneof.ts
@@ -7,15 +7,15 @@ export interface PleaseChoose {
    *  Please to be choosing one of the fields within this oneof clause.
    *  This text exists to ensure we transpose comments correctly.
    *
-   * a_number
+   * aNumber
    *  Use this if you want a number. Numbers are great. Who doesn't
    *  like them?
    *
-   * a_string
+   * aString
    *  Use this if you want a string. Strings are also nice. Not as
    *  nice as numbers, but what are you going to do...
    *
-   * a_bool
+   * aBool
    *  We also added a bool option! This was added after the 'age'
    *  field, so it has a higher number.
    */
@@ -37,43 +37,43 @@ const basePleaseChoose_Submessage: object = {
   name: "",
 };
 
-export const PleaseChoose_StateEnum = {
-  UNKNOWN: 0 as const,
-  ON: 2 as const,
-  OFF: 3 as const,
-  UNRECOGNIZED: -1 as const,
-  fromJSON(object: any): PleaseChoose_StateEnum {
-    switch (object) {
-      case 0:
-      case "UNKNOWN":
-        return PleaseChoose_StateEnum.UNKNOWN;
-      case 2:
-      case "ON":
-        return PleaseChoose_StateEnum.ON;
-      case 3:
-      case "OFF":
-        return PleaseChoose_StateEnum.OFF;
-      case -1:
-      case "UNRECOGNIZED":
-      default:
-        return PleaseChoose_StateEnum.UNRECOGNIZED;
-    }
-  },
-  toJSON(object: PleaseChoose_StateEnum): string {
-    switch (object) {
-      case PleaseChoose_StateEnum.UNKNOWN:
-        return "UNKNOWN";
-      case PleaseChoose_StateEnum.ON:
-        return "ON";
-      case PleaseChoose_StateEnum.OFF:
-        return "OFF";
-      default:
-        return "UNKNOWN";
-    }
-  },
+export enum PleaseChoose_StateEnum {
+  UNKNOWN = 0,
+  ON = 2,
+  OFF = 3,
+  UNRECOGNIZED = -1,
 }
 
-export type PleaseChoose_StateEnum = 0 | 2 | 3 | -1;
+export function pleaseChoose_StateEnumFromJSON(object: any): PleaseChoose_StateEnum {
+  switch (object) {
+    case 0:
+    case "UNKNOWN":
+      return PleaseChoose_StateEnum.UNKNOWN;
+    case 2:
+    case "ON":
+      return PleaseChoose_StateEnum.ON;
+    case 3:
+    case "OFF":
+      return PleaseChoose_StateEnum.OFF;
+    case -1:
+    case "UNRECOGNIZED":
+    default:
+      return PleaseChoose_StateEnum.UNRECOGNIZED;
+  }
+}
+
+export function pleaseChoose_StateEnumToJSON(object: PleaseChoose_StateEnum): string {
+  switch (object) {
+    case PleaseChoose_StateEnum.UNKNOWN:
+      return "UNKNOWN";
+    case PleaseChoose_StateEnum.ON:
+      return "ON";
+    case PleaseChoose_StateEnum.OFF:
+      return "OFF";
+    default:
+      return "UNKNOWN";
+  }
+}
 
 export const PleaseChoose = {
   encode(message: PleaseChoose, writer: Writer = Writer.create()): Writer {
@@ -176,7 +176,7 @@ export const PleaseChoose = {
       message.choice = {$case: 'bunchaBytes', bunchaBytes: bytesFromBase64(object.bunchaBytes)};
     }
     if (object.anEnum !== undefined && object.anEnum !== null) {
-      message.choice = {$case: 'anEnum', anEnum: PleaseChoose_StateEnum.fromJSON(object.anEnum)};
+      message.choice = {$case: 'anEnum', anEnum: pleaseChoose_StateEnumFromJSON(object.anEnum)};
     }
     if (object.age !== undefined && object.age !== null) {
       message.age = Number(object.age);
@@ -237,7 +237,7 @@ export const PleaseChoose = {
     obj.aMessage = message.choice?.$case === 'aMessage' && message.choice?.aMessage ? PleaseChoose_Submessage.toJSON(message.choice?.aMessage) : undefined;
     obj.aBool = message.choice?.$case === 'aBool' && message.choice?.aBool || undefined;
     obj.bunchaBytes = message.choice?.$case === 'bunchaBytes' && message.choice?.bunchaBytes !== undefined ? base64FromBytes(message.choice?.bunchaBytes) : undefined;
-    obj.anEnum = message.choice?.$case === 'anEnum' && message.choice?.anEnum !== undefined ? PleaseChoose_StateEnum.toJSON(message.choice?.anEnum) : undefined;
+    obj.anEnum = message.choice?.$case === 'anEnum' && message.choice?.anEnum !== undefined ? pleaseChoose_StateEnumToJSON(message.choice?.anEnum) : undefined;
     obj.age = message.age || 0;
     obj.either = message.eitherOr?.$case === 'either' && message.eitherOr?.either || undefined;
     obj.or = message.eitherOr?.$case === 'or' && message.eitherOr?.or || undefined;

--- a/integration/simple-long-string/simple.ts
+++ b/integration/simple-long-string/simple.ts
@@ -265,119 +265,119 @@ function longToString(long: Long) {
   return long.toString();
 }
 
-export const StateEnum = {
-  UNKNOWN: 0 as const,
-  ON: 2 as const,
-  OFF: 3 as const,
-  UNRECOGNIZED: -1 as const,
-  fromJSON(object: any): StateEnum {
-    switch (object) {
-      case 0:
-      case "UNKNOWN":
-        return StateEnum.UNKNOWN;
-      case 2:
-      case "ON":
-        return StateEnum.ON;
-      case 3:
-      case "OFF":
-        return StateEnum.OFF;
-      case -1:
-      case "UNRECOGNIZED":
-      default:
-        return StateEnum.UNRECOGNIZED;
-    }
-  },
-  toJSON(object: StateEnum): string {
-    switch (object) {
-      case StateEnum.UNKNOWN:
-        return "UNKNOWN";
-      case StateEnum.ON:
-        return "ON";
-      case StateEnum.OFF:
-        return "OFF";
-      default:
-        return "UNKNOWN";
-    }
-  },
+export enum StateEnum {
+  UNKNOWN = 0,
+  ON = 2,
+  OFF = 3,
+  UNRECOGNIZED = -1,
 }
 
-export type StateEnum = 0 | 2 | 3 | -1;
-
-export const Child_Type = {
-  UNKNOWN: 0 as const,
-  GOOD: 1 as const,
-  BAD: 2 as const,
-  UNRECOGNIZED: -1 as const,
-  fromJSON(object: any): Child_Type {
-    switch (object) {
-      case 0:
-      case "UNKNOWN":
-        return Child_Type.UNKNOWN;
-      case 1:
-      case "GOOD":
-        return Child_Type.GOOD;
-      case 2:
-      case "BAD":
-        return Child_Type.BAD;
-      case -1:
-      case "UNRECOGNIZED":
-      default:
-        return Child_Type.UNRECOGNIZED;
-    }
-  },
-  toJSON(object: Child_Type): string {
-    switch (object) {
-      case Child_Type.UNKNOWN:
-        return "UNKNOWN";
-      case Child_Type.GOOD:
-        return "GOOD";
-      case Child_Type.BAD:
-        return "BAD";
-      default:
-        return "UNKNOWN";
-    }
-  },
+export function stateEnumFromJSON(object: any): StateEnum {
+  switch (object) {
+    case 0:
+    case "UNKNOWN":
+      return StateEnum.UNKNOWN;
+    case 2:
+    case "ON":
+      return StateEnum.ON;
+    case 3:
+    case "OFF":
+      return StateEnum.OFF;
+    case -1:
+    case "UNRECOGNIZED":
+    default:
+      return StateEnum.UNRECOGNIZED;
+  }
 }
 
-export type Child_Type = 0 | 1 | 2 | -1;
-
-export const Nested_InnerEnum = {
-  UNKNOWN_INNER: 0 as const,
-  GOOD: 100 as const,
-  BAD: 1000 as const,
-  UNRECOGNIZED: -1 as const,
-  fromJSON(object: any): Nested_InnerEnum {
-    switch (object) {
-      case 0:
-      case "UNKNOWN_INNER":
-        return Nested_InnerEnum.UNKNOWN_INNER;
-      case 100:
-      case "GOOD":
-        return Nested_InnerEnum.GOOD;
-      case 1000:
-      case "BAD":
-        return Nested_InnerEnum.BAD;
-      case -1:
-      case "UNRECOGNIZED":
-      default:
-        return Nested_InnerEnum.UNRECOGNIZED;
-    }
-  },
-  toJSON(object: Nested_InnerEnum): string {
-    switch (object) {
-      case Nested_InnerEnum.UNKNOWN_INNER:
-        return "UNKNOWN_INNER";
-      case Nested_InnerEnum.GOOD:
-        return "GOOD";
-      case Nested_InnerEnum.BAD:
-        return "BAD";
-      default:
-        return "UNKNOWN";
-    }
-  },
+export function stateEnumToJSON(object: StateEnum): string {
+  switch (object) {
+    case StateEnum.UNKNOWN:
+      return "UNKNOWN";
+    case StateEnum.ON:
+      return "ON";
+    case StateEnum.OFF:
+      return "OFF";
+    default:
+      return "UNKNOWN";
+  }
 }
 
-export type Nested_InnerEnum = 0 | 100 | 1000 | -1;
+export enum Child_Type {
+  UNKNOWN = 0,
+  GOOD = 1,
+  BAD = 2,
+  UNRECOGNIZED = -1,
+}
+
+export function child_TypeFromJSON(object: any): Child_Type {
+  switch (object) {
+    case 0:
+    case "UNKNOWN":
+      return Child_Type.UNKNOWN;
+    case 1:
+    case "GOOD":
+      return Child_Type.GOOD;
+    case 2:
+    case "BAD":
+      return Child_Type.BAD;
+    case -1:
+    case "UNRECOGNIZED":
+    default:
+      return Child_Type.UNRECOGNIZED;
+  }
+}
+
+export function child_TypeToJSON(object: Child_Type): string {
+  switch (object) {
+    case Child_Type.UNKNOWN:
+      return "UNKNOWN";
+    case Child_Type.GOOD:
+      return "GOOD";
+    case Child_Type.BAD:
+      return "BAD";
+    default:
+      return "UNKNOWN";
+  }
+}
+
+export enum Nested_InnerEnum {
+  UNKNOWN_INNER = 0,
+  GOOD = 100,
+  BAD = 1000,
+  UNRECOGNIZED = -1,
+}
+
+export function nested_InnerEnumFromJSON(object: any): Nested_InnerEnum {
+  switch (object) {
+    case 0:
+    case "UNKNOWN_INNER":
+      return Nested_InnerEnum.UNKNOWN_INNER;
+    case 100:
+    case "GOOD":
+      return Nested_InnerEnum.GOOD;
+    case 1000:
+    case "BAD":
+      return Nested_InnerEnum.BAD;
+    case -1:
+    case "UNRECOGNIZED":
+    default:
+      return Nested_InnerEnum.UNRECOGNIZED;
+  }
+}
+
+export function nested_InnerEnumToJSON(object: Nested_InnerEnum): string {
+  switch (object) {
+    case Nested_InnerEnum.UNKNOWN_INNER:
+      return "UNKNOWN_INNER";
+    case Nested_InnerEnum.GOOD:
+      return "GOOD";
+    case Nested_InnerEnum.BAD:
+      return "BAD";
+    default:
+      return "UNKNOWN";
+  }
+}
 
 export const Simple = {
   encode(message: Simple, writer: Writer = Writer.create()): Writer {
@@ -500,7 +500,7 @@ export const Simple = {
       message.child = undefined;
     }
     if (object.state !== undefined && object.state !== null) {
-      message.state = StateEnum.fromJSON(object.state);
+      message.state = stateEnumFromJSON(object.state);
     } else {
       message.state = 0;
     }
@@ -521,7 +521,7 @@ export const Simple = {
     }
     if (object.oldStates !== undefined && object.oldStates !== null) {
       for (const e of object.oldStates) {
-        message.oldStates.push(StateEnum.fromJSON(e));
+        message.oldStates.push(stateEnumFromJSON(e));
       }
     }
     if (object.thing !== undefined && object.thing !== null) {
@@ -595,7 +595,7 @@ export const Simple = {
     obj.age = message.age || 0;
     obj.createdAt = message.createdAt !== undefined ? message.createdAt.toISOString() : null;
     obj.child = message.child ? Child.toJSON(message.child) : undefined;
-    obj.state = StateEnum.toJSON(message.state);
+    obj.state = stateEnumToJSON(message.state);
     if (message.grandChildren) {
       obj.grandChildren = message.grandChildren.map(e => e ? Child.toJSON(e) : undefined);
     } else {
@@ -612,7 +612,7 @@ export const Simple = {
       obj.snacks = [];
     }
     if (message.oldStates) {
-      obj.oldStates = message.oldStates.map(e => StateEnum.toJSON(e));
+      obj.oldStates = message.oldStates.map(e => stateEnumToJSON(e));
     } else {
       obj.oldStates = [];
     }
@@ -655,7 +655,7 @@ export const Child = {
       message.name = "";
     }
     if (object.type !== undefined && object.type !== null) {
-      message.type = Child_Type.fromJSON(object.type);
+      message.type = child_TypeFromJSON(object.type);
     } else {
       message.type = 0;
     }
@@ -678,7 +678,7 @@ export const Child = {
   toJSON(message: Child): unknown {
     const obj: any = {};
     obj.name = message.name || "";
-    obj.type = Child_Type.toJSON(message.type);
+    obj.type = child_TypeToJSON(message.type);
     return obj;
   },
 };
@@ -728,7 +728,7 @@ export const Nested = {
       message.message = undefined;
     }
     if (object.state !== undefined && object.state !== null) {
-      message.state = Nested_InnerEnum.fromJSON(object.state);
+      message.state = nested_InnerEnumFromJSON(object.state);
     } else {
       message.state = 0;
     }
@@ -757,7 +757,7 @@ export const Nested = {
     const obj: any = {};
     obj.name = message.name || "";
     obj.message = message.message ? Nested_InnerMessage.toJSON(message.message) : undefined;
-    obj.state = Nested_InnerEnum.toJSON(message.state);
+    obj.state = nested_InnerEnumToJSON(message.state);
     return obj;
   },
 };

--- a/integration/simple-long/simple.ts
+++ b/integration/simple-long/simple.ts
@@ -265,119 +265,119 @@ function numberToLong(number: number) {
   return Long.fromNumber(number);
 }
 
-export const StateEnum = {
-  UNKNOWN: 0 as const,
-  ON: 2 as const,
-  OFF: 3 as const,
-  UNRECOGNIZED: -1 as const,
-  fromJSON(object: any): StateEnum {
-    switch (object) {
-      case 0:
-      case "UNKNOWN":
-        return StateEnum.UNKNOWN;
-      case 2:
-      case "ON":
-        return StateEnum.ON;
-      case 3:
-      case "OFF":
-        return StateEnum.OFF;
-      case -1:
-      case "UNRECOGNIZED":
-      default:
-        return StateEnum.UNRECOGNIZED;
-    }
-  },
-  toJSON(object: StateEnum): string {
-    switch (object) {
-      case StateEnum.UNKNOWN:
-        return "UNKNOWN";
-      case StateEnum.ON:
-        return "ON";
-      case StateEnum.OFF:
-        return "OFF";
-      default:
-        return "UNKNOWN";
-    }
-  },
+export enum StateEnum {
+  UNKNOWN = 0,
+  ON = 2,
+  OFF = 3,
+  UNRECOGNIZED = -1,
 }
 
-export type StateEnum = 0 | 2 | 3 | -1;
-
-export const Child_Type = {
-  UNKNOWN: 0 as const,
-  GOOD: 1 as const,
-  BAD: 2 as const,
-  UNRECOGNIZED: -1 as const,
-  fromJSON(object: any): Child_Type {
-    switch (object) {
-      case 0:
-      case "UNKNOWN":
-        return Child_Type.UNKNOWN;
-      case 1:
-      case "GOOD":
-        return Child_Type.GOOD;
-      case 2:
-      case "BAD":
-        return Child_Type.BAD;
-      case -1:
-      case "UNRECOGNIZED":
-      default:
-        return Child_Type.UNRECOGNIZED;
-    }
-  },
-  toJSON(object: Child_Type): string {
-    switch (object) {
-      case Child_Type.UNKNOWN:
-        return "UNKNOWN";
-      case Child_Type.GOOD:
-        return "GOOD";
-      case Child_Type.BAD:
-        return "BAD";
-      default:
-        return "UNKNOWN";
-    }
-  },
+export function stateEnumFromJSON(object: any): StateEnum {
+  switch (object) {
+    case 0:
+    case "UNKNOWN":
+      return StateEnum.UNKNOWN;
+    case 2:
+    case "ON":
+      return StateEnum.ON;
+    case 3:
+    case "OFF":
+      return StateEnum.OFF;
+    case -1:
+    case "UNRECOGNIZED":
+    default:
+      return StateEnum.UNRECOGNIZED;
+  }
 }
 
-export type Child_Type = 0 | 1 | 2 | -1;
-
-export const Nested_InnerEnum = {
-  UNKNOWN_INNER: 0 as const,
-  GOOD: 100 as const,
-  BAD: 1000 as const,
-  UNRECOGNIZED: -1 as const,
-  fromJSON(object: any): Nested_InnerEnum {
-    switch (object) {
-      case 0:
-      case "UNKNOWN_INNER":
-        return Nested_InnerEnum.UNKNOWN_INNER;
-      case 100:
-      case "GOOD":
-        return Nested_InnerEnum.GOOD;
-      case 1000:
-      case "BAD":
-        return Nested_InnerEnum.BAD;
-      case -1:
-      case "UNRECOGNIZED":
-      default:
-        return Nested_InnerEnum.UNRECOGNIZED;
-    }
-  },
-  toJSON(object: Nested_InnerEnum): string {
-    switch (object) {
-      case Nested_InnerEnum.UNKNOWN_INNER:
-        return "UNKNOWN_INNER";
-      case Nested_InnerEnum.GOOD:
-        return "GOOD";
-      case Nested_InnerEnum.BAD:
-        return "BAD";
-      default:
-        return "UNKNOWN";
-    }
-  },
+export function stateEnumToJSON(object: StateEnum): string {
+  switch (object) {
+    case StateEnum.UNKNOWN:
+      return "UNKNOWN";
+    case StateEnum.ON:
+      return "ON";
+    case StateEnum.OFF:
+      return "OFF";
+    default:
+      return "UNKNOWN";
+  }
 }
 
-export type Nested_InnerEnum = 0 | 100 | 1000 | -1;
+export enum Child_Type {
+  UNKNOWN = 0,
+  GOOD = 1,
+  BAD = 2,
+  UNRECOGNIZED = -1,
+}
+
+export function child_TypeFromJSON(object: any): Child_Type {
+  switch (object) {
+    case 0:
+    case "UNKNOWN":
+      return Child_Type.UNKNOWN;
+    case 1:
+    case "GOOD":
+      return Child_Type.GOOD;
+    case 2:
+    case "BAD":
+      return Child_Type.BAD;
+    case -1:
+    case "UNRECOGNIZED":
+    default:
+      return Child_Type.UNRECOGNIZED;
+  }
+}
+
+export function child_TypeToJSON(object: Child_Type): string {
+  switch (object) {
+    case Child_Type.UNKNOWN:
+      return "UNKNOWN";
+    case Child_Type.GOOD:
+      return "GOOD";
+    case Child_Type.BAD:
+      return "BAD";
+    default:
+      return "UNKNOWN";
+  }
+}
+
+export enum Nested_InnerEnum {
+  UNKNOWN_INNER = 0,
+  GOOD = 100,
+  BAD = 1000,
+  UNRECOGNIZED = -1,
+}
+
+export function nested_InnerEnumFromJSON(object: any): Nested_InnerEnum {
+  switch (object) {
+    case 0:
+    case "UNKNOWN_INNER":
+      return Nested_InnerEnum.UNKNOWN_INNER;
+    case 100:
+    case "GOOD":
+      return Nested_InnerEnum.GOOD;
+    case 1000:
+    case "BAD":
+      return Nested_InnerEnum.BAD;
+    case -1:
+    case "UNRECOGNIZED":
+    default:
+      return Nested_InnerEnum.UNRECOGNIZED;
+  }
+}
+
+export function nested_InnerEnumToJSON(object: Nested_InnerEnum): string {
+  switch (object) {
+    case Nested_InnerEnum.UNKNOWN_INNER:
+      return "UNKNOWN_INNER";
+    case Nested_InnerEnum.GOOD:
+      return "GOOD";
+    case Nested_InnerEnum.BAD:
+      return "BAD";
+    default:
+      return "UNKNOWN";
+  }
+}
 
 export const Simple = {
   encode(message: Simple, writer: Writer = Writer.create()): Writer {
@@ -500,7 +500,7 @@ export const Simple = {
       message.child = undefined;
     }
     if (object.state !== undefined && object.state !== null) {
-      message.state = StateEnum.fromJSON(object.state);
+      message.state = stateEnumFromJSON(object.state);
     } else {
       message.state = 0;
     }
@@ -521,7 +521,7 @@ export const Simple = {
     }
     if (object.oldStates !== undefined && object.oldStates !== null) {
       for (const e of object.oldStates) {
-        message.oldStates.push(StateEnum.fromJSON(e));
+        message.oldStates.push(stateEnumFromJSON(e));
       }
     }
     if (object.thing !== undefined && object.thing !== null) {
@@ -595,7 +595,7 @@ export const Simple = {
     obj.age = message.age || 0;
     obj.createdAt = message.createdAt !== undefined ? message.createdAt.toISOString() : null;
     obj.child = message.child ? Child.toJSON(message.child) : undefined;
-    obj.state = StateEnum.toJSON(message.state);
+    obj.state = stateEnumToJSON(message.state);
     if (message.grandChildren) {
       obj.grandChildren = message.grandChildren.map(e => e ? Child.toJSON(e) : undefined);
     } else {
@@ -612,7 +612,7 @@ export const Simple = {
       obj.snacks = [];
     }
     if (message.oldStates) {
-      obj.oldStates = message.oldStates.map(e => StateEnum.toJSON(e));
+      obj.oldStates = message.oldStates.map(e => stateEnumToJSON(e));
     } else {
       obj.oldStates = [];
     }
@@ -655,7 +655,7 @@ export const Child = {
       message.name = "";
     }
     if (object.type !== undefined && object.type !== null) {
-      message.type = Child_Type.fromJSON(object.type);
+      message.type = child_TypeFromJSON(object.type);
     } else {
       message.type = 0;
     }
@@ -678,7 +678,7 @@ export const Child = {
   toJSON(message: Child): unknown {
     const obj: any = {};
     obj.name = message.name || "";
-    obj.type = Child_Type.toJSON(message.type);
+    obj.type = child_TypeToJSON(message.type);
     return obj;
   },
 };
@@ -728,7 +728,7 @@ export const Nested = {
       message.message = undefined;
     }
     if (object.state !== undefined && object.state !== null) {
-      message.state = Nested_InnerEnum.fromJSON(object.state);
+      message.state = nested_InnerEnumFromJSON(object.state);
     } else {
       message.state = 0;
     }
@@ -757,7 +757,7 @@ export const Nested = {
     const obj: any = {};
     obj.name = message.name || "";
     obj.message = message.message ? Nested_InnerMessage.toJSON(message.message) : undefined;
-    obj.state = Nested_InnerEnum.toJSON(message.state);
+    obj.state = nested_InnerEnumToJSON(message.state);
     return obj;
   },
 };

--- a/integration/simple-optionals/simple.ts
+++ b/integration/simple-optionals/simple.ts
@@ -268,119 +268,119 @@ function longToNumber(long: Long) {
   return long.toNumber();
 }
 
-export const StateEnum = {
-  UNKNOWN: 0 as const,
-  ON: 2 as const,
-  OFF: 3 as const,
-  UNRECOGNIZED: -1 as const,
-  fromJSON(object: any): StateEnum {
-    switch (object) {
-      case 0:
-      case "UNKNOWN":
-        return StateEnum.UNKNOWN;
-      case 2:
-      case "ON":
-        return StateEnum.ON;
-      case 3:
-      case "OFF":
-        return StateEnum.OFF;
-      case -1:
-      case "UNRECOGNIZED":
-      default:
-        return StateEnum.UNRECOGNIZED;
-    }
-  },
-  toJSON(object: StateEnum): string {
-    switch (object) {
-      case StateEnum.UNKNOWN:
-        return "UNKNOWN";
-      case StateEnum.ON:
-        return "ON";
-      case StateEnum.OFF:
-        return "OFF";
-      default:
-        return "UNKNOWN";
-    }
-  },
+export enum StateEnum {
+  UNKNOWN = 0,
+  ON = 2,
+  OFF = 3,
+  UNRECOGNIZED = -1,
 }
 
-export type StateEnum = 0 | 2 | 3 | -1;
-
-export const Child_Type = {
-  UNKNOWN: 0 as const,
-  GOOD: 1 as const,
-  BAD: 2 as const,
-  UNRECOGNIZED: -1 as const,
-  fromJSON(object: any): Child_Type {
-    switch (object) {
-      case 0:
-      case "UNKNOWN":
-        return Child_Type.UNKNOWN;
-      case 1:
-      case "GOOD":
-        return Child_Type.GOOD;
-      case 2:
-      case "BAD":
-        return Child_Type.BAD;
-      case -1:
-      case "UNRECOGNIZED":
-      default:
-        return Child_Type.UNRECOGNIZED;
-    }
-  },
-  toJSON(object: Child_Type): string {
-    switch (object) {
-      case Child_Type.UNKNOWN:
-        return "UNKNOWN";
-      case Child_Type.GOOD:
-        return "GOOD";
-      case Child_Type.BAD:
-        return "BAD";
-      default:
-        return "UNKNOWN";
-    }
-  },
+export function stateEnumFromJSON(object: any): StateEnum {
+  switch (object) {
+    case 0:
+    case "UNKNOWN":
+      return StateEnum.UNKNOWN;
+    case 2:
+    case "ON":
+      return StateEnum.ON;
+    case 3:
+    case "OFF":
+      return StateEnum.OFF;
+    case -1:
+    case "UNRECOGNIZED":
+    default:
+      return StateEnum.UNRECOGNIZED;
+  }
 }
 
-export type Child_Type = 0 | 1 | 2 | -1;
-
-export const Nested_InnerEnum = {
-  UNKNOWN_INNER: 0 as const,
-  GOOD: 100 as const,
-  BAD: 1000 as const,
-  UNRECOGNIZED: -1 as const,
-  fromJSON(object: any): Nested_InnerEnum {
-    switch (object) {
-      case 0:
-      case "UNKNOWN_INNER":
-        return Nested_InnerEnum.UNKNOWN_INNER;
-      case 100:
-      case "GOOD":
-        return Nested_InnerEnum.GOOD;
-      case 1000:
-      case "BAD":
-        return Nested_InnerEnum.BAD;
-      case -1:
-      case "UNRECOGNIZED":
-      default:
-        return Nested_InnerEnum.UNRECOGNIZED;
-    }
-  },
-  toJSON(object: Nested_InnerEnum): string {
-    switch (object) {
-      case Nested_InnerEnum.UNKNOWN_INNER:
-        return "UNKNOWN_INNER";
-      case Nested_InnerEnum.GOOD:
-        return "GOOD";
-      case Nested_InnerEnum.BAD:
-        return "BAD";
-      default:
-        return "UNKNOWN";
-    }
-  },
+export function stateEnumToJSON(object: StateEnum): string {
+  switch (object) {
+    case StateEnum.UNKNOWN:
+      return "UNKNOWN";
+    case StateEnum.ON:
+      return "ON";
+    case StateEnum.OFF:
+      return "OFF";
+    default:
+      return "UNKNOWN";
+  }
 }
 
-export type Nested_InnerEnum = 0 | 100 | 1000 | -1;
+export enum Child_Type {
+  UNKNOWN = 0,
+  GOOD = 1,
+  BAD = 2,
+  UNRECOGNIZED = -1,
+}
+
+export function child_TypeFromJSON(object: any): Child_Type {
+  switch (object) {
+    case 0:
+    case "UNKNOWN":
+      return Child_Type.UNKNOWN;
+    case 1:
+    case "GOOD":
+      return Child_Type.GOOD;
+    case 2:
+    case "BAD":
+      return Child_Type.BAD;
+    case -1:
+    case "UNRECOGNIZED":
+    default:
+      return Child_Type.UNRECOGNIZED;
+  }
+}
+
+export function child_TypeToJSON(object: Child_Type): string {
+  switch (object) {
+    case Child_Type.UNKNOWN:
+      return "UNKNOWN";
+    case Child_Type.GOOD:
+      return "GOOD";
+    case Child_Type.BAD:
+      return "BAD";
+    default:
+      return "UNKNOWN";
+  }
+}
+
+export enum Nested_InnerEnum {
+  UNKNOWN_INNER = 0,
+  GOOD = 100,
+  BAD = 1000,
+  UNRECOGNIZED = -1,
+}
+
+export function nested_InnerEnumFromJSON(object: any): Nested_InnerEnum {
+  switch (object) {
+    case 0:
+    case "UNKNOWN_INNER":
+      return Nested_InnerEnum.UNKNOWN_INNER;
+    case 100:
+    case "GOOD":
+      return Nested_InnerEnum.GOOD;
+    case 1000:
+    case "BAD":
+      return Nested_InnerEnum.BAD;
+    case -1:
+    case "UNRECOGNIZED":
+    default:
+      return Nested_InnerEnum.UNRECOGNIZED;
+  }
+}
+
+export function nested_InnerEnumToJSON(object: Nested_InnerEnum): string {
+  switch (object) {
+    case Nested_InnerEnum.UNKNOWN_INNER:
+      return "UNKNOWN_INNER";
+    case Nested_InnerEnum.GOOD:
+      return "GOOD";
+    case Nested_InnerEnum.BAD:
+      return "BAD";
+    default:
+      return "UNKNOWN";
+  }
+}
 
 export const Simple = {
   encode(message: Simple, writer: Writer = Writer.create()): Writer {
@@ -503,7 +503,7 @@ export const Simple = {
       message.child = undefined;
     }
     if (object.state !== undefined && object.state !== null) {
-      message.state = StateEnum.fromJSON(object.state);
+      message.state = stateEnumFromJSON(object.state);
     } else {
       message.state = 0;
     }
@@ -524,7 +524,7 @@ export const Simple = {
     }
     if (object.oldStates !== undefined && object.oldStates !== null) {
       for (const e of object.oldStates) {
-        message.oldStates.push(StateEnum.fromJSON(e));
+        message.oldStates.push(stateEnumFromJSON(e));
       }
     }
     if (object.thing !== undefined && object.thing !== null) {
@@ -598,7 +598,7 @@ export const Simple = {
     obj.age = message.age || 0;
     obj.createdAt = message.createdAt !== undefined ? message.createdAt.toISOString() : null;
     obj.child = message.child ? Child.toJSON(message.child) : undefined;
-    obj.state = StateEnum.toJSON(message.state);
+    obj.state = stateEnumToJSON(message.state);
     if (message.grandChildren) {
       obj.grandChildren = message.grandChildren.map(e => e ? Child.toJSON(e) : undefined);
     } else {
@@ -615,7 +615,7 @@ export const Simple = {
       obj.snacks = [];
     }
     if (message.oldStates) {
-      obj.oldStates = message.oldStates.map(e => StateEnum.toJSON(e));
+      obj.oldStates = message.oldStates.map(e => stateEnumToJSON(e));
     } else {
       obj.oldStates = [];
     }
@@ -658,7 +658,7 @@ export const Child = {
       message.name = "";
     }
     if (object.type !== undefined && object.type !== null) {
-      message.type = Child_Type.fromJSON(object.type);
+      message.type = child_TypeFromJSON(object.type);
     } else {
       message.type = 0;
     }
@@ -681,7 +681,7 @@ export const Child = {
   toJSON(message: Child): unknown {
     const obj: any = {};
     obj.name = message.name || "";
-    obj.type = Child_Type.toJSON(message.type);
+    obj.type = child_TypeToJSON(message.type);
     return obj;
   },
 };
@@ -731,7 +731,7 @@ export const Nested = {
       message.message = undefined;
     }
     if (object.state !== undefined && object.state !== null) {
-      message.state = Nested_InnerEnum.fromJSON(object.state);
+      message.state = nested_InnerEnumFromJSON(object.state);
     } else {
       message.state = 0;
     }
@@ -760,7 +760,7 @@ export const Nested = {
     const obj: any = {};
     obj.name = message.name || "";
     obj.message = message.message ? Nested_InnerMessage.toJSON(message.message) : undefined;
-    obj.state = Nested_InnerEnum.toJSON(message.state);
+    obj.state = nested_InnerEnumToJSON(message.state);
     return obj;
   },
 };

--- a/integration/simple-proto2/simple.ts
+++ b/integration/simple-proto2/simple.ts
@@ -9,37 +9,37 @@ const baseIssue56: object = {
   test: 1,
 };
 
-export const EnumWithoutZero = {
-  A: 1 as const,
-  B: 2 as const,
-  UNRECOGNIZED: -1 as const,
-  fromJSON(object: any): EnumWithoutZero {
-    switch (object) {
-      case 1:
-      case "A":
-        return EnumWithoutZero.A;
-      case 2:
-      case "B":
-        return EnumWithoutZero.B;
-      case -1:
-      case "UNRECOGNIZED":
-      default:
-        return EnumWithoutZero.UNRECOGNIZED;
-    }
-  },
-  toJSON(object: EnumWithoutZero): string {
-    switch (object) {
-      case EnumWithoutZero.A:
-        return "A";
-      case EnumWithoutZero.B:
-        return "B";
-      default:
-        return "UNKNOWN";
-    }
-  },
+export enum EnumWithoutZero {
+  A = 1,
+  B = 2,
+  UNRECOGNIZED = -1,
 }
 
-export type EnumWithoutZero = 1 | 2 | -1;
+export function enumWithoutZeroFromJSON(object: any): EnumWithoutZero {
+  switch (object) {
+    case 1:
+    case "A":
+      return EnumWithoutZero.A;
+    case 2:
+    case "B":
+      return EnumWithoutZero.B;
+    case -1:
+    case "UNRECOGNIZED":
+    default:
+      return EnumWithoutZero.UNRECOGNIZED;
+  }
+}
+
+export function enumWithoutZeroToJSON(object: EnumWithoutZero): string {
+  switch (object) {
+    case EnumWithoutZero.A:
+      return "A";
+    case EnumWithoutZero.B:
+      return "B";
+    default:
+      return "UNKNOWN";
+  }
+}
 
 export const Issue56 = {
   encode(message: Issue56, writer: Writer = Writer.create()): Writer {
@@ -66,7 +66,7 @@ export const Issue56 = {
   fromJSON(object: any): Issue56 {
     const message = { ...baseIssue56 } as Issue56;
     if (object.test !== undefined && object.test !== null) {
-      message.test = EnumWithoutZero.fromJSON(object.test);
+      message.test = enumWithoutZeroFromJSON(object.test);
     } else {
       message.test = 1;
     }
@@ -83,7 +83,7 @@ export const Issue56 = {
   },
   toJSON(message: Issue56): unknown {
     const obj: any = {};
-    obj.test = EnumWithoutZero.toJSON(message.test);
+    obj.test = enumWithoutZeroToJSON(message.test);
     return obj;
   },
 };

--- a/integration/simple-snake/simple.ts
+++ b/integration/simple-snake/simple.ts
@@ -268,119 +268,119 @@ function longToNumber(long: Long) {
   return long.toNumber();
 }
 
-export const StateEnum = {
-  UNKNOWN: 0 as const,
-  ON: 2 as const,
-  OFF: 3 as const,
-  UNRECOGNIZED: -1 as const,
-  fromJSON(object: any): StateEnum {
-    switch (object) {
-      case 0:
-      case "UNKNOWN":
-        return StateEnum.UNKNOWN;
-      case 2:
-      case "ON":
-        return StateEnum.ON;
-      case 3:
-      case "OFF":
-        return StateEnum.OFF;
-      case -1:
-      case "UNRECOGNIZED":
-      default:
-        return StateEnum.UNRECOGNIZED;
-    }
-  },
-  toJSON(object: StateEnum): string {
-    switch (object) {
-      case StateEnum.UNKNOWN:
-        return "UNKNOWN";
-      case StateEnum.ON:
-        return "ON";
-      case StateEnum.OFF:
-        return "OFF";
-      default:
-        return "UNKNOWN";
-    }
-  },
+export enum StateEnum {
+  UNKNOWN = 0,
+  ON = 2,
+  OFF = 3,
+  UNRECOGNIZED = -1,
 }
 
-export type StateEnum = 0 | 2 | 3 | -1;
-
-export const Child_Type = {
-  UNKNOWN: 0 as const,
-  GOOD: 1 as const,
-  BAD: 2 as const,
-  UNRECOGNIZED: -1 as const,
-  fromJSON(object: any): Child_Type {
-    switch (object) {
-      case 0:
-      case "UNKNOWN":
-        return Child_Type.UNKNOWN;
-      case 1:
-      case "GOOD":
-        return Child_Type.GOOD;
-      case 2:
-      case "BAD":
-        return Child_Type.BAD;
-      case -1:
-      case "UNRECOGNIZED":
-      default:
-        return Child_Type.UNRECOGNIZED;
-    }
-  },
-  toJSON(object: Child_Type): string {
-    switch (object) {
-      case Child_Type.UNKNOWN:
-        return "UNKNOWN";
-      case Child_Type.GOOD:
-        return "GOOD";
-      case Child_Type.BAD:
-        return "BAD";
-      default:
-        return "UNKNOWN";
-    }
-  },
+export function stateEnumFromJSON(object: any): StateEnum {
+  switch (object) {
+    case 0:
+    case "UNKNOWN":
+      return StateEnum.UNKNOWN;
+    case 2:
+    case "ON":
+      return StateEnum.ON;
+    case 3:
+    case "OFF":
+      return StateEnum.OFF;
+    case -1:
+    case "UNRECOGNIZED":
+    default:
+      return StateEnum.UNRECOGNIZED;
+  }
 }
 
-export type Child_Type = 0 | 1 | 2 | -1;
-
-export const Nested_InnerEnum = {
-  UNKNOWN_INNER: 0 as const,
-  GOOD: 100 as const,
-  BAD: 1000 as const,
-  UNRECOGNIZED: -1 as const,
-  fromJSON(object: any): Nested_InnerEnum {
-    switch (object) {
-      case 0:
-      case "UNKNOWN_INNER":
-        return Nested_InnerEnum.UNKNOWN_INNER;
-      case 100:
-      case "GOOD":
-        return Nested_InnerEnum.GOOD;
-      case 1000:
-      case "BAD":
-        return Nested_InnerEnum.BAD;
-      case -1:
-      case "UNRECOGNIZED":
-      default:
-        return Nested_InnerEnum.UNRECOGNIZED;
-    }
-  },
-  toJSON(object: Nested_InnerEnum): string {
-    switch (object) {
-      case Nested_InnerEnum.UNKNOWN_INNER:
-        return "UNKNOWN_INNER";
-      case Nested_InnerEnum.GOOD:
-        return "GOOD";
-      case Nested_InnerEnum.BAD:
-        return "BAD";
-      default:
-        return "UNKNOWN";
-    }
-  },
+export function stateEnumToJSON(object: StateEnum): string {
+  switch (object) {
+    case StateEnum.UNKNOWN:
+      return "UNKNOWN";
+    case StateEnum.ON:
+      return "ON";
+    case StateEnum.OFF:
+      return "OFF";
+    default:
+      return "UNKNOWN";
+  }
 }
 
-export type Nested_InnerEnum = 0 | 100 | 1000 | -1;
+export enum Child_Type {
+  UNKNOWN = 0,
+  GOOD = 1,
+  BAD = 2,
+  UNRECOGNIZED = -1,
+}
+
+export function child_TypeFromJSON(object: any): Child_Type {
+  switch (object) {
+    case 0:
+    case "UNKNOWN":
+      return Child_Type.UNKNOWN;
+    case 1:
+    case "GOOD":
+      return Child_Type.GOOD;
+    case 2:
+    case "BAD":
+      return Child_Type.BAD;
+    case -1:
+    case "UNRECOGNIZED":
+    default:
+      return Child_Type.UNRECOGNIZED;
+  }
+}
+
+export function child_TypeToJSON(object: Child_Type): string {
+  switch (object) {
+    case Child_Type.UNKNOWN:
+      return "UNKNOWN";
+    case Child_Type.GOOD:
+      return "GOOD";
+    case Child_Type.BAD:
+      return "BAD";
+    default:
+      return "UNKNOWN";
+  }
+}
+
+export enum Nested_InnerEnum {
+  UNKNOWN_INNER = 0,
+  GOOD = 100,
+  BAD = 1000,
+  UNRECOGNIZED = -1,
+}
+
+export function nested_InnerEnumFromJSON(object: any): Nested_InnerEnum {
+  switch (object) {
+    case 0:
+    case "UNKNOWN_INNER":
+      return Nested_InnerEnum.UNKNOWN_INNER;
+    case 100:
+    case "GOOD":
+      return Nested_InnerEnum.GOOD;
+    case 1000:
+    case "BAD":
+      return Nested_InnerEnum.BAD;
+    case -1:
+    case "UNRECOGNIZED":
+    default:
+      return Nested_InnerEnum.UNRECOGNIZED;
+  }
+}
+
+export function nested_InnerEnumToJSON(object: Nested_InnerEnum): string {
+  switch (object) {
+    case Nested_InnerEnum.UNKNOWN_INNER:
+      return "UNKNOWN_INNER";
+    case Nested_InnerEnum.GOOD:
+      return "GOOD";
+    case Nested_InnerEnum.BAD:
+      return "BAD";
+    default:
+      return "UNKNOWN";
+  }
+}
 
 export const Simple = {
   encode(message: Simple, writer: Writer = Writer.create()): Writer {
@@ -503,7 +503,7 @@ export const Simple = {
       message.child = undefined;
     }
     if (object.state !== undefined && object.state !== null) {
-      message.state = StateEnum.fromJSON(object.state);
+      message.state = stateEnumFromJSON(object.state);
     } else {
       message.state = 0;
     }
@@ -524,7 +524,7 @@ export const Simple = {
     }
     if (object.old_states !== undefined && object.old_states !== null) {
       for (const e of object.old_states) {
-        message.old_states.push(StateEnum.fromJSON(e));
+        message.old_states.push(stateEnumFromJSON(e));
       }
     }
     if (object.thing !== undefined && object.thing !== null) {
@@ -598,7 +598,7 @@ export const Simple = {
     obj.age = message.age || 0;
     obj.created_at = message.created_at !== undefined ? message.created_at.toISOString() : null;
     obj.child = message.child ? Child.toJSON(message.child) : undefined;
-    obj.state = StateEnum.toJSON(message.state);
+    obj.state = stateEnumToJSON(message.state);
     if (message.grand_children) {
       obj.grand_children = message.grand_children.map(e => e ? Child.toJSON(e) : undefined);
     } else {
@@ -615,7 +615,7 @@ export const Simple = {
       obj.snacks = [];
     }
     if (message.old_states) {
-      obj.old_states = message.old_states.map(e => StateEnum.toJSON(e));
+      obj.old_states = message.old_states.map(e => stateEnumToJSON(e));
     } else {
       obj.old_states = [];
     }
@@ -658,7 +658,7 @@ export const Child = {
       message.name = "";
     }
     if (object.type !== undefined && object.type !== null) {
-      message.type = Child_Type.fromJSON(object.type);
+      message.type = child_TypeFromJSON(object.type);
     } else {
       message.type = 0;
     }
@@ -681,7 +681,7 @@ export const Child = {
   toJSON(message: Child): unknown {
     const obj: any = {};
     obj.name = message.name || "";
-    obj.type = Child_Type.toJSON(message.type);
+    obj.type = child_TypeToJSON(message.type);
     return obj;
   },
 };
@@ -731,7 +731,7 @@ export const Nested = {
       message.message = undefined;
     }
     if (object.state !== undefined && object.state !== null) {
-      message.state = Nested_InnerEnum.fromJSON(object.state);
+      message.state = nested_InnerEnumFromJSON(object.state);
     } else {
       message.state = 0;
     }
@@ -760,7 +760,7 @@ export const Nested = {
     const obj: any = {};
     obj.name = message.name || "";
     obj.message = message.message ? Nested_InnerMessage.toJSON(message.message) : undefined;
-    obj.state = Nested_InnerEnum.toJSON(message.state);
+    obj.state = nested_InnerEnumToJSON(message.state);
     return obj;
   },
 };

--- a/integration/simple/simple.ts
+++ b/integration/simple/simple.ts
@@ -275,119 +275,119 @@ function longToNumber(long: Long) {
   return long.toNumber();
 }
 
-export const StateEnum = {
-  UNKNOWN: 0 as const,
-  ON: 2 as const,
-  OFF: 3 as const,
-  UNRECOGNIZED: -1 as const,
-  fromJSON(object: any): StateEnum {
-    switch (object) {
-      case 0:
-      case "UNKNOWN":
-        return StateEnum.UNKNOWN;
-      case 2:
-      case "ON":
-        return StateEnum.ON;
-      case 3:
-      case "OFF":
-        return StateEnum.OFF;
-      case -1:
-      case "UNRECOGNIZED":
-      default:
-        return StateEnum.UNRECOGNIZED;
-    }
-  },
-  toJSON(object: StateEnum): string {
-    switch (object) {
-      case StateEnum.UNKNOWN:
-        return "UNKNOWN";
-      case StateEnum.ON:
-        return "ON";
-      case StateEnum.OFF:
-        return "OFF";
-      default:
-        return "UNKNOWN";
-    }
-  },
+export enum StateEnum {
+  UNKNOWN = 0,
+  ON = 2,
+  OFF = 3,
+  UNRECOGNIZED = -1,
 }
 
-export type StateEnum = 0 | 2 | 3 | -1;
-
-export const Child_Type = {
-  UNKNOWN: 0 as const,
-  GOOD: 1 as const,
-  BAD: 2 as const,
-  UNRECOGNIZED: -1 as const,
-  fromJSON(object: any): Child_Type {
-    switch (object) {
-      case 0:
-      case "UNKNOWN":
-        return Child_Type.UNKNOWN;
-      case 1:
-      case "GOOD":
-        return Child_Type.GOOD;
-      case 2:
-      case "BAD":
-        return Child_Type.BAD;
-      case -1:
-      case "UNRECOGNIZED":
-      default:
-        return Child_Type.UNRECOGNIZED;
-    }
-  },
-  toJSON(object: Child_Type): string {
-    switch (object) {
-      case Child_Type.UNKNOWN:
-        return "UNKNOWN";
-      case Child_Type.GOOD:
-        return "GOOD";
-      case Child_Type.BAD:
-        return "BAD";
-      default:
-        return "UNKNOWN";
-    }
-  },
+export function stateEnumFromJSON(object: any): StateEnum {
+  switch (object) {
+    case 0:
+    case "UNKNOWN":
+      return StateEnum.UNKNOWN;
+    case 2:
+    case "ON":
+      return StateEnum.ON;
+    case 3:
+    case "OFF":
+      return StateEnum.OFF;
+    case -1:
+    case "UNRECOGNIZED":
+    default:
+      return StateEnum.UNRECOGNIZED;
+  }
 }
 
-export type Child_Type = 0 | 1 | 2 | -1;
-
-export const Nested_InnerEnum = {
-  UNKNOWN_INNER: 0 as const,
-  GOOD: 100 as const,
-  BAD: 1000 as const,
-  UNRECOGNIZED: -1 as const,
-  fromJSON(object: any): Nested_InnerEnum {
-    switch (object) {
-      case 0:
-      case "UNKNOWN_INNER":
-        return Nested_InnerEnum.UNKNOWN_INNER;
-      case 100:
-      case "GOOD":
-        return Nested_InnerEnum.GOOD;
-      case 1000:
-      case "BAD":
-        return Nested_InnerEnum.BAD;
-      case -1:
-      case "UNRECOGNIZED":
-      default:
-        return Nested_InnerEnum.UNRECOGNIZED;
-    }
-  },
-  toJSON(object: Nested_InnerEnum): string {
-    switch (object) {
-      case Nested_InnerEnum.UNKNOWN_INNER:
-        return "UNKNOWN_INNER";
-      case Nested_InnerEnum.GOOD:
-        return "GOOD";
-      case Nested_InnerEnum.BAD:
-        return "BAD";
-      default:
-        return "UNKNOWN";
-    }
-  },
+export function stateEnumToJSON(object: StateEnum): string {
+  switch (object) {
+    case StateEnum.UNKNOWN:
+      return "UNKNOWN";
+    case StateEnum.ON:
+      return "ON";
+    case StateEnum.OFF:
+      return "OFF";
+    default:
+      return "UNKNOWN";
+  }
 }
 
-export type Nested_InnerEnum = 0 | 100 | 1000 | -1;
+export enum Child_Type {
+  UNKNOWN = 0,
+  GOOD = 1,
+  BAD = 2,
+  UNRECOGNIZED = -1,
+}
+
+export function child_TypeFromJSON(object: any): Child_Type {
+  switch (object) {
+    case 0:
+    case "UNKNOWN":
+      return Child_Type.UNKNOWN;
+    case 1:
+    case "GOOD":
+      return Child_Type.GOOD;
+    case 2:
+    case "BAD":
+      return Child_Type.BAD;
+    case -1:
+    case "UNRECOGNIZED":
+    default:
+      return Child_Type.UNRECOGNIZED;
+  }
+}
+
+export function child_TypeToJSON(object: Child_Type): string {
+  switch (object) {
+    case Child_Type.UNKNOWN:
+      return "UNKNOWN";
+    case Child_Type.GOOD:
+      return "GOOD";
+    case Child_Type.BAD:
+      return "BAD";
+    default:
+      return "UNKNOWN";
+  }
+}
+
+export enum Nested_InnerEnum {
+  UNKNOWN_INNER = 0,
+  GOOD = 100,
+  BAD = 1000,
+  UNRECOGNIZED = -1,
+}
+
+export function nested_InnerEnumFromJSON(object: any): Nested_InnerEnum {
+  switch (object) {
+    case 0:
+    case "UNKNOWN_INNER":
+      return Nested_InnerEnum.UNKNOWN_INNER;
+    case 100:
+    case "GOOD":
+      return Nested_InnerEnum.GOOD;
+    case 1000:
+    case "BAD":
+      return Nested_InnerEnum.BAD;
+    case -1:
+    case "UNRECOGNIZED":
+    default:
+      return Nested_InnerEnum.UNRECOGNIZED;
+  }
+}
+
+export function nested_InnerEnumToJSON(object: Nested_InnerEnum): string {
+  switch (object) {
+    case Nested_InnerEnum.UNKNOWN_INNER:
+      return "UNKNOWN_INNER";
+    case Nested_InnerEnum.GOOD:
+      return "GOOD";
+    case Nested_InnerEnum.BAD:
+      return "BAD";
+    default:
+      return "UNKNOWN";
+  }
+}
 
 export const Simple = {
   encode(message: Simple, writer: Writer = Writer.create()): Writer {
@@ -518,7 +518,7 @@ export const Simple = {
       message.child = undefined;
     }
     if (object.state !== undefined && object.state !== null) {
-      message.state = StateEnum.fromJSON(object.state);
+      message.state = stateEnumFromJSON(object.state);
     } else {
       message.state = 0;
     }
@@ -539,7 +539,7 @@ export const Simple = {
     }
     if (object.oldStates !== undefined && object.oldStates !== null) {
       for (const e of object.oldStates) {
-        message.oldStates.push(StateEnum.fromJSON(e));
+        message.oldStates.push(stateEnumFromJSON(e));
       }
     }
     if (object.thing !== undefined && object.thing !== null) {
@@ -624,7 +624,7 @@ export const Simple = {
     obj.age = message.age || 0;
     obj.createdAt = message.createdAt !== undefined ? message.createdAt.toISOString() : null;
     obj.child = message.child ? Child.toJSON(message.child) : undefined;
-    obj.state = StateEnum.toJSON(message.state);
+    obj.state = stateEnumToJSON(message.state);
     if (message.grandChildren) {
       obj.grandChildren = message.grandChildren.map(e => e ? Child.toJSON(e) : undefined);
     } else {
@@ -641,7 +641,7 @@ export const Simple = {
       obj.snacks = [];
     }
     if (message.oldStates) {
-      obj.oldStates = message.oldStates.map(e => StateEnum.toJSON(e));
+      obj.oldStates = message.oldStates.map(e => stateEnumToJSON(e));
     } else {
       obj.oldStates = [];
     }
@@ -689,7 +689,7 @@ export const Child = {
       message.name = "";
     }
     if (object.type !== undefined && object.type !== null) {
-      message.type = Child_Type.fromJSON(object.type);
+      message.type = child_TypeFromJSON(object.type);
     } else {
       message.type = 0;
     }
@@ -712,7 +712,7 @@ export const Child = {
   toJSON(message: Child): unknown {
     const obj: any = {};
     obj.name = message.name || "";
-    obj.type = Child_Type.toJSON(message.type);
+    obj.type = child_TypeToJSON(message.type);
     return obj;
   },
 };
@@ -762,7 +762,7 @@ export const Nested = {
       message.message = undefined;
     }
     if (object.state !== undefined && object.state !== null) {
-      message.state = Nested_InnerEnum.fromJSON(object.state);
+      message.state = nested_InnerEnumFromJSON(object.state);
     } else {
       message.state = 0;
     }
@@ -791,7 +791,7 @@ export const Nested = {
     const obj: any = {};
     obj.name = message.name || "";
     obj.message = message.message ? Nested_InnerMessage.toJSON(message.message) : undefined;
-    obj.state = Nested_InnerEnum.toJSON(message.state);
+    obj.state = nested_InnerEnumToJSON(message.state);
     return obj;
   },
 };

--- a/integration/vector-tile/__snapshots__/vector-tile-test.ts.snap
+++ b/integration/vector-tile/__snapshots__/vector-tile-test.ts.snap
@@ -69,49 +69,49 @@ function longToNumber(long: Long) {
   return long.toNumber();
 }
 
-export const Tile_GeomType = {
-  UNKNOWN: 0 as const,
-  POINT: 1 as const,
-  LINESTRING: 2 as const,
-  POLYGON: 3 as const,
-  UNRECOGNIZED: -1 as const,
-  fromJSON(object: any): Tile_GeomType {
-    switch (object) {
-      case 0:
-      case \\"UNKNOWN\\":
-        return Tile_GeomType.UNKNOWN;
-      case 1:
-      case \\"POINT\\":
-        return Tile_GeomType.POINT;
-      case 2:
-      case \\"LINESTRING\\":
-        return Tile_GeomType.LINESTRING;
-      case 3:
-      case \\"POLYGON\\":
-        return Tile_GeomType.POLYGON;
-      case -1:
-      case \\"UNRECOGNIZED\\":
-      default:
-        return Tile_GeomType.UNRECOGNIZED;
-    }
-  },
-  toJSON(object: Tile_GeomType): string {
-    switch (object) {
-      case Tile_GeomType.UNKNOWN:
-        return \\"UNKNOWN\\";
-      case Tile_GeomType.POINT:
-        return \\"POINT\\";
-      case Tile_GeomType.LINESTRING:
-        return \\"LINESTRING\\";
-      case Tile_GeomType.POLYGON:
-        return \\"POLYGON\\";
-      default:
-        return \\"UNKNOWN\\";
-    }
-  },
+export enum Tile_GeomType {
+  UNKNOWN = 0,
+  POINT = 1,
+  LINESTRING = 2,
+  POLYGON = 3,
+  UNRECOGNIZED = -1,
 }
 
-export type Tile_GeomType = 0 | 1 | 2 | 3 | -1;
+export function tile_GeomTypeFromJSON(object: any): Tile_GeomType {
+  switch (object) {
+    case 0:
+    case \\"UNKNOWN\\":
+      return Tile_GeomType.UNKNOWN;
+    case 1:
+    case \\"POINT\\":
+      return Tile_GeomType.POINT;
+    case 2:
+    case \\"LINESTRING\\":
+      return Tile_GeomType.LINESTRING;
+    case 3:
+    case \\"POLYGON\\":
+      return Tile_GeomType.POLYGON;
+    case -1:
+    case \\"UNRECOGNIZED\\":
+    default:
+      return Tile_GeomType.UNRECOGNIZED;
+  }
+}
+
+export function tile_GeomTypeToJSON(object: Tile_GeomType): string {
+  switch (object) {
+    case Tile_GeomType.UNKNOWN:
+      return \\"UNKNOWN\\";
+    case Tile_GeomType.POINT:
+      return \\"POINT\\";
+    case Tile_GeomType.LINESTRING:
+      return \\"LINESTRING\\";
+    case Tile_GeomType.POLYGON:
+      return \\"POLYGON\\";
+    default:
+      return \\"UNKNOWN\\";
+  }
+}
 
 export const Tile = {
   encode(message: Tile, writer: Writer = Writer.create()): Writer {
@@ -379,7 +379,7 @@ export const Tile_Feature = {
       }
     }
     if (object.type !== undefined && object.type !== null) {
-      message.type = Tile_GeomType.fromJSON(object.type);
+      message.type = tile_GeomTypeFromJSON(object.type);
     } else {
       message.type = 0;
     }
@@ -424,7 +424,7 @@ export const Tile_Feature = {
     } else {
       obj.tags = [];
     }
-    obj.type = Tile_GeomType.toJSON(message.type);
+    obj.type = tile_GeomTypeToJSON(message.type);
     if (message.geometry) {
       obj.geometry = message.geometry.map(e => e || 0);
     } else {

--- a/integration/vector-tile/vector_tile.ts
+++ b/integration/vector-tile/vector_tile.ts
@@ -66,49 +66,49 @@ function longToNumber(long: Long) {
   return long.toNumber();
 }
 
-export const Tile_GeomType = {
-  UNKNOWN: 0 as const,
-  POINT: 1 as const,
-  LINESTRING: 2 as const,
-  POLYGON: 3 as const,
-  UNRECOGNIZED: -1 as const,
-  fromJSON(object: any): Tile_GeomType {
-    switch (object) {
-      case 0:
-      case "UNKNOWN":
-        return Tile_GeomType.UNKNOWN;
-      case 1:
-      case "POINT":
-        return Tile_GeomType.POINT;
-      case 2:
-      case "LINESTRING":
-        return Tile_GeomType.LINESTRING;
-      case 3:
-      case "POLYGON":
-        return Tile_GeomType.POLYGON;
-      case -1:
-      case "UNRECOGNIZED":
-      default:
-        return Tile_GeomType.UNRECOGNIZED;
-    }
-  },
-  toJSON(object: Tile_GeomType): string {
-    switch (object) {
-      case Tile_GeomType.UNKNOWN:
-        return "UNKNOWN";
-      case Tile_GeomType.POINT:
-        return "POINT";
-      case Tile_GeomType.LINESTRING:
-        return "LINESTRING";
-      case Tile_GeomType.POLYGON:
-        return "POLYGON";
-      default:
-        return "UNKNOWN";
-    }
-  },
+export enum Tile_GeomType {
+  UNKNOWN = 0,
+  POINT = 1,
+  LINESTRING = 2,
+  POLYGON = 3,
+  UNRECOGNIZED = -1,
 }
 
-export type Tile_GeomType = 0 | 1 | 2 | 3 | -1;
+export function tile_GeomTypeFromJSON(object: any): Tile_GeomType {
+  switch (object) {
+    case 0:
+    case "UNKNOWN":
+      return Tile_GeomType.UNKNOWN;
+    case 1:
+    case "POINT":
+      return Tile_GeomType.POINT;
+    case 2:
+    case "LINESTRING":
+      return Tile_GeomType.LINESTRING;
+    case 3:
+    case "POLYGON":
+      return Tile_GeomType.POLYGON;
+    case -1:
+    case "UNRECOGNIZED":
+    default:
+      return Tile_GeomType.UNRECOGNIZED;
+  }
+}
+
+export function tile_GeomTypeToJSON(object: Tile_GeomType): string {
+  switch (object) {
+    case Tile_GeomType.UNKNOWN:
+      return "UNKNOWN";
+    case Tile_GeomType.POINT:
+      return "POINT";
+    case Tile_GeomType.LINESTRING:
+      return "LINESTRING";
+    case Tile_GeomType.POLYGON:
+      return "POLYGON";
+    default:
+      return "UNKNOWN";
+  }
+}
 
 export const Tile = {
   encode(message: Tile, writer: Writer = Writer.create()): Writer {
@@ -376,7 +376,7 @@ export const Tile_Feature = {
       }
     }
     if (object.type !== undefined && object.type !== null) {
-      message.type = Tile_GeomType.fromJSON(object.type);
+      message.type = tile_GeomTypeFromJSON(object.type);
     } else {
       message.type = 0;
     }
@@ -421,7 +421,7 @@ export const Tile_Feature = {
     } else {
       obj.tags = [];
     }
-    obj.type = Tile_GeomType.toJSON(message.type);
+    obj.type = tile_GeomTypeToJSON(message.type);
     if (message.geometry) {
       obj.geometry = message.geometry.map(e => e || 0);
     } else {

--- a/src/case.ts
+++ b/src/case.ts
@@ -1,0 +1,25 @@
+import { Options } from './main';
+
+export function maybeSnakeToCamel(s: string, options: Options): string {
+  if (options.snakeToCamel) {
+    return s.replace(/(\_\w)/g, (m) => m[1].toUpperCase());
+  } else {
+    return s;
+  }
+}
+
+export function camelToSnake(s: string): string {
+  return s
+    .replace(/[\w]([A-Z])/g, function (m) {
+      return m[0] + '_' + m[1];
+    })
+    .toUpperCase();
+}
+
+export function capitalize(s: string): string {
+  return s.substring(0, 1).toUpperCase() + s.substring(1);
+}
+
+export function camelCase(s: string): string {
+  return s.substring(0, 1).toLowerCase() + s.substring(1);
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,12 +2,12 @@ import { google } from '../build/pbjs';
 import { CodeBlock, Member, TypeName, TypeNames } from 'ts-poet';
 import { Options, visit, LongOption, EnvOption, OneofOption } from './main';
 import { fail } from './utils';
-import { asSequence } from 'sequency';
 import FieldDescriptorProto = google.protobuf.FieldDescriptorProto;
 import CodeGeneratorRequest = google.protobuf.compiler.CodeGeneratorRequest;
 import EnumDescriptorProto = google.protobuf.EnumDescriptorProto;
 import DescriptorProto = google.protobuf.DescriptorProto;
 import SourceInfo from './sourceInfo';
+import { camelCase } from './case';
 
 /** Based on https://github.com/dcodeIO/protobuf.js/blob/master/src/types.js#L37. */
 export function basicWireType(type: FieldDescriptorProto.Type): number {
@@ -346,6 +346,12 @@ export function messageToTypeName(
 function toModuleAndType(typeMap: TypeMap, protoType: string): [string, string, DescriptorProto | EnumDescriptorProto] {
   return typeMap.get(protoType) || fail(`No type found for ${protoType}`);
 }
+
+export function getEnumMethod(typeMap: TypeMap, enumProtoType: string, methodSuffix: string): TypeName {
+  const [module, type] = toModuleAndType(typeMap, enumProtoType)
+  return TypeNames.importedType(`${camelCase(type)}${methodSuffix}@./${module}`);
+}
+
 
 /** Return the TypeName for any field (primitive/message/etc.) as exposed in the interface. */
 export function toTypeName(

--- a/src/types.ts
+++ b/src/types.ts
@@ -348,10 +348,9 @@ function toModuleAndType(typeMap: TypeMap, protoType: string): [string, string, 
 }
 
 export function getEnumMethod(typeMap: TypeMap, enumProtoType: string, methodSuffix: string): TypeName {
-  const [module, type] = toModuleAndType(typeMap, enumProtoType)
+  const [module, type] = toModuleAndType(typeMap, enumProtoType);
   return TypeNames.importedType(`${camelCase(type)}${methodSuffix}@./${module}`);
 }
-
 
 /** Return the TypeName for any field (primitive/message/etc.) as exposed in the interface. */
 export function toTypeName(


### PR DESCRIPTION
Previously we used an enum-like pattern so that we could attach
methods like toJSON/fromJSON to the enum itself, i.e.
StateEnum.fromJSON.

This was done out of a) convenience b/c we already knew where the
`StateEnum` came from (i.e. had it imported) and b) in-theory
developer ergonomics for calling the `StateEnum.fromJSON` method.

However, a) is easy to fix with just trying harder, i.e. a new
getEnumMethod that can find top-level functions for a given enum,
i.e. stateEnumFromJSON is in module x/y/z.

And b) is not really a factor b/c developers should rarely serialize
an enum directly and are probably/basically always working with
MessageFoo.to/fromJSON, and it's only the internals of
MessageFoo.to/fromJSON that have to know where the enum functions
live/how to call them.

So, this PR negates a) and ignores b), especially because developers
really do expect the protobuf enums to TS enums, i.e. for doing
things like Object.entries(StateEnum).