### PR TITLE
Support stringEnums in fromJson default value

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -185,8 +185,11 @@ export function defaultValue(ctx: Context, field: FieldDescriptorProto): any {
       // This is probably not great, but it's only used in fromJSON and fromPartial,
       // and I believe the semantics of those in the proto2 world are generally undefined.
       const enumProto = typeMap.get(field.typeName)![2] as EnumDescriptorProto;
-      const hasZero = enumProto.value.find((v) => v.number === 0);
-      return hasZero ? 0 : enumProto.value[0].number;
+      const zerothValue = enumProto.value.find((v) => v.number === 0);
+      if (options.stringEnums) {
+        return zerothValue ? zerothValue.name : enumProto.value[0].name;
+      }
+      return zerothValue ? 0 : enumProto.value[0].number;
     case FieldDescriptorProto.Type.TYPE_UINT64:
     case FieldDescriptorProto.Type.TYPE_FIXED64:
       if (options.forceLong === LongOption.LONG) {


### PR DESCRIPTION
Currently the default value for enums is 0, such that the `stringEnums` option is not enforced.