### PR TITLE
Make Timestamp/Date mapping optional

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -277,6 +277,8 @@ protoc --plugin=node_modules/ts-proto/protoc-gen-ts_proto ./batching.proto -I.
 
   Note that `addGrpcMetadata`, `addNestjsRestParameter` and `returnObservable` will still be false.
 
+- With `--ts_proto_opt=useDate=false`, fields of type `google.protobuf.Timestamp` will not be mapped to type `Date` in the generated types.
+
 ### Only Types
 
 If you're looking for `ts-proto` to generate only types for your Protobuf types then passing all three of `outputEncodeMethods`, `outputJsonMethods`, and `outputClientImpl` as `false` is probably what you want, i.e.:

--- a/integration/nestjs-simple/google/protobuf/timestamp.ts
+++ b/integration/nestjs-simple/google/protobuf/timestamp.ts
@@ -1,0 +1,106 @@
+
+/**
+ *  A Timestamp represents a point in time independent of any time zone or local
+ *  calendar, encoded as a count of seconds and fractions of seconds at
+ *  nanosecond resolution. The count is relative to an epoch at UTC midnight on
+ *  January 1, 1970, in the proleptic Gregorian calendar which extends the
+ *  Gregorian calendar backwards to year one.
+ *
+ *  All minutes are 60 seconds long. Leap seconds are "smeared" so that no leap
+ *  second table is needed for interpretation, using a [24-hour linear
+ *  smear](https://developers.google.com/time/smear).
+ *
+ *  The range is from 0001-01-01T00:00:00Z to 9999-12-31T23:59:59.999999999Z. By
+ *  restricting to that range, we ensure that we can convert to and from [RFC
+ *  3339](https://www.ietf.org/rfc/rfc3339.txt) date strings.
+ *
+ *  # Examples
+ *
+ *  Example 1: Compute Timestamp from POSIX `time()`.
+ *
+ *      Timestamp timestamp;
+ *      timestamp.set_seconds(time(NULL));
+ *      timestamp.set_nanos(0);
+ *
+ *  Example 2: Compute Timestamp from POSIX `gettimeofday()`.
+ *
+ *      struct timeval tv;
+ *      gettimeofday(&tv, NULL);
+ *
+ *      Timestamp timestamp;
+ *      timestamp.set_seconds(tv.tv_sec);
+ *      timestamp.set_nanos(tv.tv_usec * 1000);
+ *
+ *  Example 3: Compute Timestamp from Win32 `GetSystemTimeAsFileTime()`.
+ *
+ *      FILETIME ft;
+ *      GetSystemTimeAsFileTime(&ft);
+ *      UINT64 ticks = (((UINT64)ft.dwHighDateTime) << 32) | ft.dwLowDateTime;
+ *
+ *      // A Windows tick is 100 nanoseconds. Windows epoch 1601-01-01T00:00:00Z
+ *      // is 11644473600 seconds before Unix epoch 1970-01-01T00:00:00Z.
+ *      Timestamp timestamp;
+ *      timestamp.set_seconds((INT64) ((ticks / 10000000) - 11644473600LL));
+ *      timestamp.set_nanos((INT32) ((ticks % 10000000) * 100));
+ *
+ *  Example 4: Compute Timestamp from Java `System.currentTimeMillis()`.
+ *
+ *      long millis = System.currentTimeMillis();
+ *
+ *      Timestamp timestamp = Timestamp.newBuilder().setSeconds(millis / 1000)
+ *          .setNanos((int) ((millis % 1000) * 1000000)).build();
+ *
+ *
+ *  Example 5: Compute Timestamp from current time in Python.
+ *
+ *      timestamp = Timestamp()
+ *      timestamp.GetCurrentTime()
+ *
+ *  # JSON Mapping
+ *
+ *  In JSON format, the Timestamp type is encoded as a string in the
+ *  [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format. That is, the
+ *  format is "{year}-{month}-{day}T{hour}:{min}:{sec}[.{frac_sec}]Z"
+ *  where {year} is always expressed using four digits while {month}, {day},
+ *  {hour}, {min}, and {sec} are zero-padded to two digits each. The fractional
+ *  seconds, which can go up to 9 digits (i.e. up to 1 nanosecond resolution),
+ *  are optional. The "Z" suffix indicates the timezone ("UTC"); the timezone
+ *  is required. A proto3 JSON serializer should always use UTC (as indicated by
+ *  "Z") when printing the Timestamp type and a proto3 JSON parser should be
+ *  able to accept both UTC and other timezones (as indicated by an offset).
+ *
+ *  For example, "2017-01-15T01:30:15.01Z" encodes 15.01 seconds past
+ *  01:30 UTC on January 15, 2017.
+ *
+ *  In JavaScript, one can convert a Date object to this format using the
+ *  standard
+ *  [toISOString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString)
+ *  method. In Python, a standard `datetime.datetime` object can be converted
+ *  to this format using
+ *  [`strftime`](https://docs.python.org/2/library/time.html#time.strftime) with
+ *  the time format spec '%Y-%m-%dT%H:%M:%S.%fZ'. Likewise, in Java, one can use
+ *  the Joda Time's [`ISODateTimeFormat.dateTime()`](
+ *  http://www.joda.org/joda-time/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime%2D%2D
+ *  ) to obtain a formatter capable of generating timestamps in this format.
+ *
+ *
+ */
+export interface Timestamp {
+  /**
+   *  Represents seconds of UTC time since Unix epoch
+   *  1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
+   *  9999-12-31T23:59:59Z inclusive.
+   */
+  seconds: number;
+  /**
+   *  Non-negative fractions of a second at nanosecond resolution. Negative
+   *  second values with fractions must still have non-negative nanos values
+   *  that count forward in time. Must be from 0 to 999,999,999
+   *  inclusive.
+   */
+  nanos: number;
+}
+
+export const protobufPackage = 'google.protobuf'
+
+export const GOOGLE_PROTOBUF_PACKAGE_NAME = 'google.protobuf'

--- a/integration/nestjs-simple/hero.proto
+++ b/integration/nestjs-simple/hero.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 
 import "google/protobuf/empty.proto";
+import "google/protobuf/timestamp.proto";
 
 package hero;
 
@@ -24,6 +25,7 @@ message VillainById {
 message Hero {
     int32 id = 1;
     string name = 2;
+    google.protobuf.Timestamp birth_date = 3;
 }
 
 message Villain {

--- a/integration/nestjs-simple/hero.ts
+++ b/integration/nestjs-simple/hero.ts
@@ -1,5 +1,6 @@
 import { Observable } from 'rxjs';
 import { Empty } from './google/protobuf/empty';
+import { Timestamp } from './google/protobuf/timestamp';
 import { GrpcMethod, GrpcStreamMethod } from '@nestjs/microservices';
 
 
@@ -14,6 +15,7 @@ export interface VillainById {
 export interface Hero {
   id: number;
   name: string;
+  birthDate: Timestamp | undefined;
 }
 
 export interface Villain {

--- a/integration/nestjs-simple/nestjs-project/app.module.ts
+++ b/integration/nestjs-simple/nestjs-project/app.module.ts
@@ -1,23 +1,26 @@
 import { Module } from '@nestjs/common';
-import { HeroController } from './hero.controller';
 import { ClientsModule, Transport } from '@nestjs/microservices';
 import { join } from 'path';
 import { HERO_PACKAGE_NAME } from '../hero';
+import { HeroController } from './hero.controller';
 
 @Module({
   imports: [
     ClientsModule.register([
-        {
-            name: HERO_PACKAGE_NAME,
-            transport: Transport.GRPC,
-            options: {
-                url: '0.0.0.0:8080',
-                package: HERO_PACKAGE_NAME,
-                protoPath: join(__dirname, '../hero.proto'),
-            },
+      {
+        name: HERO_PACKAGE_NAME,
+        transport: Transport.GRPC,
+        options: {
+          url: '0.0.0.0:8080',
+          package: HERO_PACKAGE_NAME,
+          protoPath: join(__dirname, '../hero.proto'),
+          loader: {
+            longs: Number,
+          },
         },
+      },
     ]),
   ],
-  controllers: [HeroController]
+  controllers: [HeroController],
 })
 export class AppModule {}

--- a/integration/nestjs-simple/nestjs-project/hero.controller.ts
+++ b/integration/nestjs-simple/nestjs-project/hero.controller.ts
@@ -1,11 +1,14 @@
 import { Controller } from '@nestjs/common';
 import { Observable, Subject } from 'rxjs';
-import { HeroById, Hero, HeroServiceController, VillainById, Villain, HeroServiceControllerMethods } from '../hero';
+import { Hero, HeroById, HeroServiceController, HeroServiceControllerMethods, Villain, VillainById } from '../hero';
 
 @Controller('hero')
 @HeroServiceControllerMethods()
 export class HeroController implements HeroServiceController {
-  private readonly heroes: Hero[] = [{ id: 1, name: 'Stephenh' }, { id: 2, name: 'Iangregsondev' }];
+  private readonly heroes: Hero[] = [
+    { id: 1, name: 'Stephenh', birthDate: { seconds: 1, nanos: 2 } },
+    { id: 2, name: 'Iangregsondev', birthDate: { seconds: 1, nanos: 3 } },
+  ];
 
   private readonly villains: Villain[] = [{ id: 1, name: 'John' }, { id: 2, name: 'Doe' }];
 

--- a/integration/nestjs-simple/nestjs-project/main.ts
+++ b/integration/nestjs-simple/nestjs-project/main.ts
@@ -1,18 +1,21 @@
 import { NestFactory } from '@nestjs/core';
 import { MicroserviceOptions, Transport } from '@nestjs/microservices';
 import { join } from 'path';
-import { AppModule } from './app.module';
 import { HERO_PACKAGE_NAME } from '../hero';
+import { AppModule } from './app.module';
 
 export async function createApp() {
-    const app = await NestFactory.createMicroservice<MicroserviceOptions>(AppModule, {
-      transport: Transport.GRPC,
-      options: {
-        url: '0.0.0.0:8080',
-        package: HERO_PACKAGE_NAME,
-        protoPath: join(__dirname, '../hero.proto'),
+  const app = await NestFactory.createMicroservice<MicroserviceOptions>(AppModule, {
+    transport: Transport.GRPC,
+    options: {
+      url: '0.0.0.0:8080',
+      package: HERO_PACKAGE_NAME,
+      protoPath: join(__dirname, '../hero.proto'),
+      loader: {
+        longs: Number,
       },
-    });
-    
-    return app;
+    },
+  });
+
+  return app;
 }

--- a/integration/nestjs-simple/nestjs-simple-test.ts
+++ b/integration/nestjs-simple/nestjs-simple-test.ts
@@ -37,14 +37,13 @@ describe('nestjs-simple-test nestjs', () => {
   });
 
   it('should addOneHero', async () => {
-    const emptyResponse = await heroService.addOneHero({ id: 3, name: 'Toon' }).toPromise();
+    const emptyResponse = await heroService.addOneHero({ id: 3, name: 'Toon', birthDate: undefined }).toPromise();
     expect(emptyResponse).toEqual({});
   });
 
-
   it('should findOneHero', async () => {
     const hero = await heroService.findOneHero({ id: 1 }).toPromise();
-    expect(hero).toEqual({ id: 1, name: 'Stephenh' });
+    expect(hero).toEqual({ id: 1, name: 'Stephenh', birthDate: { seconds: 1, nanos: 2 } });
   });
 
   it('should findOneVillain', async () => {
@@ -52,21 +51,21 @@ describe('nestjs-simple-test nestjs', () => {
     expect(villain).toEqual({ id: 1, name: 'John' });
   });
 
-  it('should findManyVillain', done => {
+  it('should findManyVillain', (done) => {
     const villainIdSubject = new Subject<VillainById>();
     const villains: Villain[] = [];
 
     heroService.findManyVillain(villainIdSubject.asObservable()).subscribe({
-      next: villain => {
+      next: (villain) => {
         villains.push(villain);
       },
       complete: () => {
         expect(villains).toEqual([
           { id: 1, name: 'John' },
-          { id: 2, name: 'Doe' }
+          { id: 2, name: 'Doe' },
         ]);
         done();
-      }
+      },
     });
 
     villainIdSubject.next({ id: 1 });

--- a/integration/nestjs-simple/sample-service.ts
+++ b/integration/nestjs-simple/sample-service.ts
@@ -5,7 +5,7 @@ export class SampleService implements HeroServiceController {
   addOneHero(request: Hero): void {}
 
   findOneHero(request: HeroById): Promise<Hero> {
-    return Promise.resolve({ id: 1, name: 'test' });
+    return Promise.resolve({ id: 1, name: 'test', birthDate: undefined });
   }
 
   findOneVillain(request: VillainById): Promise<Villain> {

--- a/src/main.ts
+++ b/src/main.ts
@@ -73,6 +73,7 @@ export type Options = {
   snakeToCamel: boolean;
   forceLong: LongOption;
   useOptionals: boolean;
+  useDate: boolean;
   oneof: OneofOption;
   outputEncodeMethods: boolean;
   outputJsonMethods: boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -303,10 +303,6 @@ const valueTypes: { [key: string]: TypeName } = {
   '.google.protobuf.BytesValue': TypeNames.anyType('Uint8Array'),
 };
 
-const mappedTypes: { [key: string]: TypeName } = {
-  '.google.protobuf.Timestamp': TypeNames.DATE,
-};
-
 export function isTimestamp(field: FieldDescriptorProto): boolean {
   return field.typeName === '.google.protobuf.Timestamp';
 }
@@ -347,8 +343,8 @@ export function messageToTypeName(
     return TypeNames.unionType(typeName, TypeNames.UNDEFINED);
   }
   // Look for other special prototypes like Timestamp that aren't technically wrapper types
-  if (!typeOptions.keepValueType && protoType in mappedTypes) {
-    return mappedTypes[protoType];
+  if (!typeOptions.keepValueType && protoType === '.google.protobuf.Timestamp' && options.useDate) {
+    return TypeNames.DATE;
   }
   const [module, type] = toModuleAndType(typeMap, protoType);
   return TypeNames.importedType(`${type}@./${module}`);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -41,6 +41,7 @@ export function defaultOptions(): Options {
     snakeToCamel: true,
     forceLong: LongOption.NUMBER,
     useOptionals: false,
+    useDate: true,
     oneof: OneofOption.PROPERTIES,
     lowerCaseServiceMethods: false,
     outputEncodeMethods: true,
@@ -73,6 +74,9 @@ export function optionsFromParameter(parameter: string): Options {
     if (parameter.includes('useOptionals=true')) {
       options.useOptionals = true;
     }
+    if (parameter.includes('useDate=false')) {
+      options.useDate = false;
+    }
     if (parameter.includes('oneof=properties')) {
       options.oneof = OneofOption.PROPERTIES;
     }
@@ -102,6 +106,7 @@ export function optionsFromParameter(parameter: string): Options {
       options.outputEncodeMethods = false;
       options.outputJsonMethods = false;
       options.outputClientImpl = false;
+      options.useDate = false;
 
       if (parameter.includes('addGrpcMetadata=true')) {
         options.addGrpcMetadata = true;


### PR DESCRIPTION
The mapping of google.protobuf.Timestamp to Date in the generated interfaces does not seem compatible with NestJS which does not serialize these as Dates. 