### PR TITLE
fix: add deprecated comment when there are not other comments

### DIFF
--- a/integration/simple-deprecated-fields/simple.ts
+++ b/integration/simple-deprecated-fields/simple.ts
@@ -22,6 +22,10 @@ export interface Simple {
    * @deprecated
    */
   child: Child | undefined;
+  /**
+   *
+   * @deprecated
+   */
   testField: string;
   testNotDeprecated: string;
 }

--- a/integration/simple-deprecated-fields/simple.ts
+++ b/integration/simple-deprecated-fields/simple.ts
@@ -22,10 +22,7 @@ export interface Simple {
    * @deprecated
    */
   child: Child | undefined;
-  /**
-   *
-   * @deprecated
-   */
+  /** @deprecated */
   testField: string;
   testNotDeprecated: string;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 import ReadStream = NodeJS.ReadStream;
-import { EnvOption, LongOption, OneofOption, Options } from './main';
+import { Options, LongOption, EnvOption, OneofOption } from './main';
 import { SourceDescription } from './sourceInfo';
 import { code, Code } from 'ts-poet';
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -154,6 +154,7 @@ export function maybeAddComment(
   deprecated?: boolean,
   prefix: string = ''
 ): void {
+  let lines: string[] = [];
   if (desc.leadingComments || desc.trailingComments) {
     let content = (desc.leadingComments || desc.trailingComments || '').replace(CloseComment, '* /').trim();
 
@@ -168,20 +169,21 @@ export function maybeAddComment(
       content = prefix + content;
     }
 
-    const lines = content.split('\n').map((l) => l.replace(/^ /, '').replace(/\n/, ''));
+    lines = content.split('\n').map((l) => l.replace(/^ /, '').replace(/\n/, ''));
+  }
+  // Deprecated comment should be added even if no other comment was added
+  if (deprecated) {
+    lines.push('');
+    lines.push('@deprecated');
+  }
 
-    if (deprecated) {
-      lines.push('');
-      lines.push('@deprecated');
-    }
-
-    let comment: Code;
-    if (lines.length === 1) {
-      comment = code`/** ${content} */`;
-    } else {
-      comment = code`/**\n * ${lines.join('\n * ')}\n */`;
-    }
-
+  let comment: Code;
+  if (lines.length === 1) {
+    comment = code`/** ${lines[0]} */`;
+  } else {
+    comment = code`/**\n * ${lines.join('\n * ')}\n */`;
+  }
+  if (lines.length > 0) {
     chunks.push(code`\n\n${comment}\n\n`);
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 import ReadStream = NodeJS.ReadStream;
-import { Options, LongOption, EnvOption, OneofOption } from './main';
+import { EnvOption, LongOption, OneofOption, Options } from './main';
 import { SourceDescription } from './sourceInfo';
 import { code, Code } from 'ts-poet';
 
@@ -173,7 +173,9 @@ export function maybeAddComment(
   }
   // Deprecated comment should be added even if no other comment was added
   if (deprecated) {
-    lines.push('');
+    if (lines.length > 0) {
+      lines.push('');
+    }
     lines.push('@deprecated');
   }
 


### PR DESCRIPTION
Currently, deprecated fields without any comments are not marked as deprecated.

This PR fixes this by adding a comment regardless of existing comments in proto - if necessary.