### PR TITLE
fix: close server stream on observer unsubscribe

### DIFF
--- a/integration/grpc-web/example.ts
+++ b/integration/grpc-web/example.ts
@@ -1009,7 +1009,7 @@ export class GrpcWebImpl {
             }
           },
         });
-        observer.add(client.close)
+        observer.add(() => client.close());
       };
       upStream();
     }).pipe(share());

--- a/integration/grpc-web/example.ts
+++ b/integration/grpc-web/example.ts
@@ -992,7 +992,7 @@ export class GrpcWebImpl {
         : metadata || this.options.metadata;
     return new Observable((observer) => {
       const upStream = () => {
-        grpc.invoke(methodDesc, {
+        const client = grpc.invoke(methodDesc, {
           host: this.host,
           request,
           transport: this.options.streamingTransport || this.options.transport,
@@ -1009,6 +1009,7 @@ export class GrpcWebImpl {
             }
           },
         });
+        observer.add(client.close)
       };
       upStream();
     }).pipe(share());

--- a/src/generate-grpc-web.ts
+++ b/src/generate-grpc-web.ts
@@ -317,7 +317,7 @@ function createInvokeMethod() {
               }
             },
           });
-          observer.add(client.close)
+          observer.add(() => client.close());
         });
         upStream();
       }).pipe(${share}());

--- a/src/generate-grpc-web.ts
+++ b/src/generate-grpc-web.ts
@@ -300,7 +300,7 @@ function createInvokeMethod() {
         : metadata || this.options.metadata;
       return new Observable(observer => {
         const upStream = (() => {
-          ${grpc}.invoke(methodDesc, {
+          const client = ${grpc}.invoke(methodDesc, {
             host: this.host,
             request,
             transport: this.options.streamingTransport || this.options.transport,
@@ -317,6 +317,7 @@ function createInvokeMethod() {
               }
             },
           });
+          observer.add(client.close)
         });
         upStream();
       }).pipe(${share}());


### PR DESCRIPTION
I found that once a server stream is opened, there is no way to close it. Unsubscribing from the observable would not close the connection between the browser and the server.

This change adds a handler on the observer that will call the grpc.invoke's `close`, which will close the connection between the browser and the server.