### PR TITLE
feat: Bind service methods to class

### DIFF
--- a/integration/batching-with-context/batching.ts
+++ b/integration/batching-with-context/batching.ts
@@ -662,6 +662,10 @@ export class EntityServiceClientImpl<Context extends DataLoaders> implements Ent
   private readonly rpc: Rpc<Context>;
   constructor(rpc: Rpc<Context>) {
     this.rpc = rpc;
+    this.BatchQuery = this.BatchQuery.bind(this);
+    this.BatchMapQuery = this.BatchMapQuery.bind(this);
+    this.GetOnlyMethod = this.GetOnlyMethod.bind(this);
+    this.WriteMethod = this.WriteMethod.bind(this);
   }
   GetQuery(ctx: Context, id: string): Promise<Entity> {
     const dl = ctx.getDataLoader('batching.EntityService.BatchQuery', () => {

--- a/integration/batching/batching.ts
+++ b/integration/batching/batching.ts
@@ -658,6 +658,10 @@ export class EntityServiceClientImpl implements EntityService {
   private readonly rpc: Rpc;
   constructor(rpc: Rpc) {
     this.rpc = rpc;
+    this.BatchQuery = this.BatchQuery.bind(this);
+    this.BatchMapQuery = this.BatchMapQuery.bind(this);
+    this.GetOnlyMethod = this.GetOnlyMethod.bind(this);
+    this.WriteMethod = this.WriteMethod.bind(this);
   }
   BatchQuery(request: BatchQueryRequest): Promise<BatchQueryResponse> {
     const data = BatchQueryRequest.encode(request).finish();

--- a/integration/grpc-web-go-server/example.ts
+++ b/integration/grpc-web-go-server/example.ts
@@ -735,6 +735,8 @@ export class DashStateClientImpl implements DashState {
   private readonly rpc: Rpc;
   constructor(rpc: Rpc) {
     this.rpc = rpc;
+    this.UserSettings = this.UserSettings.bind(this);
+    this.ActiveUserSettingsStream = this.ActiveUserSettingsStream.bind(this);
   }
   UserSettings(request: Empty): Promise<DashUserSettingsState> {
     const data = Empty.encode(request).finish();
@@ -764,6 +766,9 @@ export class DashAPICredsClientImpl implements DashAPICreds {
   private readonly rpc: Rpc;
   constructor(rpc: Rpc) {
     this.rpc = rpc;
+    this.Create = this.Create.bind(this);
+    this.Update = this.Update.bind(this);
+    this.Delete = this.Delete.bind(this);
   }
   Create(request: DashAPICredsCreateReq): Promise<DashCred> {
     const data = DashAPICredsCreateReq.encode(request).finish();

--- a/integration/grpc-web-no-streaming-observable/example.ts
+++ b/integration/grpc-web-no-streaming-observable/example.ts
@@ -362,6 +362,7 @@ export class DashStateClientImpl implements DashState {
 
   constructor(rpc: Rpc) {
     this.rpc = rpc;
+    this.UserSettings = this.UserSettings.bind(this);
   }
 
   UserSettings(request: DeepPartial<Empty>, metadata?: grpc.Metadata): Observable<DashUserSettingsState> {

--- a/integration/grpc-web-no-streaming/example.ts
+++ b/integration/grpc-web-no-streaming/example.ts
@@ -360,6 +360,7 @@ export class DashStateClientImpl implements DashState {
 
   constructor(rpc: Rpc) {
     this.rpc = rpc;
+    this.UserSettings = this.UserSettings.bind(this);
   }
 
   UserSettings(request: DeepPartial<Empty>, metadata?: grpc.Metadata): Promise<DashUserSettingsState> {

--- a/integration/grpc-web/example-test.ts
+++ b/integration/grpc-web/example-test.ts
@@ -11,4 +11,13 @@ describe('grpc-web', () => {
     const client = new DashStateClientImpl(rpc);
     client.UserSettings({});
   });
+  it('binds rpc function', () => {
+    const rpc = {
+      unary: jest.fn(),
+      invoke: jest.fn(),
+    };
+    const client = new DashStateClientImpl(rpc);
+    const userSettings = client.UserSettings;
+    userSettings({});
+  })
 });

--- a/integration/grpc-web/example.ts
+++ b/integration/grpc-web/example.ts
@@ -739,6 +739,8 @@ export class DashStateClientImpl implements DashState {
 
   constructor(rpc: Rpc) {
     this.rpc = rpc;
+    this.UserSettings = this.UserSettings.bind(this);
+    this.ActiveUserSettingsStream = this.ActiveUserSettingsStream.bind(this);
   }
 
   UserSettings(request: DeepPartial<Empty>, metadata?: grpc.Metadata): Promise<DashUserSettingsState> {
@@ -814,6 +816,9 @@ export class DashAPICredsClientImpl implements DashAPICreds {
 
   constructor(rpc: Rpc) {
     this.rpc = rpc;
+    this.Create = this.Create.bind(this);
+    this.Update = this.Update.bind(this);
+    this.Delete = this.Delete.bind(this);
   }
 
   Create(request: DeepPartial<DashAPICredsCreateReq>, metadata?: grpc.Metadata): Promise<DashCred> {

--- a/integration/meta-typings/simple.ts
+++ b/integration/meta-typings/simple.ts
@@ -1216,6 +1216,7 @@ export class PingServiceClientImpl implements PingService {
   private readonly rpc: Rpc;
   constructor(rpc: Rpc) {
     this.rpc = rpc;
+    this.ping = this.ping.bind(this);
   }
   ping(request: PingRequest): Promise<PingResponse> {
     const data = PingRequest.encode(request).finish();

--- a/integration/no-proto-package/no-proto-package.ts
+++ b/integration/no-proto-package/no-proto-package.ts
@@ -112,6 +112,7 @@ export class UserStateClientImpl implements UserState {
   private readonly rpc: Rpc;
   constructor(rpc: Rpc) {
     this.rpc = rpc;
+    this.GetUsers = this.GetUsers.bind(this);
   }
   GetUsers(request: Empty): Promise<User> {
     const data = Empty.encode(request).finish();

--- a/integration/simple-optionals/simple.ts
+++ b/integration/simple-optionals/simple.ts
@@ -1900,6 +1900,7 @@ export class PingServiceClientImpl implements PingService {
   private readonly rpc: Rpc;
   constructor(rpc: Rpc) {
     this.rpc = rpc;
+    this.ping = this.ping.bind(this);
   }
   ping(request: PingRequest): Promise<PingResponse> {
     const data = PingRequest.encode(request).finish();

--- a/integration/simple-snake/simple.ts
+++ b/integration/simple-snake/simple.ts
@@ -1900,6 +1900,7 @@ export class PingServiceClientImpl implements PingService {
   private readonly rpc: Rpc;
   constructor(rpc: Rpc) {
     this.rpc = rpc;
+    this.ping = this.ping.bind(this);
   }
   ping(request: PingRequest): Promise<PingResponse> {
     const data = PingRequest.encode(request).finish();

--- a/integration/simple-unrecognized-enum/simple.ts
+++ b/integration/simple-unrecognized-enum/simple.ts
@@ -1891,6 +1891,7 @@ export class PingServiceClientImpl implements PingService {
   private readonly rpc: Rpc;
   constructor(rpc: Rpc) {
     this.rpc = rpc;
+    this.ping = this.ping.bind(this);
   }
   ping(request: PingRequest): Promise<PingResponse> {
     const data = PingRequest.encode(request).finish();

--- a/integration/simple/simple-service-test.ts
+++ b/integration/simple/simple-service-test.ts
@@ -1,0 +1,12 @@
+import { PingRequest, PingServiceClientImpl } from './simple';
+
+describe('simple', () => {
+  it('binds rpc function', () => {
+    const rpc = {
+      request: jest.fn().mockResolvedValue({}),
+    };
+    const client = new PingServiceClientImpl(rpc);
+    const ping = client.ping;
+    ping(PingRequest.fromPartial({}));
+  })
+})

--- a/integration/simple/simple.ts
+++ b/integration/simple/simple.ts
@@ -2562,6 +2562,7 @@ export class PingServiceClientImpl implements PingService {
   private readonly rpc: Rpc;
   constructor(rpc: Rpc) {
     this.rpc = rpc;
+    this.ping = this.ping.bind(this);
   }
   ping(request: PingRequest): Promise<PingResponse> {
     const data = PingRequest.encode(request).finish();

--- a/src/generate-grpc-web.ts
+++ b/src/generate-grpc-web.ts
@@ -28,9 +28,13 @@ export function generateGrpcClientImpl(
     private readonly rpc: Rpc;
     
     constructor(rpc: Rpc) {
-      this.rpc = rpc;
-    }
   `);
+  chunks.push(code`this.rpc = rpc;`);
+  // Bind each FooService method to the FooServiceImpl class
+  for (const methodDesc of serviceDesc.method) {
+    chunks.push(code`this.${methodDesc.name} = this.${methodDesc.name}.bind(this);`);
+  }
+  chunks.push(code`}\n`);
 
   // Create a method for each FooService method
   for (const methodDesc of serviceDesc.method) {

--- a/src/generate-services.ts
+++ b/src/generate-services.ts
@@ -148,7 +148,13 @@ export function generateServiceClientImpl(
   // Create the constructor(rpc: Rpc)
   const rpcType = options.context ? 'Rpc<Context>' : 'Rpc';
   chunks.push(code`private readonly rpc: ${rpcType};`);
-  chunks.push(code`constructor(rpc: ${rpcType}) { this.rpc = rpc; }`);
+  chunks.push(code`constructor(rpc: ${rpcType}) {`);
+  chunks.push(code`this.rpc = rpc;`);
+  // Bind each FooService method to the FooServiceImpl class
+  for (const methodDesc of serviceDesc.method) {
+    chunks.push(code`this.${methodDesc.name} = this.${methodDesc.name}.bind(this);`);
+  }
+  chunks.push(code`}`);
 
   // Create a method for each FooService method
   for (const methodDesc of serviceDesc.method) {


### PR DESCRIPTION
This makes it easier to pass around service function references. For example, with this change you can use [react-query](https://react-query.tanstack.com/guides/mutations) directly: `useMutation(fooClient.bar);`