### PR TITLE
fix: tsconfig conflict issue that occurs with ts-proto-descriptors

### DIFF
--- a/protos/.gitignore
+++ b/protos/.gitignore
@@ -1,2 +1,2 @@
 node_modules/
-*.js
+dist/

--- a/protos/build.sh
+++ b/protos/build.sh
@@ -13,7 +13,8 @@ protoc \
 ./node_modules/.bin/tsc \
   ./index.ts \
   ./google/protobuf/descriptor.ts \
-  ./google/protobuf/compiler/plugin.ts
+  ./google/protobuf/compiler/plugin.ts \
+  --outDir dist --declaration
 
 
 

--- a/protos/package.json
+++ b/protos/package.json
@@ -6,6 +6,7 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
+  "main": "dist/index.js",
   "dependencies": {
     "protobufjs": "^6.8.8",
     "long": "^4.0.0"


### PR DESCRIPTION
When importing `ts-proto-descriptors` into a typescript project, it will try to import the typescript source code, and not the generated javascript. This is an issue when the dependent project's `tsconfig` file does not agree with the `tsconfig` for `ts-proto`.

For example, my project depends on `ts-proto-descriptors` has a `tsconfig` that has enabled `esModuleInterop`. But the `ts-proto` `tsconfig` does not have this option set, meaning the `ts-proto-descriptors` source is not compatible with my project and throws the following typescript errors:
```
node_modules/ts-proto-descriptors/google/protobuf/compiler/plugin.ts:609:5 - error TS2367: This condition will always return 'true' since the types 'Constructor<Long>' and '{ default: LongConstructor; prototype: Long; MAX_UNSIGNED_VALUE: Long; MAX_VALUE: Long; MIN_VALUE: Long; NEG_ONE: Long; ONE: Long; ... 11 more ...; fromValue(val: string | ... 2 more ... | { ...; }): Long; }' have no overlap.

609 if (util.Long !== Long) {
        ~~~~~~~~~~~~~~~~~~

node_modules/ts-proto-descriptors/google/protobuf/descriptor.ts:4526:5 - error TS2367: This condition will always return 'true' since the types 'Constructor<Long>' and '{ default: LongConstructor; prototype: Long; MAX_UNSIGNED_VALUE: Long; MAX_VALUE: Long; MIN_VALUE: Long; NEG_ONE: Long; ONE: Long; ... 11 more ...; fromValue(val: string | ... 2 more ... | { ...; }): Long; }' have no overlap.

4526 if (util.Long !== Long) {
         ~~~~~~~~~~~~~~~~~~


Found 2 errors.
```

This PR addresses the underlying issue by exporting **only** the generated javascript from `ts-proto-descriptors` (along with ts definition files for type safety). This means that it cannot be broken by the outer project's `ts-config` because it is already compiled. 

From a developer perspective, there will be no change as the definition files will maintain type-safety, as if you were working with typescript directly. However if you *really* wanted to import the TS source, then you could also do that by just specifying the path explicitly (eg. `import { FileDescriptorProto } from "ts-proto-descriptors/index"`).

NOTE: This change will require a release to NPM for https://www.npmjs.com/package/ts-proto-descriptors