### PR TITLE
fix: improve type registry types

### DIFF
--- a/integration/type-registry/typeRegistry.ts
+++ b/integration/type-registry/typeRegistry.ts
@@ -1,7 +1,8 @@
 /* eslint-disable */
 import { Writer, Reader } from 'protobufjs/minimal';
 
-export interface MessageType<Message> {
+export interface MessageType<Message extends UnknownMessage = UnknownMessage> {
+  $type: Message['$type'];
   encode(message: Message, writer?: Writer): Writer;
   decode(input: Reader | Uint8Array, length?: number): Message;
   fromJSON(object: any): Message;
@@ -9,7 +10,9 @@ export interface MessageType<Message> {
   fromPartial(object: DeepPartial<Message>): Message;
 }
 
-export const messageTypeRegistry = new Map<string, MessageType<unknown>>();
+export type UnknownMessage = { $type: string };
+
+export const messageTypeRegistry = new Map<string, MessageType>();
 
 type Builtin = Date | Function | Uint8Array | string | number | undefined;
 export type DeepPartial<T> = T extends Builtin

--- a/src/generate-type-registry.ts
+++ b/src/generate-type-registry.ts
@@ -10,7 +10,11 @@ export function generateTypeRegistry(ctx: Context): Code {
   chunks.push(generateMessageType(ctx));
 
   chunks.push(code`
-    export const messageTypeRegistry = new Map<string, MessageType<unknown>>();
+    export type UnknownMessage = {$type: string};
+  `);
+
+  chunks.push(code`
+    export const messageTypeRegistry = new Map<string, MessageType>();
   `);
 
   chunks.push(code`${ctx.utils.DeepPartial.ifUsed}`);
@@ -21,7 +25,9 @@ export function generateTypeRegistry(ctx: Context): Code {
 function generateMessageType(ctx: Context): Code {
   const chunks: Code[] = [];
 
-  chunks.push(code`export interface MessageType<Message> {`);
+  chunks.push(code`export interface MessageType<Message extends UnknownMessage = UnknownMessage> {`);
+
+  chunks.push(code`$type: Message['$type'];`);
 
   if (ctx.options.outputEncodeMethods) {
     chunks.push(code`encode(message: Message, writer?: ${Writer}): ${Writer};`);


### PR DESCRIPTION
I started integrating `ts-proto`, employing the new type registry feature, and discovered that the `$type` field was missing from `MessageType` type. This PR adds the missing field.