### PR TITLE
fix: Only generate files in fileToGenerate

### DIFF
--- a/integration/codegen.ts
+++ b/integration/codegen.ts
@@ -8,6 +8,7 @@ import { prefixDisableLinter } from '../src/utils';
 import { getTsPoetOpts, optionsFromParameter } from '../src/options';
 import { Context } from '../src/context';
 import { generateTypeRegistry } from '../src/generate-type-registry';
+import { protoFilesToGenerate } from '../src/plugin';
 
 /**
  * Generates output for our integration tests from their example proto files.
@@ -31,7 +32,7 @@ async function generate(binFile: string, baseDir: string, parameter: string) {
   const options = optionsFromParameter(parameter || '');
   const typeMap = createTypeMap(request, options);
 
-  for (let file of request.protoFile) {
+  for (let file of protoFilesToGenerate(request)) {
     // Make a different utils per file to track per-file usage
     const utils = makeUtils(options);
     const ctx: Context = { options, typeMap, utils };

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,4 +1,9 @@
-import { CodeGeneratorRequest, CodeGeneratorResponse, CodeGeneratorResponse_Feature } from 'ts-proto-descriptors';
+import {
+  CodeGeneratorRequest,
+  CodeGeneratorResponse,
+  CodeGeneratorResponse_Feature,
+  FileDescriptorProto,
+} from 'ts-proto-descriptors';
 import { promisify } from 'util';
 import { prefixDisableLinter, readToBuffer } from './utils';
 import { generateFile, makeUtils } from './main';
@@ -6,6 +11,10 @@ import { createTypeMap } from './types';
 import { Context } from './context';
 import { getTsPoetOpts, optionsFromParameter } from './options';
 import { generateTypeRegistry } from './generate-type-registry';
+
+export function protoFilesToGenerate(request: CodeGeneratorRequest): FileDescriptorProto[] {
+  return request.protoFile.filter((f) => request.fileToGenerate.includes(f.name));
+}
 
 // this would be the plugin called by the protoc compiler
 async function main() {
@@ -20,7 +29,7 @@ async function main() {
   const ctx: Context = { typeMap, options, utils };
 
   const files = await Promise.all(
-    request.protoFile.map(async (file) => {
+    protoFilesToGenerate(request).map(async (file) => {
       const [path, code] = generateFile(ctx, file);
       const spec = await code.toStringWithImports({ ...getTsPoetOpts(options), path });
       return { name: path, content: prefixDisableLinter(spec) };


### PR DESCRIPTION
According to doc comments in `plugin.proto` from Google:

```
// The .proto files that were explicitly listed on the command-line.  The
// code generator should generate code only for these files.  Each file's
// descriptor will be included in proto_file, below.
repeated string file_to_generate = 1;
```