### PR TITLE
Add missing fromTimestamp function 

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -398,7 +398,7 @@ function makeTimestampMethods(options: Options, longs: ReturnType<typeof makeLon
         } else if (typeof o === "string") {
           return new Date(o);
         } else {
-          return fromTimestamp(Timestamp.fromJSON(o));
+          return ${fromTimestamp}(Timestamp.fromJSON(o));
         }
       }
     `


### PR DESCRIPTION
fromTimestamp function definition was missing when outputJsonMethods is true but outputEncodeMethods is false.