### PR TITLE
Use qualified imports for grpc-web types

### DIFF
--- a/integration/grpc-web-no-streaming-observable/example.ts
+++ b/integration/grpc-web-no-streaming-observable/example.ts
@@ -1,8 +1,7 @@
 /* eslint-disable */
-import { UnaryMethodDefinition } from '@improbable-eng/grpc-web/dist/typings/service';
+import { grpc } from '@improbable-eng/grpc-web';
 import { Observable } from 'rxjs';
 import { BrowserHeaders } from 'browser-headers';
-import { grpc } from '@improbable-eng/grpc-web';
 import { take } from 'rxjs/operators';
 import { Writer, Reader } from 'protobufjs/minimal';
 
@@ -395,7 +394,7 @@ export const DashStateUserSettingsDesc: UnaryMethodDefinitionish = {
   } as any,
 };
 
-interface UnaryMethodDefinitionishR extends UnaryMethodDefinition<any, any> {
+interface UnaryMethodDefinitionishR extends grpc.UnaryMethodDefinition<any, any> {
   requestStream: any;
   responseStream: any;
 }

--- a/integration/grpc-web-no-streaming/example.ts
+++ b/integration/grpc-web-no-streaming/example.ts
@@ -1,7 +1,6 @@
 /* eslint-disable */
-import { UnaryMethodDefinition } from '@improbable-eng/grpc-web/dist/typings/service';
-import { BrowserHeaders } from 'browser-headers';
 import { grpc } from '@improbable-eng/grpc-web';
+import { BrowserHeaders } from 'browser-headers';
 import { Writer, Reader } from 'protobufjs/minimal';
 
 export const protobufPackage = 'rpx';
@@ -393,7 +392,7 @@ export const DashStateUserSettingsDesc: UnaryMethodDefinitionish = {
   } as any,
 };
 
-interface UnaryMethodDefinitionishR extends UnaryMethodDefinition<any, any> {
+interface UnaryMethodDefinitionishR extends grpc.UnaryMethodDefinition<any, any> {
   requestStream: any;
   responseStream: any;
 }

--- a/integration/grpc-web/example.ts
+++ b/integration/grpc-web/example.ts
@@ -1,9 +1,7 @@
 /* eslint-disable */
-import { UnaryMethodDefinition } from '@improbable-eng/grpc-web/dist/typings/service';
+import { grpc } from '@improbable-eng/grpc-web';
 import { Observable } from 'rxjs';
 import { BrowserHeaders } from 'browser-headers';
-import { grpc } from '@improbable-eng/grpc-web';
-import { Code } from '@improbable-eng/grpc-web/dist/typings/Code';
 import { share } from 'rxjs/operators';
 import { Writer, Reader } from 'protobufjs/minimal';
 
@@ -900,7 +898,7 @@ export const DashAPICredsDeleteDesc: UnaryMethodDefinitionish = {
   } as any,
 };
 
-interface UnaryMethodDefinitionishR extends UnaryMethodDefinition<any, any> {
+interface UnaryMethodDefinitionishR extends grpc.UnaryMethodDefinition<any, any> {
   requestStream: any;
   responseStream: any;
 }
@@ -995,7 +993,7 @@ export class GrpcWebImpl {
           metadata: maybeCombinedMetadata,
           debug: this.options.debug,
           onMessage: (next) => observer.next(next),
-          onEnd: (code: Code, message: string) => {
+          onEnd: (code: grpc.Code, message: string) => {
             if (code === 0) {
               observer.complete();
             } else if (upStreamCodes.includes(code)) {

--- a/src/generate-grpc-web.ts
+++ b/src/generate-grpc-web.ts
@@ -8,12 +8,10 @@ import { Code, code, imp, joinCode } from 'ts-poet';
 import { Context } from './context';
 
 const grpc = imp('grpc@@improbable-eng/grpc-web');
-const UnaryMethodDefinition = imp('UnaryMethodDefinition@@improbable-eng/grpc-web/dist/typings/service');
 const share = imp('share@rxjs/operators');
 const take = imp('take@rxjs/operators');
 const BrowserHeaders = imp('BrowserHeaders@browser-headers');
 const Observable = imp('Observable@rxjs');
-const GrpcCode = imp('Code@@improbable-eng/grpc-web/dist/typings/Code');
 
 /** Generates a client that uses the `@improbable-web/grpc-web` library. */
 export function generateGrpcClientImpl(
@@ -142,7 +140,7 @@ export function addGrpcWebMisc(ctx: Context, hasStreamingMethods: boolean): Code
   const { options } = ctx;
   const chunks: Code[] = [];
   chunks.push(code`
-    interface UnaryMethodDefinitionishR extends ${UnaryMethodDefinition}<any, any> { requestStream: any; responseStream: any; }
+    interface UnaryMethodDefinitionishR extends ${grpc}.UnaryMethodDefinition<any, any> { requestStream: any; responseStream: any; }
   `);
   chunks.push(code`type UnaryMethodDefinitionish = UnaryMethodDefinitionishR;`);
   chunks.push(generateGrpcWebRpcType(options.returnObservable, hasStreamingMethods));
@@ -308,7 +306,7 @@ function createInvokeMethod() {
             metadata: maybeCombinedMetadata,
             debug: this.options.debug,
             onMessage: (next) => observer.next(next),
-            onEnd: (code: ${GrpcCode}, message: string) => {
+            onEnd: (code: ${grpc}.Code, message: string) => {
               if (code === 0) {
                 observer.complete();
               } else if (upStreamCodes.includes(code)) {


### PR DESCRIPTION
I had some issues with using the generated code in combination with
babel-loader in my webpack setup. The grpc-web output was producing
references to .d.ts files within @improbable-eng/grpc-web. This broke
compilation with babel-loader since that has no concept of type
definition files.

This fixes that by simply using the fully qualified types which are
accepted by babel-loader.