### PR TITLE
Fix typo in generate-services > generateRegularRpcMethod

### DIFF
--- a/src/generate-services.ts
+++ b/src/generate-services.ts
@@ -120,11 +120,11 @@ function generateRegularRpcMethod(
     ${methodDesc.name}(
       ${joinCode(params, { on: ',' })}
     ): ${responsePromise(ctx, methodDesc)} {
-      const data = ${inputType}.encode(request).finish(); 
+      const data = ${inputType}.encode(request).finish();
       const promise = this.rpc.request(
         ${maybeCtx}
         "${fileDesc.package}.${serviceDesc.name}",
-        "methodDesc.name",
+        "${methodDesc.name}",
         data
       );
       return promise.then(data => ${outputType}.decode(new ${Reader}(data)));


### PR DESCRIPTION
I just hit against this typo. Haven't looked into the test structure yet, but happy to add one if you point me to the right location.