### PR TITLE
Explicitly define globalThis

### DIFF
--- a/integration/angular/simple-message.ts
+++ b/integration/angular/simple-message.ts
@@ -1,6 +1,14 @@
 import { Writer, Reader } from 'protobufjs/minimal';
 
 
+function getGlobalThis() {
+  if (typeof globalThis !== "undefined") return globalThis;
+  if (typeof self !== "undefined") return self;
+  if (typeof window !== "undefined") return window;
+  if (typeof global !== "undefined") return global;
+  throw new Error("Unable to locate global object");
+}
+
 export interface SimpleMessage {
   numberField: number;
 }
@@ -8,6 +16,12 @@ export interface SimpleMessage {
 const baseSimpleMessage: object = {
   numberField: 0,
 };
+
+declare var self: any | undefined;
+
+declare var window: any | undefined;
+
+var globalThis = getGlobalThis();
 
 export const protobufPackage = 'angular'
 

--- a/integration/batching-with-context/batching.ts
+++ b/integration/batching-with-context/batching.ts
@@ -3,6 +3,14 @@ import * as hash from 'object-hash';
 import { Reader, Writer } from 'protobufjs/minimal';
 
 
+function getGlobalThis() {
+  if (typeof globalThis !== "undefined") return globalThis;
+  if (typeof self !== "undefined") return self;
+  if (typeof window !== "undefined") return window;
+  if (typeof global !== "undefined") return global;
+  throw new Error("Unable to locate global object");
+}
+
 export interface BatchQueryRequest {
   ids: string[];
 }
@@ -183,6 +191,12 @@ export interface DataLoaders {
   getDataLoader<T>(identifier: string, constructorFn: () => T): T;
 
 }
+
+declare var self: any | undefined;
+
+declare var window: any | undefined;
+
+var globalThis = getGlobalThis();
 
 export const protobufPackage = 'batching'
 

--- a/integration/batching/batching.ts
+++ b/integration/batching/batching.ts
@@ -1,6 +1,14 @@
 import { Reader, Writer } from 'protobufjs/minimal';
 
 
+function getGlobalThis() {
+  if (typeof globalThis !== "undefined") return globalThis;
+  if (typeof self !== "undefined") return self;
+  if (typeof window !== "undefined") return window;
+  if (typeof global !== "undefined") return global;
+  throw new Error("Unable to locate global object");
+}
+
 export interface BatchQueryRequest {
   ids: string[];
 }
@@ -136,6 +144,12 @@ interface Rpc {
   request(service: string, method: string, data: Uint8Array): Promise<Uint8Array>;
 
 }
+
+declare var self: any | undefined;
+
+declare var window: any | undefined;
+
+var globalThis = getGlobalThis();
 
 export const protobufPackage = 'batching'
 

--- a/integration/bytes-as-base64/message.ts
+++ b/integration/bytes-as-base64/message.ts
@@ -1,10 +1,24 @@
 
+function getGlobalThis() {
+  if (typeof globalThis !== "undefined") return globalThis;
+  if (typeof self !== "undefined") return self;
+  if (typeof window !== "undefined") return window;
+  if (typeof global !== "undefined") return global;
+  throw new Error("Unable to locate global object");
+}
+
 export interface Message {
   data: Uint8Array;
 }
 
 const baseMessage: object = {
 };
+
+declare var self: any | undefined;
+
+declare var window: any | undefined;
+
+var globalThis = getGlobalThis();
 
 export const protobufPackage = ''
 

--- a/integration/bytes-node/point.ts
+++ b/integration/bytes-node/point.ts
@@ -1,12 +1,26 @@
 import { Writer, Reader } from 'protobufjs/minimal';
 
 
+function getGlobalThis() {
+  if (typeof globalThis !== "undefined") return globalThis;
+  if (typeof self !== "undefined") return self;
+  if (typeof window !== "undefined") return window;
+  if (typeof global !== "undefined") return global;
+  throw new Error("Unable to locate global object");
+}
+
 export interface Point {
   data: Buffer;
 }
 
 const basePoint: object = {
 };
+
+declare var self: any | undefined;
+
+declare var window: any | undefined;
+
+var globalThis = getGlobalThis();
 
 export const protobufPackage = ''
 

--- a/integration/grpc-web-no-streaming-observable/example.ts
+++ b/integration/grpc-web-no-streaming-observable/example.ts
@@ -6,6 +6,14 @@ import { Writer, Reader } from 'protobufjs/minimal';
 import { UnaryMethodDefinition } from '@improbable-eng/grpc-web/dist/typings/service';
 
 
+function getGlobalThis() {
+  if (typeof globalThis !== "undefined") return globalThis;
+  if (typeof self !== "undefined") return self;
+  if (typeof window !== "undefined") return window;
+  if (typeof global !== "undefined") return global;
+  throw new Error("Unable to locate global object");
+}
+
 export interface DashFlash {
   msg: string;
   type: DashFlash_Type;
@@ -108,6 +116,12 @@ export class GrpcWebImpl implements Rpc {
           }).pipe(take(1));}
 
 }
+
+declare var self: any | undefined;
+
+declare var window: any | undefined;
+
+var globalThis = getGlobalThis();
 
 export const protobufPackage = 'rpx'
 

--- a/integration/grpc-web-no-streaming/example.ts
+++ b/integration/grpc-web-no-streaming/example.ts
@@ -4,6 +4,14 @@ import { Writer, Reader } from 'protobufjs/minimal';
 import { UnaryMethodDefinition } from '@improbable-eng/grpc-web/dist/typings/service';
 
 
+function getGlobalThis() {
+  if (typeof globalThis !== "undefined") return globalThis;
+  if (typeof self !== "undefined") return self;
+  if (typeof window !== "undefined") return window;
+  if (typeof global !== "undefined") return global;
+  throw new Error("Unable to locate global object");
+}
+
 export interface DashFlash {
   msg: string;
   type: DashFlash_Type;
@@ -108,6 +116,12 @@ export class GrpcWebImpl implements Rpc {
         });}
 
 }
+
+declare var self: any | undefined;
+
+declare var window: any | undefined;
+
+var globalThis = getGlobalThis();
 
 export const protobufPackage = 'rpx'
 

--- a/integration/grpc-web/example.ts
+++ b/integration/grpc-web/example.ts
@@ -7,6 +7,14 @@ import { Writer, Reader } from 'protobufjs/minimal';
 import { UnaryMethodDefinition } from '@improbable-eng/grpc-web/dist/typings/service';
 
 
+function getGlobalThis() {
+  if (typeof globalThis !== "undefined") return globalThis;
+  if (typeof self !== "undefined") return self;
+  if (typeof window !== "undefined") return window;
+  if (typeof global !== "undefined") return global;
+  throw new Error("Unable to locate global object");
+}
+
 export interface DashFlash {
   msg: string;
   type: DashFlash_Type;
@@ -232,6 +240,12 @@ export class GrpcWebImpl implements Rpc {
   }
 
 }
+
+declare var self: any | undefined;
+
+declare var window: any | undefined;
+
+var globalThis = getGlobalThis();
 
 export const protobufPackage = 'rpx'
 

--- a/integration/nestjs-metadata-observables/hero.ts
+++ b/integration/nestjs-metadata-observables/hero.ts
@@ -3,6 +3,14 @@ import { Observable } from 'rxjs';
 import { GrpcMethod, GrpcStreamMethod } from '@nestjs/microservices';
 
 
+function getGlobalThis() {
+  if (typeof globalThis !== "undefined") return globalThis;
+  if (typeof self !== "undefined") return self;
+  if (typeof window !== "undefined") return window;
+  if (typeof global !== "undefined") return global;
+  throw new Error("Unable to locate global object");
+}
+
 export interface HeroById {
   id: number;
 }
@@ -55,6 +63,12 @@ export function HeroServiceControllerMethods() {
     }
   }
 }
+
+declare var self: any | undefined;
+
+declare var window: any | undefined;
+
+var globalThis = getGlobalThis();
 
 export const protobufPackage = 'hero'
 

--- a/integration/nestjs-metadata-restparameters/hero.ts
+++ b/integration/nestjs-metadata-restparameters/hero.ts
@@ -3,6 +3,14 @@ import { Observable } from 'rxjs';
 import { GrpcMethod, GrpcStreamMethod } from '@nestjs/microservices';
 
 
+function getGlobalThis() {
+  if (typeof globalThis !== "undefined") return globalThis;
+  if (typeof self !== "undefined") return self;
+  if (typeof window !== "undefined") return window;
+  if (typeof global !== "undefined") return global;
+  throw new Error("Unable to locate global object");
+}
+
 export interface HeroById {
   id: number;
 }
@@ -55,6 +63,12 @@ export function HeroServiceControllerMethods() {
     }
   }
 }
+
+declare var self: any | undefined;
+
+declare var window: any | undefined;
+
+var globalThis = getGlobalThis();
 
 export const protobufPackage = 'hero'
 

--- a/integration/nestjs-metadata/hero.ts
+++ b/integration/nestjs-metadata/hero.ts
@@ -3,6 +3,14 @@ import { Observable } from 'rxjs';
 import { GrpcMethod, GrpcStreamMethod } from '@nestjs/microservices';
 
 
+function getGlobalThis() {
+  if (typeof globalThis !== "undefined") return globalThis;
+  if (typeof self !== "undefined") return self;
+  if (typeof window !== "undefined") return window;
+  if (typeof global !== "undefined") return global;
+  throw new Error("Unable to locate global object");
+}
+
 export interface HeroById {
   id: number;
 }
@@ -55,6 +63,12 @@ export function HeroServiceControllerMethods() {
     }
   }
 }
+
+declare var self: any | undefined;
+
+declare var window: any | undefined;
+
+var globalThis = getGlobalThis();
 
 export const protobufPackage = 'hero'
 

--- a/integration/nestjs-restparameters/hero.ts
+++ b/integration/nestjs-restparameters/hero.ts
@@ -2,6 +2,14 @@ import { Observable } from 'rxjs';
 import { GrpcMethod, GrpcStreamMethod } from '@nestjs/microservices';
 
 
+function getGlobalThis() {
+  if (typeof globalThis !== "undefined") return globalThis;
+  if (typeof self !== "undefined") return self;
+  if (typeof window !== "undefined") return window;
+  if (typeof global !== "undefined") return global;
+  throw new Error("Unable to locate global object");
+}
+
 export interface HeroById {
   id: number;
 }
@@ -54,6 +62,12 @@ export function HeroServiceControllerMethods() {
     }
   }
 }
+
+declare var self: any | undefined;
+
+declare var window: any | undefined;
+
+var globalThis = getGlobalThis();
 
 export const protobufPackage = 'hero'
 

--- a/integration/nestjs-simple-observables/hero.ts
+++ b/integration/nestjs-simple-observables/hero.ts
@@ -2,6 +2,14 @@ import { Observable } from 'rxjs';
 import { GrpcMethod, GrpcStreamMethod } from '@nestjs/microservices';
 
 
+function getGlobalThis() {
+  if (typeof globalThis !== "undefined") return globalThis;
+  if (typeof self !== "undefined") return self;
+  if (typeof window !== "undefined") return window;
+  if (typeof global !== "undefined") return global;
+  throw new Error("Unable to locate global object");
+}
+
 export interface HeroById {
   id: number;
 }
@@ -54,6 +62,12 @@ export function HeroServiceControllerMethods() {
     }
   }
 }
+
+declare var self: any | undefined;
+
+declare var window: any | undefined;
+
+var globalThis = getGlobalThis();
 
 export const protobufPackage = 'hero'
 

--- a/integration/nestjs-simple-restparameters/google/protobuf/empty.ts
+++ b/integration/nestjs-simple-restparameters/google/protobuf/empty.ts
@@ -1,4 +1,12 @@
 
+function getGlobalThis() {
+  if (typeof globalThis !== "undefined") return globalThis;
+  if (typeof self !== "undefined") return self;
+  if (typeof window !== "undefined") return window;
+  if (typeof global !== "undefined") return global;
+  throw new Error("Unable to locate global object");
+}
+
 /**
  *  A generic empty message that you can re-use to avoid defining duplicated
  *  empty messages in your APIs. A typical example is to use it as the request
@@ -12,6 +20,12 @@
  */
 export interface Empty {
 }
+
+declare var self: any | undefined;
+
+declare var window: any | undefined;
+
+var globalThis = getGlobalThis();
 
 export const protobufPackage = 'google.protobuf'
 

--- a/integration/nestjs-simple-restparameters/hero.ts
+++ b/integration/nestjs-simple-restparameters/hero.ts
@@ -3,6 +3,14 @@ import { Observable } from 'rxjs';
 import { GrpcMethod, GrpcStreamMethod } from '@nestjs/microservices';
 
 
+function getGlobalThis() {
+  if (typeof globalThis !== "undefined") return globalThis;
+  if (typeof self !== "undefined") return self;
+  if (typeof window !== "undefined") return window;
+  if (typeof global !== "undefined") return global;
+  throw new Error("Unable to locate global object");
+}
+
 export interface User {
   id: number;
   name: string;
@@ -34,6 +42,12 @@ export function HeroServiceControllerMethods() {
     }
   }
 }
+
+declare var self: any | undefined;
+
+declare var window: any | undefined;
+
+var globalThis = getGlobalThis();
 
 export const protobufPackage = 'hero'
 

--- a/integration/nestjs-simple/google/protobuf/empty.ts
+++ b/integration/nestjs-simple/google/protobuf/empty.ts
@@ -1,4 +1,12 @@
 
+function getGlobalThis() {
+  if (typeof globalThis !== "undefined") return globalThis;
+  if (typeof self !== "undefined") return self;
+  if (typeof window !== "undefined") return window;
+  if (typeof global !== "undefined") return global;
+  throw new Error("Unable to locate global object");
+}
+
 /**
  *  A generic empty message that you can re-use to avoid defining duplicated
  *  empty messages in your APIs. A typical example is to use it as the request
@@ -12,6 +20,12 @@
  */
 export interface Empty {
 }
+
+declare var self: any | undefined;
+
+declare var window: any | undefined;
+
+var globalThis = getGlobalThis();
 
 export const protobufPackage = 'google.protobuf'
 

--- a/integration/nestjs-simple/google/protobuf/timestamp.ts
+++ b/integration/nestjs-simple/google/protobuf/timestamp.ts
@@ -1,4 +1,12 @@
 
+function getGlobalThis() {
+  if (typeof globalThis !== "undefined") return globalThis;
+  if (typeof self !== "undefined") return self;
+  if (typeof window !== "undefined") return window;
+  if (typeof global !== "undefined") return global;
+  throw new Error("Unable to locate global object");
+}
+
 /**
  *  A Timestamp represents a point in time independent of any time zone or local
  *  calendar, encoded as a count of seconds and fractions of seconds at
@@ -100,6 +108,12 @@ export interface Timestamp {
    */
   nanos: number;
 }
+
+declare var self: any | undefined;
+
+declare var window: any | undefined;
+
+var globalThis = getGlobalThis();
 
 export const protobufPackage = 'google.protobuf'
 

--- a/integration/nestjs-simple/hero.ts
+++ b/integration/nestjs-simple/hero.ts
@@ -4,6 +4,14 @@ import { Empty } from './google/protobuf/empty';
 import { GrpcMethod, GrpcStreamMethod } from '@nestjs/microservices';
 
 
+function getGlobalThis() {
+  if (typeof globalThis !== "undefined") return globalThis;
+  if (typeof self !== "undefined") return self;
+  if (typeof window !== "undefined") return window;
+  if (typeof global !== "undefined") return global;
+  throw new Error("Unable to locate global object");
+}
+
 export interface HeroById {
   id: number;
 }
@@ -69,6 +77,12 @@ export function HeroServiceControllerMethods() {
     }
   }
 }
+
+declare var self: any | undefined;
+
+declare var window: any | undefined;
+
+var globalThis = getGlobalThis();
 
 export const protobufPackage = 'hero'
 

--- a/integration/oneof-properties/oneof.ts
+++ b/integration/oneof-properties/oneof.ts
@@ -1,6 +1,14 @@
 import { Writer, Reader } from 'protobufjs/minimal';
 
 
+function getGlobalThis() {
+  if (typeof globalThis !== "undefined") return globalThis;
+  if (typeof self !== "undefined") return self;
+  if (typeof window !== "undefined") return window;
+  if (typeof global !== "undefined") return global;
+  throw new Error("Unable to locate global object");
+}
+
 export interface PleaseChoose {
   name: string;
   /**
@@ -39,6 +47,12 @@ const basePleaseChoose: object = {
 const basePleaseChoose_Submessage: object = {
   name: "",
 };
+
+declare var self: any | undefined;
+
+declare var window: any | undefined;
+
+var globalThis = getGlobalThis();
 
 export const protobufPackage = 'oneof'
 

--- a/integration/oneof-unions/oneof.ts
+++ b/integration/oneof-unions/oneof.ts
@@ -1,6 +1,14 @@
 import { Writer, Reader } from 'protobufjs/minimal';
 
 
+function getGlobalThis() {
+  if (typeof globalThis !== "undefined") return globalThis;
+  if (typeof self !== "undefined") return self;
+  if (typeof window !== "undefined") return window;
+  if (typeof global !== "undefined") return global;
+  throw new Error("Unable to locate global object");
+}
+
 export interface PleaseChoose {
   name: string;
   /**
@@ -46,6 +54,12 @@ const basePleaseChoose_Submessage: object = {
 
 const baseSimpleButOptional: object = {
 };
+
+declare var self: any | undefined;
+
+declare var window: any | undefined;
+
+var globalThis = getGlobalThis();
 
 export const protobufPackage = 'oneof'
 

--- a/integration/only-types/google/protobuf/any.ts
+++ b/integration/only-types/google/protobuf/any.ts
@@ -1,4 +1,12 @@
 
+function getGlobalThis() {
+  if (typeof globalThis !== "undefined") return globalThis;
+  if (typeof self !== "undefined") return self;
+  if (typeof window !== "undefined") return window;
+  if (typeof global !== "undefined") return global;
+  throw new Error("Unable to locate global object");
+}
+
 /**
  *  `Any` contains an arbitrary serialized protocol buffer message along with a
  *  URL that describes the type of the serialized message.
@@ -118,5 +126,11 @@ export interface Any {
    */
   value: Uint8Array;
 }
+
+declare var self: any | undefined;
+
+declare var window: any | undefined;
+
+var globalThis = getGlobalThis();
 
 export const protobufPackage = 'google.protobuf'

--- a/integration/only-types/google/protobuf/timestamp.ts
+++ b/integration/only-types/google/protobuf/timestamp.ts
@@ -1,4 +1,12 @@
 
+function getGlobalThis() {
+  if (typeof globalThis !== "undefined") return globalThis;
+  if (typeof self !== "undefined") return self;
+  if (typeof window !== "undefined") return window;
+  if (typeof global !== "undefined") return global;
+  throw new Error("Unable to locate global object");
+}
+
 /**
  *  A Timestamp represents a point in time independent of any time zone or local
  *  calendar, encoded as a count of seconds and fractions of seconds at
@@ -100,5 +108,11 @@ export interface Timestamp {
    */
   nanos: number;
 }
+
+declare var self: any | undefined;
+
+declare var window: any | undefined;
+
+var globalThis = getGlobalThis();
 
 export const protobufPackage = 'google.protobuf'

--- a/integration/only-types/reservation.ts
+++ b/integration/only-types/reservation.ts
@@ -1,10 +1,24 @@
 import { Any } from './google/protobuf/any';
 
 
+function getGlobalThis() {
+  if (typeof globalThis !== "undefined") return globalThis;
+  if (typeof self !== "undefined") return self;
+  if (typeof window !== "undefined") return window;
+  if (typeof global !== "undefined") return global;
+  throw new Error("Unable to locate global object");
+}
+
 export interface Registration {
   eventName: string;
   date: Date | undefined;
   perks: Any | undefined;
 }
+
+declare var self: any | undefined;
+
+declare var window: any | undefined;
+
+var globalThis = getGlobalThis();
 
 export const protobufPackage = 'event'

--- a/integration/point/point.ts
+++ b/integration/point/point.ts
@@ -1,6 +1,14 @@
 import { Writer, Reader } from 'protobufjs/minimal';
 
 
+function getGlobalThis() {
+  if (typeof globalThis !== "undefined") return globalThis;
+  if (typeof self !== "undefined") return self;
+  if (typeof window !== "undefined") return window;
+  if (typeof global !== "undefined") return global;
+  throw new Error("Unable to locate global object");
+}
+
 export interface Point {
   lat: number;
   lng: number;
@@ -18,6 +26,12 @@ const basePoint: object = {
 
 const baseArea: object = {
 };
+
+declare var self: any | undefined;
+
+declare var window: any | undefined;
+
+var globalThis = getGlobalThis();
 
 export const protobufPackage = ''
 

--- a/integration/simple-long-string/google/protobuf/timestamp.ts
+++ b/integration/simple-long-string/google/protobuf/timestamp.ts
@@ -2,6 +2,14 @@ import * as Long from 'long';
 import { Writer, Reader, util, configure } from 'protobufjs/minimal';
 
 
+function getGlobalThis() {
+  if (typeof globalThis !== "undefined") return globalThis;
+  if (typeof self !== "undefined") return self;
+  if (typeof window !== "undefined") return window;
+  if (typeof global !== "undefined") return global;
+  throw new Error("Unable to locate global object");
+}
+
 /**
  *  A Timestamp represents a point in time independent of any time zone or local
  *  calendar, encoded as a count of seconds and fractions of seconds at
@@ -112,6 +120,12 @@ const baseTimestamp: object = {
 function longToString(long: Long) {
   return long.toString();
 }
+
+declare var self: any | undefined;
+
+declare var window: any | undefined;
+
+var globalThis = getGlobalThis();
 
 export const protobufPackage = 'google.protobuf'
 

--- a/integration/simple-long-string/google/protobuf/wrappers.ts
+++ b/integration/simple-long-string/google/protobuf/wrappers.ts
@@ -2,6 +2,14 @@ import * as Long from 'long';
 import { Writer, Reader, util, configure } from 'protobufjs/minimal';
 
 
+function getGlobalThis() {
+  if (typeof globalThis !== "undefined") return globalThis;
+  if (typeof self !== "undefined") return self;
+  if (typeof window !== "undefined") return window;
+  if (typeof global !== "undefined") return global;
+  throw new Error("Unable to locate global object");
+}
+
 /**
  *  Wrapper message for `double`.
  *
@@ -148,6 +156,12 @@ const baseBytesValue: object = {
 function longToString(long: Long) {
   return long.toString();
 }
+
+declare var self: any | undefined;
+
+declare var window: any | undefined;
+
+var globalThis = getGlobalThis();
 
 export const protobufPackage = 'google.protobuf'
 

--- a/integration/simple-long-string/import_dir/thing.ts
+++ b/integration/simple-long-string/import_dir/thing.ts
@@ -2,6 +2,14 @@ import { Timestamp } from '../google/protobuf/timestamp';
 import { Writer, Reader } from 'protobufjs/minimal';
 
 
+function getGlobalThis() {
+  if (typeof globalThis !== "undefined") return globalThis;
+  if (typeof self !== "undefined") return self;
+  if (typeof window !== "undefined") return window;
+  if (typeof global !== "undefined") return global;
+  throw new Error("Unable to locate global object");
+}
+
 export interface ImportedThing {
   createdAt: Date | undefined;
 }
@@ -30,6 +38,12 @@ function fromTimestamp(t: Timestamp): Date {
   millis += t.nanos / 1_000_000;
   return new Date(millis);
 }
+
+declare var self: any | undefined;
+
+declare var window: any | undefined;
+
+var globalThis = getGlobalThis();
 
 export const protobufPackage = 'simple'
 

--- a/integration/simple-long-string/simple.ts
+++ b/integration/simple-long-string/simple.ts
@@ -8,6 +8,14 @@ import * as Long from 'long';
 import { StringValue, Int32Value, BoolValue } from './google/protobuf/wrappers';
 
 
+function getGlobalThis() {
+  if (typeof globalThis !== "undefined") return globalThis;
+  if (typeof self !== "undefined") return self;
+  if (typeof window !== "undefined") return window;
+  if (typeof global !== "undefined") return global;
+  throw new Error("Unable to locate global object");
+}
+
 /**
  * * Example comment on the Simple message  */
 export interface Simple {
@@ -264,6 +272,12 @@ function fromTimestamp(t: Timestamp): Date {
 function longToString(long: Long) {
   return long.toString();
 }
+
+declare var self: any | undefined;
+
+declare var window: any | undefined;
+
+var globalThis = getGlobalThis();
 
 export const protobufPackage = 'simple'
 

--- a/integration/simple-long/google/protobuf/timestamp.ts
+++ b/integration/simple-long/google/protobuf/timestamp.ts
@@ -2,6 +2,14 @@ import * as Long from 'long';
 import { Writer, Reader } from 'protobufjs/minimal';
 
 
+function getGlobalThis() {
+  if (typeof globalThis !== "undefined") return globalThis;
+  if (typeof self !== "undefined") return self;
+  if (typeof window !== "undefined") return window;
+  if (typeof global !== "undefined") return global;
+  throw new Error("Unable to locate global object");
+}
+
 /**
  *  A Timestamp represents a point in time independent of any time zone or local
  *  calendar, encoded as a count of seconds and fractions of seconds at
@@ -108,6 +116,12 @@ const baseTimestamp: object = {
   seconds: Long.ZERO,
   nanos: 0,
 };
+
+declare var self: any | undefined;
+
+declare var window: any | undefined;
+
+var globalThis = getGlobalThis();
 
 export const protobufPackage = 'google.protobuf'
 

--- a/integration/simple-long/google/protobuf/wrappers.ts
+++ b/integration/simple-long/google/protobuf/wrappers.ts
@@ -2,6 +2,14 @@ import * as Long from 'long';
 import { Writer, Reader } from 'protobufjs/minimal';
 
 
+function getGlobalThis() {
+  if (typeof globalThis !== "undefined") return globalThis;
+  if (typeof self !== "undefined") return self;
+  if (typeof window !== "undefined") return window;
+  if (typeof global !== "undefined") return global;
+  throw new Error("Unable to locate global object");
+}
+
 /**
  *  Wrapper message for `double`.
  *
@@ -144,6 +152,12 @@ const baseStringValue: object = {
 
 const baseBytesValue: object = {
 };
+
+declare var self: any | undefined;
+
+declare var window: any | undefined;
+
+var globalThis = getGlobalThis();
 
 export const protobufPackage = 'google.protobuf'
 

--- a/integration/simple-long/import_dir/thing.ts
+++ b/integration/simple-long/import_dir/thing.ts
@@ -3,6 +3,14 @@ import * as Long from 'long';
 import { Writer, Reader, util, configure } from 'protobufjs/minimal';
 
 
+function getGlobalThis() {
+  if (typeof globalThis !== "undefined") return globalThis;
+  if (typeof self !== "undefined") return self;
+  if (typeof window !== "undefined") return window;
+  if (typeof global !== "undefined") return global;
+  throw new Error("Unable to locate global object");
+}
+
 export interface ImportedThing {
   createdAt: Date | undefined;
 }
@@ -35,6 +43,12 @@ function fromTimestamp(t: Timestamp): Date {
 function numberToLong(number: number) {
   return Long.fromNumber(number);
 }
+
+declare var self: any | undefined;
+
+declare var window: any | undefined;
+
+var globalThis = getGlobalThis();
 
 export const protobufPackage = 'simple'
 

--- a/integration/simple-long/simple.ts
+++ b/integration/simple-long/simple.ts
@@ -8,6 +8,14 @@ import { Timestamp } from './google/protobuf/timestamp';
 import { StringValue, Int32Value, BoolValue, Int64Value } from './google/protobuf/wrappers';
 
 
+function getGlobalThis() {
+  if (typeof globalThis !== "undefined") return globalThis;
+  if (typeof self !== "undefined") return self;
+  if (typeof window !== "undefined") return window;
+  if (typeof global !== "undefined") return global;
+  throw new Error("Unable to locate global object");
+}
+
 /**
  * * Example comment on the Simple message  */
 export interface Simple {
@@ -265,6 +273,12 @@ function fromTimestamp(t: Timestamp): Date {
 function numberToLong(number: number) {
   return Long.fromNumber(number);
 }
+
+declare var self: any | undefined;
+
+declare var window: any | undefined;
+
+var globalThis = getGlobalThis();
 
 export const protobufPackage = 'simple'
 

--- a/integration/simple-optionals/google/protobuf/timestamp.ts
+++ b/integration/simple-optionals/google/protobuf/timestamp.ts
@@ -2,6 +2,14 @@ import * as Long from 'long';
 import { Writer, Reader, util, configure } from 'protobufjs/minimal';
 
 
+function getGlobalThis() {
+  if (typeof globalThis !== "undefined") return globalThis;
+  if (typeof self !== "undefined") return self;
+  if (typeof window !== "undefined") return window;
+  if (typeof global !== "undefined") return global;
+  throw new Error("Unable to locate global object");
+}
+
 /**
  *  A Timestamp represents a point in time independent of any time zone or local
  *  calendar, encoded as a count of seconds and fractions of seconds at
@@ -115,6 +123,12 @@ function longToNumber(long: Long) {
   }
   return long.toNumber();
 }
+
+declare var self: any | undefined;
+
+declare var window: any | undefined;
+
+var globalThis = getGlobalThis();
 
 export const protobufPackage = 'google.protobuf'
 

--- a/integration/simple-optionals/google/protobuf/wrappers.ts
+++ b/integration/simple-optionals/google/protobuf/wrappers.ts
@@ -2,6 +2,14 @@ import * as Long from 'long';
 import { Writer, Reader, util, configure } from 'protobufjs/minimal';
 
 
+function getGlobalThis() {
+  if (typeof globalThis !== "undefined") return globalThis;
+  if (typeof self !== "undefined") return self;
+  if (typeof window !== "undefined") return window;
+  if (typeof global !== "undefined") return global;
+  throw new Error("Unable to locate global object");
+}
+
 /**
  *  Wrapper message for `double`.
  *
@@ -151,6 +159,12 @@ function longToNumber(long: Long) {
   }
   return long.toNumber();
 }
+
+declare var self: any | undefined;
+
+declare var window: any | undefined;
+
+var globalThis = getGlobalThis();
 
 export const protobufPackage = 'google.protobuf'
 

--- a/integration/simple-optionals/import_dir/thing.ts
+++ b/integration/simple-optionals/import_dir/thing.ts
@@ -2,6 +2,14 @@ import { Timestamp } from '../google/protobuf/timestamp';
 import { Writer, Reader } from 'protobufjs/minimal';
 
 
+function getGlobalThis() {
+  if (typeof globalThis !== "undefined") return globalThis;
+  if (typeof self !== "undefined") return self;
+  if (typeof window !== "undefined") return window;
+  if (typeof global !== "undefined") return global;
+  throw new Error("Unable to locate global object");
+}
+
 export interface ImportedThing {
   createdAt?: Date;
 }
@@ -30,6 +38,12 @@ function fromTimestamp(t: Timestamp): Date {
   millis += t.nanos / 1_000_000;
   return new Date(millis);
 }
+
+declare var self: any | undefined;
+
+declare var window: any | undefined;
+
+var globalThis = getGlobalThis();
 
 export const protobufPackage = 'simple'
 

--- a/integration/simple-optionals/simple.ts
+++ b/integration/simple-optionals/simple.ts
@@ -8,6 +8,14 @@ import * as Long from 'long';
 import { StringValue, Int32Value, BoolValue } from './google/protobuf/wrappers';
 
 
+function getGlobalThis() {
+  if (typeof globalThis !== "undefined") return globalThis;
+  if (typeof self !== "undefined") return self;
+  if (typeof window !== "undefined") return window;
+  if (typeof global !== "undefined") return global;
+  throw new Error("Unable to locate global object");
+}
+
 /**
  * * Example comment on the Simple message  */
 export interface Simple {
@@ -267,6 +275,12 @@ function longToNumber(long: Long) {
   }
   return long.toNumber();
 }
+
+declare var self: any | undefined;
+
+declare var window: any | undefined;
+
+var globalThis = getGlobalThis();
 
 export const protobufPackage = 'simple'
 

--- a/integration/simple-optionals/thing.ts
+++ b/integration/simple-optionals/thing.ts
@@ -2,6 +2,14 @@ import { Timestamp } from './google/protobuf/timestamp';
 import { Writer, Reader } from 'protobufjs/minimal';
 
 
+function getGlobalThis() {
+  if (typeof globalThis !== "undefined") return globalThis;
+  if (typeof self !== "undefined") return self;
+  if (typeof window !== "undefined") return window;
+  if (typeof global !== "undefined") return global;
+  throw new Error("Unable to locate global object");
+}
+
 export interface ImportedThing {
   createdAt?: Date;
 }
@@ -30,6 +38,12 @@ function fromTimestamp(t: Timestamp): Date {
   millis += t.nanos / 1_000_000;
   return new Date(millis);
 }
+
+declare var self: any | undefined;
+
+declare var window: any | undefined;
+
+var globalThis = getGlobalThis();
 
 export const protobufPackage = 'simple'
 

--- a/integration/simple-proto2/simple.ts
+++ b/integration/simple-proto2/simple.ts
@@ -1,6 +1,14 @@
 import { Writer, Reader } from 'protobufjs/minimal';
 
 
+function getGlobalThis() {
+  if (typeof globalThis !== "undefined") return globalThis;
+  if (typeof self !== "undefined") return self;
+  if (typeof window !== "undefined") return window;
+  if (typeof global !== "undefined") return global;
+  throw new Error("Unable to locate global object");
+}
+
 export interface Issue56 {
   test: EnumWithoutZero;
 }
@@ -8,6 +16,12 @@ export interface Issue56 {
 const baseIssue56: object = {
   test: 1,
 };
+
+declare var self: any | undefined;
+
+declare var window: any | undefined;
+
+var globalThis = getGlobalThis();
 
 export const protobufPackage = 'simple'
 

--- a/integration/simple-snake/google/protobuf/timestamp.ts
+++ b/integration/simple-snake/google/protobuf/timestamp.ts
@@ -2,6 +2,14 @@ import * as Long from 'long';
 import { Writer, Reader, util, configure } from 'protobufjs/minimal';
 
 
+function getGlobalThis() {
+  if (typeof globalThis !== "undefined") return globalThis;
+  if (typeof self !== "undefined") return self;
+  if (typeof window !== "undefined") return window;
+  if (typeof global !== "undefined") return global;
+  throw new Error("Unable to locate global object");
+}
+
 /**
  *  A Timestamp represents a point in time independent of any time zone or local
  *  calendar, encoded as a count of seconds and fractions of seconds at
@@ -115,6 +123,12 @@ function longToNumber(long: Long) {
   }
   return long.toNumber();
 }
+
+declare var self: any | undefined;
+
+declare var window: any | undefined;
+
+var globalThis = getGlobalThis();
 
 export const protobufPackage = 'google.protobuf'
 

--- a/integration/simple-snake/google/protobuf/wrappers.ts
+++ b/integration/simple-snake/google/protobuf/wrappers.ts
@@ -2,6 +2,14 @@ import * as Long from 'long';
 import { Writer, Reader, util, configure } from 'protobufjs/minimal';
 
 
+function getGlobalThis() {
+  if (typeof globalThis !== "undefined") return globalThis;
+  if (typeof self !== "undefined") return self;
+  if (typeof window !== "undefined") return window;
+  if (typeof global !== "undefined") return global;
+  throw new Error("Unable to locate global object");
+}
+
 /**
  *  Wrapper message for `double`.
  *
@@ -151,6 +159,12 @@ function longToNumber(long: Long) {
   }
   return long.toNumber();
 }
+
+declare var self: any | undefined;
+
+declare var window: any | undefined;
+
+var globalThis = getGlobalThis();
 
 export const protobufPackage = 'google.protobuf'
 

--- a/integration/simple-snake/import_dir/thing.ts
+++ b/integration/simple-snake/import_dir/thing.ts
@@ -2,6 +2,14 @@ import { Timestamp } from '../google/protobuf/timestamp';
 import { Writer, Reader } from 'protobufjs/minimal';
 
 
+function getGlobalThis() {
+  if (typeof globalThis !== "undefined") return globalThis;
+  if (typeof self !== "undefined") return self;
+  if (typeof window !== "undefined") return window;
+  if (typeof global !== "undefined") return global;
+  throw new Error("Unable to locate global object");
+}
+
 export interface ImportedThing {
   created_at: Date | undefined;
 }
@@ -30,6 +38,12 @@ function fromTimestamp(t: Timestamp): Date {
   millis += t.nanos / 1_000_000;
   return new Date(millis);
 }
+
+declare var self: any | undefined;
+
+declare var window: any | undefined;
+
+var globalThis = getGlobalThis();
 
 export const protobufPackage = 'simple'
 

--- a/integration/simple-snake/simple.ts
+++ b/integration/simple-snake/simple.ts
@@ -8,6 +8,14 @@ import * as Long from 'long';
 import { StringValue, Int32Value, BoolValue } from './google/protobuf/wrappers';
 
 
+function getGlobalThis() {
+  if (typeof globalThis !== "undefined") return globalThis;
+  if (typeof self !== "undefined") return self;
+  if (typeof window !== "undefined") return window;
+  if (typeof global !== "undefined") return global;
+  throw new Error("Unable to locate global object");
+}
+
 /**
  * * Example comment on the Simple message  */
 export interface Simple {
@@ -267,6 +275,12 @@ function longToNumber(long: Long) {
   }
   return long.toNumber();
 }
+
+declare var self: any | undefined;
+
+declare var window: any | undefined;
+
+var globalThis = getGlobalThis();
 
 export const protobufPackage = 'simple'
 

--- a/integration/simple-string-enums/simple.ts
+++ b/integration/simple-string-enums/simple.ts
@@ -1,9 +1,23 @@
 
 
+function getGlobalThis() {
+  if (typeof globalThis !== "undefined") return globalThis;
+  if (typeof self !== "undefined") return self;
+  if (typeof window !== "undefined") return window;
+  if (typeof global !== "undefined") return global;
+  throw new Error("Unable to locate global object");
+}
+
 export interface Simple {
   name: string;
   state: StateEnum;
 }
+
+declare var self: any | undefined;
+
+declare var window: any | undefined;
+
+var globalThis = getGlobalThis();
 
 export const protobufPackage = 'simple'
 

--- a/integration/simple-unrecognized-enum/google/protobuf/timestamp.ts
+++ b/integration/simple-unrecognized-enum/google/protobuf/timestamp.ts
@@ -2,6 +2,14 @@ import * as Long from 'long';
 import { Writer, Reader, util, configure } from 'protobufjs/minimal';
 
 
+function getGlobalThis() {
+  if (typeof globalThis !== "undefined") return globalThis;
+  if (typeof self !== "undefined") return self;
+  if (typeof window !== "undefined") return window;
+  if (typeof global !== "undefined") return global;
+  throw new Error("Unable to locate global object");
+}
+
 /**
  *  A Timestamp represents a point in time independent of any time zone or local
  *  calendar, encoded as a count of seconds and fractions of seconds at
@@ -115,6 +123,12 @@ function longToNumber(long: Long) {
   }
   return long.toNumber();
 }
+
+declare var self: any | undefined;
+
+declare var window: any | undefined;
+
+var globalThis = getGlobalThis();
 
 export const protobufPackage = 'google.protobuf'
 

--- a/integration/simple-unrecognized-enum/google/protobuf/wrappers.ts
+++ b/integration/simple-unrecognized-enum/google/protobuf/wrappers.ts
@@ -2,6 +2,14 @@ import * as Long from 'long';
 import { Writer, Reader, util, configure } from 'protobufjs/minimal';
 
 
+function getGlobalThis() {
+  if (typeof globalThis !== "undefined") return globalThis;
+  if (typeof self !== "undefined") return self;
+  if (typeof window !== "undefined") return window;
+  if (typeof global !== "undefined") return global;
+  throw new Error("Unable to locate global object");
+}
+
 /**
  *  Wrapper message for `double`.
  *
@@ -151,6 +159,12 @@ function longToNumber(long: Long) {
   }
   return long.toNumber();
 }
+
+declare var self: any | undefined;
+
+declare var window: any | undefined;
+
+var globalThis = getGlobalThis();
 
 export const protobufPackage = 'google.protobuf'
 

--- a/integration/simple-unrecognized-enum/import_dir/thing.ts
+++ b/integration/simple-unrecognized-enum/import_dir/thing.ts
@@ -2,6 +2,14 @@ import { Timestamp } from '../google/protobuf/timestamp';
 import { Writer, Reader } from 'protobufjs/minimal';
 
 
+function getGlobalThis() {
+  if (typeof globalThis !== "undefined") return globalThis;
+  if (typeof self !== "undefined") return self;
+  if (typeof window !== "undefined") return window;
+  if (typeof global !== "undefined") return global;
+  throw new Error("Unable to locate global object");
+}
+
 export interface ImportedThing {
   createdAt: Date | undefined;
 }
@@ -30,6 +38,12 @@ function fromTimestamp(t: Timestamp): Date {
   millis += t.nanos / 1_000_000;
   return new Date(millis);
 }
+
+declare var self: any | undefined;
+
+declare var window: any | undefined;
+
+var globalThis = getGlobalThis();
 
 export const protobufPackage = 'simple'
 

--- a/integration/simple-unrecognized-enum/simple.ts
+++ b/integration/simple-unrecognized-enum/simple.ts
@@ -8,6 +8,14 @@ import * as Long from 'long';
 import { StringValue, Int32Value, BoolValue } from './google/protobuf/wrappers';
 
 
+function getGlobalThis() {
+  if (typeof globalThis !== "undefined") return globalThis;
+  if (typeof self !== "undefined") return self;
+  if (typeof window !== "undefined") return window;
+  if (typeof global !== "undefined") return global;
+  throw new Error("Unable to locate global object");
+}
+
 /**
  * * Example comment on the Simple message  */
 export interface Simple {
@@ -267,6 +275,12 @@ function longToNumber(long: Long) {
   }
   return long.toNumber();
 }
+
+declare var self: any | undefined;
+
+declare var window: any | undefined;
+
+var globalThis = getGlobalThis();
 
 export const protobufPackage = 'simple'
 

--- a/integration/simple/google/protobuf/timestamp.ts
+++ b/integration/simple/google/protobuf/timestamp.ts
@@ -2,6 +2,14 @@ import * as Long from 'long';
 import { Writer, Reader, util, configure } from 'protobufjs/minimal';
 
 
+function getGlobalThis() {
+  if (typeof globalThis !== "undefined") return globalThis;
+  if (typeof self !== "undefined") return self;
+  if (typeof window !== "undefined") return window;
+  if (typeof global !== "undefined") return global;
+  throw new Error("Unable to locate global object");
+}
+
 /**
  *  A Timestamp represents a point in time independent of any time zone or local
  *  calendar, encoded as a count of seconds and fractions of seconds at
@@ -115,6 +123,12 @@ function longToNumber(long: Long) {
   }
   return long.toNumber();
 }
+
+declare var self: any | undefined;
+
+declare var window: any | undefined;
+
+var globalThis = getGlobalThis();
 
 export const protobufPackage = 'google.protobuf'
 

--- a/integration/simple/google/protobuf/wrappers.ts
+++ b/integration/simple/google/protobuf/wrappers.ts
@@ -2,6 +2,14 @@ import * as Long from 'long';
 import { Writer, Reader, util, configure } from 'protobufjs/minimal';
 
 
+function getGlobalThis() {
+  if (typeof globalThis !== "undefined") return globalThis;
+  if (typeof self !== "undefined") return self;
+  if (typeof window !== "undefined") return window;
+  if (typeof global !== "undefined") return global;
+  throw new Error("Unable to locate global object");
+}
+
 /**
  *  Wrapper message for `double`.
  *
@@ -151,6 +159,12 @@ function longToNumber(long: Long) {
   }
   return long.toNumber();
 }
+
+declare var self: any | undefined;
+
+declare var window: any | undefined;
+
+var globalThis = getGlobalThis();
 
 export const protobufPackage = 'google.protobuf'
 

--- a/integration/simple/google/type/date.ts
+++ b/integration/simple/google/type/date.ts
@@ -1,6 +1,14 @@
 import { Writer, Reader } from 'protobufjs/minimal';
 
 
+function getGlobalThis() {
+  if (typeof globalThis !== "undefined") return globalThis;
+  if (typeof self !== "undefined") return self;
+  if (typeof window !== "undefined") return window;
+  if (typeof global !== "undefined") return global;
+  throw new Error("Unable to locate global object");
+}
+
 /**
  *  Represents a whole or partial calendar date, e.g. a birthday. The time of day
  *  and time zone are either specified elsewhere or are not significant. The date
@@ -37,6 +45,12 @@ const baseDateMessage: object = {
   month: 0,
   day: 0,
 };
+
+declare var self: any | undefined;
+
+declare var window: any | undefined;
+
+var globalThis = getGlobalThis();
 
 export const protobufPackage = 'google.type'
 

--- a/integration/simple/import_dir/thing.ts
+++ b/integration/simple/import_dir/thing.ts
@@ -2,6 +2,14 @@ import { Timestamp } from '../google/protobuf/timestamp';
 import { Writer, Reader } from 'protobufjs/minimal';
 
 
+function getGlobalThis() {
+  if (typeof globalThis !== "undefined") return globalThis;
+  if (typeof self !== "undefined") return self;
+  if (typeof window !== "undefined") return window;
+  if (typeof global !== "undefined") return global;
+  throw new Error("Unable to locate global object");
+}
+
 export interface ImportedThing {
   createdAt: Date | undefined;
 }
@@ -30,6 +38,12 @@ function fromTimestamp(t: Timestamp): Date {
   millis += t.nanos / 1_000_000;
   return new Date(millis);
 }
+
+declare var self: any | undefined;
+
+declare var window: any | undefined;
+
+var globalThis = getGlobalThis();
 
 export const protobufPackage = 'simple'
 

--- a/integration/simple/simple.ts
+++ b/integration/simple/simple.ts
@@ -9,6 +9,14 @@ import * as Long from 'long';
 import { StringValue, Int32Value, BoolValue } from './google/protobuf/wrappers';
 
 
+function getGlobalThis() {
+  if (typeof globalThis !== "undefined") return globalThis;
+  if (typeof self !== "undefined") return self;
+  if (typeof window !== "undefined") return window;
+  if (typeof global !== "undefined") return global;
+  throw new Error("Unable to locate global object");
+}
+
 /**
  * * Example comment on the Simple message  */
 export interface Simple {
@@ -340,6 +348,12 @@ function longToNumber(long: Long) {
   }
   return long.toNumber();
 }
+
+declare var self: any | undefined;
+
+declare var window: any | undefined;
+
+var globalThis = getGlobalThis();
 
 export const protobufPackage = 'simple'
 

--- a/integration/types-with-underscores/file.ts
+++ b/integration/types-with-underscores/file.ts
@@ -1,6 +1,14 @@
 import { Writer, Reader } from 'protobufjs/minimal';
 
 
+function getGlobalThis() {
+  if (typeof globalThis !== "undefined") return globalThis;
+  if (typeof self !== "undefined") return self;
+  if (typeof window !== "undefined") return window;
+  if (typeof global !== "undefined") return global;
+  throw new Error("Unable to locate global object");
+}
+
 export interface Baz {
   foo: FooBar | undefined;
 }
@@ -13,6 +21,12 @@ const baseBaz: object = {
 
 const baseFooBar: object = {
 };
+
+declare var self: any | undefined;
+
+declare var window: any | undefined;
+
+var globalThis = getGlobalThis();
 
 export const protobufPackage = ''
 

--- a/integration/vector-tile/vector_tile.ts
+++ b/integration/vector-tile/vector_tile.ts
@@ -2,6 +2,14 @@ import * as Long from 'long';
 import { Writer, Reader, util, configure } from 'protobufjs/minimal';
 
 
+function getGlobalThis() {
+  if (typeof globalThis !== "undefined") return globalThis;
+  if (typeof self !== "undefined") return self;
+  if (typeof window !== "undefined") return window;
+  if (typeof global !== "undefined") return global;
+  throw new Error("Unable to locate global object");
+}
+
 export interface Tile {
   layers: Tile_Layer[];
 }
@@ -65,6 +73,12 @@ function longToNumber(long: Long) {
   }
   return long.toNumber();
 }
+
+declare var self: any | undefined;
+
+declare var window: any | undefined;
+
+var globalThis = getGlobalThis();
 
 export const protobufPackage = 'vector_tile'
 


### PR DESCRIPTION
Closes #97 

I had to include the declarations because you can't refer to undeclared variables even when using `typeof`. The `self` and `window` declarations could be `let`s but somehow `var` seemed more appropriate since their scope isn't supposed to be limited to any particular block.

Let me know if this code should be located somewhere else or if anything else is required.