### PR TITLE
docs: Add note about transport

### DIFF
--- a/integration/grpc-web/client-ts.ts
+++ b/integration/grpc-web/client-ts.ts
@@ -5,6 +5,8 @@ import { DashAPICredsClientImpl, DashStateClientImpl, GrpcWebImpl } from './exam
 import { grpc } from '@improbable-eng/grpc-web';
 
 const rpc = new GrpcWebImpl('http://localhost:9090', {
+  // Only necessary for tests running on node. Remove the
+  // transport config when actually using in the browser.
   transport: NodeHttpTransport(),
   debug: false,
   metadata: new grpc.Metadata({ SomeHeader: 'bar' }),


### PR DESCRIPTION
I've just spent about an hour trying to figure out why it wasn't working because I didn't realise that this just applies to a node environment. (Now that I know, it's quite obvious).

Since this is the reference for `grpc-web` I assume that many people will just copy this and a comment like this might be helpful.