### PR TITLE
feat: Initialize lists with map

### DIFF
--- a/integration/batching-with-context/batching.ts
+++ b/integration/batching-with-context/batching.ts
@@ -78,10 +78,8 @@ export const BatchQueryRequest = {
   fromJSON(object: any): BatchQueryRequest {
     const message = { ...baseBatchQueryRequest } as BatchQueryRequest;
     message.ids = [];
-    if (object.ids !== undefined && object.ids !== null) {
-      for (const e of object.ids) {
-        message.ids.push(String(e));
-      }
+    for (const e of object.ids ?? []) {
+      message.ids.push(String(e));
     }
     return message;
   },
@@ -99,10 +97,8 @@ export const BatchQueryRequest = {
   fromPartial(object: DeepPartial<BatchQueryRequest>): BatchQueryRequest {
     const message = { ...baseBatchQueryRequest } as BatchQueryRequest;
     message.ids = [];
-    if (object.ids !== undefined && object.ids !== null) {
-      for (const e of object.ids) {
-        message.ids.push(e);
-      }
+    for (const e of object.ids ?? []) {
+      message.ids.push(e);
     }
     return message;
   },
@@ -140,10 +136,8 @@ export const BatchQueryResponse = {
   fromJSON(object: any): BatchQueryResponse {
     const message = { ...baseBatchQueryResponse } as BatchQueryResponse;
     message.entities = [];
-    if (object.entities !== undefined && object.entities !== null) {
-      for (const e of object.entities) {
-        message.entities.push(Entity.fromJSON(e));
-      }
+    for (const e of object.entities ?? []) {
+      message.entities.push(Entity.fromJSON(e));
     }
     return message;
   },
@@ -161,10 +155,8 @@ export const BatchQueryResponse = {
   fromPartial(object: DeepPartial<BatchQueryResponse>): BatchQueryResponse {
     const message = { ...baseBatchQueryResponse } as BatchQueryResponse;
     message.entities = [];
-    if (object.entities !== undefined && object.entities !== null) {
-      for (const e of object.entities) {
-        message.entities.push(Entity.fromPartial(e));
-      }
+    for (const e of object.entities ?? []) {
+      message.entities.push(Entity.fromPartial(e));
     }
     return message;
   },
@@ -202,10 +194,8 @@ export const BatchMapQueryRequest = {
   fromJSON(object: any): BatchMapQueryRequest {
     const message = { ...baseBatchMapQueryRequest } as BatchMapQueryRequest;
     message.ids = [];
-    if (object.ids !== undefined && object.ids !== null) {
-      for (const e of object.ids) {
-        message.ids.push(String(e));
-      }
+    for (const e of object.ids ?? []) {
+      message.ids.push(String(e));
     }
     return message;
   },
@@ -223,10 +213,8 @@ export const BatchMapQueryRequest = {
   fromPartial(object: DeepPartial<BatchMapQueryRequest>): BatchMapQueryRequest {
     const message = { ...baseBatchMapQueryRequest } as BatchMapQueryRequest;
     message.ids = [];
-    if (object.ids !== undefined && object.ids !== null) {
-      for (const e of object.ids) {
-        message.ids.push(e);
-      }
+    for (const e of object.ids ?? []) {
+      message.ids.push(e);
     }
     return message;
   },

--- a/integration/batching-with-context/batching.ts
+++ b/integration/batching-with-context/batching.ts
@@ -77,10 +77,7 @@ export const BatchQueryRequest = {
 
   fromJSON(object: any): BatchQueryRequest {
     const message = { ...baseBatchQueryRequest } as BatchQueryRequest;
-    message.ids = [];
-    for (const e of object.ids ?? []) {
-      message.ids.push(String(e));
-    }
+    message.ids = (object.ids ?? []).map((e: any) => String(e));
     return message;
   },
 
@@ -96,10 +93,7 @@ export const BatchQueryRequest = {
 
   fromPartial(object: DeepPartial<BatchQueryRequest>): BatchQueryRequest {
     const message = { ...baseBatchQueryRequest } as BatchQueryRequest;
-    message.ids = [];
-    for (const e of object.ids ?? []) {
-      message.ids.push(e);
-    }
+    message.ids = (object.ids ?? []).map((e) => e);
     return message;
   },
 };
@@ -135,10 +129,7 @@ export const BatchQueryResponse = {
 
   fromJSON(object: any): BatchQueryResponse {
     const message = { ...baseBatchQueryResponse } as BatchQueryResponse;
-    message.entities = [];
-    for (const e of object.entities ?? []) {
-      message.entities.push(Entity.fromJSON(e));
-    }
+    message.entities = (object.entities ?? []).map((e: any) => Entity.fromJSON(e));
     return message;
   },
 
@@ -154,10 +145,7 @@ export const BatchQueryResponse = {
 
   fromPartial(object: DeepPartial<BatchQueryResponse>): BatchQueryResponse {
     const message = { ...baseBatchQueryResponse } as BatchQueryResponse;
-    message.entities = [];
-    for (const e of object.entities ?? []) {
-      message.entities.push(Entity.fromPartial(e));
-    }
+    message.entities = (object.entities ?? []).map((e) => Entity.fromPartial(e));
     return message;
   },
 };
@@ -193,10 +181,7 @@ export const BatchMapQueryRequest = {
 
   fromJSON(object: any): BatchMapQueryRequest {
     const message = { ...baseBatchMapQueryRequest } as BatchMapQueryRequest;
-    message.ids = [];
-    for (const e of object.ids ?? []) {
-      message.ids.push(String(e));
-    }
+    message.ids = (object.ids ?? []).map((e: any) => String(e));
     return message;
   },
 
@@ -212,10 +197,7 @@ export const BatchMapQueryRequest = {
 
   fromPartial(object: DeepPartial<BatchMapQueryRequest>): BatchMapQueryRequest {
     const message = { ...baseBatchMapQueryRequest } as BatchMapQueryRequest;
-    message.ids = [];
-    for (const e of object.ids ?? []) {
-      message.ids.push(e);
-    }
+    message.ids = (object.ids ?? []).map((e) => e);
     return message;
   },
 };

--- a/integration/batching/batching.ts
+++ b/integration/batching/batching.ts
@@ -76,10 +76,8 @@ export const BatchQueryRequest = {
   fromJSON(object: any): BatchQueryRequest {
     const message = { ...baseBatchQueryRequest } as BatchQueryRequest;
     message.ids = [];
-    if (object.ids !== undefined && object.ids !== null) {
-      for (const e of object.ids) {
-        message.ids.push(String(e));
-      }
+    for (const e of object.ids ?? []) {
+      message.ids.push(String(e));
     }
     return message;
   },
@@ -97,10 +95,8 @@ export const BatchQueryRequest = {
   fromPartial(object: DeepPartial<BatchQueryRequest>): BatchQueryRequest {
     const message = { ...baseBatchQueryRequest } as BatchQueryRequest;
     message.ids = [];
-    if (object.ids !== undefined && object.ids !== null) {
-      for (const e of object.ids) {
-        message.ids.push(e);
-      }
+    for (const e of object.ids ?? []) {
+      message.ids.push(e);
     }
     return message;
   },
@@ -138,10 +134,8 @@ export const BatchQueryResponse = {
   fromJSON(object: any): BatchQueryResponse {
     const message = { ...baseBatchQueryResponse } as BatchQueryResponse;
     message.entities = [];
-    if (object.entities !== undefined && object.entities !== null) {
-      for (const e of object.entities) {
-        message.entities.push(Entity.fromJSON(e));
-      }
+    for (const e of object.entities ?? []) {
+      message.entities.push(Entity.fromJSON(e));
     }
     return message;
   },
@@ -159,10 +153,8 @@ export const BatchQueryResponse = {
   fromPartial(object: DeepPartial<BatchQueryResponse>): BatchQueryResponse {
     const message = { ...baseBatchQueryResponse } as BatchQueryResponse;
     message.entities = [];
-    if (object.entities !== undefined && object.entities !== null) {
-      for (const e of object.entities) {
-        message.entities.push(Entity.fromPartial(e));
-      }
+    for (const e of object.entities ?? []) {
+      message.entities.push(Entity.fromPartial(e));
     }
     return message;
   },
@@ -200,10 +192,8 @@ export const BatchMapQueryRequest = {
   fromJSON(object: any): BatchMapQueryRequest {
     const message = { ...baseBatchMapQueryRequest } as BatchMapQueryRequest;
     message.ids = [];
-    if (object.ids !== undefined && object.ids !== null) {
-      for (const e of object.ids) {
-        message.ids.push(String(e));
-      }
+    for (const e of object.ids ?? []) {
+      message.ids.push(String(e));
     }
     return message;
   },
@@ -221,10 +211,8 @@ export const BatchMapQueryRequest = {
   fromPartial(object: DeepPartial<BatchMapQueryRequest>): BatchMapQueryRequest {
     const message = { ...baseBatchMapQueryRequest } as BatchMapQueryRequest;
     message.ids = [];
-    if (object.ids !== undefined && object.ids !== null) {
-      for (const e of object.ids) {
-        message.ids.push(e);
-      }
+    for (const e of object.ids ?? []) {
+      message.ids.push(e);
     }
     return message;
   },

--- a/integration/batching/batching.ts
+++ b/integration/batching/batching.ts
@@ -75,10 +75,7 @@ export const BatchQueryRequest = {
 
   fromJSON(object: any): BatchQueryRequest {
     const message = { ...baseBatchQueryRequest } as BatchQueryRequest;
-    message.ids = [];
-    for (const e of object.ids ?? []) {
-      message.ids.push(String(e));
-    }
+    message.ids = (object.ids ?? []).map((e: any) => String(e));
     return message;
   },
 
@@ -94,10 +91,7 @@ export const BatchQueryRequest = {
 
   fromPartial(object: DeepPartial<BatchQueryRequest>): BatchQueryRequest {
     const message = { ...baseBatchQueryRequest } as BatchQueryRequest;
-    message.ids = [];
-    for (const e of object.ids ?? []) {
-      message.ids.push(e);
-    }
+    message.ids = (object.ids ?? []).map((e) => e);
     return message;
   },
 };
@@ -133,10 +127,7 @@ export const BatchQueryResponse = {
 
   fromJSON(object: any): BatchQueryResponse {
     const message = { ...baseBatchQueryResponse } as BatchQueryResponse;
-    message.entities = [];
-    for (const e of object.entities ?? []) {
-      message.entities.push(Entity.fromJSON(e));
-    }
+    message.entities = (object.entities ?? []).map((e: any) => Entity.fromJSON(e));
     return message;
   },
 
@@ -152,10 +143,7 @@ export const BatchQueryResponse = {
 
   fromPartial(object: DeepPartial<BatchQueryResponse>): BatchQueryResponse {
     const message = { ...baseBatchQueryResponse } as BatchQueryResponse;
-    message.entities = [];
-    for (const e of object.entities ?? []) {
-      message.entities.push(Entity.fromPartial(e));
-    }
+    message.entities = (object.entities ?? []).map((e) => Entity.fromPartial(e));
     return message;
   },
 };
@@ -191,10 +179,7 @@ export const BatchMapQueryRequest = {
 
   fromJSON(object: any): BatchMapQueryRequest {
     const message = { ...baseBatchMapQueryRequest } as BatchMapQueryRequest;
-    message.ids = [];
-    for (const e of object.ids ?? []) {
-      message.ids.push(String(e));
-    }
+    message.ids = (object.ids ?? []).map((e: any) => String(e));
     return message;
   },
 
@@ -210,10 +195,7 @@ export const BatchMapQueryRequest = {
 
   fromPartial(object: DeepPartial<BatchMapQueryRequest>): BatchMapQueryRequest {
     const message = { ...baseBatchMapQueryRequest } as BatchMapQueryRequest;
-    message.ids = [];
-    for (const e of object.ids ?? []) {
-      message.ids.push(e);
-    }
+    message.ids = (object.ids ?? []).map((e) => e);
     return message;
   },
 };

--- a/integration/bytes-as-base64/message.ts
+++ b/integration/bytes-as-base64/message.ts
@@ -13,9 +13,10 @@ const baseMessage: object = {};
 export const Message = {
   fromJSON(object: any): Message {
     const message = { ...baseMessage } as Message;
-    message.data = new Uint8Array();
     if (object.data !== undefined && object.data !== null) {
       message.data = bytesFromBase64(object.data);
+    } else {
+      message.data = new Uint8Array();
     }
     return message;
   },

--- a/integration/bytes-node/point.ts
+++ b/integration/bytes-node/point.ts
@@ -39,9 +39,10 @@ export const Point = {
 
   fromJSON(object: any): Point {
     const message = { ...basePoint } as Point;
-    message.data = Buffer.alloc(0);
     if (object.data !== undefined && object.data !== null) {
       message.data = Buffer.from(bytesFromBase64(object.data));
+    } else {
+      message.data = Buffer.alloc(0);
     }
     return message;
   },

--- a/integration/grpc-js/google/protobuf/wrappers.ts
+++ b/integration/grpc-js/google/protobuf/wrappers.ts
@@ -533,9 +533,10 @@ export const BytesValue = {
 
   fromJSON(object: any): BytesValue {
     const message = { ...baseBytesValue } as BytesValue;
-    message.value = new Uint8Array();
     if (object.value !== undefined && object.value !== null) {
       message.value = bytesFromBase64(object.value);
+    } else {
+      message.value = new Uint8Array();
     }
     return message;
   },

--- a/integration/grpc-web-go-server/example.ts
+++ b/integration/grpc-web-go-server/example.ts
@@ -209,10 +209,7 @@ export const DashUserSettingsState = {
     } else {
       message.urls = undefined;
     }
-    message.flashes = [];
-    for (const e of object.flashes ?? []) {
-      message.flashes.push(DashFlash.fromJSON(e));
-    }
+    message.flashes = (object.flashes ?? []).map((e: any) => DashFlash.fromJSON(e));
     return message;
   },
 
@@ -237,10 +234,7 @@ export const DashUserSettingsState = {
     } else {
       message.urls = undefined;
     }
-    message.flashes = [];
-    for (const e of object.flashes ?? []) {
-      message.flashes.push(DashFlash.fromPartial(e));
-    }
+    message.flashes = (object.flashes ?? []).map((e) => DashFlash.fromPartial(e));
     return message;
   },
 };

--- a/integration/grpc-web-go-server/example.ts
+++ b/integration/grpc-web-go-server/example.ts
@@ -199,7 +199,6 @@ export const DashUserSettingsState = {
 
   fromJSON(object: any): DashUserSettingsState {
     const message = { ...baseDashUserSettingsState } as DashUserSettingsState;
-    message.flashes = [];
     if (object.email !== undefined && object.email !== null) {
       message.email = String(object.email);
     } else {
@@ -210,6 +209,7 @@ export const DashUserSettingsState = {
     } else {
       message.urls = undefined;
     }
+    message.flashes = [];
     if (object.flashes !== undefined && object.flashes !== null) {
       for (const e of object.flashes) {
         message.flashes.push(DashFlash.fromJSON(e));

--- a/integration/grpc-web-go-server/example.ts
+++ b/integration/grpc-web-go-server/example.ts
@@ -210,10 +210,8 @@ export const DashUserSettingsState = {
       message.urls = undefined;
     }
     message.flashes = [];
-    if (object.flashes !== undefined && object.flashes !== null) {
-      for (const e of object.flashes) {
-        message.flashes.push(DashFlash.fromJSON(e));
-      }
+    for (const e of object.flashes ?? []) {
+      message.flashes.push(DashFlash.fromJSON(e));
     }
     return message;
   },
@@ -240,10 +238,8 @@ export const DashUserSettingsState = {
       message.urls = undefined;
     }
     message.flashes = [];
-    if (object.flashes !== undefined && object.flashes !== null) {
-      for (const e of object.flashes) {
-        message.flashes.push(DashFlash.fromPartial(e));
-      }
+    for (const e of object.flashes ?? []) {
+      message.flashes.push(DashFlash.fromPartial(e));
     }
     return message;
   },

--- a/integration/grpc-web-no-streaming-observable/example.ts
+++ b/integration/grpc-web-no-streaming-observable/example.ts
@@ -188,10 +188,8 @@ export const DashUserSettingsState = {
       message.urls = undefined;
     }
     message.flashes = [];
-    if (object.flashes !== undefined && object.flashes !== null) {
-      for (const e of object.flashes) {
-        message.flashes.push(DashFlash.fromJSON(e));
-      }
+    for (const e of object.flashes ?? []) {
+      message.flashes.push(DashFlash.fromJSON(e));
     }
     return message;
   },
@@ -218,10 +216,8 @@ export const DashUserSettingsState = {
       message.urls = undefined;
     }
     message.flashes = [];
-    if (object.flashes !== undefined && object.flashes !== null) {
-      for (const e of object.flashes) {
-        message.flashes.push(DashFlash.fromPartial(e));
-      }
+    for (const e of object.flashes ?? []) {
+      message.flashes.push(DashFlash.fromPartial(e));
     }
     return message;
   },

--- a/integration/grpc-web-no-streaming-observable/example.ts
+++ b/integration/grpc-web-no-streaming-observable/example.ts
@@ -187,10 +187,7 @@ export const DashUserSettingsState = {
     } else {
       message.urls = undefined;
     }
-    message.flashes = [];
-    for (const e of object.flashes ?? []) {
-      message.flashes.push(DashFlash.fromJSON(e));
-    }
+    message.flashes = (object.flashes ?? []).map((e: any) => DashFlash.fromJSON(e));
     return message;
   },
 
@@ -215,10 +212,7 @@ export const DashUserSettingsState = {
     } else {
       message.urls = undefined;
     }
-    message.flashes = [];
-    for (const e of object.flashes ?? []) {
-      message.flashes.push(DashFlash.fromPartial(e));
-    }
+    message.flashes = (object.flashes ?? []).map((e) => DashFlash.fromPartial(e));
     return message;
   },
 };

--- a/integration/grpc-web-no-streaming-observable/example.ts
+++ b/integration/grpc-web-no-streaming-observable/example.ts
@@ -177,7 +177,6 @@ export const DashUserSettingsState = {
 
   fromJSON(object: any): DashUserSettingsState {
     const message = { ...baseDashUserSettingsState } as DashUserSettingsState;
-    message.flashes = [];
     if (object.email !== undefined && object.email !== null) {
       message.email = String(object.email);
     } else {
@@ -188,6 +187,7 @@ export const DashUserSettingsState = {
     } else {
       message.urls = undefined;
     }
+    message.flashes = [];
     if (object.flashes !== undefined && object.flashes !== null) {
       for (const e of object.flashes) {
         message.flashes.push(DashFlash.fromJSON(e));

--- a/integration/grpc-web-no-streaming/example.ts
+++ b/integration/grpc-web-no-streaming/example.ts
@@ -186,10 +186,8 @@ export const DashUserSettingsState = {
       message.urls = undefined;
     }
     message.flashes = [];
-    if (object.flashes !== undefined && object.flashes !== null) {
-      for (const e of object.flashes) {
-        message.flashes.push(DashFlash.fromJSON(e));
-      }
+    for (const e of object.flashes ?? []) {
+      message.flashes.push(DashFlash.fromJSON(e));
     }
     return message;
   },
@@ -216,10 +214,8 @@ export const DashUserSettingsState = {
       message.urls = undefined;
     }
     message.flashes = [];
-    if (object.flashes !== undefined && object.flashes !== null) {
-      for (const e of object.flashes) {
-        message.flashes.push(DashFlash.fromPartial(e));
-      }
+    for (const e of object.flashes ?? []) {
+      message.flashes.push(DashFlash.fromPartial(e));
     }
     return message;
   },

--- a/integration/grpc-web-no-streaming/example.ts
+++ b/integration/grpc-web-no-streaming/example.ts
@@ -185,10 +185,7 @@ export const DashUserSettingsState = {
     } else {
       message.urls = undefined;
     }
-    message.flashes = [];
-    for (const e of object.flashes ?? []) {
-      message.flashes.push(DashFlash.fromJSON(e));
-    }
+    message.flashes = (object.flashes ?? []).map((e: any) => DashFlash.fromJSON(e));
     return message;
   },
 
@@ -213,10 +210,7 @@ export const DashUserSettingsState = {
     } else {
       message.urls = undefined;
     }
-    message.flashes = [];
-    for (const e of object.flashes ?? []) {
-      message.flashes.push(DashFlash.fromPartial(e));
-    }
+    message.flashes = (object.flashes ?? []).map((e) => DashFlash.fromPartial(e));
     return message;
   },
 };

--- a/integration/grpc-web-no-streaming/example.ts
+++ b/integration/grpc-web-no-streaming/example.ts
@@ -175,7 +175,6 @@ export const DashUserSettingsState = {
 
   fromJSON(object: any): DashUserSettingsState {
     const message = { ...baseDashUserSettingsState } as DashUserSettingsState;
-    message.flashes = [];
     if (object.email !== undefined && object.email !== null) {
       message.email = String(object.email);
     } else {
@@ -186,6 +185,7 @@ export const DashUserSettingsState = {
     } else {
       message.urls = undefined;
     }
+    message.flashes = [];
     if (object.flashes !== undefined && object.flashes !== null) {
       for (const e of object.flashes) {
         message.flashes.push(DashFlash.fromJSON(e));

--- a/integration/grpc-web/example.ts
+++ b/integration/grpc-web/example.ts
@@ -211,10 +211,7 @@ export const DashUserSettingsState = {
     } else {
       message.urls = undefined;
     }
-    message.flashes = [];
-    for (const e of object.flashes ?? []) {
-      message.flashes.push(DashFlash.fromJSON(e));
-    }
+    message.flashes = (object.flashes ?? []).map((e: any) => DashFlash.fromJSON(e));
     return message;
   },
 
@@ -239,10 +236,7 @@ export const DashUserSettingsState = {
     } else {
       message.urls = undefined;
     }
-    message.flashes = [];
-    for (const e of object.flashes ?? []) {
-      message.flashes.push(DashFlash.fromPartial(e));
-    }
+    message.flashes = (object.flashes ?? []).map((e) => DashFlash.fromPartial(e));
     return message;
   },
 };

--- a/integration/grpc-web/example.ts
+++ b/integration/grpc-web/example.ts
@@ -201,7 +201,6 @@ export const DashUserSettingsState = {
 
   fromJSON(object: any): DashUserSettingsState {
     const message = { ...baseDashUserSettingsState } as DashUserSettingsState;
-    message.flashes = [];
     if (object.email !== undefined && object.email !== null) {
       message.email = String(object.email);
     } else {
@@ -212,6 +211,7 @@ export const DashUserSettingsState = {
     } else {
       message.urls = undefined;
     }
+    message.flashes = [];
     if (object.flashes !== undefined && object.flashes !== null) {
       for (const e of object.flashes) {
         message.flashes.push(DashFlash.fromJSON(e));

--- a/integration/grpc-web/example.ts
+++ b/integration/grpc-web/example.ts
@@ -212,10 +212,8 @@ export const DashUserSettingsState = {
       message.urls = undefined;
     }
     message.flashes = [];
-    if (object.flashes !== undefined && object.flashes !== null) {
-      for (const e of object.flashes) {
-        message.flashes.push(DashFlash.fromJSON(e));
-      }
+    for (const e of object.flashes ?? []) {
+      message.flashes.push(DashFlash.fromJSON(e));
     }
     return message;
   },
@@ -242,10 +240,8 @@ export const DashUserSettingsState = {
       message.urls = undefined;
     }
     message.flashes = [];
-    if (object.flashes !== undefined && object.flashes !== null) {
-      for (const e of object.flashes) {
-        message.flashes.push(DashFlash.fromPartial(e));
-      }
+    for (const e of object.flashes ?? []) {
+      message.flashes.push(DashFlash.fromPartial(e));
     }
     return message;
   },

--- a/integration/lower-case-svc-methods/math.ts
+++ b/integration/lower-case-svc-methods/math.ts
@@ -175,10 +175,8 @@ export const Numbers = {
   fromJSON(object: any): Numbers {
     const message = { ...baseNumbers } as Numbers;
     message.num = [];
-    if (object.num !== undefined && object.num !== null) {
-      for (const e of object.num) {
-        message.num.push(Number(e));
-      }
+    for (const e of object.num ?? []) {
+      message.num.push(Number(e));
     }
     return message;
   },
@@ -196,10 +194,8 @@ export const Numbers = {
   fromPartial(object: DeepPartial<Numbers>): Numbers {
     const message = { ...baseNumbers } as Numbers;
     message.num = [];
-    if (object.num !== undefined && object.num !== null) {
-      for (const e of object.num) {
-        message.num.push(e);
-      }
+    for (const e of object.num ?? []) {
+      message.num.push(e);
     }
     return message;
   },

--- a/integration/lower-case-svc-methods/math.ts
+++ b/integration/lower-case-svc-methods/math.ts
@@ -174,10 +174,7 @@ export const Numbers = {
 
   fromJSON(object: any): Numbers {
     const message = { ...baseNumbers } as Numbers;
-    message.num = [];
-    for (const e of object.num ?? []) {
-      message.num.push(Number(e));
-    }
+    message.num = (object.num ?? []).map((e: any) => Number(e));
     return message;
   },
 
@@ -193,10 +190,7 @@ export const Numbers = {
 
   fromPartial(object: DeepPartial<Numbers>): Numbers {
     const message = { ...baseNumbers } as Numbers;
-    message.num = [];
-    for (const e of object.num ?? []) {
-      message.num.push(e);
-    }
+    message.num = (object.num ?? []).map((e) => e);
     return message;
   },
 };

--- a/integration/oneof-properties/oneof.ts
+++ b/integration/oneof-properties/oneof.ts
@@ -189,6 +189,8 @@ export const PleaseChoose = {
     }
     if (object.bunchaBytes !== undefined && object.bunchaBytes !== null) {
       message.bunchaBytes = bytesFromBase64(object.bunchaBytes);
+    } else {
+      message.bunchaBytes = undefined;
     }
     if (object.anEnum !== undefined && object.anEnum !== null) {
       message.anEnum = pleaseChoose_StateEnumFromJSON(object.anEnum);

--- a/integration/oneof-unions/oneof.ts
+++ b/integration/oneof-unions/oneof.ts
@@ -166,9 +166,10 @@ export const PleaseChoose = {
 
   fromJSON(object: any): PleaseChoose {
     const message = { ...basePleaseChoose } as PleaseChoose;
-    message.signature = new Uint8Array();
     if (object.name !== undefined && object.name !== null) {
       message.name = String(object.name);
+    } else {
+      message.name = '';
     }
     if (object.aNumber !== undefined && object.aNumber !== null) {
       message.choice = { $case: 'aNumber', aNumber: Number(object.aNumber) };
@@ -190,6 +191,8 @@ export const PleaseChoose = {
     }
     if (object.age !== undefined && object.age !== null) {
       message.age = Number(object.age);
+    } else {
+      message.age = 0;
     }
     if (object.either !== undefined && object.either !== null) {
       message.eitherOr = { $case: 'either', either: String(object.either) };
@@ -202,6 +205,8 @@ export const PleaseChoose = {
     }
     if (object.signature !== undefined && object.signature !== null) {
       message.signature = bytesFromBase64(object.signature);
+    } else {
+      message.signature = new Uint8Array();
     }
     return message;
   },
@@ -313,6 +318,8 @@ export const PleaseChoose_Submessage = {
     const message = { ...basePleaseChoose_Submessage } as PleaseChoose_Submessage;
     if (object.name !== undefined && object.name !== null) {
       message.name = String(object.name);
+    } else {
+      message.name = '';
     }
     return message;
   },
@@ -368,9 +375,13 @@ export const SimpleButOptional = {
     const message = { ...baseSimpleButOptional } as SimpleButOptional;
     if (object.name !== undefined && object.name !== null) {
       message.name = String(object.name);
+    } else {
+      message.name = undefined;
     }
     if (object.age !== undefined && object.age !== null) {
       message.age = Number(object.age);
+    } else {
+      message.age = undefined;
     }
     return message;
   },

--- a/integration/simple-long-string/google/protobuf/wrappers.ts
+++ b/integration/simple-long-string/google/protobuf/wrappers.ts
@@ -533,9 +533,10 @@ export const BytesValue = {
 
   fromJSON(object: any): BytesValue {
     const message = { ...baseBytesValue } as BytesValue;
-    message.value = new Uint8Array();
     if (object.value !== undefined && object.value !== null) {
       message.value = bytesFromBase64(object.value);
+    } else {
+      message.value = new Uint8Array();
     }
     return message;
   },

--- a/integration/simple-long/google/protobuf/wrappers.ts
+++ b/integration/simple-long/google/protobuf/wrappers.ts
@@ -541,9 +541,10 @@ export const BytesValue = {
 
   fromJSON(object: any): BytesValue {
     const message = { ...baseBytesValue } as BytesValue;
-    message.value = new Uint8Array();
     if (object.value !== undefined && object.value !== null) {
       message.value = bytesFromBase64(object.value);
+    } else {
+      message.value = new Uint8Array();
     }
     return message;
   },

--- a/integration/simple-long/simple.ts
+++ b/integration/simple-long/simple.ts
@@ -129,16 +129,12 @@ export const SimpleWithWrappers = {
       message.bananas = undefined;
     }
     message.coins = [];
-    if (object.coins !== undefined && object.coins !== null) {
-      for (const e of object.coins) {
-        message.coins.push(Number(e));
-      }
+    for (const e of object.coins ?? []) {
+      message.coins.push(Number(e));
     }
     message.snacks = [];
-    if (object.snacks !== undefined && object.snacks !== null) {
-      for (const e of object.snacks) {
-        message.snacks.push(String(e));
-      }
+    for (const e of object.snacks ?? []) {
+      message.snacks.push(String(e));
     }
     return message;
   },
@@ -173,16 +169,12 @@ export const SimpleWithWrappers = {
       message.bananas = undefined;
     }
     message.coins = [];
-    if (object.coins !== undefined && object.coins !== null) {
-      for (const e of object.coins) {
-        message.coins.push(e);
-      }
+    for (const e of object.coins ?? []) {
+      message.coins.push(e);
     }
     message.snacks = [];
-    if (object.snacks !== undefined && object.snacks !== null) {
-      for (const e of object.snacks) {
-        message.snacks.push(e);
-      }
+    for (const e of object.snacks ?? []) {
+      message.snacks.push(e);
     }
     return message;
   },
@@ -601,10 +593,8 @@ export const Numbers = {
       message.sfixed64 = Long.ZERO;
     }
     message.manyUint64 = [];
-    if (object.manyUint64 !== undefined && object.manyUint64 !== null) {
-      for (const e of object.manyUint64) {
-        message.manyUint64.push(Long.fromString(e));
-      }
+    for (const e of object.manyUint64 ?? []) {
+      message.manyUint64.push(Long.fromString(e));
     }
     return message;
   },
@@ -666,10 +656,8 @@ export const Numbers = {
       message.sfixed64 = Long.ZERO;
     }
     message.manyUint64 = [];
-    if (object.manyUint64 !== undefined && object.manyUint64 !== null) {
-      for (const e of object.manyUint64) {
-        message.manyUint64.push(e);
-      }
+    for (const e of object.manyUint64 ?? []) {
+      message.manyUint64.push(e);
     }
     return message;
   },

--- a/integration/simple-long/simple.ts
+++ b/integration/simple-long/simple.ts
@@ -128,14 +128,8 @@ export const SimpleWithWrappers = {
     } else {
       message.bananas = undefined;
     }
-    message.coins = [];
-    for (const e of object.coins ?? []) {
-      message.coins.push(Number(e));
-    }
-    message.snacks = [];
-    for (const e of object.snacks ?? []) {
-      message.snacks.push(String(e));
-    }
+    message.coins = (object.coins ?? []).map((e: any) => Number(e));
+    message.snacks = (object.snacks ?? []).map((e: any) => String(e));
     return message;
   },
 
@@ -168,14 +162,8 @@ export const SimpleWithWrappers = {
     } else {
       message.bananas = undefined;
     }
-    message.coins = [];
-    for (const e of object.coins ?? []) {
-      message.coins.push(e);
-    }
-    message.snacks = [];
-    for (const e of object.snacks ?? []) {
-      message.snacks.push(e);
-    }
+    message.coins = (object.coins ?? []).map((e) => e);
+    message.snacks = (object.snacks ?? []).map((e) => e);
     return message;
   },
 };
@@ -592,10 +580,7 @@ export const Numbers = {
     } else {
       message.sfixed64 = Long.ZERO;
     }
-    message.manyUint64 = [];
-    for (const e of object.manyUint64 ?? []) {
-      message.manyUint64.push(Long.fromString(e));
-    }
+    message.manyUint64 = (object.manyUint64 ?? []).map((e: any) => Long.fromString(e));
     return message;
   },
 
@@ -655,10 +640,7 @@ export const Numbers = {
     } else {
       message.sfixed64 = Long.ZERO;
     }
-    message.manyUint64 = [];
-    for (const e of object.manyUint64 ?? []) {
-      message.manyUint64.push(e);
-    }
+    message.manyUint64 = (object.manyUint64 ?? []).map((e) => e);
     return message;
   },
 };

--- a/integration/simple-long/simple.ts
+++ b/integration/simple-long/simple.ts
@@ -108,8 +108,6 @@ export const SimpleWithWrappers = {
 
   fromJSON(object: any): SimpleWithWrappers {
     const message = { ...baseSimpleWithWrappers } as SimpleWithWrappers;
-    message.coins = [];
-    message.snacks = [];
     if (object.name !== undefined && object.name !== null) {
       message.name = String(object.name);
     } else {
@@ -130,11 +128,13 @@ export const SimpleWithWrappers = {
     } else {
       message.bananas = undefined;
     }
+    message.coins = [];
     if (object.coins !== undefined && object.coins !== null) {
       for (const e of object.coins) {
         message.coins.push(Number(e));
       }
     }
+    message.snacks = [];
     if (object.snacks !== undefined && object.snacks !== null) {
       for (const e of object.snacks) {
         message.snacks.push(String(e));
@@ -233,12 +233,12 @@ export const SimpleWithMap = {
   fromJSON(object: any): SimpleWithMap {
     const message = { ...baseSimpleWithMap } as SimpleWithMap;
     message.nameLookup = {};
-    message.intLookup = {};
     if (object.nameLookup !== undefined && object.nameLookup !== null) {
       Object.entries(object.nameLookup).forEach(([key, value]) => {
         message.nameLookup[key] = String(value);
       });
     }
+    message.intLookup = {};
     if (object.intLookup !== undefined && object.intLookup !== null) {
       Object.entries(object.intLookup).forEach(([key, value]) => {
         message.intLookup[Number(key)] = Number(value);
@@ -540,7 +540,6 @@ export const Numbers = {
 
   fromJSON(object: any): Numbers {
     const message = { ...baseNumbers } as Numbers;
-    message.manyUint64 = [];
     if (object.double !== undefined && object.double !== null) {
       message.double = Number(object.double);
     } else {
@@ -601,6 +600,7 @@ export const Numbers = {
     } else {
       message.sfixed64 = Long.ZERO;
     }
+    message.manyUint64 = [];
     if (object.manyUint64 !== undefined && object.manyUint64 !== null) {
       for (const e of object.manyUint64) {
         message.manyUint64.push(Long.fromString(e));

--- a/integration/simple-optionals/google/protobuf/wrappers.ts
+++ b/integration/simple-optionals/google/protobuf/wrappers.ts
@@ -533,9 +533,10 @@ export const BytesValue = {
 
   fromJSON(object: any): BytesValue {
     const message = { ...baseBytesValue } as BytesValue;
-    message.value = new Uint8Array();
     if (object.value !== undefined && object.value !== null) {
       message.value = bytesFromBase64(object.value);
+    } else {
+      message.value = new Uint8Array();
     }
     return message;
   },

--- a/integration/simple-optionals/simple.ts
+++ b/integration/simple-optionals/simple.ts
@@ -367,28 +367,20 @@ export const Simple = {
       message.state = 0;
     }
     message.grandChildren = [];
-    if (object.grandChildren !== undefined && object.grandChildren !== null) {
-      for (const e of object.grandChildren) {
-        message.grandChildren.push(Child.fromJSON(e));
-      }
+    for (const e of object.grandChildren ?? []) {
+      message.grandChildren.push(Child.fromJSON(e));
     }
     message.coins = [];
-    if (object.coins !== undefined && object.coins !== null) {
-      for (const e of object.coins) {
-        message.coins.push(Number(e));
-      }
+    for (const e of object.coins ?? []) {
+      message.coins.push(Number(e));
     }
     message.snacks = [];
-    if (object.snacks !== undefined && object.snacks !== null) {
-      for (const e of object.snacks) {
-        message.snacks.push(String(e));
-      }
+    for (const e of object.snacks ?? []) {
+      message.snacks.push(String(e));
     }
     message.oldStates = [];
-    if (object.oldStates !== undefined && object.oldStates !== null) {
-      for (const e of object.oldStates) {
-        message.oldStates.push(stateEnumFromJSON(e));
-      }
+    for (const e of object.oldStates ?? []) {
+      message.oldStates.push(stateEnumFromJSON(e));
     }
     if (object.thing !== undefined && object.thing !== null) {
       message.thing = ImportedThing.fromJSON(object.thing);
@@ -441,28 +433,20 @@ export const Simple = {
     }
     message.state = object.state ?? 0;
     message.grandChildren = [];
-    if (object.grandChildren !== undefined && object.grandChildren !== null) {
-      for (const e of object.grandChildren) {
-        message.grandChildren.push(Child.fromPartial(e));
-      }
+    for (const e of object.grandChildren ?? []) {
+      message.grandChildren.push(Child.fromPartial(e));
     }
     message.coins = [];
-    if (object.coins !== undefined && object.coins !== null) {
-      for (const e of object.coins) {
-        message.coins.push(e);
-      }
+    for (const e of object.coins ?? []) {
+      message.coins.push(e);
     }
     message.snacks = [];
-    if (object.snacks !== undefined && object.snacks !== null) {
-      for (const e of object.snacks) {
-        message.snacks.push(e);
-      }
+    for (const e of object.snacks ?? []) {
+      message.snacks.push(e);
     }
     message.oldStates = [];
-    if (object.oldStates !== undefined && object.oldStates !== null) {
-      for (const e of object.oldStates) {
-        message.oldStates.push(e);
-      }
+    for (const e of object.oldStates ?? []) {
+      message.oldStates.push(e);
     }
     if (object.thing !== undefined && object.thing !== null) {
       message.thing = ImportedThing.fromPartial(object.thing);
@@ -875,16 +859,12 @@ export const SimpleWithWrappers = {
       message.enabled = undefined;
     }
     message.coins = [];
-    if (object.coins !== undefined && object.coins !== null) {
-      for (const e of object.coins) {
-        message.coins.push(Number(e));
-      }
+    for (const e of object.coins ?? []) {
+      message.coins.push(Number(e));
     }
     message.snacks = [];
-    if (object.snacks !== undefined && object.snacks !== null) {
-      for (const e of object.snacks) {
-        message.snacks.push(String(e));
-      }
+    for (const e of object.snacks ?? []) {
+      message.snacks.push(String(e));
     }
     return message;
   },
@@ -913,16 +893,12 @@ export const SimpleWithWrappers = {
     message.age = object.age ?? undefined;
     message.enabled = object.enabled ?? undefined;
     message.coins = [];
-    if (object.coins !== undefined && object.coins !== null) {
-      for (const e of object.coins) {
-        message.coins.push(e);
-      }
+    for (const e of object.coins ?? []) {
+      message.coins.push(e);
     }
     message.snacks = [];
-    if (object.snacks !== undefined && object.snacks !== null) {
-      for (const e of object.snacks) {
-        message.snacks.push(e);
-      }
+    for (const e of object.snacks ?? []) {
+      message.snacks.push(e);
     }
     return message;
   },

--- a/integration/simple-optionals/simple.ts
+++ b/integration/simple-optionals/simple.ts
@@ -341,10 +341,6 @@ export const Simple = {
 
   fromJSON(object: any): Simple {
     const message = { ...baseSimple } as Simple;
-    message.grandChildren = [];
-    message.coins = [];
-    message.snacks = [];
-    message.oldStates = [];
     if (object.name !== undefined && object.name !== null) {
       message.name = String(object.name);
     } else {
@@ -370,21 +366,25 @@ export const Simple = {
     } else {
       message.state = 0;
     }
+    message.grandChildren = [];
     if (object.grandChildren !== undefined && object.grandChildren !== null) {
       for (const e of object.grandChildren) {
         message.grandChildren.push(Child.fromJSON(e));
       }
     }
+    message.coins = [];
     if (object.coins !== undefined && object.coins !== null) {
       for (const e of object.coins) {
         message.coins.push(Number(e));
       }
     }
+    message.snacks = [];
     if (object.snacks !== undefined && object.snacks !== null) {
       for (const e of object.snacks) {
         message.snacks.push(String(e));
       }
     }
+    message.oldStates = [];
     if (object.oldStates !== undefined && object.oldStates !== null) {
       for (const e of object.oldStates) {
         message.oldStates.push(stateEnumFromJSON(e));
@@ -859,8 +859,6 @@ export const SimpleWithWrappers = {
 
   fromJSON(object: any): SimpleWithWrappers {
     const message = { ...baseSimpleWithWrappers } as SimpleWithWrappers;
-    message.coins = [];
-    message.snacks = [];
     if (object.name !== undefined && object.name !== null) {
       message.name = String(object.name);
     } else {
@@ -876,11 +874,13 @@ export const SimpleWithWrappers = {
     } else {
       message.enabled = undefined;
     }
+    message.coins = [];
     if (object.coins !== undefined && object.coins !== null) {
       for (const e of object.coins) {
         message.coins.push(Number(e));
       }
     }
+    message.snacks = [];
     if (object.snacks !== undefined && object.snacks !== null) {
       for (const e of object.snacks) {
         message.snacks.push(String(e));
@@ -1034,18 +1034,18 @@ export const SimpleWithMap = {
   fromJSON(object: any): SimpleWithMap {
     const message = { ...baseSimpleWithMap } as SimpleWithMap;
     message.entitiesById = {};
-    message.nameLookup = {};
-    message.intLookup = {};
     if (object.entitiesById !== undefined && object.entitiesById !== null) {
       Object.entries(object.entitiesById).forEach(([key, value]) => {
         message.entitiesById[Number(key)] = Entity.fromJSON(value);
       });
     }
+    message.nameLookup = {};
     if (object.nameLookup !== undefined && object.nameLookup !== null) {
       Object.entries(object.nameLookup).forEach(([key, value]) => {
         message.nameLookup[key] = String(value);
       });
     }
+    message.intLookup = {};
     if (object.intLookup !== undefined && object.intLookup !== null) {
       Object.entries(object.intLookup).forEach(([key, value]) => {
         message.intLookup[Number(key)] = Number(value);

--- a/integration/simple-optionals/simple.ts
+++ b/integration/simple-optionals/simple.ts
@@ -366,22 +366,10 @@ export const Simple = {
     } else {
       message.state = 0;
     }
-    message.grandChildren = [];
-    for (const e of object.grandChildren ?? []) {
-      message.grandChildren.push(Child.fromJSON(e));
-    }
-    message.coins = [];
-    for (const e of object.coins ?? []) {
-      message.coins.push(Number(e));
-    }
-    message.snacks = [];
-    for (const e of object.snacks ?? []) {
-      message.snacks.push(String(e));
-    }
-    message.oldStates = [];
-    for (const e of object.oldStates ?? []) {
-      message.oldStates.push(stateEnumFromJSON(e));
-    }
+    message.grandChildren = (object.grandChildren ?? []).map((e: any) => Child.fromJSON(e));
+    message.coins = (object.coins ?? []).map((e: any) => Number(e));
+    message.snacks = (object.snacks ?? []).map((e: any) => String(e));
+    message.oldStates = (object.oldStates ?? []).map((e: any) => stateEnumFromJSON(e));
     if (object.thing !== undefined && object.thing !== null) {
       message.thing = ImportedThing.fromJSON(object.thing);
     } else {
@@ -432,22 +420,10 @@ export const Simple = {
       message.child = undefined;
     }
     message.state = object.state ?? 0;
-    message.grandChildren = [];
-    for (const e of object.grandChildren ?? []) {
-      message.grandChildren.push(Child.fromPartial(e));
-    }
-    message.coins = [];
-    for (const e of object.coins ?? []) {
-      message.coins.push(e);
-    }
-    message.snacks = [];
-    for (const e of object.snacks ?? []) {
-      message.snacks.push(e);
-    }
-    message.oldStates = [];
-    for (const e of object.oldStates ?? []) {
-      message.oldStates.push(e);
-    }
+    message.grandChildren = (object.grandChildren ?? []).map((e) => Child.fromPartial(e));
+    message.coins = (object.coins ?? []).map((e) => e);
+    message.snacks = (object.snacks ?? []).map((e) => e);
+    message.oldStates = (object.oldStates ?? []).map((e) => e);
     if (object.thing !== undefined && object.thing !== null) {
       message.thing = ImportedThing.fromPartial(object.thing);
     } else {
@@ -858,14 +834,8 @@ export const SimpleWithWrappers = {
     } else {
       message.enabled = undefined;
     }
-    message.coins = [];
-    for (const e of object.coins ?? []) {
-      message.coins.push(Number(e));
-    }
-    message.snacks = [];
-    for (const e of object.snacks ?? []) {
-      message.snacks.push(String(e));
-    }
+    message.coins = (object.coins ?? []).map((e: any) => Number(e));
+    message.snacks = (object.snacks ?? []).map((e: any) => String(e));
     return message;
   },
 
@@ -892,14 +862,8 @@ export const SimpleWithWrappers = {
     message.name = object.name ?? undefined;
     message.age = object.age ?? undefined;
     message.enabled = object.enabled ?? undefined;
-    message.coins = [];
-    for (const e of object.coins ?? []) {
-      message.coins.push(e);
-    }
-    message.snacks = [];
-    for (const e of object.snacks ?? []) {
-      message.snacks.push(e);
-    }
+    message.coins = (object.coins ?? []).map((e) => e);
+    message.snacks = (object.snacks ?? []).map((e) => e);
     return message;
   },
 };

--- a/integration/simple-snake/google/protobuf/wrappers.ts
+++ b/integration/simple-snake/google/protobuf/wrappers.ts
@@ -533,9 +533,10 @@ export const BytesValue = {
 
   fromJSON(object: any): BytesValue {
     const message = { ...baseBytesValue } as BytesValue;
-    message.value = new Uint8Array();
     if (object.value !== undefined && object.value !== null) {
       message.value = bytesFromBase64(object.value);
+    } else {
+      message.value = new Uint8Array();
     }
     return message;
   },

--- a/integration/simple-snake/simple.ts
+++ b/integration/simple-snake/simple.ts
@@ -367,28 +367,20 @@ export const Simple = {
       message.state = 0;
     }
     message.grand_children = [];
-    if (object.grand_children !== undefined && object.grand_children !== null) {
-      for (const e of object.grand_children) {
-        message.grand_children.push(Child.fromJSON(e));
-      }
+    for (const e of object.grand_children ?? []) {
+      message.grand_children.push(Child.fromJSON(e));
     }
     message.coins = [];
-    if (object.coins !== undefined && object.coins !== null) {
-      for (const e of object.coins) {
-        message.coins.push(Number(e));
-      }
+    for (const e of object.coins ?? []) {
+      message.coins.push(Number(e));
     }
     message.snacks = [];
-    if (object.snacks !== undefined && object.snacks !== null) {
-      for (const e of object.snacks) {
-        message.snacks.push(String(e));
-      }
+    for (const e of object.snacks ?? []) {
+      message.snacks.push(String(e));
     }
     message.old_states = [];
-    if (object.old_states !== undefined && object.old_states !== null) {
-      for (const e of object.old_states) {
-        message.old_states.push(stateEnumFromJSON(e));
-      }
+    for (const e of object.old_states ?? []) {
+      message.old_states.push(stateEnumFromJSON(e));
     }
     if (object.thing !== undefined && object.thing !== null) {
       message.thing = ImportedThing.fromJSON(object.thing);
@@ -441,28 +433,20 @@ export const Simple = {
     }
     message.state = object.state ?? 0;
     message.grand_children = [];
-    if (object.grand_children !== undefined && object.grand_children !== null) {
-      for (const e of object.grand_children) {
-        message.grand_children.push(Child.fromPartial(e));
-      }
+    for (const e of object.grand_children ?? []) {
+      message.grand_children.push(Child.fromPartial(e));
     }
     message.coins = [];
-    if (object.coins !== undefined && object.coins !== null) {
-      for (const e of object.coins) {
-        message.coins.push(e);
-      }
+    for (const e of object.coins ?? []) {
+      message.coins.push(e);
     }
     message.snacks = [];
-    if (object.snacks !== undefined && object.snacks !== null) {
-      for (const e of object.snacks) {
-        message.snacks.push(e);
-      }
+    for (const e of object.snacks ?? []) {
+      message.snacks.push(e);
     }
     message.old_states = [];
-    if (object.old_states !== undefined && object.old_states !== null) {
-      for (const e of object.old_states) {
-        message.old_states.push(e);
-      }
+    for (const e of object.old_states ?? []) {
+      message.old_states.push(e);
     }
     if (object.thing !== undefined && object.thing !== null) {
       message.thing = ImportedThing.fromPartial(object.thing);
@@ -875,16 +859,12 @@ export const SimpleWithWrappers = {
       message.enabled = undefined;
     }
     message.coins = [];
-    if (object.coins !== undefined && object.coins !== null) {
-      for (const e of object.coins) {
-        message.coins.push(Number(e));
-      }
+    for (const e of object.coins ?? []) {
+      message.coins.push(Number(e));
     }
     message.snacks = [];
-    if (object.snacks !== undefined && object.snacks !== null) {
-      for (const e of object.snacks) {
-        message.snacks.push(String(e));
-      }
+    for (const e of object.snacks ?? []) {
+      message.snacks.push(String(e));
     }
     return message;
   },
@@ -913,16 +893,12 @@ export const SimpleWithWrappers = {
     message.age = object.age ?? undefined;
     message.enabled = object.enabled ?? undefined;
     message.coins = [];
-    if (object.coins !== undefined && object.coins !== null) {
-      for (const e of object.coins) {
-        message.coins.push(e);
-      }
+    for (const e of object.coins ?? []) {
+      message.coins.push(e);
     }
     message.snacks = [];
-    if (object.snacks !== undefined && object.snacks !== null) {
-      for (const e of object.snacks) {
-        message.snacks.push(e);
-      }
+    for (const e of object.snacks ?? []) {
+      message.snacks.push(e);
     }
     return message;
   },

--- a/integration/simple-snake/simple.ts
+++ b/integration/simple-snake/simple.ts
@@ -341,10 +341,6 @@ export const Simple = {
 
   fromJSON(object: any): Simple {
     const message = { ...baseSimple } as Simple;
-    message.grand_children = [];
-    message.coins = [];
-    message.snacks = [];
-    message.old_states = [];
     if (object.name !== undefined && object.name !== null) {
       message.name = String(object.name);
     } else {
@@ -370,21 +366,25 @@ export const Simple = {
     } else {
       message.state = 0;
     }
+    message.grand_children = [];
     if (object.grand_children !== undefined && object.grand_children !== null) {
       for (const e of object.grand_children) {
         message.grand_children.push(Child.fromJSON(e));
       }
     }
+    message.coins = [];
     if (object.coins !== undefined && object.coins !== null) {
       for (const e of object.coins) {
         message.coins.push(Number(e));
       }
     }
+    message.snacks = [];
     if (object.snacks !== undefined && object.snacks !== null) {
       for (const e of object.snacks) {
         message.snacks.push(String(e));
       }
     }
+    message.old_states = [];
     if (object.old_states !== undefined && object.old_states !== null) {
       for (const e of object.old_states) {
         message.old_states.push(stateEnumFromJSON(e));
@@ -859,8 +859,6 @@ export const SimpleWithWrappers = {
 
   fromJSON(object: any): SimpleWithWrappers {
     const message = { ...baseSimpleWithWrappers } as SimpleWithWrappers;
-    message.coins = [];
-    message.snacks = [];
     if (object.name !== undefined && object.name !== null) {
       message.name = String(object.name);
     } else {
@@ -876,11 +874,13 @@ export const SimpleWithWrappers = {
     } else {
       message.enabled = undefined;
     }
+    message.coins = [];
     if (object.coins !== undefined && object.coins !== null) {
       for (const e of object.coins) {
         message.coins.push(Number(e));
       }
     }
+    message.snacks = [];
     if (object.snacks !== undefined && object.snacks !== null) {
       for (const e of object.snacks) {
         message.snacks.push(String(e));
@@ -1034,18 +1034,18 @@ export const SimpleWithMap = {
   fromJSON(object: any): SimpleWithMap {
     const message = { ...baseSimpleWithMap } as SimpleWithMap;
     message.entitiesById = {};
-    message.nameLookup = {};
-    message.intLookup = {};
     if (object.entitiesById !== undefined && object.entitiesById !== null) {
       Object.entries(object.entitiesById).forEach(([key, value]) => {
         message.entitiesById[Number(key)] = Entity.fromJSON(value);
       });
     }
+    message.nameLookup = {};
     if (object.nameLookup !== undefined && object.nameLookup !== null) {
       Object.entries(object.nameLookup).forEach(([key, value]) => {
         message.nameLookup[key] = String(value);
       });
     }
+    message.intLookup = {};
     if (object.intLookup !== undefined && object.intLookup !== null) {
       Object.entries(object.intLookup).forEach(([key, value]) => {
         message.intLookup[Number(key)] = Number(value);

--- a/integration/simple-snake/simple.ts
+++ b/integration/simple-snake/simple.ts
@@ -366,22 +366,10 @@ export const Simple = {
     } else {
       message.state = 0;
     }
-    message.grand_children = [];
-    for (const e of object.grand_children ?? []) {
-      message.grand_children.push(Child.fromJSON(e));
-    }
-    message.coins = [];
-    for (const e of object.coins ?? []) {
-      message.coins.push(Number(e));
-    }
-    message.snacks = [];
-    for (const e of object.snacks ?? []) {
-      message.snacks.push(String(e));
-    }
-    message.old_states = [];
-    for (const e of object.old_states ?? []) {
-      message.old_states.push(stateEnumFromJSON(e));
-    }
+    message.grand_children = (object.grand_children ?? []).map((e: any) => Child.fromJSON(e));
+    message.coins = (object.coins ?? []).map((e: any) => Number(e));
+    message.snacks = (object.snacks ?? []).map((e: any) => String(e));
+    message.old_states = (object.old_states ?? []).map((e: any) => stateEnumFromJSON(e));
     if (object.thing !== undefined && object.thing !== null) {
       message.thing = ImportedThing.fromJSON(object.thing);
     } else {
@@ -432,22 +420,10 @@ export const Simple = {
       message.child = undefined;
     }
     message.state = object.state ?? 0;
-    message.grand_children = [];
-    for (const e of object.grand_children ?? []) {
-      message.grand_children.push(Child.fromPartial(e));
-    }
-    message.coins = [];
-    for (const e of object.coins ?? []) {
-      message.coins.push(e);
-    }
-    message.snacks = [];
-    for (const e of object.snacks ?? []) {
-      message.snacks.push(e);
-    }
-    message.old_states = [];
-    for (const e of object.old_states ?? []) {
-      message.old_states.push(e);
-    }
+    message.grand_children = (object.grand_children ?? []).map((e) => Child.fromPartial(e));
+    message.coins = (object.coins ?? []).map((e) => e);
+    message.snacks = (object.snacks ?? []).map((e) => e);
+    message.old_states = (object.old_states ?? []).map((e) => e);
     if (object.thing !== undefined && object.thing !== null) {
       message.thing = ImportedThing.fromPartial(object.thing);
     } else {
@@ -858,14 +834,8 @@ export const SimpleWithWrappers = {
     } else {
       message.enabled = undefined;
     }
-    message.coins = [];
-    for (const e of object.coins ?? []) {
-      message.coins.push(Number(e));
-    }
-    message.snacks = [];
-    for (const e of object.snacks ?? []) {
-      message.snacks.push(String(e));
-    }
+    message.coins = (object.coins ?? []).map((e: any) => Number(e));
+    message.snacks = (object.snacks ?? []).map((e: any) => String(e));
     return message;
   },
 
@@ -892,14 +862,8 @@ export const SimpleWithWrappers = {
     message.name = object.name ?? undefined;
     message.age = object.age ?? undefined;
     message.enabled = object.enabled ?? undefined;
-    message.coins = [];
-    for (const e of object.coins ?? []) {
-      message.coins.push(e);
-    }
-    message.snacks = [];
-    for (const e of object.snacks ?? []) {
-      message.snacks.push(e);
-    }
+    message.coins = (object.coins ?? []).map((e) => e);
+    message.snacks = (object.snacks ?? []).map((e) => e);
     return message;
   },
 };

--- a/integration/simple-string-enums/simple.ts
+++ b/integration/simple-string-enums/simple.ts
@@ -113,7 +113,6 @@ export const Simple = {
 
   fromJSON(object: any): Simple {
     const message = { ...baseSimple } as Simple;
-    message.states = [];
     if (object.name !== undefined && object.name !== null) {
       message.name = String(object.name);
     } else {
@@ -124,6 +123,7 @@ export const Simple = {
     } else {
       message.state = StateEnum.UNKNOWN;
     }
+    message.states = [];
     if (object.states !== undefined && object.states !== null) {
       for (const e of object.states) {
         message.states.push(stateEnumFromJSON(e));

--- a/integration/simple-string-enums/simple.ts
+++ b/integration/simple-string-enums/simple.ts
@@ -124,10 +124,8 @@ export const Simple = {
       message.state = StateEnum.UNKNOWN;
     }
     message.states = [];
-    if (object.states !== undefined && object.states !== null) {
-      for (const e of object.states) {
-        message.states.push(stateEnumFromJSON(e));
-      }
+    for (const e of object.states ?? []) {
+      message.states.push(stateEnumFromJSON(e));
     }
     return message;
   },
@@ -149,10 +147,8 @@ export const Simple = {
     message.name = object.name ?? '';
     message.state = object.state ?? StateEnum.UNKNOWN;
     message.states = [];
-    if (object.states !== undefined && object.states !== null) {
-      for (const e of object.states) {
-        message.states.push(e);
-      }
+    for (const e of object.states ?? []) {
+      message.states.push(e);
     }
     return message;
   },

--- a/integration/simple-string-enums/simple.ts
+++ b/integration/simple-string-enums/simple.ts
@@ -123,10 +123,7 @@ export const Simple = {
     } else {
       message.state = StateEnum.UNKNOWN;
     }
-    message.states = [];
-    for (const e of object.states ?? []) {
-      message.states.push(stateEnumFromJSON(e));
-    }
+    message.states = (object.states ?? []).map((e: any) => stateEnumFromJSON(e));
     return message;
   },
 
@@ -146,10 +143,7 @@ export const Simple = {
     const message = { ...baseSimple } as Simple;
     message.name = object.name ?? '';
     message.state = object.state ?? StateEnum.UNKNOWN;
-    message.states = [];
-    for (const e of object.states ?? []) {
-      message.states.push(e);
-    }
+    message.states = (object.states ?? []).map((e) => e);
     return message;
   },
 };

--- a/integration/simple-unrecognized-enum/google/protobuf/wrappers.ts
+++ b/integration/simple-unrecognized-enum/google/protobuf/wrappers.ts
@@ -533,9 +533,10 @@ export const BytesValue = {
 
   fromJSON(object: any): BytesValue {
     const message = { ...baseBytesValue } as BytesValue;
-    message.value = new Uint8Array();
     if (object.value !== undefined && object.value !== null) {
       message.value = bytesFromBase64(object.value);
+    } else {
+      message.value = new Uint8Array();
     }
     return message;
   },

--- a/integration/simple-unrecognized-enum/simple.ts
+++ b/integration/simple-unrecognized-enum/simple.ts
@@ -358,28 +358,20 @@ export const Simple = {
       message.state = 0;
     }
     message.grandChildren = [];
-    if (object.grandChildren !== undefined && object.grandChildren !== null) {
-      for (const e of object.grandChildren) {
-        message.grandChildren.push(Child.fromJSON(e));
-      }
+    for (const e of object.grandChildren ?? []) {
+      message.grandChildren.push(Child.fromJSON(e));
     }
     message.coins = [];
-    if (object.coins !== undefined && object.coins !== null) {
-      for (const e of object.coins) {
-        message.coins.push(Number(e));
-      }
+    for (const e of object.coins ?? []) {
+      message.coins.push(Number(e));
     }
     message.snacks = [];
-    if (object.snacks !== undefined && object.snacks !== null) {
-      for (const e of object.snacks) {
-        message.snacks.push(String(e));
-      }
+    for (const e of object.snacks ?? []) {
+      message.snacks.push(String(e));
     }
     message.oldStates = [];
-    if (object.oldStates !== undefined && object.oldStates !== null) {
-      for (const e of object.oldStates) {
-        message.oldStates.push(stateEnumFromJSON(e));
-      }
+    for (const e of object.oldStates ?? []) {
+      message.oldStates.push(stateEnumFromJSON(e));
     }
     if (object.thing !== undefined && object.thing !== null) {
       message.thing = ImportedThing.fromJSON(object.thing);
@@ -432,28 +424,20 @@ export const Simple = {
     }
     message.state = object.state ?? 0;
     message.grandChildren = [];
-    if (object.grandChildren !== undefined && object.grandChildren !== null) {
-      for (const e of object.grandChildren) {
-        message.grandChildren.push(Child.fromPartial(e));
-      }
+    for (const e of object.grandChildren ?? []) {
+      message.grandChildren.push(Child.fromPartial(e));
     }
     message.coins = [];
-    if (object.coins !== undefined && object.coins !== null) {
-      for (const e of object.coins) {
-        message.coins.push(e);
-      }
+    for (const e of object.coins ?? []) {
+      message.coins.push(e);
     }
     message.snacks = [];
-    if (object.snacks !== undefined && object.snacks !== null) {
-      for (const e of object.snacks) {
-        message.snacks.push(e);
-      }
+    for (const e of object.snacks ?? []) {
+      message.snacks.push(e);
     }
     message.oldStates = [];
-    if (object.oldStates !== undefined && object.oldStates !== null) {
-      for (const e of object.oldStates) {
-        message.oldStates.push(e);
-      }
+    for (const e of object.oldStates ?? []) {
+      message.oldStates.push(e);
     }
     if (object.thing !== undefined && object.thing !== null) {
       message.thing = ImportedThing.fromPartial(object.thing);
@@ -866,16 +850,12 @@ export const SimpleWithWrappers = {
       message.enabled = undefined;
     }
     message.coins = [];
-    if (object.coins !== undefined && object.coins !== null) {
-      for (const e of object.coins) {
-        message.coins.push(Number(e));
-      }
+    for (const e of object.coins ?? []) {
+      message.coins.push(Number(e));
     }
     message.snacks = [];
-    if (object.snacks !== undefined && object.snacks !== null) {
-      for (const e of object.snacks) {
-        message.snacks.push(String(e));
-      }
+    for (const e of object.snacks ?? []) {
+      message.snacks.push(String(e));
     }
     return message;
   },
@@ -904,16 +884,12 @@ export const SimpleWithWrappers = {
     message.age = object.age ?? undefined;
     message.enabled = object.enabled ?? undefined;
     message.coins = [];
-    if (object.coins !== undefined && object.coins !== null) {
-      for (const e of object.coins) {
-        message.coins.push(e);
-      }
+    for (const e of object.coins ?? []) {
+      message.coins.push(e);
     }
     message.snacks = [];
-    if (object.snacks !== undefined && object.snacks !== null) {
-      for (const e of object.snacks) {
-        message.snacks.push(e);
-      }
+    for (const e of object.snacks ?? []) {
+      message.snacks.push(e);
     }
     return message;
   },

--- a/integration/simple-unrecognized-enum/simple.ts
+++ b/integration/simple-unrecognized-enum/simple.ts
@@ -332,10 +332,6 @@ export const Simple = {
 
   fromJSON(object: any): Simple {
     const message = { ...baseSimple } as Simple;
-    message.grandChildren = [];
-    message.coins = [];
-    message.snacks = [];
-    message.oldStates = [];
     if (object.name !== undefined && object.name !== null) {
       message.name = String(object.name);
     } else {
@@ -361,21 +357,25 @@ export const Simple = {
     } else {
       message.state = 0;
     }
+    message.grandChildren = [];
     if (object.grandChildren !== undefined && object.grandChildren !== null) {
       for (const e of object.grandChildren) {
         message.grandChildren.push(Child.fromJSON(e));
       }
     }
+    message.coins = [];
     if (object.coins !== undefined && object.coins !== null) {
       for (const e of object.coins) {
         message.coins.push(Number(e));
       }
     }
+    message.snacks = [];
     if (object.snacks !== undefined && object.snacks !== null) {
       for (const e of object.snacks) {
         message.snacks.push(String(e));
       }
     }
+    message.oldStates = [];
     if (object.oldStates !== undefined && object.oldStates !== null) {
       for (const e of object.oldStates) {
         message.oldStates.push(stateEnumFromJSON(e));
@@ -850,8 +850,6 @@ export const SimpleWithWrappers = {
 
   fromJSON(object: any): SimpleWithWrappers {
     const message = { ...baseSimpleWithWrappers } as SimpleWithWrappers;
-    message.coins = [];
-    message.snacks = [];
     if (object.name !== undefined && object.name !== null) {
       message.name = String(object.name);
     } else {
@@ -867,11 +865,13 @@ export const SimpleWithWrappers = {
     } else {
       message.enabled = undefined;
     }
+    message.coins = [];
     if (object.coins !== undefined && object.coins !== null) {
       for (const e of object.coins) {
         message.coins.push(Number(e));
       }
     }
+    message.snacks = [];
     if (object.snacks !== undefined && object.snacks !== null) {
       for (const e of object.snacks) {
         message.snacks.push(String(e));
@@ -1025,18 +1025,18 @@ export const SimpleWithMap = {
   fromJSON(object: any): SimpleWithMap {
     const message = { ...baseSimpleWithMap } as SimpleWithMap;
     message.entitiesById = {};
-    message.nameLookup = {};
-    message.intLookup = {};
     if (object.entitiesById !== undefined && object.entitiesById !== null) {
       Object.entries(object.entitiesById).forEach(([key, value]) => {
         message.entitiesById[Number(key)] = Entity.fromJSON(value);
       });
     }
+    message.nameLookup = {};
     if (object.nameLookup !== undefined && object.nameLookup !== null) {
       Object.entries(object.nameLookup).forEach(([key, value]) => {
         message.nameLookup[key] = String(value);
       });
     }
+    message.intLookup = {};
     if (object.intLookup !== undefined && object.intLookup !== null) {
       Object.entries(object.intLookup).forEach(([key, value]) => {
         message.intLookup[Number(key)] = Number(value);

--- a/integration/simple-unrecognized-enum/simple.ts
+++ b/integration/simple-unrecognized-enum/simple.ts
@@ -357,22 +357,10 @@ export const Simple = {
     } else {
       message.state = 0;
     }
-    message.grandChildren = [];
-    for (const e of object.grandChildren ?? []) {
-      message.grandChildren.push(Child.fromJSON(e));
-    }
-    message.coins = [];
-    for (const e of object.coins ?? []) {
-      message.coins.push(Number(e));
-    }
-    message.snacks = [];
-    for (const e of object.snacks ?? []) {
-      message.snacks.push(String(e));
-    }
-    message.oldStates = [];
-    for (const e of object.oldStates ?? []) {
-      message.oldStates.push(stateEnumFromJSON(e));
-    }
+    message.grandChildren = (object.grandChildren ?? []).map((e: any) => Child.fromJSON(e));
+    message.coins = (object.coins ?? []).map((e: any) => Number(e));
+    message.snacks = (object.snacks ?? []).map((e: any) => String(e));
+    message.oldStates = (object.oldStates ?? []).map((e: any) => stateEnumFromJSON(e));
     if (object.thing !== undefined && object.thing !== null) {
       message.thing = ImportedThing.fromJSON(object.thing);
     } else {
@@ -423,22 +411,10 @@ export const Simple = {
       message.child = undefined;
     }
     message.state = object.state ?? 0;
-    message.grandChildren = [];
-    for (const e of object.grandChildren ?? []) {
-      message.grandChildren.push(Child.fromPartial(e));
-    }
-    message.coins = [];
-    for (const e of object.coins ?? []) {
-      message.coins.push(e);
-    }
-    message.snacks = [];
-    for (const e of object.snacks ?? []) {
-      message.snacks.push(e);
-    }
-    message.oldStates = [];
-    for (const e of object.oldStates ?? []) {
-      message.oldStates.push(e);
-    }
+    message.grandChildren = (object.grandChildren ?? []).map((e) => Child.fromPartial(e));
+    message.coins = (object.coins ?? []).map((e) => e);
+    message.snacks = (object.snacks ?? []).map((e) => e);
+    message.oldStates = (object.oldStates ?? []).map((e) => e);
     if (object.thing !== undefined && object.thing !== null) {
       message.thing = ImportedThing.fromPartial(object.thing);
     } else {
@@ -849,14 +825,8 @@ export const SimpleWithWrappers = {
     } else {
       message.enabled = undefined;
     }
-    message.coins = [];
-    for (const e of object.coins ?? []) {
-      message.coins.push(Number(e));
-    }
-    message.snacks = [];
-    for (const e of object.snacks ?? []) {
-      message.snacks.push(String(e));
-    }
+    message.coins = (object.coins ?? []).map((e: any) => Number(e));
+    message.snacks = (object.snacks ?? []).map((e: any) => String(e));
     return message;
   },
 
@@ -883,14 +853,8 @@ export const SimpleWithWrappers = {
     message.name = object.name ?? undefined;
     message.age = object.age ?? undefined;
     message.enabled = object.enabled ?? undefined;
-    message.coins = [];
-    for (const e of object.coins ?? []) {
-      message.coins.push(e);
-    }
-    message.snacks = [];
-    for (const e of object.snacks ?? []) {
-      message.snacks.push(e);
-    }
+    message.coins = (object.coins ?? []).map((e) => e);
+    message.snacks = (object.snacks ?? []).map((e) => e);
     return message;
   },
 };

--- a/integration/simple/google/protobuf/wrappers.ts
+++ b/integration/simple/google/protobuf/wrappers.ts
@@ -533,9 +533,10 @@ export const BytesValue = {
 
   fromJSON(object: any): BytesValue {
     const message = { ...baseBytesValue } as BytesValue;
-    message.value = new Uint8Array();
     if (object.value !== undefined && object.value !== null) {
       message.value = bytesFromBase64(object.value);
+    } else {
+      message.value = new Uint8Array();
     }
     return message;
   },

--- a/integration/simple/simple.ts
+++ b/integration/simple/simple.ts
@@ -415,7 +415,6 @@ export const Simple = {
     message.snacks = [];
     message.oldStates = [];
     message.blobs = [];
-    message.blob = new Uint8Array();
     if (object.name !== undefined && object.name !== null) {
       message.name = String(object.name);
     } else {
@@ -478,6 +477,8 @@ export const Simple = {
     }
     if (object.blob !== undefined && object.blob !== null) {
       message.blob = bytesFromBase64(object.blob);
+    } else {
+      message.blob = new Uint8Array();
     }
     return message;
   },
@@ -1614,7 +1615,6 @@ export const SimpleWithMap_MapOfBytesEntry = {
 
   fromJSON(object: any): SimpleWithMap_MapOfBytesEntry {
     const message = { ...baseSimpleWithMap_MapOfBytesEntry } as SimpleWithMap_MapOfBytesEntry;
-    message.value = new Uint8Array();
     if (object.key !== undefined && object.key !== null) {
       message.key = String(object.key);
     } else {
@@ -1622,6 +1622,8 @@ export const SimpleWithMap_MapOfBytesEntry = {
     }
     if (object.value !== undefined && object.value !== null) {
       message.value = bytesFromBase64(object.value);
+    } else {
+      message.value = new Uint8Array();
     }
     return message;
   },

--- a/integration/simple/simple.ts
+++ b/integration/simple/simple.ts
@@ -436,28 +436,20 @@ export const Simple = {
       message.state = 0;
     }
     message.grandChildren = [];
-    if (object.grandChildren !== undefined && object.grandChildren !== null) {
-      for (const e of object.grandChildren) {
-        message.grandChildren.push(Child.fromJSON(e));
-      }
+    for (const e of object.grandChildren ?? []) {
+      message.grandChildren.push(Child.fromJSON(e));
     }
     message.coins = [];
-    if (object.coins !== undefined && object.coins !== null) {
-      for (const e of object.coins) {
-        message.coins.push(Number(e));
-      }
+    for (const e of object.coins ?? []) {
+      message.coins.push(Number(e));
     }
     message.snacks = [];
-    if (object.snacks !== undefined && object.snacks !== null) {
-      for (const e of object.snacks) {
-        message.snacks.push(String(e));
-      }
+    for (const e of object.snacks ?? []) {
+      message.snacks.push(String(e));
     }
     message.oldStates = [];
-    if (object.oldStates !== undefined && object.oldStates !== null) {
-      for (const e of object.oldStates) {
-        message.oldStates.push(stateEnumFromJSON(e));
-      }
+    for (const e of object.oldStates ?? []) {
+      message.oldStates.push(stateEnumFromJSON(e));
     }
     if (object.thing !== undefined && object.thing !== null) {
       message.thing = ImportedThing.fromJSON(object.thing);
@@ -465,10 +457,8 @@ export const Simple = {
       message.thing = undefined;
     }
     message.blobs = [];
-    if (object.blobs !== undefined && object.blobs !== null) {
-      for (const e of object.blobs) {
-        message.blobs.push(bytesFromBase64(e));
-      }
+    for (const e of object.blobs ?? []) {
+      message.blobs.push(bytesFromBase64(e));
     }
     if (object.birthday !== undefined && object.birthday !== null) {
       message.birthday = DateMessage.fromJSON(object.birthday);
@@ -535,28 +525,20 @@ export const Simple = {
     }
     message.state = object.state ?? 0;
     message.grandChildren = [];
-    if (object.grandChildren !== undefined && object.grandChildren !== null) {
-      for (const e of object.grandChildren) {
-        message.grandChildren.push(Child.fromPartial(e));
-      }
+    for (const e of object.grandChildren ?? []) {
+      message.grandChildren.push(Child.fromPartial(e));
     }
     message.coins = [];
-    if (object.coins !== undefined && object.coins !== null) {
-      for (const e of object.coins) {
-        message.coins.push(e);
-      }
+    for (const e of object.coins ?? []) {
+      message.coins.push(e);
     }
     message.snacks = [];
-    if (object.snacks !== undefined && object.snacks !== null) {
-      for (const e of object.snacks) {
-        message.snacks.push(e);
-      }
+    for (const e of object.snacks ?? []) {
+      message.snacks.push(e);
     }
     message.oldStates = [];
-    if (object.oldStates !== undefined && object.oldStates !== null) {
-      for (const e of object.oldStates) {
-        message.oldStates.push(e);
-      }
+    for (const e of object.oldStates ?? []) {
+      message.oldStates.push(e);
     }
     if (object.thing !== undefined && object.thing !== null) {
       message.thing = ImportedThing.fromPartial(object.thing);
@@ -564,10 +546,8 @@ export const Simple = {
       message.thing = undefined;
     }
     message.blobs = [];
-    if (object.blobs !== undefined && object.blobs !== null) {
-      for (const e of object.blobs) {
-        message.blobs.push(e);
-      }
+    for (const e of object.blobs ?? []) {
+      message.blobs.push(e);
     }
     if (object.birthday !== undefined && object.birthday !== null) {
       message.birthday = DateMessage.fromPartial(object.birthday);
@@ -987,16 +967,12 @@ export const SimpleWithWrappers = {
       message.enabled = undefined;
     }
     message.coins = [];
-    if (object.coins !== undefined && object.coins !== null) {
-      for (const e of object.coins) {
-        message.coins.push(Number(e));
-      }
+    for (const e of object.coins ?? []) {
+      message.coins.push(Number(e));
     }
     message.snacks = [];
-    if (object.snacks !== undefined && object.snacks !== null) {
-      for (const e of object.snacks) {
-        message.snacks.push(String(e));
-      }
+    for (const e of object.snacks ?? []) {
+      message.snacks.push(String(e));
     }
     if (object.id !== undefined && object.id !== null) {
       message.id = new Uint8Array(object.id);
@@ -1031,16 +1007,12 @@ export const SimpleWithWrappers = {
     message.age = object.age ?? undefined;
     message.enabled = object.enabled ?? undefined;
     message.coins = [];
-    if (object.coins !== undefined && object.coins !== null) {
-      for (const e of object.coins) {
-        message.coins.push(e);
-      }
+    for (const e of object.coins ?? []) {
+      message.coins.push(e);
     }
     message.snacks = [];
-    if (object.snacks !== undefined && object.snacks !== null) {
-      for (const e of object.snacks) {
-        message.snacks.push(e);
-      }
+    for (const e of object.snacks ?? []) {
+      message.snacks.push(e);
     }
     message.id = object.id ?? undefined;
     return message;

--- a/integration/simple/simple.ts
+++ b/integration/simple/simple.ts
@@ -435,31 +435,16 @@ export const Simple = {
     } else {
       message.state = 0;
     }
-    message.grandChildren = [];
-    for (const e of object.grandChildren ?? []) {
-      message.grandChildren.push(Child.fromJSON(e));
-    }
-    message.coins = [];
-    for (const e of object.coins ?? []) {
-      message.coins.push(Number(e));
-    }
-    message.snacks = [];
-    for (const e of object.snacks ?? []) {
-      message.snacks.push(String(e));
-    }
-    message.oldStates = [];
-    for (const e of object.oldStates ?? []) {
-      message.oldStates.push(stateEnumFromJSON(e));
-    }
+    message.grandChildren = (object.grandChildren ?? []).map((e: any) => Child.fromJSON(e));
+    message.coins = (object.coins ?? []).map((e: any) => Number(e));
+    message.snacks = (object.snacks ?? []).map((e: any) => String(e));
+    message.oldStates = (object.oldStates ?? []).map((e: any) => stateEnumFromJSON(e));
     if (object.thing !== undefined && object.thing !== null) {
       message.thing = ImportedThing.fromJSON(object.thing);
     } else {
       message.thing = undefined;
     }
-    message.blobs = [];
-    for (const e of object.blobs ?? []) {
-      message.blobs.push(bytesFromBase64(e));
-    }
+    message.blobs = (object.blobs ?? []).map((e: any) => bytesFromBase64(e));
     if (object.birthday !== undefined && object.birthday !== null) {
       message.birthday = DateMessage.fromJSON(object.birthday);
     } else {
@@ -524,31 +509,16 @@ export const Simple = {
       message.child = undefined;
     }
     message.state = object.state ?? 0;
-    message.grandChildren = [];
-    for (const e of object.grandChildren ?? []) {
-      message.grandChildren.push(Child.fromPartial(e));
-    }
-    message.coins = [];
-    for (const e of object.coins ?? []) {
-      message.coins.push(e);
-    }
-    message.snacks = [];
-    for (const e of object.snacks ?? []) {
-      message.snacks.push(e);
-    }
-    message.oldStates = [];
-    for (const e of object.oldStates ?? []) {
-      message.oldStates.push(e);
-    }
+    message.grandChildren = (object.grandChildren ?? []).map((e) => Child.fromPartial(e));
+    message.coins = (object.coins ?? []).map((e) => e);
+    message.snacks = (object.snacks ?? []).map((e) => e);
+    message.oldStates = (object.oldStates ?? []).map((e) => e);
     if (object.thing !== undefined && object.thing !== null) {
       message.thing = ImportedThing.fromPartial(object.thing);
     } else {
       message.thing = undefined;
     }
-    message.blobs = [];
-    for (const e of object.blobs ?? []) {
-      message.blobs.push(e);
-    }
+    message.blobs = (object.blobs ?? []).map((e) => e);
     if (object.birthday !== undefined && object.birthday !== null) {
       message.birthday = DateMessage.fromPartial(object.birthday);
     } else {
@@ -966,14 +936,8 @@ export const SimpleWithWrappers = {
     } else {
       message.enabled = undefined;
     }
-    message.coins = [];
-    for (const e of object.coins ?? []) {
-      message.coins.push(Number(e));
-    }
-    message.snacks = [];
-    for (const e of object.snacks ?? []) {
-      message.snacks.push(String(e));
-    }
+    message.coins = (object.coins ?? []).map((e: any) => Number(e));
+    message.snacks = (object.snacks ?? []).map((e: any) => String(e));
     if (object.id !== undefined && object.id !== null) {
       message.id = new Uint8Array(object.id);
     } else {
@@ -1006,14 +970,8 @@ export const SimpleWithWrappers = {
     message.name = object.name ?? undefined;
     message.age = object.age ?? undefined;
     message.enabled = object.enabled ?? undefined;
-    message.coins = [];
-    for (const e of object.coins ?? []) {
-      message.coins.push(e);
-    }
-    message.snacks = [];
-    for (const e of object.snacks ?? []) {
-      message.snacks.push(e);
-    }
+    message.coins = (object.coins ?? []).map((e) => e);
+    message.snacks = (object.snacks ?? []).map((e) => e);
     message.id = object.id ?? undefined;
     return message;
   },

--- a/integration/simple/simple.ts
+++ b/integration/simple/simple.ts
@@ -410,11 +410,6 @@ export const Simple = {
 
   fromJSON(object: any): Simple {
     const message = { ...baseSimple } as Simple;
-    message.grandChildren = [];
-    message.coins = [];
-    message.snacks = [];
-    message.oldStates = [];
-    message.blobs = [];
     if (object.name !== undefined && object.name !== null) {
       message.name = String(object.name);
     } else {
@@ -440,21 +435,25 @@ export const Simple = {
     } else {
       message.state = 0;
     }
+    message.grandChildren = [];
     if (object.grandChildren !== undefined && object.grandChildren !== null) {
       for (const e of object.grandChildren) {
         message.grandChildren.push(Child.fromJSON(e));
       }
     }
+    message.coins = [];
     if (object.coins !== undefined && object.coins !== null) {
       for (const e of object.coins) {
         message.coins.push(Number(e));
       }
     }
+    message.snacks = [];
     if (object.snacks !== undefined && object.snacks !== null) {
       for (const e of object.snacks) {
         message.snacks.push(String(e));
       }
     }
+    message.oldStates = [];
     if (object.oldStates !== undefined && object.oldStates !== null) {
       for (const e of object.oldStates) {
         message.oldStates.push(stateEnumFromJSON(e));
@@ -465,6 +464,7 @@ export const Simple = {
     } else {
       message.thing = undefined;
     }
+    message.blobs = [];
     if (object.blobs !== undefined && object.blobs !== null) {
       for (const e of object.blobs) {
         message.blobs.push(bytesFromBase64(e));
@@ -971,8 +971,6 @@ export const SimpleWithWrappers = {
 
   fromJSON(object: any): SimpleWithWrappers {
     const message = { ...baseSimpleWithWrappers } as SimpleWithWrappers;
-    message.coins = [];
-    message.snacks = [];
     if (object.name !== undefined && object.name !== null) {
       message.name = String(object.name);
     } else {
@@ -988,11 +986,13 @@ export const SimpleWithWrappers = {
     } else {
       message.enabled = undefined;
     }
+    message.coins = [];
     if (object.coins !== undefined && object.coins !== null) {
       for (const e of object.coins) {
         message.coins.push(Number(e));
       }
     }
+    message.snacks = [];
     if (object.snacks !== undefined && object.snacks !== null) {
       for (const e of object.snacks) {
         message.snacks.push(String(e));
@@ -1185,36 +1185,36 @@ export const SimpleWithMap = {
   fromJSON(object: any): SimpleWithMap {
     const message = { ...baseSimpleWithMap } as SimpleWithMap;
     message.entitiesById = {};
-    message.nameLookup = {};
-    message.intLookup = {};
-    message.mapOfTimestamps = {};
-    message.mapOfBytes = {};
-    message.mapOfStringValues = {};
     if (object.entitiesById !== undefined && object.entitiesById !== null) {
       Object.entries(object.entitiesById).forEach(([key, value]) => {
         message.entitiesById[Number(key)] = Entity.fromJSON(value);
       });
     }
+    message.nameLookup = {};
     if (object.nameLookup !== undefined && object.nameLookup !== null) {
       Object.entries(object.nameLookup).forEach(([key, value]) => {
         message.nameLookup[key] = String(value);
       });
     }
+    message.intLookup = {};
     if (object.intLookup !== undefined && object.intLookup !== null) {
       Object.entries(object.intLookup).forEach(([key, value]) => {
         message.intLookup[Number(key)] = Number(value);
       });
     }
+    message.mapOfTimestamps = {};
     if (object.mapOfTimestamps !== undefined && object.mapOfTimestamps !== null) {
       Object.entries(object.mapOfTimestamps).forEach(([key, value]) => {
         message.mapOfTimestamps[key] = fromJsonTimestamp(value);
       });
     }
+    message.mapOfBytes = {};
     if (object.mapOfBytes !== undefined && object.mapOfBytes !== null) {
       Object.entries(object.mapOfBytes).forEach(([key, value]) => {
         message.mapOfBytes[key] = bytesFromBase64(value as string);
       });
     }
+    message.mapOfStringValues = {};
     if (object.mapOfStringValues !== undefined && object.mapOfStringValues !== null) {
       Object.entries(object.mapOfStringValues).forEach(([key, value]) => {
         message.mapOfStringValues[key] = value as string | undefined;

--- a/integration/use-date-string/use-date-string.ts
+++ b/integration/use-date-string/use-date-string.ts
@@ -88,10 +88,8 @@ export const Todo = {
       message.timestamp = undefined;
     }
     message.repeatedTimestamp = [];
-    if (object.repeatedTimestamp !== undefined && object.repeatedTimestamp !== null) {
-      for (const e of object.repeatedTimestamp) {
-        message.repeatedTimestamp.push(String(e));
-      }
+    for (const e of object.repeatedTimestamp ?? []) {
+      message.repeatedTimestamp.push(String(e));
     }
     if (object.optionalTimestamp !== undefined && object.optionalTimestamp !== null) {
       message.optionalTimestamp = String(object.optionalTimestamp);
@@ -131,10 +129,8 @@ export const Todo = {
     message.id = object.id ?? '';
     message.timestamp = object.timestamp ?? undefined;
     message.repeatedTimestamp = [];
-    if (object.repeatedTimestamp !== undefined && object.repeatedTimestamp !== null) {
-      for (const e of object.repeatedTimestamp) {
-        message.repeatedTimestamp.push(e);
-      }
+    for (const e of object.repeatedTimestamp ?? []) {
+      message.repeatedTimestamp.push(e);
     }
     message.optionalTimestamp = object.optionalTimestamp ?? undefined;
     message.mapOfTimestamps = {};

--- a/integration/use-date-string/use-date-string.ts
+++ b/integration/use-date-string/use-date-string.ts
@@ -87,10 +87,7 @@ export const Todo = {
     } else {
       message.timestamp = undefined;
     }
-    message.repeatedTimestamp = [];
-    for (const e of object.repeatedTimestamp ?? []) {
-      message.repeatedTimestamp.push(String(e));
-    }
+    message.repeatedTimestamp = (object.repeatedTimestamp ?? []).map((e: any) => String(e));
     if (object.optionalTimestamp !== undefined && object.optionalTimestamp !== null) {
       message.optionalTimestamp = String(object.optionalTimestamp);
     } else {
@@ -128,10 +125,7 @@ export const Todo = {
     const message = { ...baseTodo } as Todo;
     message.id = object.id ?? '';
     message.timestamp = object.timestamp ?? undefined;
-    message.repeatedTimestamp = [];
-    for (const e of object.repeatedTimestamp ?? []) {
-      message.repeatedTimestamp.push(e);
-    }
+    message.repeatedTimestamp = (object.repeatedTimestamp ?? []).map((e) => e);
     message.optionalTimestamp = object.optionalTimestamp ?? undefined;
     message.mapOfTimestamps = {};
     if (object.mapOfTimestamps !== undefined && object.mapOfTimestamps !== null) {

--- a/integration/use-date-string/use-date-string.ts
+++ b/integration/use-date-string/use-date-string.ts
@@ -77,8 +77,6 @@ export const Todo = {
 
   fromJSON(object: any): Todo {
     const message = { ...baseTodo } as Todo;
-    message.repeatedTimestamp = [];
-    message.mapOfTimestamps = {};
     if (object.id !== undefined && object.id !== null) {
       message.id = String(object.id);
     } else {
@@ -89,6 +87,7 @@ export const Todo = {
     } else {
       message.timestamp = undefined;
     }
+    message.repeatedTimestamp = [];
     if (object.repeatedTimestamp !== undefined && object.repeatedTimestamp !== null) {
       for (const e of object.repeatedTimestamp) {
         message.repeatedTimestamp.push(String(e));
@@ -99,6 +98,7 @@ export const Todo = {
     } else {
       message.optionalTimestamp = undefined;
     }
+    message.mapOfTimestamps = {};
     if (object.mapOfTimestamps !== undefined && object.mapOfTimestamps !== null) {
       Object.entries(object.mapOfTimestamps).forEach(([key, value]) => {
         message.mapOfTimestamps[key] = String(value);

--- a/integration/use-date-true/use-date-true.ts
+++ b/integration/use-date-true/use-date-true.ts
@@ -88,10 +88,8 @@ export const Todo = {
       message.timestamp = undefined;
     }
     message.repeatedTimestamp = [];
-    if (object.repeatedTimestamp !== undefined && object.repeatedTimestamp !== null) {
-      for (const e of object.repeatedTimestamp) {
-        message.repeatedTimestamp.push(fromJsonTimestamp(e));
-      }
+    for (const e of object.repeatedTimestamp ?? []) {
+      message.repeatedTimestamp.push(fromJsonTimestamp(e));
     }
     if (object.optionalTimestamp !== undefined && object.optionalTimestamp !== null) {
       message.optionalTimestamp = fromJsonTimestamp(object.optionalTimestamp);
@@ -131,10 +129,8 @@ export const Todo = {
     message.id = object.id ?? '';
     message.timestamp = object.timestamp ?? undefined;
     message.repeatedTimestamp = [];
-    if (object.repeatedTimestamp !== undefined && object.repeatedTimestamp !== null) {
-      for (const e of object.repeatedTimestamp) {
-        message.repeatedTimestamp.push(e);
-      }
+    for (const e of object.repeatedTimestamp ?? []) {
+      message.repeatedTimestamp.push(e);
     }
     message.optionalTimestamp = object.optionalTimestamp ?? undefined;
     message.mapOfTimestamps = {};

--- a/integration/use-date-true/use-date-true.ts
+++ b/integration/use-date-true/use-date-true.ts
@@ -87,10 +87,7 @@ export const Todo = {
     } else {
       message.timestamp = undefined;
     }
-    message.repeatedTimestamp = [];
-    for (const e of object.repeatedTimestamp ?? []) {
-      message.repeatedTimestamp.push(fromJsonTimestamp(e));
-    }
+    message.repeatedTimestamp = (object.repeatedTimestamp ?? []).map((e: any) => fromJsonTimestamp(e));
     if (object.optionalTimestamp !== undefined && object.optionalTimestamp !== null) {
       message.optionalTimestamp = fromJsonTimestamp(object.optionalTimestamp);
     } else {
@@ -128,10 +125,7 @@ export const Todo = {
     const message = { ...baseTodo } as Todo;
     message.id = object.id ?? '';
     message.timestamp = object.timestamp ?? undefined;
-    message.repeatedTimestamp = [];
-    for (const e of object.repeatedTimestamp ?? []) {
-      message.repeatedTimestamp.push(e);
-    }
+    message.repeatedTimestamp = (object.repeatedTimestamp ?? []).map((e) => e);
     message.optionalTimestamp = object.optionalTimestamp ?? undefined;
     message.mapOfTimestamps = {};
     if (object.mapOfTimestamps !== undefined && object.mapOfTimestamps !== null) {

--- a/integration/use-date-true/use-date-true.ts
+++ b/integration/use-date-true/use-date-true.ts
@@ -77,8 +77,6 @@ export const Todo = {
 
   fromJSON(object: any): Todo {
     const message = { ...baseTodo } as Todo;
-    message.repeatedTimestamp = [];
-    message.mapOfTimestamps = {};
     if (object.id !== undefined && object.id !== null) {
       message.id = String(object.id);
     } else {
@@ -89,6 +87,7 @@ export const Todo = {
     } else {
       message.timestamp = undefined;
     }
+    message.repeatedTimestamp = [];
     if (object.repeatedTimestamp !== undefined && object.repeatedTimestamp !== null) {
       for (const e of object.repeatedTimestamp) {
         message.repeatedTimestamp.push(fromJsonTimestamp(e));
@@ -99,6 +98,7 @@ export const Todo = {
     } else {
       message.optionalTimestamp = undefined;
     }
+    message.mapOfTimestamps = {};
     if (object.mapOfTimestamps !== undefined && object.mapOfTimestamps !== null) {
       Object.entries(object.mapOfTimestamps).forEach(([key, value]) => {
         message.mapOfTimestamps[key] = fromJsonTimestamp(value);

--- a/integration/vector-tile/vector_tile.ts
+++ b/integration/vector-tile/vector_tile.ts
@@ -110,10 +110,8 @@ export const Tile = {
   fromJSON(object: any): Tile {
     const message = { ...baseTile } as Tile;
     message.layers = [];
-    if (object.layers !== undefined && object.layers !== null) {
-      for (const e of object.layers) {
-        message.layers.push(Tile_Layer.fromJSON(e));
-      }
+    for (const e of object.layers ?? []) {
+      message.layers.push(Tile_Layer.fromJSON(e));
     }
     return message;
   },
@@ -131,10 +129,8 @@ export const Tile = {
   fromPartial(object: DeepPartial<Tile>): Tile {
     const message = { ...baseTile } as Tile;
     message.layers = [];
-    if (object.layers !== undefined && object.layers !== null) {
-      for (const e of object.layers) {
-        message.layers.push(Tile_Layer.fromPartial(e));
-      }
+    for (const e of object.layers ?? []) {
+      message.layers.push(Tile_Layer.fromPartial(e));
     }
     return message;
   },
@@ -351,10 +347,8 @@ export const Tile_Feature = {
       message.id = 0;
     }
     message.tags = [];
-    if (object.tags !== undefined && object.tags !== null) {
-      for (const e of object.tags) {
-        message.tags.push(Number(e));
-      }
+    for (const e of object.tags ?? []) {
+      message.tags.push(Number(e));
     }
     if (object.type !== undefined && object.type !== null) {
       message.type = tile_GeomTypeFromJSON(object.type);
@@ -362,10 +356,8 @@ export const Tile_Feature = {
       message.type = 0;
     }
     message.geometry = [];
-    if (object.geometry !== undefined && object.geometry !== null) {
-      for (const e of object.geometry) {
-        message.geometry.push(Number(e));
-      }
+    for (const e of object.geometry ?? []) {
+      message.geometry.push(Number(e));
     }
     return message;
   },
@@ -391,17 +383,13 @@ export const Tile_Feature = {
     const message = { ...baseTile_Feature } as Tile_Feature;
     message.id = object.id ?? 0;
     message.tags = [];
-    if (object.tags !== undefined && object.tags !== null) {
-      for (const e of object.tags) {
-        message.tags.push(e);
-      }
+    for (const e of object.tags ?? []) {
+      message.tags.push(e);
     }
     message.type = object.type ?? 0;
     message.geometry = [];
-    if (object.geometry !== undefined && object.geometry !== null) {
-      for (const e of object.geometry) {
-        message.geometry.push(e);
-      }
+    for (const e of object.geometry ?? []) {
+      message.geometry.push(e);
     }
     return message;
   },
@@ -481,22 +469,16 @@ export const Tile_Layer = {
       message.name = '';
     }
     message.features = [];
-    if (object.features !== undefined && object.features !== null) {
-      for (const e of object.features) {
-        message.features.push(Tile_Feature.fromJSON(e));
-      }
+    for (const e of object.features ?? []) {
+      message.features.push(Tile_Feature.fromJSON(e));
     }
     message.keys = [];
-    if (object.keys !== undefined && object.keys !== null) {
-      for (const e of object.keys) {
-        message.keys.push(String(e));
-      }
+    for (const e of object.keys ?? []) {
+      message.keys.push(String(e));
     }
     message.values = [];
-    if (object.values !== undefined && object.values !== null) {
-      for (const e of object.values) {
-        message.values.push(Tile_Value.fromJSON(e));
-      }
+    for (const e of object.values ?? []) {
+      message.values.push(Tile_Value.fromJSON(e));
     }
     if (object.extent !== undefined && object.extent !== null) {
       message.extent = Number(object.extent);
@@ -534,22 +516,16 @@ export const Tile_Layer = {
     message.version = object.version ?? 0;
     message.name = object.name ?? '';
     message.features = [];
-    if (object.features !== undefined && object.features !== null) {
-      for (const e of object.features) {
-        message.features.push(Tile_Feature.fromPartial(e));
-      }
+    for (const e of object.features ?? []) {
+      message.features.push(Tile_Feature.fromPartial(e));
     }
     message.keys = [];
-    if (object.keys !== undefined && object.keys !== null) {
-      for (const e of object.keys) {
-        message.keys.push(e);
-      }
+    for (const e of object.keys ?? []) {
+      message.keys.push(e);
     }
     message.values = [];
-    if (object.values !== undefined && object.values !== null) {
-      for (const e of object.values) {
-        message.values.push(Tile_Value.fromPartial(e));
-      }
+    for (const e of object.values ?? []) {
+      message.values.push(Tile_Value.fromPartial(e));
     }
     message.extent = object.extent ?? 0;
     return message;

--- a/integration/vector-tile/vector_tile.ts
+++ b/integration/vector-tile/vector_tile.ts
@@ -345,13 +345,12 @@ export const Tile_Feature = {
 
   fromJSON(object: any): Tile_Feature {
     const message = { ...baseTile_Feature } as Tile_Feature;
-    message.tags = [];
-    message.geometry = [];
     if (object.id !== undefined && object.id !== null) {
       message.id = Number(object.id);
     } else {
       message.id = 0;
     }
+    message.tags = [];
     if (object.tags !== undefined && object.tags !== null) {
       for (const e of object.tags) {
         message.tags.push(Number(e));
@@ -362,6 +361,7 @@ export const Tile_Feature = {
     } else {
       message.type = 0;
     }
+    message.geometry = [];
     if (object.geometry !== undefined && object.geometry !== null) {
       for (const e of object.geometry) {
         message.geometry.push(Number(e));
@@ -470,9 +470,6 @@ export const Tile_Layer = {
 
   fromJSON(object: any): Tile_Layer {
     const message = { ...baseTile_Layer } as Tile_Layer;
-    message.features = [];
-    message.keys = [];
-    message.values = [];
     if (object.version !== undefined && object.version !== null) {
       message.version = Number(object.version);
     } else {
@@ -483,16 +480,19 @@ export const Tile_Layer = {
     } else {
       message.name = '';
     }
+    message.features = [];
     if (object.features !== undefined && object.features !== null) {
       for (const e of object.features) {
         message.features.push(Tile_Feature.fromJSON(e));
       }
     }
+    message.keys = [];
     if (object.keys !== undefined && object.keys !== null) {
       for (const e of object.keys) {
         message.keys.push(String(e));
       }
     }
+    message.values = [];
     if (object.values !== undefined && object.values !== null) {
       for (const e of object.values) {
         message.values.push(Tile_Value.fromJSON(e));

--- a/integration/vector-tile/vector_tile.ts
+++ b/integration/vector-tile/vector_tile.ts
@@ -109,10 +109,7 @@ export const Tile = {
 
   fromJSON(object: any): Tile {
     const message = { ...baseTile } as Tile;
-    message.layers = [];
-    for (const e of object.layers ?? []) {
-      message.layers.push(Tile_Layer.fromJSON(e));
-    }
+    message.layers = (object.layers ?? []).map((e: any) => Tile_Layer.fromJSON(e));
     return message;
   },
 
@@ -128,10 +125,7 @@ export const Tile = {
 
   fromPartial(object: DeepPartial<Tile>): Tile {
     const message = { ...baseTile } as Tile;
-    message.layers = [];
-    for (const e of object.layers ?? []) {
-      message.layers.push(Tile_Layer.fromPartial(e));
-    }
+    message.layers = (object.layers ?? []).map((e) => Tile_Layer.fromPartial(e));
     return message;
   },
 };
@@ -346,19 +340,13 @@ export const Tile_Feature = {
     } else {
       message.id = 0;
     }
-    message.tags = [];
-    for (const e of object.tags ?? []) {
-      message.tags.push(Number(e));
-    }
+    message.tags = (object.tags ?? []).map((e: any) => Number(e));
     if (object.type !== undefined && object.type !== null) {
       message.type = tile_GeomTypeFromJSON(object.type);
     } else {
       message.type = 0;
     }
-    message.geometry = [];
-    for (const e of object.geometry ?? []) {
-      message.geometry.push(Number(e));
-    }
+    message.geometry = (object.geometry ?? []).map((e: any) => Number(e));
     return message;
   },
 
@@ -382,15 +370,9 @@ export const Tile_Feature = {
   fromPartial(object: DeepPartial<Tile_Feature>): Tile_Feature {
     const message = { ...baseTile_Feature } as Tile_Feature;
     message.id = object.id ?? 0;
-    message.tags = [];
-    for (const e of object.tags ?? []) {
-      message.tags.push(e);
-    }
+    message.tags = (object.tags ?? []).map((e) => e);
     message.type = object.type ?? 0;
-    message.geometry = [];
-    for (const e of object.geometry ?? []) {
-      message.geometry.push(e);
-    }
+    message.geometry = (object.geometry ?? []).map((e) => e);
     return message;
   },
 };
@@ -468,18 +450,9 @@ export const Tile_Layer = {
     } else {
       message.name = '';
     }
-    message.features = [];
-    for (const e of object.features ?? []) {
-      message.features.push(Tile_Feature.fromJSON(e));
-    }
-    message.keys = [];
-    for (const e of object.keys ?? []) {
-      message.keys.push(String(e));
-    }
-    message.values = [];
-    for (const e of object.values ?? []) {
-      message.values.push(Tile_Value.fromJSON(e));
-    }
+    message.features = (object.features ?? []).map((e: any) => Tile_Feature.fromJSON(e));
+    message.keys = (object.keys ?? []).map((e: any) => String(e));
+    message.values = (object.values ?? []).map((e: any) => Tile_Value.fromJSON(e));
     if (object.extent !== undefined && object.extent !== null) {
       message.extent = Number(object.extent);
     } else {
@@ -515,18 +488,9 @@ export const Tile_Layer = {
     const message = { ...baseTile_Layer } as Tile_Layer;
     message.version = object.version ?? 0;
     message.name = object.name ?? '';
-    message.features = [];
-    for (const e of object.features ?? []) {
-      message.features.push(Tile_Feature.fromPartial(e));
-    }
-    message.keys = [];
-    for (const e of object.keys ?? []) {
-      message.keys.push(e);
-    }
-    message.values = [];
-    for (const e of object.values ?? []) {
-      message.values.push(Tile_Value.fromPartial(e));
-    }
+    message.features = (object.features ?? []).map((e) => Tile_Feature.fromPartial(e));
+    message.keys = (object.keys ?? []).map((e) => e);
+    message.values = (object.values ?? []).map((e) => Tile_Value.fromPartial(e));
     message.extent = object.extent ?? 0;
     return message;
   },

--- a/src/main.ts
+++ b/src/main.ts
@@ -901,13 +901,6 @@ function generateFromJson(ctx: Context, fullName: string, messageDesc: Descripto
       const message = { ...base${fullName} } as ${fullName};
   `);
 
-  // initialize all lists
-  messageDesc.field.filter(isRepeated).forEach((field) => {
-    const value = isMapType(ctx, messageDesc, field) ? '{}' : '[]';
-    const name = maybeSnakeToCamel(field.name, options);
-    chunks.push(code`message.${name} = ${value};`);
-  });
-
   // add a check for each incoming field
   messageDesc.field.forEach((field) => {
     const fieldName = maybeSnakeToCamel(field.name, options);
@@ -990,6 +983,9 @@ function generateFromJson(ctx: Context, fullName: string, messageDesc: Descripto
 
     // and then use the snippet to handle repeated fields if necessary
     if (isRepeated(field)) {
+      const value = isMapType(ctx, messageDesc, field) ? '{}' : '[]';
+      const name = maybeSnakeToCamel(field.name, options);
+      chunks.push(code`message.${name} = ${value};`);
       chunks.push(code`if (object.${fieldName} !== undefined && object.${fieldName} !== null) {`);
       if (isMapType(ctx, messageDesc, field)) {
         const i = maybeCastToNumber(ctx, messageDesc, field, 'key');

--- a/src/main.ts
+++ b/src/main.ts
@@ -994,11 +994,9 @@ function generateFromJson(ctx: Context, fullName: string, messageDesc: Descripto
         `);
         chunks.push(code`}`);
       } else {
-        chunks.push(code`message.${fieldName} = [];`);
+        // Explicit `any` type required to make TS with noImplicitAny happy. `object` is also `any` here.
         chunks.push(code`
-          for (const e of (object.${fieldName} ?? [])) {
-            message.${fieldName}.push(${readSnippet('e')});
-          }
+          message.${fieldName} = (object.${fieldName} ?? []).map((e: any) => ${readSnippet('e')});
         `);
       }
     } else if (isWithinOneOfThatShouldBeUnion(options, field)) {
@@ -1189,11 +1187,8 @@ function generateFromPartial(ctx: Context, fullName: string, messageDesc: Descri
         `);
         chunks.push(code`}`);
       } else {
-        chunks.push(code`message.${fieldName} = [];`);
         chunks.push(code`
-          for (const e of (object.${fieldName} ?? [])) {
-            message.${fieldName}.push(${readSnippet('e')});
-          }
+          message.${fieldName} = (object.${fieldName} ?? []).map((e) => ${readSnippet('e')});
         `);
       }
     } else if (isWithinOneOfThatShouldBeUnion(options, field)) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1225,7 +1225,7 @@ function generateFromPartial(ctx: Context, fullName: string, messageDesc: Descri
       chunks.push(code`message.${fieldName} = ${readSnippet(`object.${fieldName}`)};`);
       chunks.push(code`} else {`);
       const fallback = isWithinOneOf(field) ? 'undefined' : defaultValue(ctx, field);
-      chunks.push(code`message.${fieldName} = ${fallback}`);
+      chunks.push(code`message.${fieldName} = ${fallback};`);
       chunks.push(code`}`);
     }
   });


### PR DESCRIPTION
This uses `map` to initialize lists, such that all cases can be handled within one assignment. `if (object.ids !== undefined && object.ids !== null) {` was replaced with `object.ids ?? []` to save nesting depth and code size.