### PR TITLE
Fix left over globalThis.Error scoping when using unrecognizedEnum=false

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -460,7 +460,8 @@ function generateEnumFromJson(fullName: string, enumDesc: EnumDescriptorProto, o
   } else {
     body = body
       .add('default:%>\n')
-      .addStatement('throw new Error("Unrecognized enum value " + %L + " for enum %L")%<', 'object', fullName);
+      // We use globalThis to avoid conflicts on protobuf types named `Error`.
+      .addStatement('throw new globalThis.Error("Unrecognized enum value " + %L + " for enum %L")%<', 'object', fullName);
   }
   body = body.endControlFlow();
   return func.addCodeBlock(body);

--- a/src/main.ts
+++ b/src/main.ts
@@ -461,7 +461,11 @@ function generateEnumFromJson(fullName: string, enumDesc: EnumDescriptorProto, o
     body = body
       .add('default:%>\n')
       // We use globalThis to avoid conflicts on protobuf types named `Error`.
-      .addStatement('throw new globalThis.Error("Unrecognized enum value " + %L + " for enum %L")%<', 'object', fullName);
+      .addStatement(
+        'throw new globalThis.Error("Unrecognized enum value " + %L + " for enum %L")%<',
+        'object',
+        fullName
+      );
   }
   body = body.endControlFlow();
   return func.addCodeBlock(body);


### PR DESCRIPTION
There seemed to be one left over unscoped when `unrecognizedEnum=false`.