### PR TITLE
feat: Support bytes as base64 strings

### DIFF
--- a/integration/bytes-as-base64/message.ts
+++ b/integration/bytes-as-base64/message.ts
@@ -5,7 +5,7 @@ import * as Long from 'long';
 export const protobufPackage = '';
 
 export interface Message {
-  data: Uint8Array;
+  data: Uint8Array | string;
 }
 
 const baseMessage: object = {};
@@ -61,7 +61,10 @@ function bytesFromBase64(b64: string): Uint8Array {
 
 const btoa: (bin: string) => string =
   globalThis.btoa || ((bin) => globalThis.Buffer.from(bin, 'binary').toString('base64'));
-function base64FromBytes(arr: Uint8Array): string {
+function base64FromBytes(arr: Uint8Array | string): string {
+  if (typeof arr === 'string') {
+    return arr;
+  }
   const bin: string[] = [];
   for (let i = 0; i < arr.byteLength; ++i) {
     bin.push(String.fromCharCode(arr[i]));

--- a/integration/bytes-node/point.ts
+++ b/integration/bytes-node/point.ts
@@ -87,7 +87,10 @@ function bytesFromBase64(b64: string): Uint8Array {
 
 const btoa: (bin: string) => string =
   globalThis.btoa || ((bin) => globalThis.Buffer.from(bin, 'binary').toString('base64'));
-function base64FromBytes(arr: Uint8Array): string {
+function base64FromBytes(arr: Uint8Array | string): string {
+  if (typeof arr === 'string') {
+    return arr;
+  }
   const bin: string[] = [];
   for (let i = 0; i < arr.byteLength; ++i) {
     bin.push(String.fromCharCode(arr[i]));

--- a/integration/meta-typings/google/protobuf/wrappers.ts
+++ b/integration/meta-typings/google/protobuf/wrappers.ts
@@ -92,7 +92,7 @@ export interface StringValue {
  */
 export interface BytesValue {
   /** The bytes value. */
-  value: Uint8Array;
+  value: Uint8Array | string;
 }
 
 const baseDoubleValue: object = { value: 0 };

--- a/integration/meta-typings/simple.ts
+++ b/integration/meta-typings/simple.ts
@@ -37,9 +37,9 @@ export interface Simple {
   oldStates: StateEnum[];
   /** A thing (imported from thing) */
   thing: ImportedThing | undefined;
-  blobs: Uint8Array[];
+  blobs: (Uint8Array | string)[];
   birthday: DateMessage | undefined;
-  blob: Uint8Array;
+  blob: Uint8Array | string;
 }
 
 export interface Child {
@@ -99,7 +99,7 @@ export interface SimpleWithMap {
   nameLookup: { [key: string]: string };
   intLookup: { [key: number]: number };
   mapOfTimestamps: { [key: string]: Date };
-  mapOfBytes: { [key: string]: Uint8Array };
+  mapOfBytes: { [key: string]: Uint8Array | string };
 }
 
 export interface SimpleWithMap_EntitiesByIdEntry {
@@ -124,7 +124,7 @@ export interface SimpleWithMap_MapOfTimestampsEntry {
 
 export interface SimpleWithMap_MapOfBytesEntry {
   key: string;
-  value: Uint8Array;
+  value: Uint8Array | string;
 }
 
 export interface SimpleWithSnakeCaseMap {

--- a/integration/oneof-properties/oneof.ts
+++ b/integration/oneof-properties/oneof.ts
@@ -22,7 +22,7 @@ export interface PleaseChoose {
    * field, so it has a higher number.
    */
   aBool: boolean | undefined;
-  bunchaBytes: Uint8Array | undefined;
+  bunchaBytes: (Uint8Array | string) | undefined;
   anEnum: PleaseChoose_StateEnum | undefined;
   age: number;
   either: string | undefined;
@@ -376,7 +376,10 @@ function bytesFromBase64(b64: string): Uint8Array {
 
 const btoa: (bin: string) => string =
   globalThis.btoa || ((bin) => globalThis.Buffer.from(bin, 'binary').toString('base64'));
-function base64FromBytes(arr: Uint8Array): string {
+function base64FromBytes(arr: Uint8Array | string): string {
+  if (typeof arr === 'string') {
+    return arr;
+  }
   const bin: string[] = [];
   for (let i = 0; i < arr.byteLength; ++i) {
     bin.push(String.fromCharCode(arr[i]));

--- a/integration/oneof-unions/oneof.ts
+++ b/integration/oneof-unions/oneof.ts
@@ -11,7 +11,7 @@ export interface PleaseChoose {
     | { $case: 'aString'; aString: string }
     | { $case: 'aMessage'; aMessage: PleaseChoose_Submessage }
     | { $case: 'aBool'; aBool: boolean }
-    | { $case: 'bunchaBytes'; bunchaBytes: Uint8Array }
+    | { $case: 'bunchaBytes'; bunchaBytes: Uint8Array | string }
     | { $case: 'anEnum'; anEnum: PleaseChoose_StateEnum };
   age: number;
   eitherOr?:
@@ -408,7 +408,10 @@ function bytesFromBase64(b64: string): Uint8Array {
 
 const btoa: (bin: string) => string =
   globalThis.btoa || ((bin) => globalThis.Buffer.from(bin, 'binary').toString('base64'));
-function base64FromBytes(arr: Uint8Array): string {
+function base64FromBytes(arr: Uint8Array | string): string {
+  if (typeof arr === 'string') {
+    return arr;
+  }
   const bin: string[] = [];
   for (let i = 0; i < arr.byteLength; ++i) {
     bin.push(String.fromCharCode(arr[i]));

--- a/integration/only-types/google/protobuf/any.ts
+++ b/integration/only-types/google/protobuf/any.ts
@@ -114,5 +114,5 @@ export interface Any {
    */
   typeUrl: string;
   /** Must be a valid serialized protocol buffer of the above specified type. */
-  value: Uint8Array;
+  value: Uint8Array | string;
 }

--- a/integration/simple-long-string/google/protobuf/wrappers.ts
+++ b/integration/simple-long-string/google/protobuf/wrappers.ts
@@ -91,7 +91,7 @@ export interface StringValue {
  */
 export interface BytesValue {
   /** The bytes value. */
-  value: Uint8Array;
+  value: Uint8Array | string;
 }
 
 const baseDoubleValue: object = { value: 0 };
@@ -613,7 +613,10 @@ function bytesFromBase64(b64: string): Uint8Array {
 
 const btoa: (bin: string) => string =
   globalThis.btoa || ((bin) => globalThis.Buffer.from(bin, 'binary').toString('base64'));
-function base64FromBytes(arr: Uint8Array): string {
+function base64FromBytes(arr: Uint8Array | string): string {
+  if (typeof arr === 'string') {
+    return arr;
+  }
   const bin: string[] = [];
   for (let i = 0; i < arr.byteLength; ++i) {
     bin.push(String.fromCharCode(arr[i]));

--- a/integration/simple-long/google/protobuf/wrappers.ts
+++ b/integration/simple-long/google/protobuf/wrappers.ts
@@ -91,7 +91,7 @@ export interface StringValue {
  */
 export interface BytesValue {
   /** The bytes value. */
-  value: Uint8Array;
+  value: Uint8Array | string;
 }
 
 const baseDoubleValue: object = { value: 0 };
@@ -613,7 +613,10 @@ function bytesFromBase64(b64: string): Uint8Array {
 
 const btoa: (bin: string) => string =
   globalThis.btoa || ((bin) => globalThis.Buffer.from(bin, 'binary').toString('base64'));
-function base64FromBytes(arr: Uint8Array): string {
+function base64FromBytes(arr: Uint8Array | string): string {
+  if (typeof arr === 'string') {
+    return arr;
+  }
   const bin: string[] = [];
   for (let i = 0; i < arr.byteLength; ++i) {
     bin.push(String.fromCharCode(arr[i]));

--- a/integration/simple-optionals/google/protobuf/wrappers.ts
+++ b/integration/simple-optionals/google/protobuf/wrappers.ts
@@ -91,7 +91,7 @@ export interface StringValue {
  */
 export interface BytesValue {
   /** The bytes value. */
-  value: Uint8Array;
+  value: Uint8Array | string;
 }
 
 const baseDoubleValue: object = { value: 0 };
@@ -613,7 +613,10 @@ function bytesFromBase64(b64: string): Uint8Array {
 
 const btoa: (bin: string) => string =
   globalThis.btoa || ((bin) => globalThis.Buffer.from(bin, 'binary').toString('base64'));
-function base64FromBytes(arr: Uint8Array): string {
+function base64FromBytes(arr: Uint8Array | string): string {
+  if (typeof arr === 'string') {
+    return arr;
+  }
   const bin: string[] = [];
   for (let i = 0; i < arr.byteLength; ++i) {
     bin.push(String.fromCharCode(arr[i]));

--- a/integration/simple-snake/google/protobuf/wrappers.ts
+++ b/integration/simple-snake/google/protobuf/wrappers.ts
@@ -91,7 +91,7 @@ export interface StringValue {
  */
 export interface BytesValue {
   /** The bytes value. */
-  value: Uint8Array;
+  value: Uint8Array | string;
 }
 
 const baseDoubleValue: object = { value: 0 };
@@ -613,7 +613,10 @@ function bytesFromBase64(b64: string): Uint8Array {
 
 const btoa: (bin: string) => string =
   globalThis.btoa || ((bin) => globalThis.Buffer.from(bin, 'binary').toString('base64'));
-function base64FromBytes(arr: Uint8Array): string {
+function base64FromBytes(arr: Uint8Array | string): string {
+  if (typeof arr === 'string') {
+    return arr;
+  }
   const bin: string[] = [];
   for (let i = 0; i < arr.byteLength; ++i) {
     bin.push(String.fromCharCode(arr[i]));

--- a/integration/simple-unrecognized-enum/google/protobuf/wrappers.ts
+++ b/integration/simple-unrecognized-enum/google/protobuf/wrappers.ts
@@ -91,7 +91,7 @@ export interface StringValue {
  */
 export interface BytesValue {
   /** The bytes value. */
-  value: Uint8Array;
+  value: Uint8Array | string;
 }
 
 const baseDoubleValue: object = { value: 0 };
@@ -613,7 +613,10 @@ function bytesFromBase64(b64: string): Uint8Array {
 
 const btoa: (bin: string) => string =
   globalThis.btoa || ((bin) => globalThis.Buffer.from(bin, 'binary').toString('base64'));
-function base64FromBytes(arr: Uint8Array): string {
+function base64FromBytes(arr: Uint8Array | string): string {
+  if (typeof arr === 'string') {
+    return arr;
+  }
   const bin: string[] = [];
   for (let i = 0; i < arr.byteLength; ++i) {
     bin.push(String.fromCharCode(arr[i]));

--- a/integration/simple/google/protobuf/wrappers.ts
+++ b/integration/simple/google/protobuf/wrappers.ts
@@ -91,7 +91,7 @@ export interface StringValue {
  */
 export interface BytesValue {
   /** The bytes value. */
-  value: Uint8Array;
+  value: Uint8Array | string;
 }
 
 const baseDoubleValue: object = { value: 0 };
@@ -613,7 +613,10 @@ function bytesFromBase64(b64: string): Uint8Array {
 
 const btoa: (bin: string) => string =
   globalThis.btoa || ((bin) => globalThis.Buffer.from(bin, 'binary').toString('base64'));
-function base64FromBytes(arr: Uint8Array): string {
+function base64FromBytes(arr: Uint8Array | string): string {
+  if (typeof arr === 'string') {
+    return arr;
+  }
   const bin: string[] = [];
   for (let i = 0; i < arr.byteLength; ++i) {
     bin.push(String.fromCharCode(arr[i]));

--- a/integration/simple/simple.ts
+++ b/integration/simple/simple.ts
@@ -67,9 +67,9 @@ export interface Simple {
   oldStates: StateEnum[];
   /** A thing (imported from thing) */
   thing: ImportedThing | undefined;
-  blobs: Uint8Array[];
+  blobs: (Uint8Array | string)[];
   birthday: DateMessage | undefined;
-  blob: Uint8Array;
+  blob: Uint8Array | string;
 }
 
 export interface Child {
@@ -180,7 +180,7 @@ export interface SimpleWithWrappers {
   enabled: boolean | undefined;
   coins: number[];
   snacks: string[];
-  id: Uint8Array | undefined;
+  id: (Uint8Array | string) | undefined;
 }
 
 export interface Entity {
@@ -192,7 +192,7 @@ export interface SimpleWithMap {
   nameLookup: { [key: string]: string };
   intLookup: { [key: number]: number };
   mapOfTimestamps: { [key: string]: Date };
-  mapOfBytes: { [key: string]: Uint8Array };
+  mapOfBytes: { [key: string]: Uint8Array | string };
 }
 
 export interface SimpleWithMap_EntitiesByIdEntry {
@@ -217,7 +217,7 @@ export interface SimpleWithMap_MapOfTimestampsEntry {
 
 export interface SimpleWithMap_MapOfBytesEntry {
   key: string;
-  value: Uint8Array;
+  value: Uint8Array | string;
 }
 
 export interface SimpleWithSnakeCaseMap {
@@ -1044,7 +1044,7 @@ export const SimpleWithWrappers = {
       }
     }
     if (object.id !== undefined && object.id !== null) {
-      message.id = new Uint8Array(object.id);
+      message.id = typeof object.id === 'string' ? object.id : new Uint8Array(object.id);
     } else {
       message.id = undefined;
     }
@@ -2597,7 +2597,10 @@ function bytesFromBase64(b64: string): Uint8Array {
 
 const btoa: (bin: string) => string =
   globalThis.btoa || ((bin) => globalThis.Buffer.from(bin, 'binary').toString('base64'));
-function base64FromBytes(arr: Uint8Array): string {
+function base64FromBytes(arr: Uint8Array | string): string {
+  if (typeof arr === 'string') {
+    return arr;
+  }
   const bin: string[] = [];
   for (let i = 0; i < arr.byteLength; ++i) {
     bin.push(String.fromCharCode(arr[i]));

--- a/src/main.ts
+++ b/src/main.ts
@@ -355,7 +355,10 @@ function makeByteUtils() {
     'base64FromBytes',
     code`
       const btoa : (bin: string) => string = ${globalThis}.btoa || ((bin) => ${globalThis}.Buffer.from(bin, 'binary').toString('base64'));
-      function base64FromBytes(arr: Uint8Array): string {
+      function base64FromBytes(arr: Uint8Array | string): string {
+        if (typeof arr === 'string') {
+          return arr;
+        }
         const bin: string[] = [];
         for (let i = 0; i < arr.byteLength; ++i) {
           bin.push(String.fromCharCode(arr[i]));

--- a/src/main.ts
+++ b/src/main.ts
@@ -906,7 +906,8 @@ function generateFromJson(ctx: Context, fullName: string, messageDesc: Descripto
         if (isLongValueType(field) && options.forceLong === LongOption.LONG) {
           return code`${capitalize(valueType.toCodeString())}.fromValue(${from})`;
         } else if (isBytesValueType(field)) {
-          return code`new ${capitalize(valueType.toCodeString())}(${from})`;
+          const typeCheck = code`typeof ${from} === 'string'`;
+          return code`(${typeCheck} ? ${from} : new Uint8Array(${from}))`;
         } else {
           return code`${capitalize(valueType.toCodeString())}(${from})`;
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -94,7 +94,7 @@ export function basicTypeName(
       if (options.env === EnvOption.NODE) {
         return code`Buffer`;
       } else {
-        return code`Uint8Array | string`;
+        return code`(Uint8Array | string)`;
       }
     case FieldDescriptorProto_Type.TYPE_MESSAGE:
     case FieldDescriptorProto_Type.TYPE_ENUM:
@@ -398,7 +398,7 @@ export function valueTypeName(ctx: Context, typeName: string): Code | undefined 
     case '.google.protobuf.BoolValue':
       return code`boolean`;
     case '.google.protobuf.BytesValue':
-      return code`Uint8Array`;
+      return code`(Uint8Array | string)`;
     default:
       return undefined;
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -94,7 +94,7 @@ export function basicTypeName(
       if (options.env === EnvOption.NODE) {
         return code`Buffer`;
       } else {
-        return code`Uint8Array`;
+        return code`Uint8Array | string`;
       }
     case FieldDescriptorProto_Type.TYPE_MESSAGE:
     case FieldDescriptorProto_Type.TYPE_ENUM:


### PR DESCRIPTION
Currently, `bytes` fields are converted to JavaScript `Uint8Array` types. So, given the following schema:
```protobuf
message Message {
    bytes data = 1;
}
```
The following TypeScript interface would be produced:
```typescript
interface Message {
    data: Uint8Array;
}
```
This pull request adds support for base64 strings in addition to the already supported Uint8Array representation:
```typescript
interface Message {
    data: Uint8Array | string;
}
```