### PR TITLE
fix: add missing `boolean` to `DeepPartial`

### DIFF
--- a/integration/angular/simple-message.ts
+++ b/integration/angular/simple-message.ts
@@ -63,7 +63,7 @@ export const SimpleMessage = {
   },
 };
 
-type Builtin = Date | Function | Uint8Array | string | number | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>

--- a/integration/avoid-import-conflicts/simple.ts
+++ b/integration/avoid-import-conflicts/simple.ts
@@ -83,7 +83,7 @@ export const Simple = {
   },
 };
 
-type Builtin = Date | Function | Uint8Array | string | number | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>

--- a/integration/avoid-import-conflicts/simple2.ts
+++ b/integration/avoid-import-conflicts/simple2.ts
@@ -81,7 +81,7 @@ export const Simple = {
   },
 };
 
-type Builtin = Date | Function | Uint8Array | string | number | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>

--- a/integration/barrel-imports/bar.ts
+++ b/integration/barrel-imports/bar.ts
@@ -79,7 +79,7 @@ export const Bar = {
   },
 };
 
-type Builtin = Date | Function | Uint8Array | string | number | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>

--- a/integration/barrel-imports/foo.ts
+++ b/integration/barrel-imports/foo.ts
@@ -80,7 +80,7 @@ export const Foo = {
   },
 };
 
-type Builtin = Date | Function | Uint8Array | string | number | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>

--- a/integration/batching-with-context/batching.ts
+++ b/integration/batching-with-context/batching.ts
@@ -740,7 +740,7 @@ export interface DataLoaders {
   getDataLoader<T>(identifier: string, constructorFn: () => T): T;
 }
 
-type Builtin = Date | Function | Uint8Array | string | number | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>

--- a/integration/batching/batching.ts
+++ b/integration/batching/batching.ts
@@ -688,7 +688,7 @@ interface Rpc {
   request(service: string, method: string, data: Uint8Array): Promise<Uint8Array>;
 }
 
-type Builtin = Date | Function | Uint8Array | string | number | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>

--- a/integration/bytes-as-base64/message.ts
+++ b/integration/bytes-as-base64/message.ts
@@ -69,7 +69,7 @@ function base64FromBytes(arr: Uint8Array): string {
   return btoa(bin.join(''));
 }
 
-type Builtin = Date | Function | Uint8Array | string | number | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>

--- a/integration/bytes-node/point.ts
+++ b/integration/bytes-node/point.ts
@@ -95,7 +95,7 @@ function base64FromBytes(arr: Uint8Array): string {
   return btoa(bin.join(''));
 }
 
-type Builtin = Date | Function | Uint8Array | string | number | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>

--- a/integration/const-enum/const-enum.ts
+++ b/integration/const-enum/const-enum.ts
@@ -122,7 +122,7 @@ export const DividerData = {
   },
 };
 
-type Builtin = Date | Function | Uint8Array | string | number | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>

--- a/integration/global-this/global-this.ts
+++ b/integration/global-this/global-this.ts
@@ -122,7 +122,7 @@ export const Error = {
   },
 };
 
-type Builtin = Date | Function | Uint8Array | string | number | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>

--- a/integration/grpc-js/google/protobuf/empty.ts
+++ b/integration/grpc-js/google/protobuf/empty.ts
@@ -55,7 +55,7 @@ export const Empty = {
   },
 };
 
-type Builtin = Date | Function | Uint8Array | string | number | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>

--- a/integration/grpc-js/google/protobuf/timestamp.ts
+++ b/integration/grpc-js/google/protobuf/timestamp.ts
@@ -186,7 +186,7 @@ var globalThis: any = (() => {
   throw 'Unable to locate global object';
 })();
 
-type Builtin = Date | Function | Uint8Array | string | number | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>

--- a/integration/grpc-js/simple.ts
+++ b/integration/grpc-js/simple.ts
@@ -202,7 +202,7 @@ export const TestClient = (makeGenericClientConstructor(TestService, 'simple.Tes
   new (address: string, credentials: ChannelCredentials, options?: Partial<ChannelOptions>): TestClient;
 };
 
-type Builtin = Date | Function | Uint8Array | string | number | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>

--- a/integration/grpc-web-go-server/example.ts
+++ b/integration/grpc-web-go-server/example.ts
@@ -788,7 +788,7 @@ interface Rpc {
   request(service: string, method: string, data: Uint8Array): Promise<Uint8Array>;
 }
 
-type Builtin = Date | Function | Uint8Array | string | number | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>

--- a/integration/grpc-web-no-streaming-observable/example.ts
+++ b/integration/grpc-web-no-streaming-observable/example.ts
@@ -462,7 +462,7 @@ export class GrpcWebImpl {
   }
 }
 
-type Builtin = Date | Function | Uint8Array | string | number | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>

--- a/integration/grpc-web-no-streaming/example.ts
+++ b/integration/grpc-web-no-streaming/example.ts
@@ -462,7 +462,7 @@ export class GrpcWebImpl {
   }
 }
 
-type Builtin = Date | Function | Uint8Array | string | number | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>

--- a/integration/grpc-web/example.ts
+++ b/integration/grpc-web/example.ts
@@ -1010,7 +1010,7 @@ export class GrpcWebImpl {
   }
 }
 
-type Builtin = Date | Function | Uint8Array | string | number | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>

--- a/integration/no-proto-package/no-proto-package.ts
+++ b/integration/no-proto-package/no-proto-package.ts
@@ -124,7 +124,7 @@ interface Rpc {
   request(service: string, method: string, data: Uint8Array): Promise<Uint8Array>;
 }
 
-type Builtin = Date | Function | Uint8Array | string | number | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>

--- a/integration/oneof-properties/oneof.ts
+++ b/integration/oneof-properties/oneof.ts
@@ -384,7 +384,7 @@ function base64FromBytes(arr: Uint8Array): string {
   return btoa(bin.join(''));
 }
 
-type Builtin = Date | Function | Uint8Array | string | number | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>

--- a/integration/oneof-unions/oneof.ts
+++ b/integration/oneof-unions/oneof.ts
@@ -416,7 +416,7 @@ function base64FromBytes(arr: Uint8Array): string {
   return btoa(bin.join(''));
 }
 
-type Builtin = Date | Function | Uint8Array | string | number | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>

--- a/integration/point/point.ts
+++ b/integration/point/point.ts
@@ -158,7 +158,7 @@ export const Area = {
   },
 };
 
-type Builtin = Date | Function | Uint8Array | string | number | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>

--- a/integration/return-observable/observable.ts
+++ b/integration/return-observable/observable.ts
@@ -127,7 +127,7 @@ export interface Factory {
   Produce(request: ProduceRequest): Observable<ProduceReply>;
 }
 
-type Builtin = Date | Function | Uint8Array | string | number | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>

--- a/integration/simple-deprecated-fields/simple.ts
+++ b/integration/simple-deprecated-fields/simple.ts
@@ -210,7 +210,7 @@ export const Child = {
   },
 };
 
-type Builtin = Date | Function | Uint8Array | string | number | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>

--- a/integration/simple-esmodule-interop/simple.ts
+++ b/integration/simple-esmodule-interop/simple.ts
@@ -361,7 +361,7 @@ var globalThis: any = (() => {
   throw 'Unable to locate global object';
 })();
 
-type Builtin = Date | Function | Uint8Array | string | number | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>

--- a/integration/simple-long-string/google/protobuf/timestamp.ts
+++ b/integration/simple-long-string/google/protobuf/timestamp.ts
@@ -185,7 +185,7 @@ export const Timestamp = {
   },
 };
 
-type Builtin = Date | Function | Uint8Array | string | number | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>

--- a/integration/simple-long-string/google/protobuf/wrappers.ts
+++ b/integration/simple-long-string/google/protobuf/wrappers.ts
@@ -621,7 +621,7 @@ function base64FromBytes(arr: Uint8Array): string {
   return btoa(bin.join(''));
 }
 
-type Builtin = Date | Function | Uint8Array | string | number | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>

--- a/integration/simple-long-string/simple.ts
+++ b/integration/simple-long-string/simple.ts
@@ -312,7 +312,7 @@ export const Numbers = {
   },
 };
 
-type Builtin = Date | Function | Uint8Array | string | number | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>

--- a/integration/simple-long/google/protobuf/wrappers.ts
+++ b/integration/simple-long/google/protobuf/wrappers.ts
@@ -621,7 +621,7 @@ function base64FromBytes(arr: Uint8Array): string {
   return btoa(bin.join(''));
 }
 
-type Builtin = Date | Function | Uint8Array | string | number | undefined | Long;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined | Long;
 export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>

--- a/integration/simple-long/simple.ts
+++ b/integration/simple-long/simple.ts
@@ -731,7 +731,7 @@ export const Numbers = {
   },
 };
 
-type Builtin = Date | Function | Uint8Array | string | number | undefined | Long;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined | Long;
 export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>

--- a/integration/simple-optionals/google/protobuf/timestamp.ts
+++ b/integration/simple-optionals/google/protobuf/timestamp.ts
@@ -186,7 +186,7 @@ var globalThis: any = (() => {
   throw 'Unable to locate global object';
 })();
 
-type Builtin = Date | Function | Uint8Array | string | number | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>

--- a/integration/simple-optionals/google/protobuf/wrappers.ts
+++ b/integration/simple-optionals/google/protobuf/wrappers.ts
@@ -621,7 +621,7 @@ function base64FromBytes(arr: Uint8Array): string {
   return btoa(bin.join(''));
 }
 
-type Builtin = Date | Function | Uint8Array | string | number | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>

--- a/integration/simple-optionals/import_dir/thing.ts
+++ b/integration/simple-optionals/import_dir/thing.ts
@@ -64,7 +64,7 @@ export const ImportedThing = {
   },
 };
 
-type Builtin = Date | Function | Uint8Array | string | number | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>

--- a/integration/simple-optionals/simple.ts
+++ b/integration/simple-optionals/simple.ts
@@ -1922,7 +1922,7 @@ var globalThis: any = (() => {
   throw 'Unable to locate global object';
 })();
 
-type Builtin = Date | Function | Uint8Array | string | number | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>

--- a/integration/simple-optionals/thing.ts
+++ b/integration/simple-optionals/thing.ts
@@ -64,7 +64,7 @@ export const ImportedThing = {
   },
 };
 
-type Builtin = Date | Function | Uint8Array | string | number | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>

--- a/integration/simple-proto2/simple.ts
+++ b/integration/simple-proto2/simple.ts
@@ -95,7 +95,7 @@ export const Issue56 = {
   },
 };
 
-type Builtin = Date | Function | Uint8Array | string | number | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>

--- a/integration/simple-snake/google/protobuf/timestamp.ts
+++ b/integration/simple-snake/google/protobuf/timestamp.ts
@@ -186,7 +186,7 @@ var globalThis: any = (() => {
   throw 'Unable to locate global object';
 })();
 
-type Builtin = Date | Function | Uint8Array | string | number | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>

--- a/integration/simple-snake/google/protobuf/wrappers.ts
+++ b/integration/simple-snake/google/protobuf/wrappers.ts
@@ -621,7 +621,7 @@ function base64FromBytes(arr: Uint8Array): string {
   return btoa(bin.join(''));
 }
 
-type Builtin = Date | Function | Uint8Array | string | number | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>

--- a/integration/simple-snake/import_dir/thing.ts
+++ b/integration/simple-snake/import_dir/thing.ts
@@ -64,7 +64,7 @@ export const ImportedThing = {
   },
 };
 
-type Builtin = Date | Function | Uint8Array | string | number | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>

--- a/integration/simple-snake/simple.ts
+++ b/integration/simple-snake/simple.ts
@@ -1922,7 +1922,7 @@ var globalThis: any = (() => {
   throw 'Unable to locate global object';
 })();
 
-type Builtin = Date | Function | Uint8Array | string | number | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>

--- a/integration/simple-string-enums/simple.ts
+++ b/integration/simple-string-enums/simple.ts
@@ -166,7 +166,7 @@ export const Simple = {
   },
 };
 
-type Builtin = Date | Function | Uint8Array | string | number | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>

--- a/integration/simple-unrecognized-enum/google/protobuf/timestamp.ts
+++ b/integration/simple-unrecognized-enum/google/protobuf/timestamp.ts
@@ -186,7 +186,7 @@ var globalThis: any = (() => {
   throw 'Unable to locate global object';
 })();
 
-type Builtin = Date | Function | Uint8Array | string | number | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>

--- a/integration/simple-unrecognized-enum/google/protobuf/wrappers.ts
+++ b/integration/simple-unrecognized-enum/google/protobuf/wrappers.ts
@@ -621,7 +621,7 @@ function base64FromBytes(arr: Uint8Array): string {
   return btoa(bin.join(''));
 }
 
-type Builtin = Date | Function | Uint8Array | string | number | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>

--- a/integration/simple-unrecognized-enum/import_dir/thing.ts
+++ b/integration/simple-unrecognized-enum/import_dir/thing.ts
@@ -64,7 +64,7 @@ export const ImportedThing = {
   },
 };
 
-type Builtin = Date | Function | Uint8Array | string | number | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>

--- a/integration/simple-unrecognized-enum/simple.ts
+++ b/integration/simple-unrecognized-enum/simple.ts
@@ -1913,7 +1913,7 @@ var globalThis: any = (() => {
   throw 'Unable to locate global object';
 })();
 
-type Builtin = Date | Function | Uint8Array | string | number | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>

--- a/integration/simple/google/protobuf/timestamp.ts
+++ b/integration/simple/google/protobuf/timestamp.ts
@@ -186,7 +186,7 @@ var globalThis: any = (() => {
   throw 'Unable to locate global object';
 })();
 
-type Builtin = Date | Function | Uint8Array | string | number | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>

--- a/integration/simple/google/protobuf/wrappers.ts
+++ b/integration/simple/google/protobuf/wrappers.ts
@@ -621,7 +621,7 @@ function base64FromBytes(arr: Uint8Array): string {
   return btoa(bin.join(''));
 }
 
-type Builtin = Date | Function | Uint8Array | string | number | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>

--- a/integration/simple/google/type/date.ts
+++ b/integration/simple/google/type/date.ts
@@ -124,7 +124,7 @@ export const DateMessage = {
   },
 };
 
-type Builtin = Date | Function | Uint8Array | string | number | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>

--- a/integration/simple/import_dir/thing.ts
+++ b/integration/simple/import_dir/thing.ts
@@ -64,7 +64,7 @@ export const ImportedThing = {
   },
 };
 
-type Builtin = Date | Function | Uint8Array | string | number | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>

--- a/integration/simple/simple.ts
+++ b/integration/simple/simple.ts
@@ -2605,7 +2605,7 @@ function base64FromBytes(arr: Uint8Array): string {
   return btoa(bin.join(''));
 }
 
-type Builtin = Date | Function | Uint8Array | string | number | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>

--- a/integration/type-registry/bar/bar.ts
+++ b/integration/type-registry/bar/bar.ts
@@ -70,7 +70,7 @@ export const Bar = {
 
 messageTypeRegistry.set(Bar.$type, Bar);
 
-type Builtin = Date | Function | Uint8Array | string | number | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>

--- a/integration/type-registry/foo.ts
+++ b/integration/type-registry/foo.ts
@@ -134,7 +134,7 @@ export const Foo2 = {
 
 messageTypeRegistry.set(Foo2.$type, Foo2);
 
-type Builtin = Date | Function | Uint8Array | string | number | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>

--- a/integration/type-registry/google/protobuf/timestamp.ts
+++ b/integration/type-registry/google/protobuf/timestamp.ts
@@ -201,7 +201,7 @@ var globalThis: any = (() => {
   throw 'Unable to locate global object';
 })();
 
-type Builtin = Date | Function | Uint8Array | string | number | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>

--- a/integration/type-registry/typeRegistry.ts
+++ b/integration/type-registry/typeRegistry.ts
@@ -14,7 +14,7 @@ export type UnknownMessage = { $type: string };
 
 export const messageTypeRegistry = new Map<string, MessageType>();
 
-type Builtin = Date | Function | Uint8Array | string | number | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>

--- a/integration/types-with-underscores/file.ts
+++ b/integration/types-with-underscores/file.ts
@@ -103,7 +103,7 @@ export const FooBar = {
   },
 };
 
-type Builtin = Date | Function | Uint8Array | string | number | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>

--- a/integration/use-date-false/google/protobuf/timestamp.ts
+++ b/integration/use-date-false/google/protobuf/timestamp.ts
@@ -186,7 +186,7 @@ var globalThis: any = (() => {
   throw 'Unable to locate global object';
 })();
 
-type Builtin = Date | Function | Uint8Array | string | number | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>

--- a/integration/use-date-false/metadata.ts
+++ b/integration/use-date-false/metadata.ts
@@ -64,7 +64,7 @@ export const Metadata = {
   },
 };
 
-type Builtin = Date | Function | Uint8Array | string | number | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>

--- a/integration/use-date-string/google/protobuf/timestamp.ts
+++ b/integration/use-date-string/google/protobuf/timestamp.ts
@@ -186,7 +186,7 @@ var globalThis: any = (() => {
   throw 'Unable to locate global object';
 })();
 
-type Builtin = Date | Function | Uint8Array | string | number | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>

--- a/integration/use-date-string/use-date-string.ts
+++ b/integration/use-date-string/use-date-string.ts
@@ -233,7 +233,7 @@ export const Todo_MapOfTimestampsEntry = {
   },
 };
 
-type Builtin = Date | Function | Uint8Array | string | number | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>

--- a/integration/use-date-true/google/protobuf/timestamp.ts
+++ b/integration/use-date-true/google/protobuf/timestamp.ts
@@ -186,7 +186,7 @@ var globalThis: any = (() => {
   throw 'Unable to locate global object';
 })();
 
-type Builtin = Date | Function | Uint8Array | string | number | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>

--- a/integration/use-date-true/use-date-true.ts
+++ b/integration/use-date-true/use-date-true.ts
@@ -233,7 +233,7 @@ export const Todo_MapOfTimestampsEntry = {
   },
 };
 
-type Builtin = Date | Function | Uint8Array | string | number | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>

--- a/integration/vector-tile/vector_tile.ts
+++ b/integration/vector-tile/vector_tile.ts
@@ -614,7 +614,7 @@ var globalThis: any = (() => {
   throw 'Unable to locate global object';
 })();
 
-type Builtin = Date | Function | Uint8Array | string | number | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>

--- a/src/main.ts
+++ b/src/main.ts
@@ -378,7 +378,7 @@ function makeDeepPartial(options: Options, longs: ReturnType<typeof makeLongUtil
   const DeepPartial = conditionalOutput(
     'DeepPartial',
     code`
-      type Builtin = Date | Function | Uint8Array | string | number | undefined${maybeLong};
+      type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined${maybeLong};
       ${maybeExport} type DeepPartial<T> = T extends Builtin
         ? T
         : T extends Array<infer U>


### PR DESCRIPTION
After making `DeepPartial` ignore the `$type` field (https://github.com/stephenh/ts-proto/pull/282), the `DeepPartial<boolean>` produced incorrect result:

```ts
type Test = DeepPartial<boolean>;
// {
//    valueOf?: (() => boolean) | undefined;
// } | {
//    valueOf?: (() => boolean) | undefined;
// }
```

This PR adds `boolean` to the list of built-in types.