### PR TITLE
Generate protobuf package constant for each file

### DIFF
--- a/integration/angular/simple-message.ts
+++ b/integration/angular/simple-message.ts
@@ -9,6 +9,8 @@ const baseSimpleMessage: object = {
   numberField: 0,
 };
 
+export const protobufPackage = 'angular'
+
 export const SimpleMessage = {
   encode(message: SimpleMessage, writer: Writer = Writer.create()): Writer {
     writer.uint32(8).int32(message.numberField);

--- a/integration/batching-with-context/batching.ts
+++ b/integration/batching-with-context/batching.ts
@@ -179,6 +179,8 @@ export interface DataLoaders {
 
 }
 
+export const protobufPackage = 'batching'
+
 export const BatchQueryRequest = {
   encode(message: BatchQueryRequest, writer: Writer = Writer.create()): Writer {
     for (const v of message.ids) {

--- a/integration/batching/batching.ts
+++ b/integration/batching/batching.ts
@@ -137,6 +137,8 @@ interface Rpc {
 
 }
 
+export const protobufPackage = 'batching'
+
 export const BatchQueryRequest = {
   encode(message: BatchQueryRequest, writer: Writer = Writer.create()): Writer {
     for (const v of message.ids) {

--- a/integration/bytes-as-base64/message.ts
+++ b/integration/bytes-as-base64/message.ts
@@ -6,6 +6,8 @@ export interface Message {
 const baseMessage: object = {
 };
 
+export const protobufPackage = ''
+
 export const Message = {
   fromJSON(object: any): Message {
     const message = { ...baseMessage } as Message;

--- a/integration/bytes-node/point.ts
+++ b/integration/bytes-node/point.ts
@@ -8,6 +8,8 @@ export interface Point {
 const basePoint: object = {
 };
 
+export const protobufPackage = ''
+
 export const Point = {
   encode(message: Point, writer: Writer = Writer.create()): Writer {
     writer.uint32(10).bytes(message.data);

--- a/integration/grpc-web/example.ts
+++ b/integration/grpc-web/example.ts
@@ -182,6 +182,8 @@ export class GrpcWebImpl implements Rpc {
 
 }
 
+export const protobufPackage = 'rpx'
+
 export enum DashFlash_Type {
   Undefined = 0,
   Success = 1,

--- a/integration/grpc-web/types.ts
+++ b/integration/grpc-web/types.ts
@@ -96,6 +96,8 @@ function longToNumber(long: Long) {
   return long.toNumber();
 }
 
+export const protobufPackage = 'pb'
+
 export const Timestamp = {
   encode(message: Timestamp, writer: Writer = Writer.create()): Writer {
     writer.uint32(8).int64(message.seconds);

--- a/integration/nestjs-metadata-observables/hero.ts
+++ b/integration/nestjs-metadata-observables/hero.ts
@@ -56,5 +56,7 @@ export function HeroServiceControllerMethods() {
   }
 }
 
+export const protobufPackage = 'hero'
+
 export const HERO_PACKAGE_NAME = 'hero'
 export const HERO_SERVICE_NAME = 'HeroService';

--- a/integration/nestjs-metadata-restparameters/hero.ts
+++ b/integration/nestjs-metadata-restparameters/hero.ts
@@ -56,5 +56,7 @@ export function HeroServiceControllerMethods() {
   }
 }
 
+export const protobufPackage = 'hero'
+
 export const HERO_PACKAGE_NAME = 'hero'
 export const HERO_SERVICE_NAME = 'HeroService';

--- a/integration/nestjs-metadata/hero.ts
+++ b/integration/nestjs-metadata/hero.ts
@@ -56,5 +56,7 @@ export function HeroServiceControllerMethods() {
   }
 }
 
+export const protobufPackage = 'hero'
+
 export const HERO_PACKAGE_NAME = 'hero'
 export const HERO_SERVICE_NAME = 'HeroService';

--- a/integration/nestjs-restparameters/hero.ts
+++ b/integration/nestjs-restparameters/hero.ts
@@ -55,5 +55,7 @@ export function HeroServiceControllerMethods() {
   }
 }
 
+export const protobufPackage = 'hero'
+
 export const HERO_PACKAGE_NAME = 'hero'
 export const HERO_SERVICE_NAME = 'HeroService';

--- a/integration/nestjs-simple-observables/hero.ts
+++ b/integration/nestjs-simple-observables/hero.ts
@@ -55,5 +55,7 @@ export function HeroServiceControllerMethods() {
   }
 }
 
+export const protobufPackage = 'hero'
+
 export const HERO_PACKAGE_NAME = 'hero'
 export const HERO_SERVICE_NAME = 'HeroService';

--- a/integration/nestjs-simple-restparameters/google/protobuf/empty.ts
+++ b/integration/nestjs-simple-restparameters/google/protobuf/empty.ts
@@ -13,4 +13,6 @@
 export interface Empty {
 }
 
+export const protobufPackage = 'google.protobuf'
+
 export const GOOGLE_PROTOBUF_PACKAGE_NAME = 'google.protobuf'

--- a/integration/nestjs-simple-restparameters/hero.ts
+++ b/integration/nestjs-simple-restparameters/hero.ts
@@ -35,5 +35,7 @@ export function HeroServiceControllerMethods() {
   }
 }
 
+export const protobufPackage = 'hero'
+
 export const HERO_PACKAGE_NAME = 'hero'
 export const HERO_SERVICE_NAME = 'HeroService';

--- a/integration/nestjs-simple/google/protobuf/empty.ts
+++ b/integration/nestjs-simple/google/protobuf/empty.ts
@@ -13,4 +13,6 @@
 export interface Empty {
 }
 
+export const protobufPackage = 'google.protobuf'
+
 export const GOOGLE_PROTOBUF_PACKAGE_NAME = 'google.protobuf'

--- a/integration/nestjs-simple/hero.ts
+++ b/integration/nestjs-simple/hero.ts
@@ -68,5 +68,7 @@ export function HeroServiceControllerMethods() {
   }
 }
 
+export const protobufPackage = 'hero'
+
 export const HERO_PACKAGE_NAME = 'hero'
 export const HERO_SERVICE_NAME = 'HeroService';

--- a/integration/oneof-properties/oneof.ts
+++ b/integration/oneof-properties/oneof.ts
@@ -40,6 +40,8 @@ const basePleaseChoose_Submessage: object = {
   name: "",
 };
 
+export const protobufPackage = 'oneof'
+
 export enum PleaseChoose_StateEnum {
   UNKNOWN = 0,
   ON = 2,

--- a/integration/oneof-unions/oneof.ts
+++ b/integration/oneof-unions/oneof.ts
@@ -47,6 +47,8 @@ const basePleaseChoose_Submessage: object = {
 const baseSimpleButOptional: object = {
 };
 
+export const protobufPackage = 'oneof'
+
 export enum PleaseChoose_StateEnum {
   UNKNOWN = 0,
   ON = 2,

--- a/integration/only-types/google/protobuf/any.ts
+++ b/integration/only-types/google/protobuf/any.ts
@@ -118,3 +118,5 @@ export interface Any {
    */
   value: Uint8Array;
 }
+
+export const protobufPackage = 'google.protobuf'

--- a/integration/only-types/google/protobuf/timestamp.ts
+++ b/integration/only-types/google/protobuf/timestamp.ts
@@ -100,3 +100,5 @@ export interface Timestamp {
    */
   nanos: number;
 }
+
+export const protobufPackage = 'google.protobuf'

--- a/integration/only-types/reservation.ts
+++ b/integration/only-types/reservation.ts
@@ -6,3 +6,5 @@ export interface Registration {
   date: Date | undefined;
   perks: Any | undefined;
 }
+
+export const protobufPackage = 'event'

--- a/integration/point/point.ts
+++ b/integration/point/point.ts
@@ -19,6 +19,8 @@ const basePoint: object = {
 const baseArea: object = {
 };
 
+export const protobufPackage = ''
+
 export const Point = {
   encode(message: Point, writer: Writer = Writer.create()): Writer {
     writer.uint32(9).double(message.lat);

--- a/integration/simple-long-string/google/protobuf/timestamp.ts
+++ b/integration/simple-long-string/google/protobuf/timestamp.ts
@@ -113,6 +113,8 @@ function longToString(long: Long) {
   return long.toString();
 }
 
+export const protobufPackage = 'google.protobuf'
+
 export const Timestamp = {
   encode(message: Timestamp, writer: Writer = Writer.create()): Writer {
     writer.uint32(8).int64(message.seconds);

--- a/integration/simple-long-string/google/protobuf/wrappers.ts
+++ b/integration/simple-long-string/google/protobuf/wrappers.ts
@@ -149,6 +149,8 @@ function longToString(long: Long) {
   return long.toString();
 }
 
+export const protobufPackage = 'google.protobuf'
+
 export const DoubleValue = {
   encode(message: DoubleValue, writer: Writer = Writer.create()): Writer {
     writer.uint32(9).double(message.value);

--- a/integration/simple-long-string/import_dir/thing.ts
+++ b/integration/simple-long-string/import_dir/thing.ts
@@ -31,6 +31,8 @@ function fromTimestamp(t: Timestamp): Date {
   return new Date(millis);
 }
 
+export const protobufPackage = 'simple'
+
 export const ImportedThing = {
   encode(message: ImportedThing, writer: Writer = Writer.create()): Writer {
     if (message.createdAt !== undefined && message.createdAt !== undefined) {

--- a/integration/simple-long-string/simple.ts
+++ b/integration/simple-long-string/simple.ts
@@ -265,6 +265,8 @@ function longToString(long: Long) {
   return long.toString();
 }
 
+export const protobufPackage = 'simple'
+
 export enum StateEnum {
   UNKNOWN = 0,
   ON = 2,

--- a/integration/simple-long/google/protobuf/timestamp.ts
+++ b/integration/simple-long/google/protobuf/timestamp.ts
@@ -109,6 +109,8 @@ const baseTimestamp: object = {
   nanos: 0,
 };
 
+export const protobufPackage = 'google.protobuf'
+
 export const Timestamp = {
   encode(message: Timestamp, writer: Writer = Writer.create()): Writer {
     writer.uint32(8).int64(message.seconds);

--- a/integration/simple-long/google/protobuf/wrappers.ts
+++ b/integration/simple-long/google/protobuf/wrappers.ts
@@ -145,6 +145,8 @@ const baseStringValue: object = {
 const baseBytesValue: object = {
 };
 
+export const protobufPackage = 'google.protobuf'
+
 export const DoubleValue = {
   encode(message: DoubleValue, writer: Writer = Writer.create()): Writer {
     writer.uint32(9).double(message.value);

--- a/integration/simple-long/import_dir/thing.ts
+++ b/integration/simple-long/import_dir/thing.ts
@@ -36,6 +36,8 @@ function numberToLong(number: number) {
   return Long.fromNumber(number);
 }
 
+export const protobufPackage = 'simple'
+
 export const ImportedThing = {
   encode(message: ImportedThing, writer: Writer = Writer.create()): Writer {
     if (message.createdAt !== undefined && message.createdAt !== undefined) {

--- a/integration/simple-long/simple.ts
+++ b/integration/simple-long/simple.ts
@@ -265,6 +265,8 @@ function numberToLong(number: number) {
   return Long.fromNumber(number);
 }
 
+export const protobufPackage = 'simple'
+
 export enum StateEnum {
   UNKNOWN = 0,
   ON = 2,

--- a/integration/simple-optionals/google/protobuf/timestamp.ts
+++ b/integration/simple-optionals/google/protobuf/timestamp.ts
@@ -116,6 +116,8 @@ function longToNumber(long: Long) {
   return long.toNumber();
 }
 
+export const protobufPackage = 'google.protobuf'
+
 export const Timestamp = {
   encode(message: Timestamp, writer: Writer = Writer.create()): Writer {
     writer.uint32(8).int64(message.seconds);

--- a/integration/simple-optionals/google/protobuf/wrappers.ts
+++ b/integration/simple-optionals/google/protobuf/wrappers.ts
@@ -152,6 +152,8 @@ function longToNumber(long: Long) {
   return long.toNumber();
 }
 
+export const protobufPackage = 'google.protobuf'
+
 export const DoubleValue = {
   encode(message: DoubleValue, writer: Writer = Writer.create()): Writer {
     writer.uint32(9).double(message.value);

--- a/integration/simple-optionals/import_dir/thing.ts
+++ b/integration/simple-optionals/import_dir/thing.ts
@@ -31,6 +31,8 @@ function fromTimestamp(t: Timestamp): Date {
   return new Date(millis);
 }
 
+export const protobufPackage = 'simple'
+
 export const ImportedThing = {
   encode(message: ImportedThing, writer: Writer = Writer.create()): Writer {
     if (message.createdAt !== undefined && message.createdAt !== undefined) {

--- a/integration/simple-optionals/simple.ts
+++ b/integration/simple-optionals/simple.ts
@@ -268,6 +268,8 @@ function longToNumber(long: Long) {
   return long.toNumber();
 }
 
+export const protobufPackage = 'simple'
+
 export enum StateEnum {
   UNKNOWN = 0,
   ON = 2,

--- a/integration/simple-optionals/thing.ts
+++ b/integration/simple-optionals/thing.ts
@@ -31,6 +31,8 @@ function fromTimestamp(t: Timestamp): Date {
   return new Date(millis);
 }
 
+export const protobufPackage = 'simple'
+
 export const ImportedThing = {
   encode(message: ImportedThing, writer: Writer = Writer.create()): Writer {
     if (message.createdAt !== undefined && message.createdAt !== undefined) {

--- a/integration/simple-proto2/simple.ts
+++ b/integration/simple-proto2/simple.ts
@@ -9,6 +9,8 @@ const baseIssue56: object = {
   test: 1,
 };
 
+export const protobufPackage = 'simple'
+
 export enum EnumWithoutZero {
   A = 1,
   B = 2,

--- a/integration/simple-snake/google/protobuf/timestamp.ts
+++ b/integration/simple-snake/google/protobuf/timestamp.ts
@@ -116,6 +116,8 @@ function longToNumber(long: Long) {
   return long.toNumber();
 }
 
+export const protobufPackage = 'google.protobuf'
+
 export const Timestamp = {
   encode(message: Timestamp, writer: Writer = Writer.create()): Writer {
     writer.uint32(8).int64(message.seconds);

--- a/integration/simple-snake/google/protobuf/wrappers.ts
+++ b/integration/simple-snake/google/protobuf/wrappers.ts
@@ -152,6 +152,8 @@ function longToNumber(long: Long) {
   return long.toNumber();
 }
 
+export const protobufPackage = 'google.protobuf'
+
 export const DoubleValue = {
   encode(message: DoubleValue, writer: Writer = Writer.create()): Writer {
     writer.uint32(9).double(message.value);

--- a/integration/simple-snake/import_dir/thing.ts
+++ b/integration/simple-snake/import_dir/thing.ts
@@ -31,6 +31,8 @@ function fromTimestamp(t: Timestamp): Date {
   return new Date(millis);
 }
 
+export const protobufPackage = 'simple'
+
 export const ImportedThing = {
   encode(message: ImportedThing, writer: Writer = Writer.create()): Writer {
     if (message.created_at !== undefined && message.created_at !== undefined) {

--- a/integration/simple-snake/simple.ts
+++ b/integration/simple-snake/simple.ts
@@ -268,6 +268,8 @@ function longToNumber(long: Long) {
   return long.toNumber();
 }
 
+export const protobufPackage = 'simple'
+
 export enum StateEnum {
   UNKNOWN = 0,
   ON = 2,

--- a/integration/simple/google/protobuf/timestamp.ts
+++ b/integration/simple/google/protobuf/timestamp.ts
@@ -116,6 +116,8 @@ function longToNumber(long: Long) {
   return long.toNumber();
 }
 
+export const protobufPackage = 'google.protobuf'
+
 export const Timestamp = {
   encode(message: Timestamp, writer: Writer = Writer.create()): Writer {
     writer.uint32(8).int64(message.seconds);

--- a/integration/simple/google/protobuf/wrappers.ts
+++ b/integration/simple/google/protobuf/wrappers.ts
@@ -152,6 +152,8 @@ function longToNumber(long: Long) {
   return long.toNumber();
 }
 
+export const protobufPackage = 'google.protobuf'
+
 export const DoubleValue = {
   encode(message: DoubleValue, writer: Writer = Writer.create()): Writer {
     writer.uint32(9).double(message.value);

--- a/integration/simple/google/type/date.ts
+++ b/integration/simple/google/type/date.ts
@@ -38,6 +38,8 @@ const baseDateMessage: object = {
   day: 0,
 };
 
+export const protobufPackage = 'google.type'
+
 export const DateMessage = {
   encode(message: DateMessage, writer: Writer = Writer.create()): Writer {
     writer.uint32(8).int32(message.year);

--- a/integration/simple/import_dir/thing.ts
+++ b/integration/simple/import_dir/thing.ts
@@ -31,6 +31,8 @@ function fromTimestamp(t: Timestamp): Date {
   return new Date(millis);
 }
 
+export const protobufPackage = 'simple'
+
 export const ImportedThing = {
   encode(message: ImportedThing, writer: Writer = Writer.create()): Writer {
     if (message.createdAt !== undefined && message.createdAt !== undefined) {

--- a/integration/simple/simple-test.ts
+++ b/integration/simple/simple-test.ts
@@ -1,5 +1,5 @@
 import { Reader } from 'protobufjs';
-import { Child_Type, Nested, Nested_InnerEnum, OneOfMessage, Simple, SimpleWithMap, StateEnum, SimpleWithMapOfEnums } from './simple';
+import { protobufPackage, Child_Type, Nested, Nested_InnerEnum, OneOfMessage, Simple, SimpleWithMap, StateEnum, SimpleWithMapOfEnums } from './simple';
 import { simple as pbjs, google } from './pbjs';
 import ISimple = pbjs.ISimple;
 import PbChild = pbjs.Child;
@@ -38,6 +38,10 @@ describe('simple', () => {
       birthday: undefined,
     };
     expect(simple.name).toEqual('asdf');
+  });
+
+  it('generates its protobuf package constant', () => {
+    expect(protobufPackage).toEqual('simple')
   });
 
   it('can decode', () => {

--- a/integration/simple/simple.ts
+++ b/integration/simple/simple.ts
@@ -341,6 +341,8 @@ function longToNumber(long: Long) {
   return long.toNumber();
 }
 
+export const protobufPackage = 'simple'
+
 export enum StateEnum {
   UNKNOWN = 0,
   ON = 2,

--- a/integration/types-with-underscores/file.ts
+++ b/integration/types-with-underscores/file.ts
@@ -14,6 +14,8 @@ const baseBaz: object = {
 const baseFooBar: object = {
 };
 
+export const protobufPackage = ''
+
 export const Baz = {
   encode(message: Baz, writer: Writer = Writer.create()): Writer {
     if (message.foo !== undefined) {

--- a/integration/vector-tile/vector_tile.ts
+++ b/integration/vector-tile/vector_tile.ts
@@ -66,6 +66,8 @@ function longToNumber(long: Long) {
   return long.toNumber();
 }
 
+export const protobufPackage = 'vector_tile'
+
 export enum Tile_GeomType {
   UNKNOWN = 0,
   POINT = 1,

--- a/src/main.ts
+++ b/src/main.ts
@@ -102,6 +102,14 @@ export function generateFile(typeMap: TypeMap, fileDesc: FileDescriptorProto, pa
   const moduleName = fileDesc.name.replace('.proto', '.ts');
   let file = FileSpec.create(moduleName);
 
+  // Indicate this file's source protobuf package for reflective use with google.protobuf.Any
+  file = file.addCode(
+    CodeBlock.empty().add(
+      `export const protobufPackage = '%L'\n`,
+      fileDesc.package
+    )
+  );
+
   const sourceInfo = SourceInfo.fromDescriptor(fileDesc);
 
   // Syntax, unlike most fields, is not repeated and thus does not use an index

--- a/src/main.ts
+++ b/src/main.ts
@@ -103,12 +103,7 @@ export function generateFile(typeMap: TypeMap, fileDesc: FileDescriptorProto, pa
   let file = FileSpec.create(moduleName);
 
   // Indicate this file's source protobuf package for reflective use with google.protobuf.Any
-  file = file.addCode(
-    CodeBlock.empty().add(
-      `export const protobufPackage = '%L'\n`,
-      fileDesc.package
-    )
-  );
+  file = file.addCode(CodeBlock.empty().add(`export const protobufPackage = '%L'\n`, fileDesc.package));
 
   const sourceInfo = SourceInfo.fromDescriptor(fileDesc);
 


### PR DESCRIPTION
Here's a first pass at allowing code to see the protobuf package associated with generated types. I see some NestJS-associated package names as well, but they lack a uniform name.

Resolves #142.