### PR TITLE
Fix implicit any

### DIFF
--- a/integration/nestjs-metadata-observables/hero.ts
+++ b/integration/nestjs-metadata-observables/hero.ts
@@ -43,12 +43,12 @@ export interface HeroServiceController {
 
 export function HeroServiceControllerMethods() {
   return function (constructor: Function) {
-    const grpcMethods = ['findOneHero', 'findOneVillain'];
+    const grpcMethods: string[] = ['findOneHero', 'findOneVillain'];
     for (const method of grpcMethods) {
       const descriptor: any = Reflect.getOwnPropertyDescriptor(constructor.prototype, method);
       GrpcMethod('HeroService', method)(constructor.prototype[method], method, descriptor);
     }
-    const grpcStreamMethods = ['findManyVillain'];
+    const grpcStreamMethods: string[] = ['findManyVillain'];
     for (const method of grpcStreamMethods) {
       const descriptor: any = Reflect.getOwnPropertyDescriptor(constructor.prototype, method);
       GrpcStreamMethod('HeroService', method)(constructor.prototype[method], method, descriptor);

--- a/integration/nestjs-metadata-restparameters/hero.ts
+++ b/integration/nestjs-metadata-restparameters/hero.ts
@@ -47,12 +47,12 @@ export interface HeroServiceController {
 
 export function HeroServiceControllerMethods() {
   return function (constructor: Function) {
-    const grpcMethods = ['findOneHero', 'findOneVillain'];
+    const grpcMethods: string[] = ['findOneHero', 'findOneVillain'];
     for (const method of grpcMethods) {
       const descriptor: any = Reflect.getOwnPropertyDescriptor(constructor.prototype, method);
       GrpcMethod('HeroService', method)(constructor.prototype[method], method, descriptor);
     }
-    const grpcStreamMethods = ['findManyVillain'];
+    const grpcStreamMethods: string[] = ['findManyVillain'];
     for (const method of grpcStreamMethods) {
       const descriptor: any = Reflect.getOwnPropertyDescriptor(constructor.prototype, method);
       GrpcStreamMethod('HeroService', method)(constructor.prototype[method], method, descriptor);

--- a/integration/nestjs-metadata/hero.ts
+++ b/integration/nestjs-metadata/hero.ts
@@ -43,12 +43,12 @@ export interface HeroServiceController {
 
 export function HeroServiceControllerMethods() {
   return function (constructor: Function) {
-    const grpcMethods = ['findOneHero', 'findOneVillain'];
+    const grpcMethods: string[] = ['findOneHero', 'findOneVillain'];
     for (const method of grpcMethods) {
       const descriptor: any = Reflect.getOwnPropertyDescriptor(constructor.prototype, method);
       GrpcMethod('HeroService', method)(constructor.prototype[method], method, descriptor);
     }
-    const grpcStreamMethods = ['findManyVillain'];
+    const grpcStreamMethods: string[] = ['findManyVillain'];
     for (const method of grpcStreamMethods) {
       const descriptor: any = Reflect.getOwnPropertyDescriptor(constructor.prototype, method);
       GrpcStreamMethod('HeroService', method)(constructor.prototype[method], method, descriptor);

--- a/integration/nestjs-restparameters/hero.ts
+++ b/integration/nestjs-restparameters/hero.ts
@@ -42,12 +42,12 @@ export interface HeroServiceController {
 
 export function HeroServiceControllerMethods() {
   return function (constructor: Function) {
-    const grpcMethods = ['findOneHero', 'findOneVillain'];
+    const grpcMethods: string[] = ['findOneHero', 'findOneVillain'];
     for (const method of grpcMethods) {
       const descriptor: any = Reflect.getOwnPropertyDescriptor(constructor.prototype, method);
       GrpcMethod('HeroService', method)(constructor.prototype[method], method, descriptor);
     }
-    const grpcStreamMethods = ['findManyVillain'];
+    const grpcStreamMethods: string[] = ['findManyVillain'];
     for (const method of grpcStreamMethods) {
       const descriptor: any = Reflect.getOwnPropertyDescriptor(constructor.prototype, method);
       GrpcStreamMethod('HeroService', method)(constructor.prototype[method], method, descriptor);

--- a/integration/nestjs-simple-observables/hero.ts
+++ b/integration/nestjs-simple-observables/hero.ts
@@ -42,12 +42,12 @@ export interface HeroServiceController {
 
 export function HeroServiceControllerMethods() {
   return function (constructor: Function) {
-    const grpcMethods = ['findOneHero', 'findOneVillain'];
+    const grpcMethods: string[] = ['findOneHero', 'findOneVillain'];
     for (const method of grpcMethods) {
       const descriptor: any = Reflect.getOwnPropertyDescriptor(constructor.prototype, method);
       GrpcMethod('HeroService', method)(constructor.prototype[method], method, descriptor);
     }
-    const grpcStreamMethods = ['findManyVillain'];
+    const grpcStreamMethods: string[] = ['findManyVillain'];
     for (const method of grpcStreamMethods) {
       const descriptor: any = Reflect.getOwnPropertyDescriptor(constructor.prototype, method);
       GrpcStreamMethod('HeroService', method)(constructor.prototype[method], method, descriptor);

--- a/integration/nestjs-simple-restparameters/hero.ts
+++ b/integration/nestjs-simple-restparameters/hero.ts
@@ -22,12 +22,12 @@ export interface HeroServiceController {
 
 export function HeroServiceControllerMethods() {
   return function (constructor: Function) {
-    const grpcMethods = ['findCurrentUser'];
+    const grpcMethods: string[] = ['findCurrentUser'];
     for (const method of grpcMethods) {
       const descriptor: any = Reflect.getOwnPropertyDescriptor(constructor.prototype, method);
       GrpcMethod('HeroService', method)(constructor.prototype[method], method, descriptor);
     }
-    const grpcStreamMethods = [];
+    const grpcStreamMethods: string[] = [];
     for (const method of grpcStreamMethods) {
       const descriptor: any = Reflect.getOwnPropertyDescriptor(constructor.prototype, method);
       GrpcStreamMethod('HeroService', method)(constructor.prototype[method], method, descriptor);

--- a/integration/nestjs-simple/hero.ts
+++ b/integration/nestjs-simple/hero.ts
@@ -57,12 +57,12 @@ export interface HeroServiceController {
 
 export function HeroServiceControllerMethods() {
   return function (constructor: Function) {
-    const grpcMethods = ['addOneHero', 'findOneHero', 'findOneVillain', 'findManyVillainStreamOut'];
+    const grpcMethods: string[] = ['addOneHero', 'findOneHero', 'findOneVillain', 'findManyVillainStreamOut'];
     for (const method of grpcMethods) {
       const descriptor: any = Reflect.getOwnPropertyDescriptor(constructor.prototype, method);
       GrpcMethod('HeroService', method)(constructor.prototype[method], method, descriptor);
     }
-    const grpcStreamMethods = ['findManyVillain', 'findManyVillainStreamIn'];
+    const grpcStreamMethods: string[] = ['findManyVillain', 'findManyVillainStreamIn'];
     for (const method of grpcStreamMethods) {
       const descriptor: any = Reflect.getOwnPropertyDescriptor(constructor.prototype, method);
       GrpcStreamMethod('HeroService', method)(constructor.prototype[method], method, descriptor);

--- a/integration/simple-esmodule-interop/tsconfig.json
+++ b/integration/simple-esmodule-interop/tsconfig.json
@@ -7,7 +7,6 @@
     "outDir": "build",
     "skipLibCheck": true,
     "experimentalDecorators": true,
-    "noImplicitAny": false,
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true
   },

--- a/integration/tsconfig.json
+++ b/integration/tsconfig.json
@@ -6,8 +6,7 @@
     "strict": true,
     "outDir": "build",
     "skipLibCheck": true,
-    "experimentalDecorators": true,
-    "noImplicitAny": false
+    "experimentalDecorators": true
   },
   "include": ["./"]
 }

--- a/src/generate-nestjs.ts
+++ b/src/generate-nestjs.ts
@@ -168,12 +168,12 @@ export function generateNestjsGrpcServiceMethodsDecorator(ctx: Context, serviceD
   return code`
     export function ${serviceDesc.name}ControllerMethods() {
       return function(constructor: Function) {
-        const grpcMethods = [${grpcMethods.join(', ')}];
+        const grpcMethods: string[] = [${grpcMethods.join(', ')}];
         for (const method of grpcMethods) {
           const descriptor: any = Reflect.getOwnPropertyDescriptor(constructor.prototype, method);
           ${GrpcMethod}('${serviceDesc.name}', method)(constructor.prototype[method], method, descriptor);
         }
-        const grpcStreamMethods = [${grpcStreamMethods.join(', ')}];
+        const grpcStreamMethods: string[] = [${grpcStreamMethods.join(', ')}];
         for (const method of grpcStreamMethods) {
           const descriptor: any = Reflect.getOwnPropertyDescriptor(constructor.prototype, method);
           ${GrpcStreamMethod}('${serviceDesc.name}', method)(constructor.prototype[method], method, descriptor);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,8 +6,7 @@
     "strict": true,
     "outDir": "build",
     "skipLibCheck": true,
-    "experimentalDecorators": true,
-    "noImplicitAny": false
+    "experimentalDecorators": true
   },
   "include": ["src"]
 }


### PR DESCRIPTION
Fixes #235 

Having tsconfig `strict: true` and `noImplicitAny: false` is not recommended. See [this comment](https://github.com/Microsoft/TypeScript/issues/18687#issuecomment-331469718)

With `noImplicitAny` enabled, `nestjs-simple-restparameters` catches this failure