### PR TITLE
Avoid "import =" in grpc-web code generation

### DIFF
--- a/integration/grpc-web/example.ts
+++ b/integration/grpc-web/example.ts
@@ -832,8 +832,7 @@ const DashAPICredsDeleteDesc: UnaryMethodDefinitionish = {
     ,
   } as any,
 }
-import UnaryMethodDefinition = grpc.UnaryMethodDefinition;
-type UnaryMethodDefinitionish = UnaryMethodDefinition<any, any>;
+type UnaryMethodDefinitionish = grpc.UnaryMethodDefinition<any, any>;
 
 type Builtin = Date | Function | Uint8Array | string | number | undefined;
 type DeepPartial<T> = T extends Builtin

--- a/src/generate-grpc-web.ts
+++ b/src/generate-grpc-web.ts
@@ -1,5 +1,3 @@
-import { google } from '../build/pbjs';
-import { requestType, responsePromise, responseType, TypeMap } from './types';
 import {
   ClassSpec,
   CodeBlock,
@@ -10,7 +8,9 @@ import {
   PropertySpec,
   TypeNames,
 } from 'ts-poet';
+import { google } from '../build/pbjs';
 import { Options } from './main';
+import { requestType, responsePromise, responseType, TypeMap } from './types';
 import MethodDescriptorProto = google.protobuf.MethodDescriptorProto;
 import FileDescriptorProto = google.protobuf.FileDescriptorProto;
 import ServiceDescriptorProto = google.protobuf.ServiceDescriptorProto;
@@ -148,9 +148,7 @@ function methodDescName(serviceDesc: ServiceDescriptorProto, methodDesc: MethodD
 export function addGrpcWebMisc(options: Options, _file: FileSpec): FileSpec {
   let file = _file;
   file = file.addCode(
-    CodeBlock.empty()
-      .addStatement('import UnaryMethodDefinition = grpc.UnaryMethodDefinition')
-      .addStatement('type UnaryMethodDefinitionish = UnaryMethodDefinition<any, any>')
+    CodeBlock.empty().addStatement('type UnaryMethodDefinitionish = grpc.UnaryMethodDefinition<any, any>')
   );
   file = file.addInterface(generateGrpcWebRpcType());
   file = file.addClass(generateGrpcWebImpl());


### PR DESCRIPTION
"import =" is not supported by @babel/plugin-transform-typescript (https://github.com/babel/babel/issues/7062) so the grpc-web generated code has compilation issues for Create React App and Parcel 2 compiled browser applications. 
It seems this syntax can be trivially avoided which seems preferable. 