### PR TITLE
Add way to pass data loader options

### DIFF
--- a/integration/batching-with-context/batching.ts
+++ b/integration/batching-with-context/batching.ts
@@ -116,7 +116,7 @@ export class EntityServiceClientImpl<Context extends DataLoaders> implements Ent
       return new DataLoader<string, Entity>((ids) => {
         const request = { ids };
         return this.BatchQuery(ctx, request).then(res => res.entities);
-      }, { cacheKeyFn: hash });
+      }, { cacheKeyFn: hash, ...ctx.rpcDataLoaderOptions });
     });
     return dl.load(id);
   }
@@ -134,7 +134,7 @@ export class EntityServiceClientImpl<Context extends DataLoaders> implements Ent
         return this.BatchMapQuery(ctx, request).then(res => {
           return ids.map(key => res.entities[key]);
         })
-      }, { cacheKeyFn: hash });
+      }, { cacheKeyFn: hash, ...ctx.rpcDataLoaderOptions });
     });
     return dl.load(id);
   }
@@ -154,7 +154,7 @@ export class EntityServiceClientImpl<Context extends DataLoaders> implements Ent
           return GetOnlyMethodResponse.decode(new Reader(response));
         })
         return Promise.all(responses);
-      }, { cacheKeyFn: hash });
+      }, { cacheKeyFn: hash, ...ctx.rpcDataLoaderOptions  });
     });
     return dl.load(request);
   }
@@ -173,7 +173,12 @@ interface Rpc<Context> {
 
 }
 
+export interface DataLoaderOptions {
+  cache?: boolean;
+}
+
 export interface DataLoaders {
+  rpcDataLoaderOptions?: DataLoaderOptions;
 
   getDataLoader<T>(identifier: string, constructorFn: () => T): T;
 

--- a/src/generate-services.ts
+++ b/src/generate-services.ts
@@ -200,7 +200,7 @@ function generateBatchingRpcMethod(typeMap: TypeMap, batchMethod: BatchMethod): 
     .addParameter(singular(inputFieldName), inputType)
     .addCode('const dl = ctx.getDataLoader(%S, () => {%>\n', uniqueIdentifier)
     .addCode(
-      'return new %T<%T, %T>(%L, { cacheKeyFn: %T });\n',
+      'return new %T<%T, %T>(%L, { cacheKeyFn: %T, ...ctx.rpcDataLoaderOptions });\n',
       dataloader,
       inputType,
       outputType,
@@ -241,7 +241,7 @@ function generateCachingRpcMethod(
     .addParameter('request', inputType)
     .addCode('const dl = ctx.getDataLoader(%S, () => {%>\n', uniqueIdentifier)
     .addCode(
-      'return new %T<%T, %T>(%L, { cacheKeyFn: %T });\n',
+      'return new %T<%T, %T>(%L, { cacheKeyFn: %T, ...ctx.rpcDataLoaderOptions  });\n',
       dataloader,
       inputType,
       outputType,
@@ -288,5 +288,9 @@ export function generateDataLoadersType(): InterfaceSpec {
     .addParameter('identifier', TypeNames.STRING)
     .addParameter('constructorFn', TypeNames.lambda2([], TypeNames.typeVariable('T')))
     .returns(TypeNames.typeVariable('T'));
-  return InterfaceSpec.create('DataLoaders').addModifiers(Modifier.EXPORT).addFunction(fn);
+  return InterfaceSpec.create('DataLoaders').addModifiers(Modifier.EXPORT).addFunction(fn).addProperty('rpcDataLoaderOptions', 'DataLoaderOptions', { optional: true });
+}
+
+export function generateDataLoaderOptionsType(): InterfaceSpec {
+  return InterfaceSpec.create('DataLoaderOptions').addModifiers(Modifier.EXPORT).addProperty('cache', 'boolean', { optional: true });
 }

--- a/src/generate-services.ts
+++ b/src/generate-services.ts
@@ -288,9 +288,14 @@ export function generateDataLoadersType(): InterfaceSpec {
     .addParameter('identifier', TypeNames.STRING)
     .addParameter('constructorFn', TypeNames.lambda2([], TypeNames.typeVariable('T')))
     .returns(TypeNames.typeVariable('T'));
-  return InterfaceSpec.create('DataLoaders').addModifiers(Modifier.EXPORT).addFunction(fn).addProperty('rpcDataLoaderOptions', 'DataLoaderOptions', { optional: true });
+  return InterfaceSpec.create('DataLoaders')
+    .addModifiers(Modifier.EXPORT)
+    .addFunction(fn)
+    .addProperty('rpcDataLoaderOptions', 'DataLoaderOptions', { optional: true });
 }
 
 export function generateDataLoaderOptionsType(): InterfaceSpec {
-  return InterfaceSpec.create('DataLoaderOptions').addModifiers(Modifier.EXPORT).addProperty('cache', 'boolean', { optional: true });
+  return InterfaceSpec.create('DataLoaderOptions')
+    .addModifiers(Modifier.EXPORT)
+    .addProperty('cache', 'boolean', { optional: true });
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,6 +35,7 @@ import {
 } from './generate-nestjs';
 import {
   generateDataLoadersType,
+  generateDataLoaderOptionsType,
   generateRpcType,
   generateService,
   generateServiceClientImpl,
@@ -204,6 +205,7 @@ export function generateFile(typeMap: TypeMap, fileDesc: FileDescriptorProto, pa
   }
 
   if (options.useContext) {
+    file = file.addInterface(generateDataLoaderOptionsType());
     file = file.addInterface(generateDataLoadersType());
   }
 


### PR DESCRIPTION
Adds an optional `rpcDataLoaderOptions` field to `ctx` which would allow us to pass options to the data loader during runtime to, for instance, disable caching for a particular request. 