### PR TITLE
Remove redundant default check for messages

### DIFF
--- a/integration/avoid-import-conflicts/simple.ts
+++ b/integration/avoid-import-conflicts/simple.ts
@@ -14,7 +14,7 @@ const baseSimple: object = { name: '' };
 export const Simple = {
   encode(message: Simple, writer: Writer = Writer.create()): Writer {
     writer.uint32(10).string(message.name);
-    if (message.otherSimple !== undefined && message.otherSimple !== undefined) {
+    if (message.otherSimple !== undefined) {
       Simple1.encode(message.otherSimple, writer.uint32(18).fork()).ldelim();
     }
     return writer;

--- a/integration/barrel-imports/foo.ts
+++ b/integration/barrel-imports/foo.ts
@@ -12,7 +12,7 @@ const baseFoo: object = { name: '' };
 export const Foo = {
   encode(message: Foo, writer: Writer = Writer.create()): Writer {
     writer.uint32(10).string(message.name);
-    if (message.bar !== undefined && message.bar !== undefined) {
+    if (message.bar !== undefined) {
       Bar.encode(message.bar, writer.uint32(18).fork()).ldelim();
     }
     return writer;

--- a/integration/batching-with-context/batching.ts
+++ b/integration/batching-with-context/batching.ts
@@ -304,7 +304,7 @@ const baseBatchMapQueryResponse_EntitiesEntry: object = { key: '' };
 export const BatchMapQueryResponse_EntitiesEntry = {
   encode(message: BatchMapQueryResponse_EntitiesEntry, writer: Writer = Writer.create()): Writer {
     writer.uint32(10).string(message.key);
-    if (message.value !== undefined && message.value !== undefined) {
+    if (message.value !== undefined) {
       Entity.encode(message.value, writer.uint32(18).fork()).ldelim();
     }
     return writer;
@@ -426,7 +426,7 @@ const baseGetOnlyMethodResponse: object = {};
 
 export const GetOnlyMethodResponse = {
   encode(message: GetOnlyMethodResponse, writer: Writer = Writer.create()): Writer {
-    if (message.entity !== undefined && message.entity !== undefined) {
+    if (message.entity !== undefined) {
       Entity.encode(message.entity, writer.uint32(10).fork()).ldelim();
     }
     return writer;

--- a/integration/batching/batching.ts
+++ b/integration/batching/batching.ts
@@ -302,7 +302,7 @@ const baseBatchMapQueryResponse_EntitiesEntry: object = { key: '' };
 export const BatchMapQueryResponse_EntitiesEntry = {
   encode(message: BatchMapQueryResponse_EntitiesEntry, writer: Writer = Writer.create()): Writer {
     writer.uint32(10).string(message.key);
-    if (message.value !== undefined && message.value !== undefined) {
+    if (message.value !== undefined) {
       Entity.encode(message.value, writer.uint32(18).fork()).ldelim();
     }
     return writer;
@@ -424,7 +424,7 @@ const baseGetOnlyMethodResponse: object = {};
 
 export const GetOnlyMethodResponse = {
   encode(message: GetOnlyMethodResponse, writer: Writer = Writer.create()): Writer {
-    if (message.entity !== undefined && message.entity !== undefined) {
+    if (message.entity !== undefined) {
       Entity.encode(message.entity, writer.uint32(10).fork()).ldelim();
     }
     return writer;

--- a/integration/grpc-web-go-server/example.ts
+++ b/integration/grpc-web-go-server/example.ts
@@ -1,11 +1,6 @@
 /* eslint-disable */
-import { UnaryMethodDefinition } from '@improbable-eng/grpc-web/dist/typings/service';
 import { Observable } from 'rxjs';
-import { BrowserHeaders } from 'browser-headers';
-import { grpc } from '@improbable-eng/grpc-web';
-import { Code } from '@improbable-eng/grpc-web/dist/typings/Code';
-import { share } from 'rxjs/operators';
-import { Writer, Reader } from 'protobufjs/minimal';
+import { Reader, Writer } from 'protobufjs/minimal';
 
 export const protobufPackage = 'rpx';
 
@@ -697,73 +692,27 @@ export const Empty = {
 };
 
 export interface DashState {
-  UserSettings(request: DeepPartial<Empty>, metadata?: grpc.Metadata): Promise<DashUserSettingsState>;
-  ActiveUserSettingsStream(request: DeepPartial<Empty>, metadata?: grpc.Metadata): Observable<DashUserSettingsState>;
+  UserSettings(request: Empty): Promise<DashUserSettingsState>;
+  ActiveUserSettingsStream(request: Empty): Observable<DashUserSettingsState>;
 }
 
 export class DashStateClientImpl implements DashState {
   private readonly rpc: Rpc;
-
   constructor(rpc: Rpc) {
     this.rpc = rpc;
   }
-
-  UserSettings(request: DeepPartial<Empty>, metadata?: grpc.Metadata): Promise<DashUserSettingsState> {
-    return this.rpc.unary(DashStateUserSettingsDesc, Empty.fromPartial(request), metadata);
+  UserSettings(request: Empty): Promise<DashUserSettingsState> {
+    const data = Empty.encode(request).finish();
+    const promise = this.rpc.request('rpx.DashState', 'UserSettings', data);
+    return promise.then((data) => DashUserSettingsState.decode(new Reader(data)));
   }
 
-  ActiveUserSettingsStream(request: DeepPartial<Empty>, metadata?: grpc.Metadata): Observable<DashUserSettingsState> {
-    return this.rpc.invoke(DashStateActiveUserSettingsStreamDesc, Empty.fromPartial(request), metadata);
+  ActiveUserSettingsStream(request: Empty): Promise<DashUserSettingsState> {
+    const data = Empty.encode(request).finish();
+    const promise = this.rpc.request('rpx.DashState', 'ActiveUserSettingsStream', data);
+    return promise.then((data) => DashUserSettingsState.decode(new Reader(data)));
   }
 }
-
-export const DashStateDesc = {
-  serviceName: 'rpx.DashState',
-};
-
-export const DashStateUserSettingsDesc: UnaryMethodDefinitionish = {
-  methodName: 'UserSettings',
-  service: DashStateDesc,
-  requestStream: false,
-  responseStream: false,
-  requestType: {
-    serializeBinary() {
-      return Empty.encode(this).finish();
-    },
-  } as any,
-  responseType: {
-    deserializeBinary(data: Uint8Array) {
-      return {
-        ...DashUserSettingsState.decode(data),
-        toObject() {
-          return this;
-        },
-      };
-    },
-  } as any,
-};
-
-export const DashStateActiveUserSettingsStreamDesc: UnaryMethodDefinitionish = {
-  methodName: 'ActiveUserSettingsStream',
-  service: DashStateDesc,
-  requestStream: false,
-  responseStream: true,
-  requestType: {
-    serializeBinary() {
-      return Empty.encode(this).finish();
-    },
-  } as any,
-  responseType: {
-    deserializeBinary(data: Uint8Array) {
-      return {
-        ...DashUserSettingsState.decode(data),
-        toObject() {
-          return this;
-        },
-      };
-    },
-  } as any,
-};
 
 /**
  * ----------------------
@@ -771,210 +720,37 @@ export const DashStateActiveUserSettingsStreamDesc: UnaryMethodDefinitionish = {
  * ----------------------
  */
 export interface DashAPICreds {
-  Create(request: DeepPartial<DashAPICredsCreateReq>, metadata?: grpc.Metadata): Promise<DashCred>;
-  Update(request: DeepPartial<DashAPICredsUpdateReq>, metadata?: grpc.Metadata): Promise<DashCred>;
-  Delete(request: DeepPartial<DashAPICredsDeleteReq>, metadata?: grpc.Metadata): Promise<DashCred>;
+  Create(request: DashAPICredsCreateReq): Promise<DashCred>;
+  Update(request: DashAPICredsUpdateReq): Promise<DashCred>;
+  Delete(request: DashAPICredsDeleteReq): Promise<DashCred>;
 }
 
 export class DashAPICredsClientImpl implements DashAPICreds {
   private readonly rpc: Rpc;
-
   constructor(rpc: Rpc) {
     this.rpc = rpc;
   }
-
-  Create(request: DeepPartial<DashAPICredsCreateReq>, metadata?: grpc.Metadata): Promise<DashCred> {
-    return this.rpc.unary(DashAPICredsCreateDesc, DashAPICredsCreateReq.fromPartial(request), metadata);
+  Create(request: DashAPICredsCreateReq): Promise<DashCred> {
+    const data = DashAPICredsCreateReq.encode(request).finish();
+    const promise = this.rpc.request('rpx.DashAPICreds', 'Create', data);
+    return promise.then((data) => DashCred.decode(new Reader(data)));
   }
 
-  Update(request: DeepPartial<DashAPICredsUpdateReq>, metadata?: grpc.Metadata): Promise<DashCred> {
-    return this.rpc.unary(DashAPICredsUpdateDesc, DashAPICredsUpdateReq.fromPartial(request), metadata);
+  Update(request: DashAPICredsUpdateReq): Promise<DashCred> {
+    const data = DashAPICredsUpdateReq.encode(request).finish();
+    const promise = this.rpc.request('rpx.DashAPICreds', 'Update', data);
+    return promise.then((data) => DashCred.decode(new Reader(data)));
   }
 
-  Delete(request: DeepPartial<DashAPICredsDeleteReq>, metadata?: grpc.Metadata): Promise<DashCred> {
-    return this.rpc.unary(DashAPICredsDeleteDesc, DashAPICredsDeleteReq.fromPartial(request), metadata);
+  Delete(request: DashAPICredsDeleteReq): Promise<DashCred> {
+    const data = DashAPICredsDeleteReq.encode(request).finish();
+    const promise = this.rpc.request('rpx.DashAPICreds', 'Delete', data);
+    return promise.then((data) => DashCred.decode(new Reader(data)));
   }
 }
-
-export const DashAPICredsDesc = {
-  serviceName: 'rpx.DashAPICreds',
-};
-
-export const DashAPICredsCreateDesc: UnaryMethodDefinitionish = {
-  methodName: 'Create',
-  service: DashAPICredsDesc,
-  requestStream: false,
-  responseStream: false,
-  requestType: {
-    serializeBinary() {
-      return DashAPICredsCreateReq.encode(this).finish();
-    },
-  } as any,
-  responseType: {
-    deserializeBinary(data: Uint8Array) {
-      return {
-        ...DashCred.decode(data),
-        toObject() {
-          return this;
-        },
-      };
-    },
-  } as any,
-};
-
-export const DashAPICredsUpdateDesc: UnaryMethodDefinitionish = {
-  methodName: 'Update',
-  service: DashAPICredsDesc,
-  requestStream: false,
-  responseStream: false,
-  requestType: {
-    serializeBinary() {
-      return DashAPICredsUpdateReq.encode(this).finish();
-    },
-  } as any,
-  responseType: {
-    deserializeBinary(data: Uint8Array) {
-      return {
-        ...DashCred.decode(data),
-        toObject() {
-          return this;
-        },
-      };
-    },
-  } as any,
-};
-
-export const DashAPICredsDeleteDesc: UnaryMethodDefinitionish = {
-  methodName: 'Delete',
-  service: DashAPICredsDesc,
-  requestStream: false,
-  responseStream: false,
-  requestType: {
-    serializeBinary() {
-      return DashAPICredsDeleteReq.encode(this).finish();
-    },
-  } as any,
-  responseType: {
-    deserializeBinary(data: Uint8Array) {
-      return {
-        ...DashCred.decode(data),
-        toObject() {
-          return this;
-        },
-      };
-    },
-  } as any,
-};
-
-interface UnaryMethodDefinitionishR extends UnaryMethodDefinition<any, any> {
-  requestStream: any;
-  responseStream: any;
-}
-
-type UnaryMethodDefinitionish = UnaryMethodDefinitionishR;
 
 interface Rpc {
-  unary<T extends UnaryMethodDefinitionish>(
-    methodDesc: T,
-    request: any,
-    metadata: grpc.Metadata | undefined
-  ): Promise<any>;
-  invoke<T extends UnaryMethodDefinitionish>(
-    methodDesc: T,
-    request: any,
-    metadata: grpc.Metadata | undefined
-  ): Observable<any>;
-}
-
-export class GrpcWebImpl {
-  private host: string;
-  private options: {
-    transport?: grpc.TransportFactory;
-    streamingTransport?: grpc.TransportFactory;
-    debug?: boolean;
-    metadata?: grpc.Metadata;
-  };
-
-  constructor(
-    host: string,
-    options: {
-      transport?: grpc.TransportFactory;
-      streamingTransport?: grpc.TransportFactory;
-      debug?: boolean;
-      metadata?: grpc.Metadata;
-    }
-  ) {
-    this.host = host;
-    this.options = options;
-  }
-
-  unary<T extends UnaryMethodDefinitionish>(
-    methodDesc: T,
-    _request: any,
-    metadata: grpc.Metadata | undefined
-  ): Promise<any> {
-    const request = { ..._request, ...methodDesc.requestType };
-    const maybeCombinedMetadata =
-      metadata && this.options.metadata
-        ? new BrowserHeaders({ ...this.options?.metadata.headersMap, ...metadata?.headersMap })
-        : metadata || this.options.metadata;
-    return new Promise((resolve, reject) => {
-      grpc.unary(methodDesc, {
-        request,
-        host: this.host,
-        metadata: maybeCombinedMetadata,
-        transport: this.options.transport,
-        debug: this.options.debug,
-        onEnd: function (response) {
-          if (response.status === grpc.Code.OK) {
-            resolve(response.message);
-          } else {
-            const err = new Error(response.statusMessage) as any;
-            err.code = response.status;
-            err.metadata = response.trailers;
-            reject(err);
-          }
-        },
-      });
-    });
-  }
-
-  invoke<T extends UnaryMethodDefinitionish>(
-    methodDesc: T,
-    _request: any,
-    metadata: grpc.Metadata | undefined
-  ): Observable<any> {
-    // Status Response Codes (https://developers.google.com/maps-booking/reference/grpc-api/status_codes)
-    const upStreamCodes = [2, 4, 8, 9, 10, 13, 14, 15];
-    const DEFAULT_TIMEOUT_TIME: number = 3_000;
-    const request = { ..._request, ...methodDesc.requestType };
-    const maybeCombinedMetadata =
-      metadata && this.options.metadata
-        ? new BrowserHeaders({ ...this.options?.metadata.headersMap, ...metadata?.headersMap })
-        : metadata || this.options.metadata;
-    return new Observable((observer) => {
-      const upStream = () => {
-        grpc.invoke(methodDesc, {
-          host: this.host,
-          request,
-          transport: this.options.streamingTransport || this.options.transport,
-          metadata: maybeCombinedMetadata,
-          debug: this.options.debug,
-          onMessage: (next) => observer.next(next),
-          onEnd: (code: Code, message: string) => {
-            if (code === 0) {
-              observer.complete();
-            } else if (upStreamCodes.includes(code)) {
-              setTimeout(upStream, DEFAULT_TIMEOUT_TIME);
-            } else {
-              observer.error(new Error(`Error ${code} ${message}`));
-            }
-          },
-        });
-      };
-      upStream();
-    }).pipe(share());
-  }
+  request(service: string, method: string, data: Uint8Array): Promise<Uint8Array>;
 }
 
 type Builtin = Date | Function | Uint8Array | string | number | undefined;

--- a/integration/grpc-web-no-streaming-observable/example.ts
+++ b/integration/grpc-web-no-streaming-observable/example.ts
@@ -143,7 +143,7 @@ const baseDashUserSettingsState: object = { email: '' };
 export const DashUserSettingsState = {
   encode(message: DashUserSettingsState, writer: Writer = Writer.create()): Writer {
     writer.uint32(10).string(message.email);
-    if (message.urls !== undefined && message.urls !== undefined) {
+    if (message.urls !== undefined) {
       DashUserSettingsState_URLs.encode(message.urls, writer.uint32(50).fork()).ldelim();
     }
     for (const v of message.flashes) {

--- a/integration/grpc-web-no-streaming/example.ts
+++ b/integration/grpc-web-no-streaming/example.ts
@@ -141,7 +141,7 @@ const baseDashUserSettingsState: object = { email: '' };
 export const DashUserSettingsState = {
   encode(message: DashUserSettingsState, writer: Writer = Writer.create()): Writer {
     writer.uint32(10).string(message.email);
-    if (message.urls !== undefined && message.urls !== undefined) {
+    if (message.urls !== undefined) {
       DashUserSettingsState_URLs.encode(message.urls, writer.uint32(50).fork()).ldelim();
     }
     for (const v of message.flashes) {

--- a/integration/point/point.ts
+++ b/integration/point/point.ts
@@ -85,10 +85,10 @@ const baseArea: object = {};
 
 export const Area = {
   encode(message: Area, writer: Writer = Writer.create()): Writer {
-    if (message.nw !== undefined && message.nw !== undefined) {
+    if (message.nw !== undefined) {
       Point.encode(message.nw, writer.uint32(10).fork()).ldelim();
     }
-    if (message.se !== undefined && message.se !== undefined) {
+    if (message.se !== undefined) {
       Point.encode(message.se, writer.uint32(18).fork()).ldelim();
     }
     return writer;

--- a/integration/simple-deprecated-fields/simple.ts
+++ b/integration/simple-deprecated-fields/simple.ts
@@ -37,7 +37,7 @@ export const Simple = {
   encode(message: Simple, writer: Writer = Writer.create()): Writer {
     writer.uint32(10).string(message.name);
     writer.uint32(16).int32(message.age);
-    if (message.child !== undefined && message.child !== undefined) {
+    if (message.child !== undefined) {
       Child.encode(message.child, writer.uint32(26).fork()).ldelim();
     }
     writer.uint32(34).string(message.testField);

--- a/integration/simple-long-string/simple.ts
+++ b/integration/simple-long-string/simple.ts
@@ -50,7 +50,7 @@ export const Numbers = {
     writer.uint32(81).fixed64(message.fixed64);
     writer.uint32(93).sfixed32(message.sfixed32);
     writer.uint32(97).sfixed64(message.sfixed64);
-    if (message.guint64 !== undefined && message.guint64 !== undefined) {
+    if (message.guint64 !== undefined) {
       UInt64Value.encode({ value: message.guint64! }, writer.uint32(106).fork()).ldelim();
     }
     return writer;

--- a/integration/simple-long/simple.ts
+++ b/integration/simple-long/simple.ts
@@ -50,16 +50,16 @@ const baseSimpleWithWrappers: object = {};
 
 export const SimpleWithWrappers = {
   encode(message: SimpleWithWrappers, writer: Writer = Writer.create()): Writer {
-    if (message.name !== undefined && message.name !== undefined) {
+    if (message.name !== undefined) {
       StringValue.encode({ value: message.name! }, writer.uint32(10).fork()).ldelim();
     }
-    if (message.age !== undefined && message.age !== undefined) {
+    if (message.age !== undefined) {
       Int32Value.encode({ value: message.age! }, writer.uint32(18).fork()).ldelim();
     }
-    if (message.enabled !== undefined && message.enabled !== undefined) {
+    if (message.enabled !== undefined) {
       BoolValue.encode({ value: message.enabled! }, writer.uint32(26).fork()).ldelim();
     }
-    if (message.bananas !== undefined && message.bananas !== undefined) {
+    if (message.bananas !== undefined) {
       Int64Value.encode({ value: message.bananas! }, writer.uint32(34).fork()).ldelim();
     }
     for (const v of message.coins) {

--- a/integration/simple-optionals/import_dir/thing.ts
+++ b/integration/simple-optionals/import_dir/thing.ts
@@ -12,7 +12,7 @@ const baseImportedThing: object = {};
 
 export const ImportedThing = {
   encode(message: ImportedThing, writer: Writer = Writer.create()): Writer {
-    if (message.createdAt !== undefined && message.createdAt !== undefined) {
+    if (message.createdAt !== undefined) {
       Timestamp.encode(toTimestamp(message.createdAt), writer.uint32(10).fork()).ldelim();
     }
     return writer;

--- a/integration/simple-optionals/simple.ts
+++ b/integration/simple-optionals/simple.ts
@@ -241,10 +241,10 @@ export const Simple = {
   encode(message: Simple, writer: Writer = Writer.create()): Writer {
     writer.uint32(10).string(message.name);
     writer.uint32(16).int32(message.age);
-    if (message.createdAt !== undefined && message.createdAt !== undefined) {
+    if (message.createdAt !== undefined) {
       Timestamp.encode(toTimestamp(message.createdAt), writer.uint32(74).fork()).ldelim();
     }
-    if (message.child !== undefined && message.child !== undefined) {
+    if (message.child !== undefined) {
       Child.encode(message.child, writer.uint32(26).fork()).ldelim();
     }
     writer.uint32(32).int32(message.state);
@@ -264,7 +264,7 @@ export const Simple = {
       writer.int32(v);
     }
     writer.ldelim();
-    if (message.thing !== undefined && message.thing !== undefined) {
+    if (message.thing !== undefined) {
       ImportedThing.encode(message.thing, writer.uint32(82).fork()).ldelim();
     }
     return writer;
@@ -557,7 +557,7 @@ const baseNested: object = { name: '', state: 0 };
 export const Nested = {
   encode(message: Nested, writer: Writer = Writer.create()): Writer {
     writer.uint32(10).string(message.name);
-    if (message.message !== undefined && message.message !== undefined) {
+    if (message.message !== undefined) {
       Nested_InnerMessage.encode(message.message, writer.uint32(18).fork()).ldelim();
     }
     writer.uint32(24).int32(message.state);
@@ -643,7 +643,7 @@ const baseNested_InnerMessage: object = { name: '' };
 export const Nested_InnerMessage = {
   encode(message: Nested_InnerMessage, writer: Writer = Writer.create()): Writer {
     writer.uint32(10).string(message.name);
-    if (message.deep !== undefined && message.deep !== undefined) {
+    if (message.deep !== undefined) {
       Nested_InnerMessage_DeepMessage.encode(message.deep, writer.uint32(18).fork()).ldelim();
     }
     return writer;
@@ -838,13 +838,13 @@ const baseSimpleWithWrappers: object = {};
 
 export const SimpleWithWrappers = {
   encode(message: SimpleWithWrappers, writer: Writer = Writer.create()): Writer {
-    if (message.name !== undefined && message.name !== undefined) {
+    if (message.name !== undefined) {
       StringValue.encode({ value: message.name! }, writer.uint32(10).fork()).ldelim();
     }
-    if (message.age !== undefined && message.age !== undefined) {
+    if (message.age !== undefined) {
       Int32Value.encode({ value: message.age! }, writer.uint32(18).fork()).ldelim();
     }
-    if (message.enabled !== undefined && message.enabled !== undefined) {
+    if (message.enabled !== undefined) {
       BoolValue.encode({ value: message.enabled! }, writer.uint32(26).fork()).ldelim();
     }
     for (const v of message.coins) {
@@ -1157,7 +1157,7 @@ const baseSimpleWithMap_EntitiesByIdEntry: object = { key: 0 };
 export const SimpleWithMap_EntitiesByIdEntry = {
   encode(message: SimpleWithMap_EntitiesByIdEntry, writer: Writer = Writer.create()): Writer {
     writer.uint32(8).int32(message.key);
-    if (message.value !== undefined && message.value !== undefined) {
+    if (message.value !== undefined) {
       Entity.encode(message.value, writer.uint32(18).fork()).ldelim();
     }
     return writer;
@@ -1431,7 +1431,7 @@ const baseSimpleWithSnakeCaseMap_EntitiesByIdEntry: object = { key: 0 };
 export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
   encode(message: SimpleWithSnakeCaseMap_EntitiesByIdEntry, writer: Writer = Writer.create()): Writer {
     writer.uint32(8).int32(message.key);
-    if (message.value !== undefined && message.value !== undefined) {
+    if (message.value !== undefined) {
       Entity.encode(message.value, writer.uint32(18).fork()).ldelim();
     }
     return writer;

--- a/integration/simple-optionals/thing.ts
+++ b/integration/simple-optionals/thing.ts
@@ -12,7 +12,7 @@ const baseImportedThing: object = {};
 
 export const ImportedThing = {
   encode(message: ImportedThing, writer: Writer = Writer.create()): Writer {
-    if (message.createdAt !== undefined && message.createdAt !== undefined) {
+    if (message.createdAt !== undefined) {
       Timestamp.encode(toTimestamp(message.createdAt), writer.uint32(10).fork()).ldelim();
     }
     return writer;

--- a/integration/simple-snake/import_dir/thing.ts
+++ b/integration/simple-snake/import_dir/thing.ts
@@ -12,7 +12,7 @@ const baseImportedThing: object = {};
 
 export const ImportedThing = {
   encode(message: ImportedThing, writer: Writer = Writer.create()): Writer {
-    if (message.created_at !== undefined && message.created_at !== undefined) {
+    if (message.created_at !== undefined) {
       Timestamp.encode(toTimestamp(message.created_at), writer.uint32(10).fork()).ldelim();
     }
     return writer;

--- a/integration/simple-snake/simple.ts
+++ b/integration/simple-snake/simple.ts
@@ -241,10 +241,10 @@ export const Simple = {
   encode(message: Simple, writer: Writer = Writer.create()): Writer {
     writer.uint32(10).string(message.name);
     writer.uint32(16).int32(message.age);
-    if (message.created_at !== undefined && message.created_at !== undefined) {
+    if (message.created_at !== undefined) {
       Timestamp.encode(toTimestamp(message.created_at), writer.uint32(74).fork()).ldelim();
     }
-    if (message.child !== undefined && message.child !== undefined) {
+    if (message.child !== undefined) {
       Child.encode(message.child, writer.uint32(26).fork()).ldelim();
     }
     writer.uint32(32).int32(message.state);
@@ -264,7 +264,7 @@ export const Simple = {
       writer.int32(v);
     }
     writer.ldelim();
-    if (message.thing !== undefined && message.thing !== undefined) {
+    if (message.thing !== undefined) {
       ImportedThing.encode(message.thing, writer.uint32(82).fork()).ldelim();
     }
     return writer;
@@ -557,7 +557,7 @@ const baseNested: object = { name: '', state: 0 };
 export const Nested = {
   encode(message: Nested, writer: Writer = Writer.create()): Writer {
     writer.uint32(10).string(message.name);
-    if (message.message !== undefined && message.message !== undefined) {
+    if (message.message !== undefined) {
       Nested_InnerMessage.encode(message.message, writer.uint32(18).fork()).ldelim();
     }
     writer.uint32(24).int32(message.state);
@@ -643,7 +643,7 @@ const baseNested_InnerMessage: object = { name: '' };
 export const Nested_InnerMessage = {
   encode(message: Nested_InnerMessage, writer: Writer = Writer.create()): Writer {
     writer.uint32(10).string(message.name);
-    if (message.deep !== undefined && message.deep !== undefined) {
+    if (message.deep !== undefined) {
       Nested_InnerMessage_DeepMessage.encode(message.deep, writer.uint32(18).fork()).ldelim();
     }
     return writer;
@@ -838,13 +838,13 @@ const baseSimpleWithWrappers: object = {};
 
 export const SimpleWithWrappers = {
   encode(message: SimpleWithWrappers, writer: Writer = Writer.create()): Writer {
-    if (message.name !== undefined && message.name !== undefined) {
+    if (message.name !== undefined) {
       StringValue.encode({ value: message.name! }, writer.uint32(10).fork()).ldelim();
     }
-    if (message.age !== undefined && message.age !== undefined) {
+    if (message.age !== undefined) {
       Int32Value.encode({ value: message.age! }, writer.uint32(18).fork()).ldelim();
     }
-    if (message.enabled !== undefined && message.enabled !== undefined) {
+    if (message.enabled !== undefined) {
       BoolValue.encode({ value: message.enabled! }, writer.uint32(26).fork()).ldelim();
     }
     for (const v of message.coins) {
@@ -1157,7 +1157,7 @@ const baseSimpleWithMap_EntitiesByIdEntry: object = { key: 0 };
 export const SimpleWithMap_EntitiesByIdEntry = {
   encode(message: SimpleWithMap_EntitiesByIdEntry, writer: Writer = Writer.create()): Writer {
     writer.uint32(8).int32(message.key);
-    if (message.value !== undefined && message.value !== undefined) {
+    if (message.value !== undefined) {
       Entity.encode(message.value, writer.uint32(18).fork()).ldelim();
     }
     return writer;
@@ -1431,7 +1431,7 @@ const baseSimpleWithSnakeCaseMap_EntitiesByIdEntry: object = { key: 0 };
 export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
   encode(message: SimpleWithSnakeCaseMap_EntitiesByIdEntry, writer: Writer = Writer.create()): Writer {
     writer.uint32(8).int32(message.key);
-    if (message.value !== undefined && message.value !== undefined) {
+    if (message.value !== undefined) {
       Entity.encode(message.value, writer.uint32(18).fork()).ldelim();
     }
     return writer;

--- a/integration/simple-unrecognized-enum/import_dir/thing.ts
+++ b/integration/simple-unrecognized-enum/import_dir/thing.ts
@@ -12,7 +12,7 @@ const baseImportedThing: object = {};
 
 export const ImportedThing = {
   encode(message: ImportedThing, writer: Writer = Writer.create()): Writer {
-    if (message.createdAt !== undefined && message.createdAt !== undefined) {
+    if (message.createdAt !== undefined) {
       Timestamp.encode(toTimestamp(message.createdAt), writer.uint32(10).fork()).ldelim();
     }
     return writer;

--- a/integration/simple-unrecognized-enum/simple.ts
+++ b/integration/simple-unrecognized-enum/simple.ts
@@ -232,10 +232,10 @@ export const Simple = {
   encode(message: Simple, writer: Writer = Writer.create()): Writer {
     writer.uint32(10).string(message.name);
     writer.uint32(16).int32(message.age);
-    if (message.createdAt !== undefined && message.createdAt !== undefined) {
+    if (message.createdAt !== undefined) {
       Timestamp.encode(toTimestamp(message.createdAt), writer.uint32(74).fork()).ldelim();
     }
-    if (message.child !== undefined && message.child !== undefined) {
+    if (message.child !== undefined) {
       Child.encode(message.child, writer.uint32(26).fork()).ldelim();
     }
     writer.uint32(32).int32(message.state);
@@ -255,7 +255,7 @@ export const Simple = {
       writer.int32(v);
     }
     writer.ldelim();
-    if (message.thing !== undefined && message.thing !== undefined) {
+    if (message.thing !== undefined) {
       ImportedThing.encode(message.thing, writer.uint32(82).fork()).ldelim();
     }
     return writer;
@@ -548,7 +548,7 @@ const baseNested: object = { name: '', state: 0 };
 export const Nested = {
   encode(message: Nested, writer: Writer = Writer.create()): Writer {
     writer.uint32(10).string(message.name);
-    if (message.message !== undefined && message.message !== undefined) {
+    if (message.message !== undefined) {
       Nested_InnerMessage.encode(message.message, writer.uint32(18).fork()).ldelim();
     }
     writer.uint32(24).int32(message.state);
@@ -634,7 +634,7 @@ const baseNested_InnerMessage: object = { name: '' };
 export const Nested_InnerMessage = {
   encode(message: Nested_InnerMessage, writer: Writer = Writer.create()): Writer {
     writer.uint32(10).string(message.name);
-    if (message.deep !== undefined && message.deep !== undefined) {
+    if (message.deep !== undefined) {
       Nested_InnerMessage_DeepMessage.encode(message.deep, writer.uint32(18).fork()).ldelim();
     }
     return writer;
@@ -829,13 +829,13 @@ const baseSimpleWithWrappers: object = {};
 
 export const SimpleWithWrappers = {
   encode(message: SimpleWithWrappers, writer: Writer = Writer.create()): Writer {
-    if (message.name !== undefined && message.name !== undefined) {
+    if (message.name !== undefined) {
       StringValue.encode({ value: message.name! }, writer.uint32(10).fork()).ldelim();
     }
-    if (message.age !== undefined && message.age !== undefined) {
+    if (message.age !== undefined) {
       Int32Value.encode({ value: message.age! }, writer.uint32(18).fork()).ldelim();
     }
-    if (message.enabled !== undefined && message.enabled !== undefined) {
+    if (message.enabled !== undefined) {
       BoolValue.encode({ value: message.enabled! }, writer.uint32(26).fork()).ldelim();
     }
     for (const v of message.coins) {
@@ -1148,7 +1148,7 @@ const baseSimpleWithMap_EntitiesByIdEntry: object = { key: 0 };
 export const SimpleWithMap_EntitiesByIdEntry = {
   encode(message: SimpleWithMap_EntitiesByIdEntry, writer: Writer = Writer.create()): Writer {
     writer.uint32(8).int32(message.key);
-    if (message.value !== undefined && message.value !== undefined) {
+    if (message.value !== undefined) {
       Entity.encode(message.value, writer.uint32(18).fork()).ldelim();
     }
     return writer;
@@ -1422,7 +1422,7 @@ const baseSimpleWithSnakeCaseMap_EntitiesByIdEntry: object = { key: 0 };
 export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
   encode(message: SimpleWithSnakeCaseMap_EntitiesByIdEntry, writer: Writer = Writer.create()): Writer {
     writer.uint32(8).int32(message.key);
-    if (message.value !== undefined && message.value !== undefined) {
+    if (message.value !== undefined) {
       Entity.encode(message.value, writer.uint32(18).fork()).ldelim();
     }
     return writer;

--- a/integration/simple/import_dir/thing.ts
+++ b/integration/simple/import_dir/thing.ts
@@ -12,7 +12,7 @@ const baseImportedThing: object = {};
 
 export const ImportedThing = {
   encode(message: ImportedThing, writer: Writer = Writer.create()): Writer {
-    if (message.createdAt !== undefined && message.createdAt !== undefined) {
+    if (message.createdAt !== undefined) {
       Timestamp.encode(toTimestamp(message.createdAt), writer.uint32(10).fork()).ldelim();
     }
     return writer;

--- a/integration/simple/simple.ts
+++ b/integration/simple/simple.ts
@@ -284,10 +284,10 @@ export const Simple = {
   encode(message: Simple, writer: Writer = Writer.create()): Writer {
     writer.uint32(10).string(message.name);
     writer.uint32(16).int32(message.age);
-    if (message.createdAt !== undefined && message.createdAt !== undefined) {
+    if (message.createdAt !== undefined) {
       Timestamp.encode(toTimestamp(message.createdAt), writer.uint32(74).fork()).ldelim();
     }
-    if (message.child !== undefined && message.child !== undefined) {
+    if (message.child !== undefined) {
       Child.encode(message.child, writer.uint32(26).fork()).ldelim();
     }
     writer.uint32(32).int32(message.state);
@@ -307,13 +307,13 @@ export const Simple = {
       writer.int32(v);
     }
     writer.ldelim();
-    if (message.thing !== undefined && message.thing !== undefined) {
+    if (message.thing !== undefined) {
       ImportedThing.encode(message.thing, writer.uint32(82).fork()).ldelim();
     }
     for (const v of message.blobs) {
       writer.uint32(90).bytes(v!);
     }
-    if (message.birthday !== undefined && message.birthday !== undefined) {
+    if (message.birthday !== undefined) {
       DateMessage.encode(message.birthday, writer.uint32(98).fork()).ldelim();
     }
     writer.uint32(106).bytes(message.blob);
@@ -656,7 +656,7 @@ const baseNested: object = { name: '', state: 0 };
 export const Nested = {
   encode(message: Nested, writer: Writer = Writer.create()): Writer {
     writer.uint32(10).string(message.name);
-    if (message.message !== undefined && message.message !== undefined) {
+    if (message.message !== undefined) {
       Nested_InnerMessage.encode(message.message, writer.uint32(18).fork()).ldelim();
     }
     writer.uint32(24).int32(message.state);
@@ -742,7 +742,7 @@ const baseNested_InnerMessage: object = { name: '' };
 export const Nested_InnerMessage = {
   encode(message: Nested_InnerMessage, writer: Writer = Writer.create()): Writer {
     writer.uint32(10).string(message.name);
-    if (message.deep !== undefined && message.deep !== undefined) {
+    if (message.deep !== undefined) {
       Nested_InnerMessage_DeepMessage.encode(message.deep, writer.uint32(18).fork()).ldelim();
     }
     return writer;
@@ -937,13 +937,13 @@ const baseSimpleWithWrappers: object = {};
 
 export const SimpleWithWrappers = {
   encode(message: SimpleWithWrappers, writer: Writer = Writer.create()): Writer {
-    if (message.name !== undefined && message.name !== undefined) {
+    if (message.name !== undefined) {
       StringValue.encode({ value: message.name! }, writer.uint32(10).fork()).ldelim();
     }
-    if (message.age !== undefined && message.age !== undefined) {
+    if (message.age !== undefined) {
       Int32Value.encode({ value: message.age! }, writer.uint32(18).fork()).ldelim();
     }
-    if (message.enabled !== undefined && message.enabled !== undefined) {
+    if (message.enabled !== undefined) {
       BoolValue.encode({ value: message.enabled! }, writer.uint32(26).fork()).ldelim();
     }
     for (const v of message.coins) {
@@ -952,7 +952,7 @@ export const SimpleWithWrappers = {
     for (const v of message.snacks) {
       StringValue.encode({ value: v!! }, writer.uint32(58).fork()).ldelim();
     }
-    if (message.id !== undefined && message.id !== undefined) {
+    if (message.id !== undefined) {
       BytesValue.encode({ value: message.id! }, writer.uint32(66).fork()).ldelim();
     }
     return writer;
@@ -1333,7 +1333,7 @@ const baseSimpleWithMap_EntitiesByIdEntry: object = { key: 0 };
 export const SimpleWithMap_EntitiesByIdEntry = {
   encode(message: SimpleWithMap_EntitiesByIdEntry, writer: Writer = Writer.create()): Writer {
     writer.uint32(8).int32(message.key);
-    if (message.value !== undefined && message.value !== undefined) {
+    if (message.value !== undefined) {
       Entity.encode(message.value, writer.uint32(18).fork()).ldelim();
     }
     return writer;
@@ -1539,7 +1539,7 @@ const baseSimpleWithMap_MapOfTimestampsEntry: object = { key: '' };
 export const SimpleWithMap_MapOfTimestampsEntry = {
   encode(message: SimpleWithMap_MapOfTimestampsEntry, writer: Writer = Writer.create()): Writer {
     writer.uint32(10).string(message.key);
-    if (message.value !== undefined && message.value !== undefined) {
+    if (message.value !== undefined) {
       Timestamp.encode(toTimestamp(message.value), writer.uint32(18).fork()).ldelim();
     }
     return writer;
@@ -1744,7 +1744,7 @@ const baseSimpleWithSnakeCaseMap_EntitiesByIdEntry: object = { key: 0 };
 export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
   encode(message: SimpleWithSnakeCaseMap_EntitiesByIdEntry, writer: Writer = Writer.create()): Writer {
     writer.uint32(8).int32(message.key);
-    if (message.value !== undefined && message.value !== undefined) {
+    if (message.value !== undefined) {
       Entity.encode(message.value, writer.uint32(18).fork()).ldelim();
     }
     return writer;

--- a/src/main.ts
+++ b/src/main.ts
@@ -714,7 +714,7 @@ function generateEncode(ctx: Context, fullName: string, messageDesc: DescriptorP
       `);
     } else if (isMessage(field)) {
       chunks.push(code`
-        if (message.${fieldName} !== undefined && message.${fieldName} !== ${defaultValue(ctx, field)}) {
+        if (message.${fieldName} !== undefined) {
           ${writeSnippet(`message.${fieldName}`)};
         }
       `);


### PR DESCRIPTION
I came across this when working on #213.

Since `${defaultValue(ctx, field)}` is always `undefined` for messages, this generates the ame test code twice.