### PR TITLE
feat: Use ternary operator for conditional assignments

### DIFF
--- a/integration/angular/simple-message.ts
+++ b/integration/angular/simple-message.ts
@@ -38,11 +38,8 @@ export const SimpleMessage = {
 
   fromJSON(object: any): SimpleMessage {
     const message = { ...baseSimpleMessage } as SimpleMessage;
-    if (object.numberField !== undefined && object.numberField !== null) {
-      message.numberField = Number(object.numberField);
-    } else {
-      message.numberField = 0;
-    }
+    message.numberField =
+      object.numberField !== undefined && object.numberField !== null ? Number(object.numberField) : 0;
     return message;
   },
 

--- a/integration/avoid-import-conflicts/simple.ts
+++ b/integration/avoid-import-conflicts/simple.ts
@@ -94,16 +94,11 @@ export const Simple = {
 
   fromJSON(object: any): Simple {
     const message = { ...baseSimple } as Simple;
-    if (object.name !== undefined && object.name !== null) {
-      message.name = String(object.name);
-    } else {
-      message.name = '';
-    }
-    if (object.otherSimple !== undefined && object.otherSimple !== null) {
-      message.otherSimple = Simple2.fromJSON(object.otherSimple);
-    } else {
-      message.otherSimple = undefined;
-    }
+    message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
+    message.otherSimple =
+      object.otherSimple !== undefined && object.otherSimple !== null
+        ? Simple2.fromJSON(object.otherSimple)
+        : undefined;
     return message;
   },
 
@@ -118,11 +113,10 @@ export const Simple = {
   fromPartial(object: DeepPartial<Simple>): Simple {
     const message = { ...baseSimple } as Simple;
     message.name = object.name ?? '';
-    if (object.otherSimple !== undefined && object.otherSimple !== null) {
-      message.otherSimple = Simple2.fromPartial(object.otherSimple);
-    } else {
-      message.otherSimple = undefined;
-    }
+    message.otherSimple =
+      object.otherSimple !== undefined && object.otherSimple !== null
+        ? Simple2.fromPartial(object.otherSimple)
+        : undefined;
     return message;
   },
 };
@@ -163,16 +157,10 @@ export const SimpleEnums = {
 
   fromJSON(object: any): SimpleEnums {
     const message = { ...baseSimpleEnums } as SimpleEnums;
-    if (object.localEnum !== undefined && object.localEnum !== null) {
-      message.localEnum = simpleEnumFromJSON(object.localEnum);
-    } else {
-      message.localEnum = 0;
-    }
-    if (object.importEnum !== undefined && object.importEnum !== null) {
-      message.importEnum = simpleEnumFromJSON3(object.importEnum);
-    } else {
-      message.importEnum = 0;
-    }
+    message.localEnum =
+      object.localEnum !== undefined && object.localEnum !== null ? simpleEnumFromJSON(object.localEnum) : 0;
+    message.importEnum =
+      object.importEnum !== undefined && object.importEnum !== null ? simpleEnumFromJSON3(object.importEnum) : 0;
     return message;
   },
 

--- a/integration/avoid-import-conflicts/simple2.ts
+++ b/integration/avoid-import-conflicts/simple2.ts
@@ -83,16 +83,8 @@ export const Simple = {
 
   fromJSON(object: any): Simple {
     const message = { ...baseSimple } as Simple;
-    if (object.name !== undefined && object.name !== null) {
-      message.name = String(object.name);
-    } else {
-      message.name = '';
-    }
-    if (object.age !== undefined && object.age !== null) {
-      message.age = Number(object.age);
-    } else {
-      message.age = 0;
-    }
+    message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
+    message.age = object.age !== undefined && object.age !== null ? Number(object.age) : 0;
     return message;
   },
 

--- a/integration/barrel-imports/bar.ts
+++ b/integration/barrel-imports/bar.ts
@@ -43,16 +43,8 @@ export const Bar = {
 
   fromJSON(object: any): Bar {
     const message = { ...baseBar } as Bar;
-    if (object.name !== undefined && object.name !== null) {
-      message.name = String(object.name);
-    } else {
-      message.name = '';
-    }
-    if (object.age !== undefined && object.age !== null) {
-      message.age = Number(object.age);
-    } else {
-      message.age = 0;
-    }
+    message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
+    message.age = object.age !== undefined && object.age !== null ? Number(object.age) : 0;
     return message;
   },
 

--- a/integration/barrel-imports/foo.ts
+++ b/integration/barrel-imports/foo.ts
@@ -44,16 +44,8 @@ export const Foo = {
 
   fromJSON(object: any): Foo {
     const message = { ...baseFoo } as Foo;
-    if (object.name !== undefined && object.name !== null) {
-      message.name = String(object.name);
-    } else {
-      message.name = '';
-    }
-    if (object.bar !== undefined && object.bar !== null) {
-      message.bar = Bar.fromJSON(object.bar);
-    } else {
-      message.bar = undefined;
-    }
+    message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
+    message.bar = object.bar !== undefined && object.bar !== null ? Bar.fromJSON(object.bar) : undefined;
     return message;
   },
 
@@ -67,11 +59,7 @@ export const Foo = {
   fromPartial(object: DeepPartial<Foo>): Foo {
     const message = { ...baseFoo } as Foo;
     message.name = object.name ?? '';
-    if (object.bar !== undefined && object.bar !== null) {
-      message.bar = Bar.fromPartial(object.bar);
-    } else {
-      message.bar = undefined;
-    }
+    message.bar = object.bar !== undefined && object.bar !== null ? Bar.fromPartial(object.bar) : undefined;
     return message;
   },
 };

--- a/integration/batching-with-context/batching.ts
+++ b/integration/batching-with-context/batching.ts
@@ -306,16 +306,8 @@ export const BatchMapQueryResponse_EntitiesEntry = {
 
   fromJSON(object: any): BatchMapQueryResponse_EntitiesEntry {
     const message = { ...baseBatchMapQueryResponse_EntitiesEntry } as BatchMapQueryResponse_EntitiesEntry;
-    if (object.key !== undefined && object.key !== null) {
-      message.key = String(object.key);
-    } else {
-      message.key = '';
-    }
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Entity.fromJSON(object.value);
-    } else {
-      message.value = undefined;
-    }
+    message.key = object.key !== undefined && object.key !== null ? String(object.key) : '';
+    message.value = object.value !== undefined && object.value !== null ? Entity.fromJSON(object.value) : undefined;
     return message;
   },
 
@@ -329,11 +321,7 @@ export const BatchMapQueryResponse_EntitiesEntry = {
   fromPartial(object: DeepPartial<BatchMapQueryResponse_EntitiesEntry>): BatchMapQueryResponse_EntitiesEntry {
     const message = { ...baseBatchMapQueryResponse_EntitiesEntry } as BatchMapQueryResponse_EntitiesEntry;
     message.key = object.key ?? '';
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Entity.fromPartial(object.value);
-    } else {
-      message.value = undefined;
-    }
+    message.value = object.value !== undefined && object.value !== null ? Entity.fromPartial(object.value) : undefined;
     return message;
   },
 };
@@ -368,11 +356,7 @@ export const GetOnlyMethodRequest = {
 
   fromJSON(object: any): GetOnlyMethodRequest {
     const message = { ...baseGetOnlyMethodRequest } as GetOnlyMethodRequest;
-    if (object.id !== undefined && object.id !== null) {
-      message.id = String(object.id);
-    } else {
-      message.id = '';
-    }
+    message.id = object.id !== undefined && object.id !== null ? String(object.id) : '';
     return message;
   },
 
@@ -419,11 +403,7 @@ export const GetOnlyMethodResponse = {
 
   fromJSON(object: any): GetOnlyMethodResponse {
     const message = { ...baseGetOnlyMethodResponse } as GetOnlyMethodResponse;
-    if (object.entity !== undefined && object.entity !== null) {
-      message.entity = Entity.fromJSON(object.entity);
-    } else {
-      message.entity = undefined;
-    }
+    message.entity = object.entity !== undefined && object.entity !== null ? Entity.fromJSON(object.entity) : undefined;
     return message;
   },
 
@@ -435,11 +415,8 @@ export const GetOnlyMethodResponse = {
 
   fromPartial(object: DeepPartial<GetOnlyMethodResponse>): GetOnlyMethodResponse {
     const message = { ...baseGetOnlyMethodResponse } as GetOnlyMethodResponse;
-    if (object.entity !== undefined && object.entity !== null) {
-      message.entity = Entity.fromPartial(object.entity);
-    } else {
-      message.entity = undefined;
-    }
+    message.entity =
+      object.entity !== undefined && object.entity !== null ? Entity.fromPartial(object.entity) : undefined;
     return message;
   },
 };
@@ -474,11 +451,7 @@ export const WriteMethodRequest = {
 
   fromJSON(object: any): WriteMethodRequest {
     const message = { ...baseWriteMethodRequest } as WriteMethodRequest;
-    if (object.id !== undefined && object.id !== null) {
-      message.id = String(object.id);
-    } else {
-      message.id = '';
-    }
+    message.id = object.id !== undefined && object.id !== null ? String(object.id) : '';
     return message;
   },
 
@@ -569,16 +542,8 @@ export const Entity = {
 
   fromJSON(object: any): Entity {
     const message = { ...baseEntity } as Entity;
-    if (object.id !== undefined && object.id !== null) {
-      message.id = String(object.id);
-    } else {
-      message.id = '';
-    }
-    if (object.name !== undefined && object.name !== null) {
-      message.name = String(object.name);
-    } else {
-      message.name = '';
-    }
+    message.id = object.id !== undefined && object.id !== null ? String(object.id) : '';
+    message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
     return message;
   },
 

--- a/integration/batching/batching.ts
+++ b/integration/batching/batching.ts
@@ -304,16 +304,8 @@ export const BatchMapQueryResponse_EntitiesEntry = {
 
   fromJSON(object: any): BatchMapQueryResponse_EntitiesEntry {
     const message = { ...baseBatchMapQueryResponse_EntitiesEntry } as BatchMapQueryResponse_EntitiesEntry;
-    if (object.key !== undefined && object.key !== null) {
-      message.key = String(object.key);
-    } else {
-      message.key = '';
-    }
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Entity.fromJSON(object.value);
-    } else {
-      message.value = undefined;
-    }
+    message.key = object.key !== undefined && object.key !== null ? String(object.key) : '';
+    message.value = object.value !== undefined && object.value !== null ? Entity.fromJSON(object.value) : undefined;
     return message;
   },
 
@@ -327,11 +319,7 @@ export const BatchMapQueryResponse_EntitiesEntry = {
   fromPartial(object: DeepPartial<BatchMapQueryResponse_EntitiesEntry>): BatchMapQueryResponse_EntitiesEntry {
     const message = { ...baseBatchMapQueryResponse_EntitiesEntry } as BatchMapQueryResponse_EntitiesEntry;
     message.key = object.key ?? '';
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Entity.fromPartial(object.value);
-    } else {
-      message.value = undefined;
-    }
+    message.value = object.value !== undefined && object.value !== null ? Entity.fromPartial(object.value) : undefined;
     return message;
   },
 };
@@ -366,11 +354,7 @@ export const GetOnlyMethodRequest = {
 
   fromJSON(object: any): GetOnlyMethodRequest {
     const message = { ...baseGetOnlyMethodRequest } as GetOnlyMethodRequest;
-    if (object.id !== undefined && object.id !== null) {
-      message.id = String(object.id);
-    } else {
-      message.id = '';
-    }
+    message.id = object.id !== undefined && object.id !== null ? String(object.id) : '';
     return message;
   },
 
@@ -417,11 +401,7 @@ export const GetOnlyMethodResponse = {
 
   fromJSON(object: any): GetOnlyMethodResponse {
     const message = { ...baseGetOnlyMethodResponse } as GetOnlyMethodResponse;
-    if (object.entity !== undefined && object.entity !== null) {
-      message.entity = Entity.fromJSON(object.entity);
-    } else {
-      message.entity = undefined;
-    }
+    message.entity = object.entity !== undefined && object.entity !== null ? Entity.fromJSON(object.entity) : undefined;
     return message;
   },
 
@@ -433,11 +413,8 @@ export const GetOnlyMethodResponse = {
 
   fromPartial(object: DeepPartial<GetOnlyMethodResponse>): GetOnlyMethodResponse {
     const message = { ...baseGetOnlyMethodResponse } as GetOnlyMethodResponse;
-    if (object.entity !== undefined && object.entity !== null) {
-      message.entity = Entity.fromPartial(object.entity);
-    } else {
-      message.entity = undefined;
-    }
+    message.entity =
+      object.entity !== undefined && object.entity !== null ? Entity.fromPartial(object.entity) : undefined;
     return message;
   },
 };
@@ -472,11 +449,7 @@ export const WriteMethodRequest = {
 
   fromJSON(object: any): WriteMethodRequest {
     const message = { ...baseWriteMethodRequest } as WriteMethodRequest;
-    if (object.id !== undefined && object.id !== null) {
-      message.id = String(object.id);
-    } else {
-      message.id = '';
-    }
+    message.id = object.id !== undefined && object.id !== null ? String(object.id) : '';
     return message;
   },
 
@@ -567,16 +540,8 @@ export const Entity = {
 
   fromJSON(object: any): Entity {
     const message = { ...baseEntity } as Entity;
-    if (object.id !== undefined && object.id !== null) {
-      message.id = String(object.id);
-    } else {
-      message.id = '';
-    }
-    if (object.name !== undefined && object.name !== null) {
-      message.name = String(object.name);
-    } else {
-      message.name = '';
-    }
+    message.id = object.id !== undefined && object.id !== null ? String(object.id) : '';
+    message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
     return message;
   },
 

--- a/integration/bytes-as-base64/message.ts
+++ b/integration/bytes-as-base64/message.ts
@@ -13,11 +13,7 @@ const baseMessage: object = {};
 export const Message = {
   fromJSON(object: any): Message {
     const message = { ...baseMessage } as Message;
-    if (object.data !== undefined && object.data !== null) {
-      message.data = bytesFromBase64(object.data);
-    } else {
-      message.data = new Uint8Array();
-    }
+    message.data = object.data !== undefined && object.data !== null ? bytesFromBase64(object.data) : new Uint8Array();
     return message;
   },
 

--- a/integration/bytes-node/point.ts
+++ b/integration/bytes-node/point.ts
@@ -39,11 +39,8 @@ export const Point = {
 
   fromJSON(object: any): Point {
     const message = { ...basePoint } as Point;
-    if (object.data !== undefined && object.data !== null) {
-      message.data = Buffer.from(bytesFromBase64(object.data));
-    } else {
-      message.data = Buffer.alloc(0);
-    }
+    message.data =
+      object.data !== undefined && object.data !== null ? Buffer.from(bytesFromBase64(object.data)) : Buffer.alloc(0);
     return message;
   },
 

--- a/integration/const-enum/const-enum.ts
+++ b/integration/const-enum/const-enum.ts
@@ -97,11 +97,10 @@ export const DividerData = {
 
   fromJSON(object: any): DividerData {
     const message = { ...baseDividerData } as DividerData;
-    if (object.type !== undefined && object.type !== null) {
-      message.type = dividerData_DividerTypeFromJSON(object.type);
-    } else {
-      message.type = DividerData_DividerType.DOUBLE;
-    }
+    message.type =
+      object.type !== undefined && object.type !== null
+        ? dividerData_DividerTypeFromJSON(object.type)
+        : DividerData_DividerType.DOUBLE;
     return message;
   },
 

--- a/integration/generic-service-definitions/simple.ts
+++ b/integration/generic-service-definitions/simple.ts
@@ -38,11 +38,7 @@ export const TestMessage = {
 
   fromJSON(object: any): TestMessage {
     const message = { ...baseTestMessage } as TestMessage;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = String(object.value);
-    } else {
-      message.value = '';
-    }
+    message.value = object.value !== undefined && object.value !== null ? String(object.value) : '';
     return message;
   },
 

--- a/integration/global-this/global-this.ts
+++ b/integration/global-this/global-this.ts
@@ -42,11 +42,7 @@ export const Object = {
 
   fromJSON(object: any): Object {
     const message = { ...baseObject } as Object;
-    if (object.name !== undefined && object.name !== null) {
-      message.name = String(object.name);
-    } else {
-      message.name = '';
-    }
+    message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
     return message;
   },
 
@@ -93,11 +89,7 @@ export const Error = {
 
   fromJSON(object: any): Error {
     const message = { ...baseError } as Error;
-    if (object.name !== undefined && object.name !== null) {
-      message.name = String(object.name);
-    } else {
-      message.name = '';
-    }
+    message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
     return message;
   },
 

--- a/integration/grpc-js/google/protobuf/timestamp.ts
+++ b/integration/grpc-js/google/protobuf/timestamp.ts
@@ -140,16 +140,8 @@ export const Timestamp = {
 
   fromJSON(object: any): Timestamp {
     const message = { ...baseTimestamp } as Timestamp;
-    if (object.seconds !== undefined && object.seconds !== null) {
-      message.seconds = Number(object.seconds);
-    } else {
-      message.seconds = 0;
-    }
-    if (object.nanos !== undefined && object.nanos !== null) {
-      message.nanos = Number(object.nanos);
-    } else {
-      message.nanos = 0;
-    }
+    message.seconds = object.seconds !== undefined && object.seconds !== null ? Number(object.seconds) : 0;
+    message.nanos = object.nanos !== undefined && object.nanos !== null ? Number(object.nanos) : 0;
     return message;
   },
 

--- a/integration/grpc-js/google/protobuf/wrappers.ts
+++ b/integration/grpc-js/google/protobuf/wrappers.ts
@@ -124,11 +124,7 @@ export const DoubleValue = {
 
   fromJSON(object: any): DoubleValue {
     const message = { ...baseDoubleValue } as DoubleValue;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Number(object.value);
-    } else {
-      message.value = 0;
-    }
+    message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
 
@@ -175,11 +171,7 @@ export const FloatValue = {
 
   fromJSON(object: any): FloatValue {
     const message = { ...baseFloatValue } as FloatValue;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Number(object.value);
-    } else {
-      message.value = 0;
-    }
+    message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
 
@@ -226,11 +218,7 @@ export const Int64Value = {
 
   fromJSON(object: any): Int64Value {
     const message = { ...baseInt64Value } as Int64Value;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Number(object.value);
-    } else {
-      message.value = 0;
-    }
+    message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
 
@@ -277,11 +265,7 @@ export const UInt64Value = {
 
   fromJSON(object: any): UInt64Value {
     const message = { ...baseUInt64Value } as UInt64Value;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Number(object.value);
-    } else {
-      message.value = 0;
-    }
+    message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
 
@@ -328,11 +312,7 @@ export const Int32Value = {
 
   fromJSON(object: any): Int32Value {
     const message = { ...baseInt32Value } as Int32Value;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Number(object.value);
-    } else {
-      message.value = 0;
-    }
+    message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
 
@@ -379,11 +359,7 @@ export const UInt32Value = {
 
   fromJSON(object: any): UInt32Value {
     const message = { ...baseUInt32Value } as UInt32Value;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Number(object.value);
-    } else {
-      message.value = 0;
-    }
+    message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
 
@@ -430,11 +406,7 @@ export const BoolValue = {
 
   fromJSON(object: any): BoolValue {
     const message = { ...baseBoolValue } as BoolValue;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Boolean(object.value);
-    } else {
-      message.value = false;
-    }
+    message.value = object.value !== undefined && object.value !== null ? Boolean(object.value) : false;
     return message;
   },
 
@@ -481,11 +453,7 @@ export const StringValue = {
 
   fromJSON(object: any): StringValue {
     const message = { ...baseStringValue } as StringValue;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = String(object.value);
-    } else {
-      message.value = '';
-    }
+    message.value = object.value !== undefined && object.value !== null ? String(object.value) : '';
     return message;
   },
 
@@ -533,11 +501,8 @@ export const BytesValue = {
 
   fromJSON(object: any): BytesValue {
     const message = { ...baseBytesValue } as BytesValue;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = bytesFromBase64(object.value);
-    } else {
-      message.value = new Uint8Array();
-    }
+    message.value =
+      object.value !== undefined && object.value !== null ? bytesFromBase64(object.value) : new Uint8Array();
     return message;
   },
 

--- a/integration/grpc-js/simple.ts
+++ b/integration/grpc-js/simple.ts
@@ -69,11 +69,8 @@ export const TestMessage = {
 
   fromJSON(object: any): TestMessage {
     const message = { ...baseTestMessage } as TestMessage;
-    if (object.timestamp !== undefined && object.timestamp !== null) {
-      message.timestamp = fromJsonTimestamp(object.timestamp);
-    } else {
-      message.timestamp = undefined;
-    }
+    message.timestamp =
+      object.timestamp !== undefined && object.timestamp !== null ? fromJsonTimestamp(object.timestamp) : undefined;
     return message;
   },
 

--- a/integration/grpc-web-go-server/example.ts
+++ b/integration/grpc-web-go-server/example.ts
@@ -128,16 +128,8 @@ export const DashFlash = {
 
   fromJSON(object: any): DashFlash {
     const message = { ...baseDashFlash } as DashFlash;
-    if (object.msg !== undefined && object.msg !== null) {
-      message.msg = String(object.msg);
-    } else {
-      message.msg = '';
-    }
-    if (object.type !== undefined && object.type !== null) {
-      message.type = dashFlash_TypeFromJSON(object.type);
-    } else {
-      message.type = 0;
-    }
+    message.msg = object.msg !== undefined && object.msg !== null ? String(object.msg) : '';
+    message.type = object.type !== undefined && object.type !== null ? dashFlash_TypeFromJSON(object.type) : 0;
     return message;
   },
 
@@ -199,16 +191,9 @@ export const DashUserSettingsState = {
 
   fromJSON(object: any): DashUserSettingsState {
     const message = { ...baseDashUserSettingsState } as DashUserSettingsState;
-    if (object.email !== undefined && object.email !== null) {
-      message.email = String(object.email);
-    } else {
-      message.email = '';
-    }
-    if (object.urls !== undefined && object.urls !== null) {
-      message.urls = DashUserSettingsState_URLs.fromJSON(object.urls);
-    } else {
-      message.urls = undefined;
-    }
+    message.email = object.email !== undefined && object.email !== null ? String(object.email) : '';
+    message.urls =
+      object.urls !== undefined && object.urls !== null ? DashUserSettingsState_URLs.fromJSON(object.urls) : undefined;
     message.flashes = (object.flashes ?? []).map((e: any) => DashFlash.fromJSON(e));
     return message;
   },
@@ -229,11 +214,10 @@ export const DashUserSettingsState = {
   fromPartial(object: DeepPartial<DashUserSettingsState>): DashUserSettingsState {
     const message = { ...baseDashUserSettingsState } as DashUserSettingsState;
     message.email = object.email ?? '';
-    if (object.urls !== undefined && object.urls !== null) {
-      message.urls = DashUserSettingsState_URLs.fromPartial(object.urls);
-    } else {
-      message.urls = undefined;
-    }
+    message.urls =
+      object.urls !== undefined && object.urls !== null
+        ? DashUserSettingsState_URLs.fromPartial(object.urls)
+        : undefined;
     message.flashes = (object.flashes ?? []).map((e) => DashFlash.fromPartial(e));
     return message;
   },
@@ -275,16 +259,10 @@ export const DashUserSettingsState_URLs = {
 
   fromJSON(object: any): DashUserSettingsState_URLs {
     const message = { ...baseDashUserSettingsState_URLs } as DashUserSettingsState_URLs;
-    if (object.connectGoogle !== undefined && object.connectGoogle !== null) {
-      message.connectGoogle = String(object.connectGoogle);
-    } else {
-      message.connectGoogle = '';
-    }
-    if (object.connectGithub !== undefined && object.connectGithub !== null) {
-      message.connectGithub = String(object.connectGithub);
-    } else {
-      message.connectGithub = '';
-    }
+    message.connectGoogle =
+      object.connectGoogle !== undefined && object.connectGoogle !== null ? String(object.connectGoogle) : '';
+    message.connectGithub =
+      object.connectGithub !== undefined && object.connectGithub !== null ? String(object.connectGithub) : '';
     return message;
   },
 
@@ -351,26 +329,11 @@ export const DashCred = {
 
   fromJSON(object: any): DashCred {
     const message = { ...baseDashCred } as DashCred;
-    if (object.description !== undefined && object.description !== null) {
-      message.description = String(object.description);
-    } else {
-      message.description = '';
-    }
-    if (object.metadata !== undefined && object.metadata !== null) {
-      message.metadata = String(object.metadata);
-    } else {
-      message.metadata = '';
-    }
-    if (object.token !== undefined && object.token !== null) {
-      message.token = String(object.token);
-    } else {
-      message.token = '';
-    }
-    if (object.id !== undefined && object.id !== null) {
-      message.id = String(object.id);
-    } else {
-      message.id = '';
-    }
+    message.description =
+      object.description !== undefined && object.description !== null ? String(object.description) : '';
+    message.metadata = object.metadata !== undefined && object.metadata !== null ? String(object.metadata) : '';
+    message.token = object.token !== undefined && object.token !== null ? String(object.token) : '';
+    message.id = object.id !== undefined && object.id !== null ? String(object.id) : '';
     return message;
   },
 
@@ -429,16 +392,9 @@ export const DashAPICredsCreateReq = {
 
   fromJSON(object: any): DashAPICredsCreateReq {
     const message = { ...baseDashAPICredsCreateReq } as DashAPICredsCreateReq;
-    if (object.description !== undefined && object.description !== null) {
-      message.description = String(object.description);
-    } else {
-      message.description = '';
-    }
-    if (object.metadata !== undefined && object.metadata !== null) {
-      message.metadata = String(object.metadata);
-    } else {
-      message.metadata = '';
-    }
+    message.description =
+      object.description !== undefined && object.description !== null ? String(object.description) : '';
+    message.metadata = object.metadata !== undefined && object.metadata !== null ? String(object.metadata) : '';
     return message;
   },
 
@@ -505,26 +461,11 @@ export const DashAPICredsUpdateReq = {
 
   fromJSON(object: any): DashAPICredsUpdateReq {
     const message = { ...baseDashAPICredsUpdateReq } as DashAPICredsUpdateReq;
-    if (object.credSid !== undefined && object.credSid !== null) {
-      message.credSid = String(object.credSid);
-    } else {
-      message.credSid = '';
-    }
-    if (object.description !== undefined && object.description !== null) {
-      message.description = String(object.description);
-    } else {
-      message.description = '';
-    }
-    if (object.metadata !== undefined && object.metadata !== null) {
-      message.metadata = String(object.metadata);
-    } else {
-      message.metadata = '';
-    }
-    if (object.id !== undefined && object.id !== null) {
-      message.id = String(object.id);
-    } else {
-      message.id = '';
-    }
+    message.credSid = object.credSid !== undefined && object.credSid !== null ? String(object.credSid) : '';
+    message.description =
+      object.description !== undefined && object.description !== null ? String(object.description) : '';
+    message.metadata = object.metadata !== undefined && object.metadata !== null ? String(object.metadata) : '';
+    message.id = object.id !== undefined && object.id !== null ? String(object.id) : '';
     return message;
   },
 
@@ -583,16 +524,8 @@ export const DashAPICredsDeleteReq = {
 
   fromJSON(object: any): DashAPICredsDeleteReq {
     const message = { ...baseDashAPICredsDeleteReq } as DashAPICredsDeleteReq;
-    if (object.credSid !== undefined && object.credSid !== null) {
-      message.credSid = String(object.credSid);
-    } else {
-      message.credSid = '';
-    }
-    if (object.id !== undefined && object.id !== null) {
-      message.id = String(object.id);
-    } else {
-      message.id = '';
-    }
+    message.credSid = object.credSid !== undefined && object.credSid !== null ? String(object.credSid) : '';
+    message.id = object.id !== undefined && object.id !== null ? String(object.id) : '';
     return message;
   },
 

--- a/integration/grpc-web-no-streaming-observable/example.ts
+++ b/integration/grpc-web-no-streaming-observable/example.ts
@@ -106,16 +106,8 @@ export const DashFlash = {
 
   fromJSON(object: any): DashFlash {
     const message = { ...baseDashFlash } as DashFlash;
-    if (object.msg !== undefined && object.msg !== null) {
-      message.msg = String(object.msg);
-    } else {
-      message.msg = '';
-    }
-    if (object.type !== undefined && object.type !== null) {
-      message.type = dashFlash_TypeFromJSON(object.type);
-    } else {
-      message.type = 0;
-    }
+    message.msg = object.msg !== undefined && object.msg !== null ? String(object.msg) : '';
+    message.type = object.type !== undefined && object.type !== null ? dashFlash_TypeFromJSON(object.type) : 0;
     return message;
   },
 
@@ -177,16 +169,9 @@ export const DashUserSettingsState = {
 
   fromJSON(object: any): DashUserSettingsState {
     const message = { ...baseDashUserSettingsState } as DashUserSettingsState;
-    if (object.email !== undefined && object.email !== null) {
-      message.email = String(object.email);
-    } else {
-      message.email = '';
-    }
-    if (object.urls !== undefined && object.urls !== null) {
-      message.urls = DashUserSettingsState_URLs.fromJSON(object.urls);
-    } else {
-      message.urls = undefined;
-    }
+    message.email = object.email !== undefined && object.email !== null ? String(object.email) : '';
+    message.urls =
+      object.urls !== undefined && object.urls !== null ? DashUserSettingsState_URLs.fromJSON(object.urls) : undefined;
     message.flashes = (object.flashes ?? []).map((e: any) => DashFlash.fromJSON(e));
     return message;
   },
@@ -207,11 +192,10 @@ export const DashUserSettingsState = {
   fromPartial(object: DeepPartial<DashUserSettingsState>): DashUserSettingsState {
     const message = { ...baseDashUserSettingsState } as DashUserSettingsState;
     message.email = object.email ?? '';
-    if (object.urls !== undefined && object.urls !== null) {
-      message.urls = DashUserSettingsState_URLs.fromPartial(object.urls);
-    } else {
-      message.urls = undefined;
-    }
+    message.urls =
+      object.urls !== undefined && object.urls !== null
+        ? DashUserSettingsState_URLs.fromPartial(object.urls)
+        : undefined;
     message.flashes = (object.flashes ?? []).map((e) => DashFlash.fromPartial(e));
     return message;
   },
@@ -253,16 +237,10 @@ export const DashUserSettingsState_URLs = {
 
   fromJSON(object: any): DashUserSettingsState_URLs {
     const message = { ...baseDashUserSettingsState_URLs } as DashUserSettingsState_URLs;
-    if (object.connectGoogle !== undefined && object.connectGoogle !== null) {
-      message.connectGoogle = String(object.connectGoogle);
-    } else {
-      message.connectGoogle = '';
-    }
-    if (object.connectGithub !== undefined && object.connectGithub !== null) {
-      message.connectGithub = String(object.connectGithub);
-    } else {
-      message.connectGithub = '';
-    }
+    message.connectGoogle =
+      object.connectGoogle !== undefined && object.connectGoogle !== null ? String(object.connectGoogle) : '';
+    message.connectGithub =
+      object.connectGithub !== undefined && object.connectGithub !== null ? String(object.connectGithub) : '';
     return message;
   },
 

--- a/integration/grpc-web-no-streaming/example.ts
+++ b/integration/grpc-web-no-streaming/example.ts
@@ -104,16 +104,8 @@ export const DashFlash = {
 
   fromJSON(object: any): DashFlash {
     const message = { ...baseDashFlash } as DashFlash;
-    if (object.msg !== undefined && object.msg !== null) {
-      message.msg = String(object.msg);
-    } else {
-      message.msg = '';
-    }
-    if (object.type !== undefined && object.type !== null) {
-      message.type = dashFlash_TypeFromJSON(object.type);
-    } else {
-      message.type = 0;
-    }
+    message.msg = object.msg !== undefined && object.msg !== null ? String(object.msg) : '';
+    message.type = object.type !== undefined && object.type !== null ? dashFlash_TypeFromJSON(object.type) : 0;
     return message;
   },
 
@@ -175,16 +167,9 @@ export const DashUserSettingsState = {
 
   fromJSON(object: any): DashUserSettingsState {
     const message = { ...baseDashUserSettingsState } as DashUserSettingsState;
-    if (object.email !== undefined && object.email !== null) {
-      message.email = String(object.email);
-    } else {
-      message.email = '';
-    }
-    if (object.urls !== undefined && object.urls !== null) {
-      message.urls = DashUserSettingsState_URLs.fromJSON(object.urls);
-    } else {
-      message.urls = undefined;
-    }
+    message.email = object.email !== undefined && object.email !== null ? String(object.email) : '';
+    message.urls =
+      object.urls !== undefined && object.urls !== null ? DashUserSettingsState_URLs.fromJSON(object.urls) : undefined;
     message.flashes = (object.flashes ?? []).map((e: any) => DashFlash.fromJSON(e));
     return message;
   },
@@ -205,11 +190,10 @@ export const DashUserSettingsState = {
   fromPartial(object: DeepPartial<DashUserSettingsState>): DashUserSettingsState {
     const message = { ...baseDashUserSettingsState } as DashUserSettingsState;
     message.email = object.email ?? '';
-    if (object.urls !== undefined && object.urls !== null) {
-      message.urls = DashUserSettingsState_URLs.fromPartial(object.urls);
-    } else {
-      message.urls = undefined;
-    }
+    message.urls =
+      object.urls !== undefined && object.urls !== null
+        ? DashUserSettingsState_URLs.fromPartial(object.urls)
+        : undefined;
     message.flashes = (object.flashes ?? []).map((e) => DashFlash.fromPartial(e));
     return message;
   },
@@ -251,16 +235,10 @@ export const DashUserSettingsState_URLs = {
 
   fromJSON(object: any): DashUserSettingsState_URLs {
     const message = { ...baseDashUserSettingsState_URLs } as DashUserSettingsState_URLs;
-    if (object.connectGoogle !== undefined && object.connectGoogle !== null) {
-      message.connectGoogle = String(object.connectGoogle);
-    } else {
-      message.connectGoogle = '';
-    }
-    if (object.connectGithub !== undefined && object.connectGithub !== null) {
-      message.connectGithub = String(object.connectGithub);
-    } else {
-      message.connectGithub = '';
-    }
+    message.connectGoogle =
+      object.connectGoogle !== undefined && object.connectGoogle !== null ? String(object.connectGoogle) : '';
+    message.connectGithub =
+      object.connectGithub !== undefined && object.connectGithub !== null ? String(object.connectGithub) : '';
     return message;
   },
 

--- a/integration/grpc-web/example.ts
+++ b/integration/grpc-web/example.ts
@@ -130,16 +130,8 @@ export const DashFlash = {
 
   fromJSON(object: any): DashFlash {
     const message = { ...baseDashFlash } as DashFlash;
-    if (object.msg !== undefined && object.msg !== null) {
-      message.msg = String(object.msg);
-    } else {
-      message.msg = '';
-    }
-    if (object.type !== undefined && object.type !== null) {
-      message.type = dashFlash_TypeFromJSON(object.type);
-    } else {
-      message.type = 0;
-    }
+    message.msg = object.msg !== undefined && object.msg !== null ? String(object.msg) : '';
+    message.type = object.type !== undefined && object.type !== null ? dashFlash_TypeFromJSON(object.type) : 0;
     return message;
   },
 
@@ -201,16 +193,9 @@ export const DashUserSettingsState = {
 
   fromJSON(object: any): DashUserSettingsState {
     const message = { ...baseDashUserSettingsState } as DashUserSettingsState;
-    if (object.email !== undefined && object.email !== null) {
-      message.email = String(object.email);
-    } else {
-      message.email = '';
-    }
-    if (object.urls !== undefined && object.urls !== null) {
-      message.urls = DashUserSettingsState_URLs.fromJSON(object.urls);
-    } else {
-      message.urls = undefined;
-    }
+    message.email = object.email !== undefined && object.email !== null ? String(object.email) : '';
+    message.urls =
+      object.urls !== undefined && object.urls !== null ? DashUserSettingsState_URLs.fromJSON(object.urls) : undefined;
     message.flashes = (object.flashes ?? []).map((e: any) => DashFlash.fromJSON(e));
     return message;
   },
@@ -231,11 +216,10 @@ export const DashUserSettingsState = {
   fromPartial(object: DeepPartial<DashUserSettingsState>): DashUserSettingsState {
     const message = { ...baseDashUserSettingsState } as DashUserSettingsState;
     message.email = object.email ?? '';
-    if (object.urls !== undefined && object.urls !== null) {
-      message.urls = DashUserSettingsState_URLs.fromPartial(object.urls);
-    } else {
-      message.urls = undefined;
-    }
+    message.urls =
+      object.urls !== undefined && object.urls !== null
+        ? DashUserSettingsState_URLs.fromPartial(object.urls)
+        : undefined;
     message.flashes = (object.flashes ?? []).map((e) => DashFlash.fromPartial(e));
     return message;
   },
@@ -277,16 +261,10 @@ export const DashUserSettingsState_URLs = {
 
   fromJSON(object: any): DashUserSettingsState_URLs {
     const message = { ...baseDashUserSettingsState_URLs } as DashUserSettingsState_URLs;
-    if (object.connectGoogle !== undefined && object.connectGoogle !== null) {
-      message.connectGoogle = String(object.connectGoogle);
-    } else {
-      message.connectGoogle = '';
-    }
-    if (object.connectGithub !== undefined && object.connectGithub !== null) {
-      message.connectGithub = String(object.connectGithub);
-    } else {
-      message.connectGithub = '';
-    }
+    message.connectGoogle =
+      object.connectGoogle !== undefined && object.connectGoogle !== null ? String(object.connectGoogle) : '';
+    message.connectGithub =
+      object.connectGithub !== undefined && object.connectGithub !== null ? String(object.connectGithub) : '';
     return message;
   },
 
@@ -353,26 +331,11 @@ export const DashCred = {
 
   fromJSON(object: any): DashCred {
     const message = { ...baseDashCred } as DashCred;
-    if (object.description !== undefined && object.description !== null) {
-      message.description = String(object.description);
-    } else {
-      message.description = '';
-    }
-    if (object.metadata !== undefined && object.metadata !== null) {
-      message.metadata = String(object.metadata);
-    } else {
-      message.metadata = '';
-    }
-    if (object.token !== undefined && object.token !== null) {
-      message.token = String(object.token);
-    } else {
-      message.token = '';
-    }
-    if (object.id !== undefined && object.id !== null) {
-      message.id = String(object.id);
-    } else {
-      message.id = '';
-    }
+    message.description =
+      object.description !== undefined && object.description !== null ? String(object.description) : '';
+    message.metadata = object.metadata !== undefined && object.metadata !== null ? String(object.metadata) : '';
+    message.token = object.token !== undefined && object.token !== null ? String(object.token) : '';
+    message.id = object.id !== undefined && object.id !== null ? String(object.id) : '';
     return message;
   },
 
@@ -431,16 +394,9 @@ export const DashAPICredsCreateReq = {
 
   fromJSON(object: any): DashAPICredsCreateReq {
     const message = { ...baseDashAPICredsCreateReq } as DashAPICredsCreateReq;
-    if (object.description !== undefined && object.description !== null) {
-      message.description = String(object.description);
-    } else {
-      message.description = '';
-    }
-    if (object.metadata !== undefined && object.metadata !== null) {
-      message.metadata = String(object.metadata);
-    } else {
-      message.metadata = '';
-    }
+    message.description =
+      object.description !== undefined && object.description !== null ? String(object.description) : '';
+    message.metadata = object.metadata !== undefined && object.metadata !== null ? String(object.metadata) : '';
     return message;
   },
 
@@ -507,26 +463,11 @@ export const DashAPICredsUpdateReq = {
 
   fromJSON(object: any): DashAPICredsUpdateReq {
     const message = { ...baseDashAPICredsUpdateReq } as DashAPICredsUpdateReq;
-    if (object.credSid !== undefined && object.credSid !== null) {
-      message.credSid = String(object.credSid);
-    } else {
-      message.credSid = '';
-    }
-    if (object.description !== undefined && object.description !== null) {
-      message.description = String(object.description);
-    } else {
-      message.description = '';
-    }
-    if (object.metadata !== undefined && object.metadata !== null) {
-      message.metadata = String(object.metadata);
-    } else {
-      message.metadata = '';
-    }
-    if (object.id !== undefined && object.id !== null) {
-      message.id = String(object.id);
-    } else {
-      message.id = '';
-    }
+    message.credSid = object.credSid !== undefined && object.credSid !== null ? String(object.credSid) : '';
+    message.description =
+      object.description !== undefined && object.description !== null ? String(object.description) : '';
+    message.metadata = object.metadata !== undefined && object.metadata !== null ? String(object.metadata) : '';
+    message.id = object.id !== undefined && object.id !== null ? String(object.id) : '';
     return message;
   },
 
@@ -585,16 +526,8 @@ export const DashAPICredsDeleteReq = {
 
   fromJSON(object: any): DashAPICredsDeleteReq {
     const message = { ...baseDashAPICredsDeleteReq } as DashAPICredsDeleteReq;
-    if (object.credSid !== undefined && object.credSid !== null) {
-      message.credSid = String(object.credSid);
-    } else {
-      message.credSid = '';
-    }
-    if (object.id !== undefined && object.id !== null) {
-      message.id = String(object.id);
-    } else {
-      message.id = '';
-    }
+    message.credSid = object.credSid !== undefined && object.credSid !== null ? String(object.credSid) : '';
+    message.id = object.id !== undefined && object.id !== null ? String(object.id) : '';
     return message;
   },
 

--- a/integration/lower-case-svc-methods/math.ts
+++ b/integration/lower-case-svc-methods/math.ts
@@ -55,16 +55,8 @@ export const NumPair = {
 
   fromJSON(object: any): NumPair {
     const message = { ...baseNumPair } as NumPair;
-    if (object.num1 !== undefined && object.num1 !== null) {
-      message.num1 = Number(object.num1);
-    } else {
-      message.num1 = 0;
-    }
-    if (object.num2 !== undefined && object.num2 !== null) {
-      message.num2 = Number(object.num2);
-    } else {
-      message.num2 = 0;
-    }
+    message.num1 = object.num1 !== undefined && object.num1 !== null ? Number(object.num1) : 0;
+    message.num2 = object.num2 !== undefined && object.num2 !== null ? Number(object.num2) : 0;
     return message;
   },
 
@@ -113,11 +105,7 @@ export const NumSingle = {
 
   fromJSON(object: any): NumSingle {
     const message = { ...baseNumSingle } as NumSingle;
-    if (object.num !== undefined && object.num !== null) {
-      message.num = Number(object.num);
-    } else {
-      message.num = 0;
-    }
+    message.num = object.num !== undefined && object.num !== null ? Number(object.num) : 0;
     return message;
   },
 

--- a/integration/no-proto-package/no-proto-package.ts
+++ b/integration/no-proto-package/no-proto-package.ts
@@ -42,11 +42,7 @@ export const User = {
 
   fromJSON(object: any): User {
     const message = { ...baseUser } as User;
-    if (object.name !== undefined && object.name !== null) {
-      message.name = String(object.name);
-    } else {
-      message.name = '';
-    }
+    message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
     return message;
   },
 

--- a/integration/oneof-properties/oneof.ts
+++ b/integration/oneof-properties/oneof.ts
@@ -162,61 +162,23 @@ export const PleaseChoose = {
 
   fromJSON(object: any): PleaseChoose {
     const message = { ...basePleaseChoose } as PleaseChoose;
-    if (object.name !== undefined && object.name !== null) {
-      message.name = String(object.name);
-    } else {
-      message.name = '';
-    }
-    if (object.aNumber !== undefined && object.aNumber !== null) {
-      message.aNumber = Number(object.aNumber);
-    } else {
-      message.aNumber = undefined;
-    }
-    if (object.aString !== undefined && object.aString !== null) {
-      message.aString = String(object.aString);
-    } else {
-      message.aString = undefined;
-    }
-    if (object.aMessage !== undefined && object.aMessage !== null) {
-      message.aMessage = PleaseChoose_Submessage.fromJSON(object.aMessage);
-    } else {
-      message.aMessage = undefined;
-    }
-    if (object.aBool !== undefined && object.aBool !== null) {
-      message.aBool = Boolean(object.aBool);
-    } else {
-      message.aBool = undefined;
-    }
-    if (object.bunchaBytes !== undefined && object.bunchaBytes !== null) {
-      message.bunchaBytes = bytesFromBase64(object.bunchaBytes);
-    } else {
-      message.bunchaBytes = undefined;
-    }
-    if (object.anEnum !== undefined && object.anEnum !== null) {
-      message.anEnum = pleaseChoose_StateEnumFromJSON(object.anEnum);
-    } else {
-      message.anEnum = undefined;
-    }
-    if (object.age !== undefined && object.age !== null) {
-      message.age = Number(object.age);
-    } else {
-      message.age = 0;
-    }
-    if (object.either !== undefined && object.either !== null) {
-      message.either = String(object.either);
-    } else {
-      message.either = undefined;
-    }
-    if (object.or !== undefined && object.or !== null) {
-      message.or = String(object.or);
-    } else {
-      message.or = undefined;
-    }
-    if (object.thirdOption !== undefined && object.thirdOption !== null) {
-      message.thirdOption = String(object.thirdOption);
-    } else {
-      message.thirdOption = undefined;
-    }
+    message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
+    message.aNumber = object.aNumber !== undefined && object.aNumber !== null ? Number(object.aNumber) : undefined;
+    message.aString = object.aString !== undefined && object.aString !== null ? String(object.aString) : undefined;
+    message.aMessage =
+      object.aMessage !== undefined && object.aMessage !== null
+        ? PleaseChoose_Submessage.fromJSON(object.aMessage)
+        : undefined;
+    message.aBool = object.aBool !== undefined && object.aBool !== null ? Boolean(object.aBool) : undefined;
+    message.bunchaBytes =
+      object.bunchaBytes !== undefined && object.bunchaBytes !== null ? bytesFromBase64(object.bunchaBytes) : undefined;
+    message.anEnum =
+      object.anEnum !== undefined && object.anEnum !== null ? pleaseChoose_StateEnumFromJSON(object.anEnum) : undefined;
+    message.age = object.age !== undefined && object.age !== null ? Number(object.age) : 0;
+    message.either = object.either !== undefined && object.either !== null ? String(object.either) : undefined;
+    message.or = object.or !== undefined && object.or !== null ? String(object.or) : undefined;
+    message.thirdOption =
+      object.thirdOption !== undefined && object.thirdOption !== null ? String(object.thirdOption) : undefined;
     return message;
   },
 
@@ -244,11 +206,10 @@ export const PleaseChoose = {
     message.name = object.name ?? '';
     message.aNumber = object.aNumber ?? undefined;
     message.aString = object.aString ?? undefined;
-    if (object.aMessage !== undefined && object.aMessage !== null) {
-      message.aMessage = PleaseChoose_Submessage.fromPartial(object.aMessage);
-    } else {
-      message.aMessage = undefined;
-    }
+    message.aMessage =
+      object.aMessage !== undefined && object.aMessage !== null
+        ? PleaseChoose_Submessage.fromPartial(object.aMessage)
+        : undefined;
     message.aBool = object.aBool ?? undefined;
     message.bunchaBytes = object.bunchaBytes ?? undefined;
     message.anEnum = object.anEnum ?? undefined;
@@ -290,11 +251,7 @@ export const PleaseChoose_Submessage = {
 
   fromJSON(object: any): PleaseChoose_Submessage {
     const message = { ...basePleaseChoose_Submessage } as PleaseChoose_Submessage;
-    if (object.name !== undefined && object.name !== null) {
-      message.name = String(object.name);
-    } else {
-      message.name = '';
-    }
+    message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
     return message;
   },
 

--- a/integration/oneof-unions/oneof.ts
+++ b/integration/oneof-unions/oneof.ts
@@ -166,11 +166,7 @@ export const PleaseChoose = {
 
   fromJSON(object: any): PleaseChoose {
     const message = { ...basePleaseChoose } as PleaseChoose;
-    if (object.name !== undefined && object.name !== null) {
-      message.name = String(object.name);
-    } else {
-      message.name = '';
-    }
+    message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
     if (object.aNumber !== undefined && object.aNumber !== null) {
       message.choice = { $case: 'aNumber', aNumber: Number(object.aNumber) };
     }
@@ -189,11 +185,7 @@ export const PleaseChoose = {
     if (object.anEnum !== undefined && object.anEnum !== null) {
       message.choice = { $case: 'anEnum', anEnum: pleaseChoose_StateEnumFromJSON(object.anEnum) };
     }
-    if (object.age !== undefined && object.age !== null) {
-      message.age = Number(object.age);
-    } else {
-      message.age = 0;
-    }
+    message.age = object.age !== undefined && object.age !== null ? Number(object.age) : 0;
     if (object.either !== undefined && object.either !== null) {
       message.eitherOr = { $case: 'either', either: String(object.either) };
     }
@@ -203,11 +195,10 @@ export const PleaseChoose = {
     if (object.thirdOption !== undefined && object.thirdOption !== null) {
       message.eitherOr = { $case: 'thirdOption', thirdOption: String(object.thirdOption) };
     }
-    if (object.signature !== undefined && object.signature !== null) {
-      message.signature = bytesFromBase64(object.signature);
-    } else {
-      message.signature = new Uint8Array();
-    }
+    message.signature =
+      object.signature !== undefined && object.signature !== null
+        ? bytesFromBase64(object.signature)
+        : new Uint8Array();
     return message;
   },
 
@@ -316,11 +307,7 @@ export const PleaseChoose_Submessage = {
 
   fromJSON(object: any): PleaseChoose_Submessage {
     const message = { ...basePleaseChoose_Submessage } as PleaseChoose_Submessage;
-    if (object.name !== undefined && object.name !== null) {
-      message.name = String(object.name);
-    } else {
-      message.name = '';
-    }
+    message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
     return message;
   },
 
@@ -373,16 +360,8 @@ export const SimpleButOptional = {
 
   fromJSON(object: any): SimpleButOptional {
     const message = { ...baseSimpleButOptional } as SimpleButOptional;
-    if (object.name !== undefined && object.name !== null) {
-      message.name = String(object.name);
-    } else {
-      message.name = undefined;
-    }
-    if (object.age !== undefined && object.age !== null) {
-      message.age = Number(object.age);
-    } else {
-      message.age = undefined;
-    }
+    message.name = object.name !== undefined && object.name !== null ? String(object.name) : undefined;
+    message.age = object.age !== undefined && object.age !== null ? Number(object.age) : undefined;
     return message;
   },
 

--- a/integration/point/point.ts
+++ b/integration/point/point.ts
@@ -50,16 +50,8 @@ export const Point = {
 
   fromJSON(object: any): Point {
     const message = { ...basePoint } as Point;
-    if (object.lat !== undefined && object.lat !== null) {
-      message.lat = Number(object.lat);
-    } else {
-      message.lat = 0;
-    }
-    if (object.lng !== undefined && object.lng !== null) {
-      message.lng = Number(object.lng);
-    } else {
-      message.lng = 0;
-    }
+    message.lat = object.lat !== undefined && object.lat !== null ? Number(object.lat) : 0;
+    message.lng = object.lng !== undefined && object.lng !== null ? Number(object.lng) : 0;
     return message;
   },
 
@@ -114,16 +106,8 @@ export const Area = {
 
   fromJSON(object: any): Area {
     const message = { ...baseArea } as Area;
-    if (object.nw !== undefined && object.nw !== null) {
-      message.nw = Point.fromJSON(object.nw);
-    } else {
-      message.nw = undefined;
-    }
-    if (object.se !== undefined && object.se !== null) {
-      message.se = Point.fromJSON(object.se);
-    } else {
-      message.se = undefined;
-    }
+    message.nw = object.nw !== undefined && object.nw !== null ? Point.fromJSON(object.nw) : undefined;
+    message.se = object.se !== undefined && object.se !== null ? Point.fromJSON(object.se) : undefined;
     return message;
   },
 
@@ -136,16 +120,8 @@ export const Area = {
 
   fromPartial(object: DeepPartial<Area>): Area {
     const message = { ...baseArea } as Area;
-    if (object.nw !== undefined && object.nw !== null) {
-      message.nw = Point.fromPartial(object.nw);
-    } else {
-      message.nw = undefined;
-    }
-    if (object.se !== undefined && object.se !== null) {
-      message.se = Point.fromPartial(object.se);
-    } else {
-      message.se = undefined;
-    }
+    message.nw = object.nw !== undefined && object.nw !== null ? Point.fromPartial(object.nw) : undefined;
+    message.se = object.se !== undefined && object.se !== null ? Point.fromPartial(object.se) : undefined;
     return message;
   },
 };

--- a/integration/return-observable/observable.ts
+++ b/integration/return-observable/observable.ts
@@ -43,11 +43,8 @@ export const ProduceRequest = {
 
   fromJSON(object: any): ProduceRequest {
     const message = { ...baseProduceRequest } as ProduceRequest;
-    if (object.ingredients !== undefined && object.ingredients !== null) {
-      message.ingredients = String(object.ingredients);
-    } else {
-      message.ingredients = '';
-    }
+    message.ingredients =
+      object.ingredients !== undefined && object.ingredients !== null ? String(object.ingredients) : '';
     return message;
   },
 
@@ -94,11 +91,7 @@ export const ProduceReply = {
 
   fromJSON(object: any): ProduceReply {
     const message = { ...baseProduceReply } as ProduceReply;
-    if (object.result !== undefined && object.result !== null) {
-      message.result = String(object.result);
-    } else {
-      message.result = '';
-    }
+    message.result = object.result !== undefined && object.result !== null ? String(object.result) : '';
     return message;
   },
 

--- a/integration/simple-deprecated-fields/simple.ts
+++ b/integration/simple-deprecated-fields/simple.ts
@@ -86,31 +86,14 @@ export const Simple = {
 
   fromJSON(object: any): Simple {
     const message = { ...baseSimple } as Simple;
-    if (object.name !== undefined && object.name !== null) {
-      message.name = String(object.name);
-    } else {
-      message.name = '';
-    }
-    if (object.age !== undefined && object.age !== null) {
-      message.age = Number(object.age);
-    } else {
-      message.age = 0;
-    }
-    if (object.child !== undefined && object.child !== null) {
-      message.child = Child.fromJSON(object.child);
-    } else {
-      message.child = undefined;
-    }
-    if (object.testField !== undefined && object.testField !== null) {
-      message.testField = String(object.testField);
-    } else {
-      message.testField = '';
-    }
-    if (object.testNotDeprecated !== undefined && object.testNotDeprecated !== null) {
-      message.testNotDeprecated = String(object.testNotDeprecated);
-    } else {
-      message.testNotDeprecated = '';
-    }
+    message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
+    message.age = object.age !== undefined && object.age !== null ? Number(object.age) : 0;
+    message.child = object.child !== undefined && object.child !== null ? Child.fromJSON(object.child) : undefined;
+    message.testField = object.testField !== undefined && object.testField !== null ? String(object.testField) : '';
+    message.testNotDeprecated =
+      object.testNotDeprecated !== undefined && object.testNotDeprecated !== null
+        ? String(object.testNotDeprecated)
+        : '';
     return message;
   },
 
@@ -128,11 +111,7 @@ export const Simple = {
     const message = { ...baseSimple } as Simple;
     message.name = object.name ?? '';
     message.age = object.age ?? 0;
-    if (object.child !== undefined && object.child !== null) {
-      message.child = Child.fromPartial(object.child);
-    } else {
-      message.child = undefined;
-    }
+    message.child = object.child !== undefined && object.child !== null ? Child.fromPartial(object.child) : undefined;
     message.testField = object.testField ?? '';
     message.testNotDeprecated = object.testNotDeprecated ?? '';
     return message;
@@ -169,11 +148,7 @@ export const Child = {
 
   fromJSON(object: any): Child {
     const message = { ...baseChild } as Child;
-    if (object.name !== undefined && object.name !== null) {
-      message.name = String(object.name);
-    } else {
-      message.name = '';
-    }
+    message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
     return message;
   },
 

--- a/integration/simple-esmodule-interop/simple.ts
+++ b/integration/simple-esmodule-interop/simple.ts
@@ -60,16 +60,8 @@ export const Simple = {
 
   fromJSON(object: any): Simple {
     const message = { ...baseSimple } as Simple;
-    if (object.name !== undefined && object.name !== null) {
-      message.name = String(object.name);
-    } else {
-      message.name = '';
-    }
-    if (object.age !== undefined && object.age !== null) {
-      message.age = Number(object.age);
-    } else {
-      message.age = 0;
-    }
+    message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
+    message.age = object.age !== undefined && object.age !== null ? Number(object.age) : 0;
     return message;
   },
 
@@ -197,66 +189,18 @@ export const Numbers = {
 
   fromJSON(object: any): Numbers {
     const message = { ...baseNumbers } as Numbers;
-    if (object.double !== undefined && object.double !== null) {
-      message.double = Number(object.double);
-    } else {
-      message.double = 0;
-    }
-    if (object.float !== undefined && object.float !== null) {
-      message.float = Number(object.float);
-    } else {
-      message.float = 0;
-    }
-    if (object.int32 !== undefined && object.int32 !== null) {
-      message.int32 = Number(object.int32);
-    } else {
-      message.int32 = 0;
-    }
-    if (object.int64 !== undefined && object.int64 !== null) {
-      message.int64 = Number(object.int64);
-    } else {
-      message.int64 = 0;
-    }
-    if (object.uint32 !== undefined && object.uint32 !== null) {
-      message.uint32 = Number(object.uint32);
-    } else {
-      message.uint32 = 0;
-    }
-    if (object.uint64 !== undefined && object.uint64 !== null) {
-      message.uint64 = Number(object.uint64);
-    } else {
-      message.uint64 = 0;
-    }
-    if (object.sint32 !== undefined && object.sint32 !== null) {
-      message.sint32 = Number(object.sint32);
-    } else {
-      message.sint32 = 0;
-    }
-    if (object.sint64 !== undefined && object.sint64 !== null) {
-      message.sint64 = Number(object.sint64);
-    } else {
-      message.sint64 = 0;
-    }
-    if (object.fixed32 !== undefined && object.fixed32 !== null) {
-      message.fixed32 = Number(object.fixed32);
-    } else {
-      message.fixed32 = 0;
-    }
-    if (object.fixed64 !== undefined && object.fixed64 !== null) {
-      message.fixed64 = Number(object.fixed64);
-    } else {
-      message.fixed64 = 0;
-    }
-    if (object.sfixed32 !== undefined && object.sfixed32 !== null) {
-      message.sfixed32 = Number(object.sfixed32);
-    } else {
-      message.sfixed32 = 0;
-    }
-    if (object.sfixed64 !== undefined && object.sfixed64 !== null) {
-      message.sfixed64 = Number(object.sfixed64);
-    } else {
-      message.sfixed64 = 0;
-    }
+    message.double = object.double !== undefined && object.double !== null ? Number(object.double) : 0;
+    message.float = object.float !== undefined && object.float !== null ? Number(object.float) : 0;
+    message.int32 = object.int32 !== undefined && object.int32 !== null ? Number(object.int32) : 0;
+    message.int64 = object.int64 !== undefined && object.int64 !== null ? Number(object.int64) : 0;
+    message.uint32 = object.uint32 !== undefined && object.uint32 !== null ? Number(object.uint32) : 0;
+    message.uint64 = object.uint64 !== undefined && object.uint64 !== null ? Number(object.uint64) : 0;
+    message.sint32 = object.sint32 !== undefined && object.sint32 !== null ? Number(object.sint32) : 0;
+    message.sint64 = object.sint64 !== undefined && object.sint64 !== null ? Number(object.sint64) : 0;
+    message.fixed32 = object.fixed32 !== undefined && object.fixed32 !== null ? Number(object.fixed32) : 0;
+    message.fixed64 = object.fixed64 !== undefined && object.fixed64 !== null ? Number(object.fixed64) : 0;
+    message.sfixed32 = object.sfixed32 !== undefined && object.sfixed32 !== null ? Number(object.sfixed32) : 0;
+    message.sfixed64 = object.sfixed64 !== undefined && object.sfixed64 !== null ? Number(object.sfixed64) : 0;
     return message;
   },
 

--- a/integration/simple-long-string/google/protobuf/timestamp.ts
+++ b/integration/simple-long-string/google/protobuf/timestamp.ts
@@ -140,16 +140,8 @@ export const Timestamp = {
 
   fromJSON(object: any): Timestamp {
     const message = { ...baseTimestamp } as Timestamp;
-    if (object.seconds !== undefined && object.seconds !== null) {
-      message.seconds = String(object.seconds);
-    } else {
-      message.seconds = '0';
-    }
-    if (object.nanos !== undefined && object.nanos !== null) {
-      message.nanos = Number(object.nanos);
-    } else {
-      message.nanos = 0;
-    }
+    message.seconds = object.seconds !== undefined && object.seconds !== null ? String(object.seconds) : '0';
+    message.nanos = object.nanos !== undefined && object.nanos !== null ? Number(object.nanos) : 0;
     return message;
   },
 

--- a/integration/simple-long-string/google/protobuf/wrappers.ts
+++ b/integration/simple-long-string/google/protobuf/wrappers.ts
@@ -124,11 +124,7 @@ export const DoubleValue = {
 
   fromJSON(object: any): DoubleValue {
     const message = { ...baseDoubleValue } as DoubleValue;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Number(object.value);
-    } else {
-      message.value = 0;
-    }
+    message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
 
@@ -175,11 +171,7 @@ export const FloatValue = {
 
   fromJSON(object: any): FloatValue {
     const message = { ...baseFloatValue } as FloatValue;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Number(object.value);
-    } else {
-      message.value = 0;
-    }
+    message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
 
@@ -226,11 +218,7 @@ export const Int64Value = {
 
   fromJSON(object: any): Int64Value {
     const message = { ...baseInt64Value } as Int64Value;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = String(object.value);
-    } else {
-      message.value = '0';
-    }
+    message.value = object.value !== undefined && object.value !== null ? String(object.value) : '0';
     return message;
   },
 
@@ -277,11 +265,7 @@ export const UInt64Value = {
 
   fromJSON(object: any): UInt64Value {
     const message = { ...baseUInt64Value } as UInt64Value;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = String(object.value);
-    } else {
-      message.value = '0';
-    }
+    message.value = object.value !== undefined && object.value !== null ? String(object.value) : '0';
     return message;
   },
 
@@ -328,11 +312,7 @@ export const Int32Value = {
 
   fromJSON(object: any): Int32Value {
     const message = { ...baseInt32Value } as Int32Value;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Number(object.value);
-    } else {
-      message.value = 0;
-    }
+    message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
 
@@ -379,11 +359,7 @@ export const UInt32Value = {
 
   fromJSON(object: any): UInt32Value {
     const message = { ...baseUInt32Value } as UInt32Value;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Number(object.value);
-    } else {
-      message.value = 0;
-    }
+    message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
 
@@ -430,11 +406,7 @@ export const BoolValue = {
 
   fromJSON(object: any): BoolValue {
     const message = { ...baseBoolValue } as BoolValue;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Boolean(object.value);
-    } else {
-      message.value = false;
-    }
+    message.value = object.value !== undefined && object.value !== null ? Boolean(object.value) : false;
     return message;
   },
 
@@ -481,11 +453,7 @@ export const StringValue = {
 
   fromJSON(object: any): StringValue {
     const message = { ...baseStringValue } as StringValue;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = String(object.value);
-    } else {
-      message.value = '';
-    }
+    message.value = object.value !== undefined && object.value !== null ? String(object.value) : '';
     return message;
   },
 
@@ -533,11 +501,8 @@ export const BytesValue = {
 
   fromJSON(object: any): BytesValue {
     const message = { ...baseBytesValue } as BytesValue;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = bytesFromBase64(object.value);
-    } else {
-      message.value = new Uint8Array();
-    }
+    message.value =
+      object.value !== undefined && object.value !== null ? bytesFromBase64(object.value) : new Uint8Array();
     return message;
   },
 

--- a/integration/simple-long-string/simple.ts
+++ b/integration/simple-long-string/simple.ts
@@ -144,76 +144,21 @@ export const Numbers = {
 
   fromJSON(object: any): Numbers {
     const message = { ...baseNumbers } as Numbers;
-    if (object.double !== undefined && object.double !== null) {
-      message.double = Number(object.double);
-    } else {
-      message.double = 0;
-    }
-    if (object.float !== undefined && object.float !== null) {
-      message.float = Number(object.float);
-    } else {
-      message.float = 0;
-    }
-    if (object.int32 !== undefined && object.int32 !== null) {
-      message.int32 = Number(object.int32);
-    } else {
-      message.int32 = 0;
-    }
-    if (object.int64 !== undefined && object.int64 !== null) {
-      message.int64 = String(object.int64);
-    } else {
-      message.int64 = '0';
-    }
-    if (object.uint32 !== undefined && object.uint32 !== null) {
-      message.uint32 = Number(object.uint32);
-    } else {
-      message.uint32 = 0;
-    }
-    if (object.uint64 !== undefined && object.uint64 !== null) {
-      message.uint64 = String(object.uint64);
-    } else {
-      message.uint64 = '0';
-    }
-    if (object.sint32 !== undefined && object.sint32 !== null) {
-      message.sint32 = Number(object.sint32);
-    } else {
-      message.sint32 = 0;
-    }
-    if (object.sint64 !== undefined && object.sint64 !== null) {
-      message.sint64 = String(object.sint64);
-    } else {
-      message.sint64 = '0';
-    }
-    if (object.fixed32 !== undefined && object.fixed32 !== null) {
-      message.fixed32 = Number(object.fixed32);
-    } else {
-      message.fixed32 = 0;
-    }
-    if (object.fixed64 !== undefined && object.fixed64 !== null) {
-      message.fixed64 = String(object.fixed64);
-    } else {
-      message.fixed64 = '0';
-    }
-    if (object.sfixed32 !== undefined && object.sfixed32 !== null) {
-      message.sfixed32 = Number(object.sfixed32);
-    } else {
-      message.sfixed32 = 0;
-    }
-    if (object.sfixed64 !== undefined && object.sfixed64 !== null) {
-      message.sfixed64 = String(object.sfixed64);
-    } else {
-      message.sfixed64 = '0';
-    }
-    if (object.guint64 !== undefined && object.guint64 !== null) {
-      message.guint64 = String(object.guint64);
-    } else {
-      message.guint64 = undefined;
-    }
-    if (object.timestamp !== undefined && object.timestamp !== null) {
-      message.timestamp = fromJsonTimestamp(object.timestamp);
-    } else {
-      message.timestamp = undefined;
-    }
+    message.double = object.double !== undefined && object.double !== null ? Number(object.double) : 0;
+    message.float = object.float !== undefined && object.float !== null ? Number(object.float) : 0;
+    message.int32 = object.int32 !== undefined && object.int32 !== null ? Number(object.int32) : 0;
+    message.int64 = object.int64 !== undefined && object.int64 !== null ? String(object.int64) : '0';
+    message.uint32 = object.uint32 !== undefined && object.uint32 !== null ? Number(object.uint32) : 0;
+    message.uint64 = object.uint64 !== undefined && object.uint64 !== null ? String(object.uint64) : '0';
+    message.sint32 = object.sint32 !== undefined && object.sint32 !== null ? Number(object.sint32) : 0;
+    message.sint64 = object.sint64 !== undefined && object.sint64 !== null ? String(object.sint64) : '0';
+    message.fixed32 = object.fixed32 !== undefined && object.fixed32 !== null ? Number(object.fixed32) : 0;
+    message.fixed64 = object.fixed64 !== undefined && object.fixed64 !== null ? String(object.fixed64) : '0';
+    message.sfixed32 = object.sfixed32 !== undefined && object.sfixed32 !== null ? Number(object.sfixed32) : 0;
+    message.sfixed64 = object.sfixed64 !== undefined && object.sfixed64 !== null ? String(object.sfixed64) : '0';
+    message.guint64 = object.guint64 !== undefined && object.guint64 !== null ? String(object.guint64) : undefined;
+    message.timestamp =
+      object.timestamp !== undefined && object.timestamp !== null ? fromJsonTimestamp(object.timestamp) : undefined;
     return message;
   },
 

--- a/integration/simple-long/google/protobuf/wrappers.ts
+++ b/integration/simple-long/google/protobuf/wrappers.ts
@@ -124,11 +124,7 @@ export const DoubleValue = {
 
   fromJSON(object: any): DoubleValue {
     const message = { ...baseDoubleValue } as DoubleValue;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Number(object.value);
-    } else {
-      message.value = 0;
-    }
+    message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
 
@@ -175,11 +171,7 @@ export const FloatValue = {
 
   fromJSON(object: any): FloatValue {
     const message = { ...baseFloatValue } as FloatValue;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Number(object.value);
-    } else {
-      message.value = 0;
-    }
+    message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
 
@@ -226,11 +218,7 @@ export const Int64Value = {
 
   fromJSON(object: any): Int64Value {
     const message = { ...baseInt64Value } as Int64Value;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Long.fromString(object.value);
-    } else {
-      message.value = Long.ZERO;
-    }
+    message.value = object.value !== undefined && object.value !== null ? Long.fromString(object.value) : Long.ZERO;
     return message;
   },
 
@@ -281,11 +269,7 @@ export const UInt64Value = {
 
   fromJSON(object: any): UInt64Value {
     const message = { ...baseUInt64Value } as UInt64Value;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Long.fromString(object.value);
-    } else {
-      message.value = Long.UZERO;
-    }
+    message.value = object.value !== undefined && object.value !== null ? Long.fromString(object.value) : Long.UZERO;
     return message;
   },
 
@@ -336,11 +320,7 @@ export const Int32Value = {
 
   fromJSON(object: any): Int32Value {
     const message = { ...baseInt32Value } as Int32Value;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Number(object.value);
-    } else {
-      message.value = 0;
-    }
+    message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
 
@@ -387,11 +367,7 @@ export const UInt32Value = {
 
   fromJSON(object: any): UInt32Value {
     const message = { ...baseUInt32Value } as UInt32Value;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Number(object.value);
-    } else {
-      message.value = 0;
-    }
+    message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
 
@@ -438,11 +414,7 @@ export const BoolValue = {
 
   fromJSON(object: any): BoolValue {
     const message = { ...baseBoolValue } as BoolValue;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Boolean(object.value);
-    } else {
-      message.value = false;
-    }
+    message.value = object.value !== undefined && object.value !== null ? Boolean(object.value) : false;
     return message;
   },
 
@@ -489,11 +461,7 @@ export const StringValue = {
 
   fromJSON(object: any): StringValue {
     const message = { ...baseStringValue } as StringValue;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = String(object.value);
-    } else {
-      message.value = '';
-    }
+    message.value = object.value !== undefined && object.value !== null ? String(object.value) : '';
     return message;
   },
 
@@ -541,11 +509,8 @@ export const BytesValue = {
 
   fromJSON(object: any): BytesValue {
     const message = { ...baseBytesValue } as BytesValue;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = bytesFromBase64(object.value);
-    } else {
-      message.value = new Uint8Array();
-    }
+    message.value =
+      object.value !== undefined && object.value !== null ? bytesFromBase64(object.value) : new Uint8Array();
     return message;
   },
 

--- a/integration/simple-long/simple.ts
+++ b/integration/simple-long/simple.ts
@@ -108,26 +108,11 @@ export const SimpleWithWrappers = {
 
   fromJSON(object: any): SimpleWithWrappers {
     const message = { ...baseSimpleWithWrappers } as SimpleWithWrappers;
-    if (object.name !== undefined && object.name !== null) {
-      message.name = String(object.name);
-    } else {
-      message.name = undefined;
-    }
-    if (object.age !== undefined && object.age !== null) {
-      message.age = Number(object.age);
-    } else {
-      message.age = undefined;
-    }
-    if (object.enabled !== undefined && object.enabled !== null) {
-      message.enabled = Boolean(object.enabled);
-    } else {
-      message.enabled = undefined;
-    }
-    if (object.bananas !== undefined && object.bananas !== null) {
-      message.bananas = Long.fromValue(object.bananas);
-    } else {
-      message.bananas = undefined;
-    }
+    message.name = object.name !== undefined && object.name !== null ? String(object.name) : undefined;
+    message.age = object.age !== undefined && object.age !== null ? Number(object.age) : undefined;
+    message.enabled = object.enabled !== undefined && object.enabled !== null ? Boolean(object.enabled) : undefined;
+    message.bananas =
+      object.bananas !== undefined && object.bananas !== null ? Long.fromValue(object.bananas) : undefined;
     message.coins = (object.coins ?? []).map((e: any) => Number(e));
     message.snacks = (object.snacks ?? []).map((e: any) => String(e));
     return message;
@@ -302,16 +287,8 @@ export const SimpleWithMap_NameLookupEntry = {
 
   fromJSON(object: any): SimpleWithMap_NameLookupEntry {
     const message = { ...baseSimpleWithMap_NameLookupEntry } as SimpleWithMap_NameLookupEntry;
-    if (object.key !== undefined && object.key !== null) {
-      message.key = String(object.key);
-    } else {
-      message.key = '';
-    }
-    if (object.value !== undefined && object.value !== null) {
-      message.value = String(object.value);
-    } else {
-      message.value = '';
-    }
+    message.key = object.key !== undefined && object.key !== null ? String(object.key) : '';
+    message.value = object.value !== undefined && object.value !== null ? String(object.value) : '';
     return message;
   },
 
@@ -366,16 +343,8 @@ export const SimpleWithMap_IntLookupEntry = {
 
   fromJSON(object: any): SimpleWithMap_IntLookupEntry {
     const message = { ...baseSimpleWithMap_IntLookupEntry } as SimpleWithMap_IntLookupEntry;
-    if (object.key !== undefined && object.key !== null) {
-      message.key = Number(object.key);
-    } else {
-      message.key = 0;
-    }
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Number(object.value);
-    } else {
-      message.value = 0;
-    }
+    message.key = object.key !== undefined && object.key !== null ? Number(object.key) : 0;
+    message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
 
@@ -520,66 +489,21 @@ export const Numbers = {
 
   fromJSON(object: any): Numbers {
     const message = { ...baseNumbers } as Numbers;
-    if (object.double !== undefined && object.double !== null) {
-      message.double = Number(object.double);
-    } else {
-      message.double = 0;
-    }
-    if (object.float !== undefined && object.float !== null) {
-      message.float = Number(object.float);
-    } else {
-      message.float = 0;
-    }
-    if (object.int32 !== undefined && object.int32 !== null) {
-      message.int32 = Number(object.int32);
-    } else {
-      message.int32 = 0;
-    }
-    if (object.int64 !== undefined && object.int64 !== null) {
-      message.int64 = Long.fromString(object.int64);
-    } else {
-      message.int64 = Long.ZERO;
-    }
-    if (object.uint32 !== undefined && object.uint32 !== null) {
-      message.uint32 = Number(object.uint32);
-    } else {
-      message.uint32 = 0;
-    }
-    if (object.uint64 !== undefined && object.uint64 !== null) {
-      message.uint64 = Long.fromString(object.uint64);
-    } else {
-      message.uint64 = Long.UZERO;
-    }
-    if (object.sint32 !== undefined && object.sint32 !== null) {
-      message.sint32 = Number(object.sint32);
-    } else {
-      message.sint32 = 0;
-    }
-    if (object.sint64 !== undefined && object.sint64 !== null) {
-      message.sint64 = Long.fromString(object.sint64);
-    } else {
-      message.sint64 = Long.ZERO;
-    }
-    if (object.fixed32 !== undefined && object.fixed32 !== null) {
-      message.fixed32 = Number(object.fixed32);
-    } else {
-      message.fixed32 = 0;
-    }
-    if (object.fixed64 !== undefined && object.fixed64 !== null) {
-      message.fixed64 = Long.fromString(object.fixed64);
-    } else {
-      message.fixed64 = Long.UZERO;
-    }
-    if (object.sfixed32 !== undefined && object.sfixed32 !== null) {
-      message.sfixed32 = Number(object.sfixed32);
-    } else {
-      message.sfixed32 = 0;
-    }
-    if (object.sfixed64 !== undefined && object.sfixed64 !== null) {
-      message.sfixed64 = Long.fromString(object.sfixed64);
-    } else {
-      message.sfixed64 = Long.ZERO;
-    }
+    message.double = object.double !== undefined && object.double !== null ? Number(object.double) : 0;
+    message.float = object.float !== undefined && object.float !== null ? Number(object.float) : 0;
+    message.int32 = object.int32 !== undefined && object.int32 !== null ? Number(object.int32) : 0;
+    message.int64 = object.int64 !== undefined && object.int64 !== null ? Long.fromString(object.int64) : Long.ZERO;
+    message.uint32 = object.uint32 !== undefined && object.uint32 !== null ? Number(object.uint32) : 0;
+    message.uint64 =
+      object.uint64 !== undefined && object.uint64 !== null ? Long.fromString(object.uint64) : Long.UZERO;
+    message.sint32 = object.sint32 !== undefined && object.sint32 !== null ? Number(object.sint32) : 0;
+    message.sint64 = object.sint64 !== undefined && object.sint64 !== null ? Long.fromString(object.sint64) : Long.ZERO;
+    message.fixed32 = object.fixed32 !== undefined && object.fixed32 !== null ? Number(object.fixed32) : 0;
+    message.fixed64 =
+      object.fixed64 !== undefined && object.fixed64 !== null ? Long.fromString(object.fixed64) : Long.UZERO;
+    message.sfixed32 = object.sfixed32 !== undefined && object.sfixed32 !== null ? Number(object.sfixed32) : 0;
+    message.sfixed64 =
+      object.sfixed64 !== undefined && object.sfixed64 !== null ? Long.fromString(object.sfixed64) : Long.ZERO;
     message.manyUint64 = (object.manyUint64 ?? []).map((e: any) => Long.fromString(e));
     return message;
   },

--- a/integration/simple-optionals/google/protobuf/timestamp.ts
+++ b/integration/simple-optionals/google/protobuf/timestamp.ts
@@ -140,16 +140,8 @@ export const Timestamp = {
 
   fromJSON(object: any): Timestamp {
     const message = { ...baseTimestamp } as Timestamp;
-    if (object.seconds !== undefined && object.seconds !== null) {
-      message.seconds = Number(object.seconds);
-    } else {
-      message.seconds = 0;
-    }
-    if (object.nanos !== undefined && object.nanos !== null) {
-      message.nanos = Number(object.nanos);
-    } else {
-      message.nanos = 0;
-    }
+    message.seconds = object.seconds !== undefined && object.seconds !== null ? Number(object.seconds) : 0;
+    message.nanos = object.nanos !== undefined && object.nanos !== null ? Number(object.nanos) : 0;
     return message;
   },
 

--- a/integration/simple-optionals/google/protobuf/wrappers.ts
+++ b/integration/simple-optionals/google/protobuf/wrappers.ts
@@ -124,11 +124,7 @@ export const DoubleValue = {
 
   fromJSON(object: any): DoubleValue {
     const message = { ...baseDoubleValue } as DoubleValue;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Number(object.value);
-    } else {
-      message.value = 0;
-    }
+    message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
 
@@ -175,11 +171,7 @@ export const FloatValue = {
 
   fromJSON(object: any): FloatValue {
     const message = { ...baseFloatValue } as FloatValue;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Number(object.value);
-    } else {
-      message.value = 0;
-    }
+    message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
 
@@ -226,11 +218,7 @@ export const Int64Value = {
 
   fromJSON(object: any): Int64Value {
     const message = { ...baseInt64Value } as Int64Value;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Number(object.value);
-    } else {
-      message.value = 0;
-    }
+    message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
 
@@ -277,11 +265,7 @@ export const UInt64Value = {
 
   fromJSON(object: any): UInt64Value {
     const message = { ...baseUInt64Value } as UInt64Value;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Number(object.value);
-    } else {
-      message.value = 0;
-    }
+    message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
 
@@ -328,11 +312,7 @@ export const Int32Value = {
 
   fromJSON(object: any): Int32Value {
     const message = { ...baseInt32Value } as Int32Value;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Number(object.value);
-    } else {
-      message.value = 0;
-    }
+    message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
 
@@ -379,11 +359,7 @@ export const UInt32Value = {
 
   fromJSON(object: any): UInt32Value {
     const message = { ...baseUInt32Value } as UInt32Value;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Number(object.value);
-    } else {
-      message.value = 0;
-    }
+    message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
 
@@ -430,11 +406,7 @@ export const BoolValue = {
 
   fromJSON(object: any): BoolValue {
     const message = { ...baseBoolValue } as BoolValue;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Boolean(object.value);
-    } else {
-      message.value = false;
-    }
+    message.value = object.value !== undefined && object.value !== null ? Boolean(object.value) : false;
     return message;
   },
 
@@ -481,11 +453,7 @@ export const StringValue = {
 
   fromJSON(object: any): StringValue {
     const message = { ...baseStringValue } as StringValue;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = String(object.value);
-    } else {
-      message.value = '';
-    }
+    message.value = object.value !== undefined && object.value !== null ? String(object.value) : '';
     return message;
   },
 
@@ -533,11 +501,8 @@ export const BytesValue = {
 
   fromJSON(object: any): BytesValue {
     const message = { ...baseBytesValue } as BytesValue;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = bytesFromBase64(object.value);
-    } else {
-      message.value = new Uint8Array();
-    }
+    message.value =
+      object.value !== undefined && object.value !== null ? bytesFromBase64(object.value) : new Uint8Array();
     return message;
   },
 

--- a/integration/simple-optionals/import_dir/thing.ts
+++ b/integration/simple-optionals/import_dir/thing.ts
@@ -39,11 +39,8 @@ export const ImportedThing = {
 
   fromJSON(object: any): ImportedThing {
     const message = { ...baseImportedThing } as ImportedThing;
-    if (object.createdAt !== undefined && object.createdAt !== null) {
-      message.createdAt = fromJsonTimestamp(object.createdAt);
-    } else {
-      message.createdAt = undefined;
-    }
+    message.createdAt =
+      object.createdAt !== undefined && object.createdAt !== null ? fromJsonTimestamp(object.createdAt) : undefined;
     return message;
   },
 

--- a/integration/simple-optionals/simple.ts
+++ b/integration/simple-optionals/simple.ts
@@ -341,40 +341,18 @@ export const Simple = {
 
   fromJSON(object: any): Simple {
     const message = { ...baseSimple } as Simple;
-    if (object.name !== undefined && object.name !== null) {
-      message.name = String(object.name);
-    } else {
-      message.name = '';
-    }
-    if (object.age !== undefined && object.age !== null) {
-      message.age = Number(object.age);
-    } else {
-      message.age = 0;
-    }
-    if (object.createdAt !== undefined && object.createdAt !== null) {
-      message.createdAt = fromJsonTimestamp(object.createdAt);
-    } else {
-      message.createdAt = undefined;
-    }
-    if (object.child !== undefined && object.child !== null) {
-      message.child = Child.fromJSON(object.child);
-    } else {
-      message.child = undefined;
-    }
-    if (object.state !== undefined && object.state !== null) {
-      message.state = stateEnumFromJSON(object.state);
-    } else {
-      message.state = 0;
-    }
+    message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
+    message.age = object.age !== undefined && object.age !== null ? Number(object.age) : 0;
+    message.createdAt =
+      object.createdAt !== undefined && object.createdAt !== null ? fromJsonTimestamp(object.createdAt) : undefined;
+    message.child = object.child !== undefined && object.child !== null ? Child.fromJSON(object.child) : undefined;
+    message.state = object.state !== undefined && object.state !== null ? stateEnumFromJSON(object.state) : 0;
     message.grandChildren = (object.grandChildren ?? []).map((e: any) => Child.fromJSON(e));
     message.coins = (object.coins ?? []).map((e: any) => Number(e));
     message.snacks = (object.snacks ?? []).map((e: any) => String(e));
     message.oldStates = (object.oldStates ?? []).map((e: any) => stateEnumFromJSON(e));
-    if (object.thing !== undefined && object.thing !== null) {
-      message.thing = ImportedThing.fromJSON(object.thing);
-    } else {
-      message.thing = undefined;
-    }
+    message.thing =
+      object.thing !== undefined && object.thing !== null ? ImportedThing.fromJSON(object.thing) : undefined;
     return message;
   },
 
@@ -414,21 +392,14 @@ export const Simple = {
     message.name = object.name ?? '';
     message.age = object.age ?? 0;
     message.createdAt = object.createdAt ?? undefined;
-    if (object.child !== undefined && object.child !== null) {
-      message.child = Child.fromPartial(object.child);
-    } else {
-      message.child = undefined;
-    }
+    message.child = object.child !== undefined && object.child !== null ? Child.fromPartial(object.child) : undefined;
     message.state = object.state ?? 0;
     message.grandChildren = (object.grandChildren ?? []).map((e) => Child.fromPartial(e));
     message.coins = (object.coins ?? []).map((e) => e);
     message.snacks = (object.snacks ?? []).map((e) => e);
     message.oldStates = (object.oldStates ?? []).map((e) => e);
-    if (object.thing !== undefined && object.thing !== null) {
-      message.thing = ImportedThing.fromPartial(object.thing);
-    } else {
-      message.thing = undefined;
-    }
+    message.thing =
+      object.thing !== undefined && object.thing !== null ? ImportedThing.fromPartial(object.thing) : undefined;
     return message;
   },
 };
@@ -469,16 +440,8 @@ export const Child = {
 
   fromJSON(object: any): Child {
     const message = { ...baseChild } as Child;
-    if (object.name !== undefined && object.name !== null) {
-      message.name = String(object.name);
-    } else {
-      message.name = '';
-    }
-    if (object.type !== undefined && object.type !== null) {
-      message.type = child_TypeFromJSON(object.type);
-    } else {
-      message.type = 0;
-    }
+    message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
+    message.type = object.type !== undefined && object.type !== null ? child_TypeFromJSON(object.type) : 0;
     return message;
   },
 
@@ -539,21 +502,12 @@ export const Nested = {
 
   fromJSON(object: any): Nested {
     const message = { ...baseNested } as Nested;
-    if (object.name !== undefined && object.name !== null) {
-      message.name = String(object.name);
-    } else {
-      message.name = '';
-    }
-    if (object.message !== undefined && object.message !== null) {
-      message.message = Nested_InnerMessage.fromJSON(object.message);
-    } else {
-      message.message = undefined;
-    }
-    if (object.state !== undefined && object.state !== null) {
-      message.state = nested_InnerEnumFromJSON(object.state);
-    } else {
-      message.state = 0;
-    }
+    message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
+    message.message =
+      object.message !== undefined && object.message !== null
+        ? Nested_InnerMessage.fromJSON(object.message)
+        : undefined;
+    message.state = object.state !== undefined && object.state !== null ? nested_InnerEnumFromJSON(object.state) : 0;
     return message;
   },
 
@@ -569,11 +523,10 @@ export const Nested = {
   fromPartial(object: DeepPartial<Nested>): Nested {
     const message = { ...baseNested } as Nested;
     message.name = object.name ?? '';
-    if (object.message !== undefined && object.message !== null) {
-      message.message = Nested_InnerMessage.fromPartial(object.message);
-    } else {
-      message.message = undefined;
-    }
+    message.message =
+      object.message !== undefined && object.message !== null
+        ? Nested_InnerMessage.fromPartial(object.message)
+        : undefined;
     message.state = object.state ?? 0;
     return message;
   },
@@ -615,16 +568,11 @@ export const Nested_InnerMessage = {
 
   fromJSON(object: any): Nested_InnerMessage {
     const message = { ...baseNested_InnerMessage } as Nested_InnerMessage;
-    if (object.name !== undefined && object.name !== null) {
-      message.name = String(object.name);
-    } else {
-      message.name = '';
-    }
-    if (object.deep !== undefined && object.deep !== null) {
-      message.deep = Nested_InnerMessage_DeepMessage.fromJSON(object.deep);
-    } else {
-      message.deep = undefined;
-    }
+    message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
+    message.deep =
+      object.deep !== undefined && object.deep !== null
+        ? Nested_InnerMessage_DeepMessage.fromJSON(object.deep)
+        : undefined;
     return message;
   },
 
@@ -639,11 +587,10 @@ export const Nested_InnerMessage = {
   fromPartial(object: DeepPartial<Nested_InnerMessage>): Nested_InnerMessage {
     const message = { ...baseNested_InnerMessage } as Nested_InnerMessage;
     message.name = object.name ?? '';
-    if (object.deep !== undefined && object.deep !== null) {
-      message.deep = Nested_InnerMessage_DeepMessage.fromPartial(object.deep);
-    } else {
-      message.deep = undefined;
-    }
+    message.deep =
+      object.deep !== undefined && object.deep !== null
+        ? Nested_InnerMessage_DeepMessage.fromPartial(object.deep)
+        : undefined;
     return message;
   },
 };
@@ -678,11 +625,7 @@ export const Nested_InnerMessage_DeepMessage = {
 
   fromJSON(object: any): Nested_InnerMessage_DeepMessage {
     const message = { ...baseNested_InnerMessage_DeepMessage } as Nested_InnerMessage_DeepMessage;
-    if (object.name !== undefined && object.name !== null) {
-      message.name = String(object.name);
-    } else {
-      message.name = '';
-    }
+    message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
     return message;
   },
 
@@ -735,16 +678,8 @@ export const OneOfMessage = {
 
   fromJSON(object: any): OneOfMessage {
     const message = { ...baseOneOfMessage } as OneOfMessage;
-    if (object.first !== undefined && object.first !== null) {
-      message.first = String(object.first);
-    } else {
-      message.first = undefined;
-    }
-    if (object.last !== undefined && object.last !== null) {
-      message.last = String(object.last);
-    } else {
-      message.last = undefined;
-    }
+    message.first = object.first !== undefined && object.first !== null ? String(object.first) : undefined;
+    message.last = object.last !== undefined && object.last !== null ? String(object.last) : undefined;
     return message;
   },
 
@@ -819,21 +754,9 @@ export const SimpleWithWrappers = {
 
   fromJSON(object: any): SimpleWithWrappers {
     const message = { ...baseSimpleWithWrappers } as SimpleWithWrappers;
-    if (object.name !== undefined && object.name !== null) {
-      message.name = String(object.name);
-    } else {
-      message.name = undefined;
-    }
-    if (object.age !== undefined && object.age !== null) {
-      message.age = Number(object.age);
-    } else {
-      message.age = undefined;
-    }
-    if (object.enabled !== undefined && object.enabled !== null) {
-      message.enabled = Boolean(object.enabled);
-    } else {
-      message.enabled = undefined;
-    }
+    message.name = object.name !== undefined && object.name !== null ? String(object.name) : undefined;
+    message.age = object.age !== undefined && object.age !== null ? Number(object.age) : undefined;
+    message.enabled = object.enabled !== undefined && object.enabled !== null ? Boolean(object.enabled) : undefined;
     message.coins = (object.coins ?? []).map((e: any) => Number(e));
     message.snacks = (object.snacks ?? []).map((e: any) => String(e));
     return message;
@@ -898,11 +821,7 @@ export const Entity = {
 
   fromJSON(object: any): Entity {
     const message = { ...baseEntity } as Entity;
-    if (object.id !== undefined && object.id !== null) {
-      message.id = Number(object.id);
-    } else {
-      message.id = 0;
-    }
+    message.id = object.id !== undefined && object.id !== null ? Number(object.id) : 0;
     return message;
   },
 
@@ -1083,16 +1002,8 @@ export const SimpleWithMap_EntitiesByIdEntry = {
 
   fromJSON(object: any): SimpleWithMap_EntitiesByIdEntry {
     const message = { ...baseSimpleWithMap_EntitiesByIdEntry } as SimpleWithMap_EntitiesByIdEntry;
-    if (object.key !== undefined && object.key !== null) {
-      message.key = Number(object.key);
-    } else {
-      message.key = 0;
-    }
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Entity.fromJSON(object.value);
-    } else {
-      message.value = undefined;
-    }
+    message.key = object.key !== undefined && object.key !== null ? Number(object.key) : 0;
+    message.value = object.value !== undefined && object.value !== null ? Entity.fromJSON(object.value) : undefined;
     return message;
   },
 
@@ -1106,11 +1017,7 @@ export const SimpleWithMap_EntitiesByIdEntry = {
   fromPartial(object: DeepPartial<SimpleWithMap_EntitiesByIdEntry>): SimpleWithMap_EntitiesByIdEntry {
     const message = { ...baseSimpleWithMap_EntitiesByIdEntry } as SimpleWithMap_EntitiesByIdEntry;
     message.key = object.key ?? 0;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Entity.fromPartial(object.value);
-    } else {
-      message.value = undefined;
-    }
+    message.value = object.value !== undefined && object.value !== null ? Entity.fromPartial(object.value) : undefined;
     return message;
   },
 };
@@ -1151,16 +1058,8 @@ export const SimpleWithMap_NameLookupEntry = {
 
   fromJSON(object: any): SimpleWithMap_NameLookupEntry {
     const message = { ...baseSimpleWithMap_NameLookupEntry } as SimpleWithMap_NameLookupEntry;
-    if (object.key !== undefined && object.key !== null) {
-      message.key = String(object.key);
-    } else {
-      message.key = '';
-    }
-    if (object.value !== undefined && object.value !== null) {
-      message.value = String(object.value);
-    } else {
-      message.value = '';
-    }
+    message.key = object.key !== undefined && object.key !== null ? String(object.key) : '';
+    message.value = object.value !== undefined && object.value !== null ? String(object.value) : '';
     return message;
   },
 
@@ -1215,16 +1114,8 @@ export const SimpleWithMap_IntLookupEntry = {
 
   fromJSON(object: any): SimpleWithMap_IntLookupEntry {
     const message = { ...baseSimpleWithMap_IntLookupEntry } as SimpleWithMap_IntLookupEntry;
-    if (object.key !== undefined && object.key !== null) {
-      message.key = Number(object.key);
-    } else {
-      message.key = 0;
-    }
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Number(object.value);
-    } else {
-      message.value = 0;
-    }
+    message.key = object.key !== undefined && object.key !== null ? Number(object.key) : 0;
+    message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
 
@@ -1347,16 +1238,8 @@ export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
 
   fromJSON(object: any): SimpleWithSnakeCaseMap_EntitiesByIdEntry {
     const message = { ...baseSimpleWithSnakeCaseMap_EntitiesByIdEntry } as SimpleWithSnakeCaseMap_EntitiesByIdEntry;
-    if (object.key !== undefined && object.key !== null) {
-      message.key = Number(object.key);
-    } else {
-      message.key = 0;
-    }
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Entity.fromJSON(object.value);
-    } else {
-      message.value = undefined;
-    }
+    message.key = object.key !== undefined && object.key !== null ? Number(object.key) : 0;
+    message.value = object.value !== undefined && object.value !== null ? Entity.fromJSON(object.value) : undefined;
     return message;
   },
 
@@ -1370,11 +1253,7 @@ export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
   fromPartial(object: DeepPartial<SimpleWithSnakeCaseMap_EntitiesByIdEntry>): SimpleWithSnakeCaseMap_EntitiesByIdEntry {
     const message = { ...baseSimpleWithSnakeCaseMap_EntitiesByIdEntry } as SimpleWithSnakeCaseMap_EntitiesByIdEntry;
     message.key = object.key ?? 0;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Entity.fromPartial(object.value);
-    } else {
-      message.value = undefined;
-    }
+    message.value = object.value !== undefined && object.value !== null ? Entity.fromPartial(object.value) : undefined;
     return message;
   },
 };
@@ -1409,11 +1288,7 @@ export const PingRequest = {
 
   fromJSON(object: any): PingRequest {
     const message = { ...basePingRequest } as PingRequest;
-    if (object.input !== undefined && object.input !== null) {
-      message.input = String(object.input);
-    } else {
-      message.input = '';
-    }
+    message.input = object.input !== undefined && object.input !== null ? String(object.input) : '';
     return message;
   },
 
@@ -1460,11 +1335,7 @@ export const PingResponse = {
 
   fromJSON(object: any): PingResponse {
     const message = { ...basePingResponse } as PingResponse;
-    if (object.output !== undefined && object.output !== null) {
-      message.output = String(object.output);
-    } else {
-      message.output = '';
-    }
+    message.output = object.output !== undefined && object.output !== null ? String(object.output) : '';
     return message;
   },
 
@@ -1590,66 +1461,18 @@ export const Numbers = {
 
   fromJSON(object: any): Numbers {
     const message = { ...baseNumbers } as Numbers;
-    if (object.double !== undefined && object.double !== null) {
-      message.double = Number(object.double);
-    } else {
-      message.double = 0;
-    }
-    if (object.float !== undefined && object.float !== null) {
-      message.float = Number(object.float);
-    } else {
-      message.float = 0;
-    }
-    if (object.int32 !== undefined && object.int32 !== null) {
-      message.int32 = Number(object.int32);
-    } else {
-      message.int32 = 0;
-    }
-    if (object.int64 !== undefined && object.int64 !== null) {
-      message.int64 = Number(object.int64);
-    } else {
-      message.int64 = 0;
-    }
-    if (object.uint32 !== undefined && object.uint32 !== null) {
-      message.uint32 = Number(object.uint32);
-    } else {
-      message.uint32 = 0;
-    }
-    if (object.uint64 !== undefined && object.uint64 !== null) {
-      message.uint64 = Number(object.uint64);
-    } else {
-      message.uint64 = 0;
-    }
-    if (object.sint32 !== undefined && object.sint32 !== null) {
-      message.sint32 = Number(object.sint32);
-    } else {
-      message.sint32 = 0;
-    }
-    if (object.sint64 !== undefined && object.sint64 !== null) {
-      message.sint64 = Number(object.sint64);
-    } else {
-      message.sint64 = 0;
-    }
-    if (object.fixed32 !== undefined && object.fixed32 !== null) {
-      message.fixed32 = Number(object.fixed32);
-    } else {
-      message.fixed32 = 0;
-    }
-    if (object.fixed64 !== undefined && object.fixed64 !== null) {
-      message.fixed64 = Number(object.fixed64);
-    } else {
-      message.fixed64 = 0;
-    }
-    if (object.sfixed32 !== undefined && object.sfixed32 !== null) {
-      message.sfixed32 = Number(object.sfixed32);
-    } else {
-      message.sfixed32 = 0;
-    }
-    if (object.sfixed64 !== undefined && object.sfixed64 !== null) {
-      message.sfixed64 = Number(object.sfixed64);
-    } else {
-      message.sfixed64 = 0;
-    }
+    message.double = object.double !== undefined && object.double !== null ? Number(object.double) : 0;
+    message.float = object.float !== undefined && object.float !== null ? Number(object.float) : 0;
+    message.int32 = object.int32 !== undefined && object.int32 !== null ? Number(object.int32) : 0;
+    message.int64 = object.int64 !== undefined && object.int64 !== null ? Number(object.int64) : 0;
+    message.uint32 = object.uint32 !== undefined && object.uint32 !== null ? Number(object.uint32) : 0;
+    message.uint64 = object.uint64 !== undefined && object.uint64 !== null ? Number(object.uint64) : 0;
+    message.sint32 = object.sint32 !== undefined && object.sint32 !== null ? Number(object.sint32) : 0;
+    message.sint64 = object.sint64 !== undefined && object.sint64 !== null ? Number(object.sint64) : 0;
+    message.fixed32 = object.fixed32 !== undefined && object.fixed32 !== null ? Number(object.fixed32) : 0;
+    message.fixed64 = object.fixed64 !== undefined && object.fixed64 !== null ? Number(object.fixed64) : 0;
+    message.sfixed32 = object.sfixed32 !== undefined && object.sfixed32 !== null ? Number(object.sfixed32) : 0;
+    message.sfixed64 = object.sfixed64 !== undefined && object.sfixed64 !== null ? Number(object.sfixed64) : 0;
     return message;
   },
 

--- a/integration/simple-optionals/thing.ts
+++ b/integration/simple-optionals/thing.ts
@@ -39,11 +39,8 @@ export const ImportedThing = {
 
   fromJSON(object: any): ImportedThing {
     const message = { ...baseImportedThing } as ImportedThing;
-    if (object.createdAt !== undefined && object.createdAt !== null) {
-      message.createdAt = fromJsonTimestamp(object.createdAt);
-    } else {
-      message.createdAt = undefined;
-    }
+    message.createdAt =
+      object.createdAt !== undefined && object.createdAt !== null ? fromJsonTimestamp(object.createdAt) : undefined;
     return message;
   },
 

--- a/integration/simple-proto2/simple.ts
+++ b/integration/simple-proto2/simple.ts
@@ -70,11 +70,7 @@ export const Issue56 = {
 
   fromJSON(object: any): Issue56 {
     const message = { ...baseIssue56 } as Issue56;
-    if (object.test !== undefined && object.test !== null) {
-      message.test = enumWithoutZeroFromJSON(object.test);
-    } else {
-      message.test = 1;
-    }
+    message.test = object.test !== undefined && object.test !== null ? enumWithoutZeroFromJSON(object.test) : 1;
     return message;
   },
 

--- a/integration/simple-snake/google/protobuf/timestamp.ts
+++ b/integration/simple-snake/google/protobuf/timestamp.ts
@@ -140,16 +140,8 @@ export const Timestamp = {
 
   fromJSON(object: any): Timestamp {
     const message = { ...baseTimestamp } as Timestamp;
-    if (object.seconds !== undefined && object.seconds !== null) {
-      message.seconds = Number(object.seconds);
-    } else {
-      message.seconds = 0;
-    }
-    if (object.nanos !== undefined && object.nanos !== null) {
-      message.nanos = Number(object.nanos);
-    } else {
-      message.nanos = 0;
-    }
+    message.seconds = object.seconds !== undefined && object.seconds !== null ? Number(object.seconds) : 0;
+    message.nanos = object.nanos !== undefined && object.nanos !== null ? Number(object.nanos) : 0;
     return message;
   },
 

--- a/integration/simple-snake/google/protobuf/wrappers.ts
+++ b/integration/simple-snake/google/protobuf/wrappers.ts
@@ -124,11 +124,7 @@ export const DoubleValue = {
 
   fromJSON(object: any): DoubleValue {
     const message = { ...baseDoubleValue } as DoubleValue;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Number(object.value);
-    } else {
-      message.value = 0;
-    }
+    message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
 
@@ -175,11 +171,7 @@ export const FloatValue = {
 
   fromJSON(object: any): FloatValue {
     const message = { ...baseFloatValue } as FloatValue;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Number(object.value);
-    } else {
-      message.value = 0;
-    }
+    message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
 
@@ -226,11 +218,7 @@ export const Int64Value = {
 
   fromJSON(object: any): Int64Value {
     const message = { ...baseInt64Value } as Int64Value;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Number(object.value);
-    } else {
-      message.value = 0;
-    }
+    message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
 
@@ -277,11 +265,7 @@ export const UInt64Value = {
 
   fromJSON(object: any): UInt64Value {
     const message = { ...baseUInt64Value } as UInt64Value;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Number(object.value);
-    } else {
-      message.value = 0;
-    }
+    message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
 
@@ -328,11 +312,7 @@ export const Int32Value = {
 
   fromJSON(object: any): Int32Value {
     const message = { ...baseInt32Value } as Int32Value;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Number(object.value);
-    } else {
-      message.value = 0;
-    }
+    message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
 
@@ -379,11 +359,7 @@ export const UInt32Value = {
 
   fromJSON(object: any): UInt32Value {
     const message = { ...baseUInt32Value } as UInt32Value;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Number(object.value);
-    } else {
-      message.value = 0;
-    }
+    message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
 
@@ -430,11 +406,7 @@ export const BoolValue = {
 
   fromJSON(object: any): BoolValue {
     const message = { ...baseBoolValue } as BoolValue;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Boolean(object.value);
-    } else {
-      message.value = false;
-    }
+    message.value = object.value !== undefined && object.value !== null ? Boolean(object.value) : false;
     return message;
   },
 
@@ -481,11 +453,7 @@ export const StringValue = {
 
   fromJSON(object: any): StringValue {
     const message = { ...baseStringValue } as StringValue;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = String(object.value);
-    } else {
-      message.value = '';
-    }
+    message.value = object.value !== undefined && object.value !== null ? String(object.value) : '';
     return message;
   },
 
@@ -533,11 +501,8 @@ export const BytesValue = {
 
   fromJSON(object: any): BytesValue {
     const message = { ...baseBytesValue } as BytesValue;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = bytesFromBase64(object.value);
-    } else {
-      message.value = new Uint8Array();
-    }
+    message.value =
+      object.value !== undefined && object.value !== null ? bytesFromBase64(object.value) : new Uint8Array();
     return message;
   },
 

--- a/integration/simple-snake/import_dir/thing.ts
+++ b/integration/simple-snake/import_dir/thing.ts
@@ -39,11 +39,8 @@ export const ImportedThing = {
 
   fromJSON(object: any): ImportedThing {
     const message = { ...baseImportedThing } as ImportedThing;
-    if (object.created_at !== undefined && object.created_at !== null) {
-      message.created_at = fromJsonTimestamp(object.created_at);
-    } else {
-      message.created_at = undefined;
-    }
+    message.created_at =
+      object.created_at !== undefined && object.created_at !== null ? fromJsonTimestamp(object.created_at) : undefined;
     return message;
   },
 

--- a/integration/simple-snake/simple.ts
+++ b/integration/simple-snake/simple.ts
@@ -341,40 +341,18 @@ export const Simple = {
 
   fromJSON(object: any): Simple {
     const message = { ...baseSimple } as Simple;
-    if (object.name !== undefined && object.name !== null) {
-      message.name = String(object.name);
-    } else {
-      message.name = '';
-    }
-    if (object.age !== undefined && object.age !== null) {
-      message.age = Number(object.age);
-    } else {
-      message.age = 0;
-    }
-    if (object.created_at !== undefined && object.created_at !== null) {
-      message.created_at = fromJsonTimestamp(object.created_at);
-    } else {
-      message.created_at = undefined;
-    }
-    if (object.child !== undefined && object.child !== null) {
-      message.child = Child.fromJSON(object.child);
-    } else {
-      message.child = undefined;
-    }
-    if (object.state !== undefined && object.state !== null) {
-      message.state = stateEnumFromJSON(object.state);
-    } else {
-      message.state = 0;
-    }
+    message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
+    message.age = object.age !== undefined && object.age !== null ? Number(object.age) : 0;
+    message.created_at =
+      object.created_at !== undefined && object.created_at !== null ? fromJsonTimestamp(object.created_at) : undefined;
+    message.child = object.child !== undefined && object.child !== null ? Child.fromJSON(object.child) : undefined;
+    message.state = object.state !== undefined && object.state !== null ? stateEnumFromJSON(object.state) : 0;
     message.grand_children = (object.grand_children ?? []).map((e: any) => Child.fromJSON(e));
     message.coins = (object.coins ?? []).map((e: any) => Number(e));
     message.snacks = (object.snacks ?? []).map((e: any) => String(e));
     message.old_states = (object.old_states ?? []).map((e: any) => stateEnumFromJSON(e));
-    if (object.thing !== undefined && object.thing !== null) {
-      message.thing = ImportedThing.fromJSON(object.thing);
-    } else {
-      message.thing = undefined;
-    }
+    message.thing =
+      object.thing !== undefined && object.thing !== null ? ImportedThing.fromJSON(object.thing) : undefined;
     return message;
   },
 
@@ -414,21 +392,14 @@ export const Simple = {
     message.name = object.name ?? '';
     message.age = object.age ?? 0;
     message.created_at = object.created_at ?? undefined;
-    if (object.child !== undefined && object.child !== null) {
-      message.child = Child.fromPartial(object.child);
-    } else {
-      message.child = undefined;
-    }
+    message.child = object.child !== undefined && object.child !== null ? Child.fromPartial(object.child) : undefined;
     message.state = object.state ?? 0;
     message.grand_children = (object.grand_children ?? []).map((e) => Child.fromPartial(e));
     message.coins = (object.coins ?? []).map((e) => e);
     message.snacks = (object.snacks ?? []).map((e) => e);
     message.old_states = (object.old_states ?? []).map((e) => e);
-    if (object.thing !== undefined && object.thing !== null) {
-      message.thing = ImportedThing.fromPartial(object.thing);
-    } else {
-      message.thing = undefined;
-    }
+    message.thing =
+      object.thing !== undefined && object.thing !== null ? ImportedThing.fromPartial(object.thing) : undefined;
     return message;
   },
 };
@@ -469,16 +440,8 @@ export const Child = {
 
   fromJSON(object: any): Child {
     const message = { ...baseChild } as Child;
-    if (object.name !== undefined && object.name !== null) {
-      message.name = String(object.name);
-    } else {
-      message.name = '';
-    }
-    if (object.type !== undefined && object.type !== null) {
-      message.type = child_TypeFromJSON(object.type);
-    } else {
-      message.type = 0;
-    }
+    message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
+    message.type = object.type !== undefined && object.type !== null ? child_TypeFromJSON(object.type) : 0;
     return message;
   },
 
@@ -539,21 +502,12 @@ export const Nested = {
 
   fromJSON(object: any): Nested {
     const message = { ...baseNested } as Nested;
-    if (object.name !== undefined && object.name !== null) {
-      message.name = String(object.name);
-    } else {
-      message.name = '';
-    }
-    if (object.message !== undefined && object.message !== null) {
-      message.message = Nested_InnerMessage.fromJSON(object.message);
-    } else {
-      message.message = undefined;
-    }
-    if (object.state !== undefined && object.state !== null) {
-      message.state = nested_InnerEnumFromJSON(object.state);
-    } else {
-      message.state = 0;
-    }
+    message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
+    message.message =
+      object.message !== undefined && object.message !== null
+        ? Nested_InnerMessage.fromJSON(object.message)
+        : undefined;
+    message.state = object.state !== undefined && object.state !== null ? nested_InnerEnumFromJSON(object.state) : 0;
     return message;
   },
 
@@ -569,11 +523,10 @@ export const Nested = {
   fromPartial(object: DeepPartial<Nested>): Nested {
     const message = { ...baseNested } as Nested;
     message.name = object.name ?? '';
-    if (object.message !== undefined && object.message !== null) {
-      message.message = Nested_InnerMessage.fromPartial(object.message);
-    } else {
-      message.message = undefined;
-    }
+    message.message =
+      object.message !== undefined && object.message !== null
+        ? Nested_InnerMessage.fromPartial(object.message)
+        : undefined;
     message.state = object.state ?? 0;
     return message;
   },
@@ -615,16 +568,11 @@ export const Nested_InnerMessage = {
 
   fromJSON(object: any): Nested_InnerMessage {
     const message = { ...baseNested_InnerMessage } as Nested_InnerMessage;
-    if (object.name !== undefined && object.name !== null) {
-      message.name = String(object.name);
-    } else {
-      message.name = '';
-    }
-    if (object.deep !== undefined && object.deep !== null) {
-      message.deep = Nested_InnerMessage_DeepMessage.fromJSON(object.deep);
-    } else {
-      message.deep = undefined;
-    }
+    message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
+    message.deep =
+      object.deep !== undefined && object.deep !== null
+        ? Nested_InnerMessage_DeepMessage.fromJSON(object.deep)
+        : undefined;
     return message;
   },
 
@@ -639,11 +587,10 @@ export const Nested_InnerMessage = {
   fromPartial(object: DeepPartial<Nested_InnerMessage>): Nested_InnerMessage {
     const message = { ...baseNested_InnerMessage } as Nested_InnerMessage;
     message.name = object.name ?? '';
-    if (object.deep !== undefined && object.deep !== null) {
-      message.deep = Nested_InnerMessage_DeepMessage.fromPartial(object.deep);
-    } else {
-      message.deep = undefined;
-    }
+    message.deep =
+      object.deep !== undefined && object.deep !== null
+        ? Nested_InnerMessage_DeepMessage.fromPartial(object.deep)
+        : undefined;
     return message;
   },
 };
@@ -678,11 +625,7 @@ export const Nested_InnerMessage_DeepMessage = {
 
   fromJSON(object: any): Nested_InnerMessage_DeepMessage {
     const message = { ...baseNested_InnerMessage_DeepMessage } as Nested_InnerMessage_DeepMessage;
-    if (object.name !== undefined && object.name !== null) {
-      message.name = String(object.name);
-    } else {
-      message.name = '';
-    }
+    message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
     return message;
   },
 
@@ -735,16 +678,8 @@ export const OneOfMessage = {
 
   fromJSON(object: any): OneOfMessage {
     const message = { ...baseOneOfMessage } as OneOfMessage;
-    if (object.first !== undefined && object.first !== null) {
-      message.first = String(object.first);
-    } else {
-      message.first = undefined;
-    }
-    if (object.last !== undefined && object.last !== null) {
-      message.last = String(object.last);
-    } else {
-      message.last = undefined;
-    }
+    message.first = object.first !== undefined && object.first !== null ? String(object.first) : undefined;
+    message.last = object.last !== undefined && object.last !== null ? String(object.last) : undefined;
     return message;
   },
 
@@ -819,21 +754,9 @@ export const SimpleWithWrappers = {
 
   fromJSON(object: any): SimpleWithWrappers {
     const message = { ...baseSimpleWithWrappers } as SimpleWithWrappers;
-    if (object.name !== undefined && object.name !== null) {
-      message.name = String(object.name);
-    } else {
-      message.name = undefined;
-    }
-    if (object.age !== undefined && object.age !== null) {
-      message.age = Number(object.age);
-    } else {
-      message.age = undefined;
-    }
-    if (object.enabled !== undefined && object.enabled !== null) {
-      message.enabled = Boolean(object.enabled);
-    } else {
-      message.enabled = undefined;
-    }
+    message.name = object.name !== undefined && object.name !== null ? String(object.name) : undefined;
+    message.age = object.age !== undefined && object.age !== null ? Number(object.age) : undefined;
+    message.enabled = object.enabled !== undefined && object.enabled !== null ? Boolean(object.enabled) : undefined;
     message.coins = (object.coins ?? []).map((e: any) => Number(e));
     message.snacks = (object.snacks ?? []).map((e: any) => String(e));
     return message;
@@ -898,11 +821,7 @@ export const Entity = {
 
   fromJSON(object: any): Entity {
     const message = { ...baseEntity } as Entity;
-    if (object.id !== undefined && object.id !== null) {
-      message.id = Number(object.id);
-    } else {
-      message.id = 0;
-    }
+    message.id = object.id !== undefined && object.id !== null ? Number(object.id) : 0;
     return message;
   },
 
@@ -1083,16 +1002,8 @@ export const SimpleWithMap_EntitiesByIdEntry = {
 
   fromJSON(object: any): SimpleWithMap_EntitiesByIdEntry {
     const message = { ...baseSimpleWithMap_EntitiesByIdEntry } as SimpleWithMap_EntitiesByIdEntry;
-    if (object.key !== undefined && object.key !== null) {
-      message.key = Number(object.key);
-    } else {
-      message.key = 0;
-    }
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Entity.fromJSON(object.value);
-    } else {
-      message.value = undefined;
-    }
+    message.key = object.key !== undefined && object.key !== null ? Number(object.key) : 0;
+    message.value = object.value !== undefined && object.value !== null ? Entity.fromJSON(object.value) : undefined;
     return message;
   },
 
@@ -1106,11 +1017,7 @@ export const SimpleWithMap_EntitiesByIdEntry = {
   fromPartial(object: DeepPartial<SimpleWithMap_EntitiesByIdEntry>): SimpleWithMap_EntitiesByIdEntry {
     const message = { ...baseSimpleWithMap_EntitiesByIdEntry } as SimpleWithMap_EntitiesByIdEntry;
     message.key = object.key ?? 0;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Entity.fromPartial(object.value);
-    } else {
-      message.value = undefined;
-    }
+    message.value = object.value !== undefined && object.value !== null ? Entity.fromPartial(object.value) : undefined;
     return message;
   },
 };
@@ -1151,16 +1058,8 @@ export const SimpleWithMap_NameLookupEntry = {
 
   fromJSON(object: any): SimpleWithMap_NameLookupEntry {
     const message = { ...baseSimpleWithMap_NameLookupEntry } as SimpleWithMap_NameLookupEntry;
-    if (object.key !== undefined && object.key !== null) {
-      message.key = String(object.key);
-    } else {
-      message.key = '';
-    }
-    if (object.value !== undefined && object.value !== null) {
-      message.value = String(object.value);
-    } else {
-      message.value = '';
-    }
+    message.key = object.key !== undefined && object.key !== null ? String(object.key) : '';
+    message.value = object.value !== undefined && object.value !== null ? String(object.value) : '';
     return message;
   },
 
@@ -1215,16 +1114,8 @@ export const SimpleWithMap_IntLookupEntry = {
 
   fromJSON(object: any): SimpleWithMap_IntLookupEntry {
     const message = { ...baseSimpleWithMap_IntLookupEntry } as SimpleWithMap_IntLookupEntry;
-    if (object.key !== undefined && object.key !== null) {
-      message.key = Number(object.key);
-    } else {
-      message.key = 0;
-    }
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Number(object.value);
-    } else {
-      message.value = 0;
-    }
+    message.key = object.key !== undefined && object.key !== null ? Number(object.key) : 0;
+    message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
 
@@ -1347,16 +1238,8 @@ export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
 
   fromJSON(object: any): SimpleWithSnakeCaseMap_EntitiesByIdEntry {
     const message = { ...baseSimpleWithSnakeCaseMap_EntitiesByIdEntry } as SimpleWithSnakeCaseMap_EntitiesByIdEntry;
-    if (object.key !== undefined && object.key !== null) {
-      message.key = Number(object.key);
-    } else {
-      message.key = 0;
-    }
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Entity.fromJSON(object.value);
-    } else {
-      message.value = undefined;
-    }
+    message.key = object.key !== undefined && object.key !== null ? Number(object.key) : 0;
+    message.value = object.value !== undefined && object.value !== null ? Entity.fromJSON(object.value) : undefined;
     return message;
   },
 
@@ -1370,11 +1253,7 @@ export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
   fromPartial(object: DeepPartial<SimpleWithSnakeCaseMap_EntitiesByIdEntry>): SimpleWithSnakeCaseMap_EntitiesByIdEntry {
     const message = { ...baseSimpleWithSnakeCaseMap_EntitiesByIdEntry } as SimpleWithSnakeCaseMap_EntitiesByIdEntry;
     message.key = object.key ?? 0;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Entity.fromPartial(object.value);
-    } else {
-      message.value = undefined;
-    }
+    message.value = object.value !== undefined && object.value !== null ? Entity.fromPartial(object.value) : undefined;
     return message;
   },
 };
@@ -1409,11 +1288,7 @@ export const PingRequest = {
 
   fromJSON(object: any): PingRequest {
     const message = { ...basePingRequest } as PingRequest;
-    if (object.input !== undefined && object.input !== null) {
-      message.input = String(object.input);
-    } else {
-      message.input = '';
-    }
+    message.input = object.input !== undefined && object.input !== null ? String(object.input) : '';
     return message;
   },
 
@@ -1460,11 +1335,7 @@ export const PingResponse = {
 
   fromJSON(object: any): PingResponse {
     const message = { ...basePingResponse } as PingResponse;
-    if (object.output !== undefined && object.output !== null) {
-      message.output = String(object.output);
-    } else {
-      message.output = '';
-    }
+    message.output = object.output !== undefined && object.output !== null ? String(object.output) : '';
     return message;
   },
 
@@ -1590,66 +1461,18 @@ export const Numbers = {
 
   fromJSON(object: any): Numbers {
     const message = { ...baseNumbers } as Numbers;
-    if (object.double !== undefined && object.double !== null) {
-      message.double = Number(object.double);
-    } else {
-      message.double = 0;
-    }
-    if (object.float !== undefined && object.float !== null) {
-      message.float = Number(object.float);
-    } else {
-      message.float = 0;
-    }
-    if (object.int32 !== undefined && object.int32 !== null) {
-      message.int32 = Number(object.int32);
-    } else {
-      message.int32 = 0;
-    }
-    if (object.int64 !== undefined && object.int64 !== null) {
-      message.int64 = Number(object.int64);
-    } else {
-      message.int64 = 0;
-    }
-    if (object.uint32 !== undefined && object.uint32 !== null) {
-      message.uint32 = Number(object.uint32);
-    } else {
-      message.uint32 = 0;
-    }
-    if (object.uint64 !== undefined && object.uint64 !== null) {
-      message.uint64 = Number(object.uint64);
-    } else {
-      message.uint64 = 0;
-    }
-    if (object.sint32 !== undefined && object.sint32 !== null) {
-      message.sint32 = Number(object.sint32);
-    } else {
-      message.sint32 = 0;
-    }
-    if (object.sint64 !== undefined && object.sint64 !== null) {
-      message.sint64 = Number(object.sint64);
-    } else {
-      message.sint64 = 0;
-    }
-    if (object.fixed32 !== undefined && object.fixed32 !== null) {
-      message.fixed32 = Number(object.fixed32);
-    } else {
-      message.fixed32 = 0;
-    }
-    if (object.fixed64 !== undefined && object.fixed64 !== null) {
-      message.fixed64 = Number(object.fixed64);
-    } else {
-      message.fixed64 = 0;
-    }
-    if (object.sfixed32 !== undefined && object.sfixed32 !== null) {
-      message.sfixed32 = Number(object.sfixed32);
-    } else {
-      message.sfixed32 = 0;
-    }
-    if (object.sfixed64 !== undefined && object.sfixed64 !== null) {
-      message.sfixed64 = Number(object.sfixed64);
-    } else {
-      message.sfixed64 = 0;
-    }
+    message.double = object.double !== undefined && object.double !== null ? Number(object.double) : 0;
+    message.float = object.float !== undefined && object.float !== null ? Number(object.float) : 0;
+    message.int32 = object.int32 !== undefined && object.int32 !== null ? Number(object.int32) : 0;
+    message.int64 = object.int64 !== undefined && object.int64 !== null ? Number(object.int64) : 0;
+    message.uint32 = object.uint32 !== undefined && object.uint32 !== null ? Number(object.uint32) : 0;
+    message.uint64 = object.uint64 !== undefined && object.uint64 !== null ? Number(object.uint64) : 0;
+    message.sint32 = object.sint32 !== undefined && object.sint32 !== null ? Number(object.sint32) : 0;
+    message.sint64 = object.sint64 !== undefined && object.sint64 !== null ? Number(object.sint64) : 0;
+    message.fixed32 = object.fixed32 !== undefined && object.fixed32 !== null ? Number(object.fixed32) : 0;
+    message.fixed64 = object.fixed64 !== undefined && object.fixed64 !== null ? Number(object.fixed64) : 0;
+    message.sfixed32 = object.sfixed32 !== undefined && object.sfixed32 !== null ? Number(object.sfixed32) : 0;
+    message.sfixed64 = object.sfixed64 !== undefined && object.sfixed64 !== null ? Number(object.sfixed64) : 0;
     return message;
   },
 

--- a/integration/simple-string-enums/simple.ts
+++ b/integration/simple-string-enums/simple.ts
@@ -113,16 +113,9 @@ export const Simple = {
 
   fromJSON(object: any): Simple {
     const message = { ...baseSimple } as Simple;
-    if (object.name !== undefined && object.name !== null) {
-      message.name = String(object.name);
-    } else {
-      message.name = '';
-    }
-    if (object.state !== undefined && object.state !== null) {
-      message.state = stateEnumFromJSON(object.state);
-    } else {
-      message.state = StateEnum.UNKNOWN;
-    }
+    message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
+    message.state =
+      object.state !== undefined && object.state !== null ? stateEnumFromJSON(object.state) : StateEnum.UNKNOWN;
     message.states = (object.states ?? []).map((e: any) => stateEnumFromJSON(e));
     return message;
   },

--- a/integration/simple-unrecognized-enum/google/protobuf/timestamp.ts
+++ b/integration/simple-unrecognized-enum/google/protobuf/timestamp.ts
@@ -140,16 +140,8 @@ export const Timestamp = {
 
   fromJSON(object: any): Timestamp {
     const message = { ...baseTimestamp } as Timestamp;
-    if (object.seconds !== undefined && object.seconds !== null) {
-      message.seconds = Number(object.seconds);
-    } else {
-      message.seconds = 0;
-    }
-    if (object.nanos !== undefined && object.nanos !== null) {
-      message.nanos = Number(object.nanos);
-    } else {
-      message.nanos = 0;
-    }
+    message.seconds = object.seconds !== undefined && object.seconds !== null ? Number(object.seconds) : 0;
+    message.nanos = object.nanos !== undefined && object.nanos !== null ? Number(object.nanos) : 0;
     return message;
   },
 

--- a/integration/simple-unrecognized-enum/google/protobuf/wrappers.ts
+++ b/integration/simple-unrecognized-enum/google/protobuf/wrappers.ts
@@ -124,11 +124,7 @@ export const DoubleValue = {
 
   fromJSON(object: any): DoubleValue {
     const message = { ...baseDoubleValue } as DoubleValue;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Number(object.value);
-    } else {
-      message.value = 0;
-    }
+    message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
 
@@ -175,11 +171,7 @@ export const FloatValue = {
 
   fromJSON(object: any): FloatValue {
     const message = { ...baseFloatValue } as FloatValue;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Number(object.value);
-    } else {
-      message.value = 0;
-    }
+    message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
 
@@ -226,11 +218,7 @@ export const Int64Value = {
 
   fromJSON(object: any): Int64Value {
     const message = { ...baseInt64Value } as Int64Value;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Number(object.value);
-    } else {
-      message.value = 0;
-    }
+    message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
 
@@ -277,11 +265,7 @@ export const UInt64Value = {
 
   fromJSON(object: any): UInt64Value {
     const message = { ...baseUInt64Value } as UInt64Value;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Number(object.value);
-    } else {
-      message.value = 0;
-    }
+    message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
 
@@ -328,11 +312,7 @@ export const Int32Value = {
 
   fromJSON(object: any): Int32Value {
     const message = { ...baseInt32Value } as Int32Value;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Number(object.value);
-    } else {
-      message.value = 0;
-    }
+    message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
 
@@ -379,11 +359,7 @@ export const UInt32Value = {
 
   fromJSON(object: any): UInt32Value {
     const message = { ...baseUInt32Value } as UInt32Value;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Number(object.value);
-    } else {
-      message.value = 0;
-    }
+    message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
 
@@ -430,11 +406,7 @@ export const BoolValue = {
 
   fromJSON(object: any): BoolValue {
     const message = { ...baseBoolValue } as BoolValue;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Boolean(object.value);
-    } else {
-      message.value = false;
-    }
+    message.value = object.value !== undefined && object.value !== null ? Boolean(object.value) : false;
     return message;
   },
 
@@ -481,11 +453,7 @@ export const StringValue = {
 
   fromJSON(object: any): StringValue {
     const message = { ...baseStringValue } as StringValue;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = String(object.value);
-    } else {
-      message.value = '';
-    }
+    message.value = object.value !== undefined && object.value !== null ? String(object.value) : '';
     return message;
   },
 
@@ -533,11 +501,8 @@ export const BytesValue = {
 
   fromJSON(object: any): BytesValue {
     const message = { ...baseBytesValue } as BytesValue;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = bytesFromBase64(object.value);
-    } else {
-      message.value = new Uint8Array();
-    }
+    message.value =
+      object.value !== undefined && object.value !== null ? bytesFromBase64(object.value) : new Uint8Array();
     return message;
   },
 

--- a/integration/simple-unrecognized-enum/import_dir/thing.ts
+++ b/integration/simple-unrecognized-enum/import_dir/thing.ts
@@ -39,11 +39,8 @@ export const ImportedThing = {
 
   fromJSON(object: any): ImportedThing {
     const message = { ...baseImportedThing } as ImportedThing;
-    if (object.createdAt !== undefined && object.createdAt !== null) {
-      message.createdAt = fromJsonTimestamp(object.createdAt);
-    } else {
-      message.createdAt = undefined;
-    }
+    message.createdAt =
+      object.createdAt !== undefined && object.createdAt !== null ? fromJsonTimestamp(object.createdAt) : undefined;
     return message;
   },
 

--- a/integration/simple-unrecognized-enum/simple.ts
+++ b/integration/simple-unrecognized-enum/simple.ts
@@ -332,40 +332,18 @@ export const Simple = {
 
   fromJSON(object: any): Simple {
     const message = { ...baseSimple } as Simple;
-    if (object.name !== undefined && object.name !== null) {
-      message.name = String(object.name);
-    } else {
-      message.name = '';
-    }
-    if (object.age !== undefined && object.age !== null) {
-      message.age = Number(object.age);
-    } else {
-      message.age = 0;
-    }
-    if (object.createdAt !== undefined && object.createdAt !== null) {
-      message.createdAt = fromJsonTimestamp(object.createdAt);
-    } else {
-      message.createdAt = undefined;
-    }
-    if (object.child !== undefined && object.child !== null) {
-      message.child = Child.fromJSON(object.child);
-    } else {
-      message.child = undefined;
-    }
-    if (object.state !== undefined && object.state !== null) {
-      message.state = stateEnumFromJSON(object.state);
-    } else {
-      message.state = 0;
-    }
+    message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
+    message.age = object.age !== undefined && object.age !== null ? Number(object.age) : 0;
+    message.createdAt =
+      object.createdAt !== undefined && object.createdAt !== null ? fromJsonTimestamp(object.createdAt) : undefined;
+    message.child = object.child !== undefined && object.child !== null ? Child.fromJSON(object.child) : undefined;
+    message.state = object.state !== undefined && object.state !== null ? stateEnumFromJSON(object.state) : 0;
     message.grandChildren = (object.grandChildren ?? []).map((e: any) => Child.fromJSON(e));
     message.coins = (object.coins ?? []).map((e: any) => Number(e));
     message.snacks = (object.snacks ?? []).map((e: any) => String(e));
     message.oldStates = (object.oldStates ?? []).map((e: any) => stateEnumFromJSON(e));
-    if (object.thing !== undefined && object.thing !== null) {
-      message.thing = ImportedThing.fromJSON(object.thing);
-    } else {
-      message.thing = undefined;
-    }
+    message.thing =
+      object.thing !== undefined && object.thing !== null ? ImportedThing.fromJSON(object.thing) : undefined;
     return message;
   },
 
@@ -405,21 +383,14 @@ export const Simple = {
     message.name = object.name ?? '';
     message.age = object.age ?? 0;
     message.createdAt = object.createdAt ?? undefined;
-    if (object.child !== undefined && object.child !== null) {
-      message.child = Child.fromPartial(object.child);
-    } else {
-      message.child = undefined;
-    }
+    message.child = object.child !== undefined && object.child !== null ? Child.fromPartial(object.child) : undefined;
     message.state = object.state ?? 0;
     message.grandChildren = (object.grandChildren ?? []).map((e) => Child.fromPartial(e));
     message.coins = (object.coins ?? []).map((e) => e);
     message.snacks = (object.snacks ?? []).map((e) => e);
     message.oldStates = (object.oldStates ?? []).map((e) => e);
-    if (object.thing !== undefined && object.thing !== null) {
-      message.thing = ImportedThing.fromPartial(object.thing);
-    } else {
-      message.thing = undefined;
-    }
+    message.thing =
+      object.thing !== undefined && object.thing !== null ? ImportedThing.fromPartial(object.thing) : undefined;
     return message;
   },
 };
@@ -460,16 +431,8 @@ export const Child = {
 
   fromJSON(object: any): Child {
     const message = { ...baseChild } as Child;
-    if (object.name !== undefined && object.name !== null) {
-      message.name = String(object.name);
-    } else {
-      message.name = '';
-    }
-    if (object.type !== undefined && object.type !== null) {
-      message.type = child_TypeFromJSON(object.type);
-    } else {
-      message.type = 0;
-    }
+    message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
+    message.type = object.type !== undefined && object.type !== null ? child_TypeFromJSON(object.type) : 0;
     return message;
   },
 
@@ -530,21 +493,12 @@ export const Nested = {
 
   fromJSON(object: any): Nested {
     const message = { ...baseNested } as Nested;
-    if (object.name !== undefined && object.name !== null) {
-      message.name = String(object.name);
-    } else {
-      message.name = '';
-    }
-    if (object.message !== undefined && object.message !== null) {
-      message.message = Nested_InnerMessage.fromJSON(object.message);
-    } else {
-      message.message = undefined;
-    }
-    if (object.state !== undefined && object.state !== null) {
-      message.state = nested_InnerEnumFromJSON(object.state);
-    } else {
-      message.state = 0;
-    }
+    message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
+    message.message =
+      object.message !== undefined && object.message !== null
+        ? Nested_InnerMessage.fromJSON(object.message)
+        : undefined;
+    message.state = object.state !== undefined && object.state !== null ? nested_InnerEnumFromJSON(object.state) : 0;
     return message;
   },
 
@@ -560,11 +514,10 @@ export const Nested = {
   fromPartial(object: DeepPartial<Nested>): Nested {
     const message = { ...baseNested } as Nested;
     message.name = object.name ?? '';
-    if (object.message !== undefined && object.message !== null) {
-      message.message = Nested_InnerMessage.fromPartial(object.message);
-    } else {
-      message.message = undefined;
-    }
+    message.message =
+      object.message !== undefined && object.message !== null
+        ? Nested_InnerMessage.fromPartial(object.message)
+        : undefined;
     message.state = object.state ?? 0;
     return message;
   },
@@ -606,16 +559,11 @@ export const Nested_InnerMessage = {
 
   fromJSON(object: any): Nested_InnerMessage {
     const message = { ...baseNested_InnerMessage } as Nested_InnerMessage;
-    if (object.name !== undefined && object.name !== null) {
-      message.name = String(object.name);
-    } else {
-      message.name = '';
-    }
-    if (object.deep !== undefined && object.deep !== null) {
-      message.deep = Nested_InnerMessage_DeepMessage.fromJSON(object.deep);
-    } else {
-      message.deep = undefined;
-    }
+    message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
+    message.deep =
+      object.deep !== undefined && object.deep !== null
+        ? Nested_InnerMessage_DeepMessage.fromJSON(object.deep)
+        : undefined;
     return message;
   },
 
@@ -630,11 +578,10 @@ export const Nested_InnerMessage = {
   fromPartial(object: DeepPartial<Nested_InnerMessage>): Nested_InnerMessage {
     const message = { ...baseNested_InnerMessage } as Nested_InnerMessage;
     message.name = object.name ?? '';
-    if (object.deep !== undefined && object.deep !== null) {
-      message.deep = Nested_InnerMessage_DeepMessage.fromPartial(object.deep);
-    } else {
-      message.deep = undefined;
-    }
+    message.deep =
+      object.deep !== undefined && object.deep !== null
+        ? Nested_InnerMessage_DeepMessage.fromPartial(object.deep)
+        : undefined;
     return message;
   },
 };
@@ -669,11 +616,7 @@ export const Nested_InnerMessage_DeepMessage = {
 
   fromJSON(object: any): Nested_InnerMessage_DeepMessage {
     const message = { ...baseNested_InnerMessage_DeepMessage } as Nested_InnerMessage_DeepMessage;
-    if (object.name !== undefined && object.name !== null) {
-      message.name = String(object.name);
-    } else {
-      message.name = '';
-    }
+    message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
     return message;
   },
 
@@ -726,16 +669,8 @@ export const OneOfMessage = {
 
   fromJSON(object: any): OneOfMessage {
     const message = { ...baseOneOfMessage } as OneOfMessage;
-    if (object.first !== undefined && object.first !== null) {
-      message.first = String(object.first);
-    } else {
-      message.first = undefined;
-    }
-    if (object.last !== undefined && object.last !== null) {
-      message.last = String(object.last);
-    } else {
-      message.last = undefined;
-    }
+    message.first = object.first !== undefined && object.first !== null ? String(object.first) : undefined;
+    message.last = object.last !== undefined && object.last !== null ? String(object.last) : undefined;
     return message;
   },
 
@@ -810,21 +745,9 @@ export const SimpleWithWrappers = {
 
   fromJSON(object: any): SimpleWithWrappers {
     const message = { ...baseSimpleWithWrappers } as SimpleWithWrappers;
-    if (object.name !== undefined && object.name !== null) {
-      message.name = String(object.name);
-    } else {
-      message.name = undefined;
-    }
-    if (object.age !== undefined && object.age !== null) {
-      message.age = Number(object.age);
-    } else {
-      message.age = undefined;
-    }
-    if (object.enabled !== undefined && object.enabled !== null) {
-      message.enabled = Boolean(object.enabled);
-    } else {
-      message.enabled = undefined;
-    }
+    message.name = object.name !== undefined && object.name !== null ? String(object.name) : undefined;
+    message.age = object.age !== undefined && object.age !== null ? Number(object.age) : undefined;
+    message.enabled = object.enabled !== undefined && object.enabled !== null ? Boolean(object.enabled) : undefined;
     message.coins = (object.coins ?? []).map((e: any) => Number(e));
     message.snacks = (object.snacks ?? []).map((e: any) => String(e));
     return message;
@@ -889,11 +812,7 @@ export const Entity = {
 
   fromJSON(object: any): Entity {
     const message = { ...baseEntity } as Entity;
-    if (object.id !== undefined && object.id !== null) {
-      message.id = Number(object.id);
-    } else {
-      message.id = 0;
-    }
+    message.id = object.id !== undefined && object.id !== null ? Number(object.id) : 0;
     return message;
   },
 
@@ -1074,16 +993,8 @@ export const SimpleWithMap_EntitiesByIdEntry = {
 
   fromJSON(object: any): SimpleWithMap_EntitiesByIdEntry {
     const message = { ...baseSimpleWithMap_EntitiesByIdEntry } as SimpleWithMap_EntitiesByIdEntry;
-    if (object.key !== undefined && object.key !== null) {
-      message.key = Number(object.key);
-    } else {
-      message.key = 0;
-    }
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Entity.fromJSON(object.value);
-    } else {
-      message.value = undefined;
-    }
+    message.key = object.key !== undefined && object.key !== null ? Number(object.key) : 0;
+    message.value = object.value !== undefined && object.value !== null ? Entity.fromJSON(object.value) : undefined;
     return message;
   },
 
@@ -1097,11 +1008,7 @@ export const SimpleWithMap_EntitiesByIdEntry = {
   fromPartial(object: DeepPartial<SimpleWithMap_EntitiesByIdEntry>): SimpleWithMap_EntitiesByIdEntry {
     const message = { ...baseSimpleWithMap_EntitiesByIdEntry } as SimpleWithMap_EntitiesByIdEntry;
     message.key = object.key ?? 0;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Entity.fromPartial(object.value);
-    } else {
-      message.value = undefined;
-    }
+    message.value = object.value !== undefined && object.value !== null ? Entity.fromPartial(object.value) : undefined;
     return message;
   },
 };
@@ -1142,16 +1049,8 @@ export const SimpleWithMap_NameLookupEntry = {
 
   fromJSON(object: any): SimpleWithMap_NameLookupEntry {
     const message = { ...baseSimpleWithMap_NameLookupEntry } as SimpleWithMap_NameLookupEntry;
-    if (object.key !== undefined && object.key !== null) {
-      message.key = String(object.key);
-    } else {
-      message.key = '';
-    }
-    if (object.value !== undefined && object.value !== null) {
-      message.value = String(object.value);
-    } else {
-      message.value = '';
-    }
+    message.key = object.key !== undefined && object.key !== null ? String(object.key) : '';
+    message.value = object.value !== undefined && object.value !== null ? String(object.value) : '';
     return message;
   },
 
@@ -1206,16 +1105,8 @@ export const SimpleWithMap_IntLookupEntry = {
 
   fromJSON(object: any): SimpleWithMap_IntLookupEntry {
     const message = { ...baseSimpleWithMap_IntLookupEntry } as SimpleWithMap_IntLookupEntry;
-    if (object.key !== undefined && object.key !== null) {
-      message.key = Number(object.key);
-    } else {
-      message.key = 0;
-    }
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Number(object.value);
-    } else {
-      message.value = 0;
-    }
+    message.key = object.key !== undefined && object.key !== null ? Number(object.key) : 0;
+    message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
 
@@ -1338,16 +1229,8 @@ export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
 
   fromJSON(object: any): SimpleWithSnakeCaseMap_EntitiesByIdEntry {
     const message = { ...baseSimpleWithSnakeCaseMap_EntitiesByIdEntry } as SimpleWithSnakeCaseMap_EntitiesByIdEntry;
-    if (object.key !== undefined && object.key !== null) {
-      message.key = Number(object.key);
-    } else {
-      message.key = 0;
-    }
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Entity.fromJSON(object.value);
-    } else {
-      message.value = undefined;
-    }
+    message.key = object.key !== undefined && object.key !== null ? Number(object.key) : 0;
+    message.value = object.value !== undefined && object.value !== null ? Entity.fromJSON(object.value) : undefined;
     return message;
   },
 
@@ -1361,11 +1244,7 @@ export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
   fromPartial(object: DeepPartial<SimpleWithSnakeCaseMap_EntitiesByIdEntry>): SimpleWithSnakeCaseMap_EntitiesByIdEntry {
     const message = { ...baseSimpleWithSnakeCaseMap_EntitiesByIdEntry } as SimpleWithSnakeCaseMap_EntitiesByIdEntry;
     message.key = object.key ?? 0;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Entity.fromPartial(object.value);
-    } else {
-      message.value = undefined;
-    }
+    message.value = object.value !== undefined && object.value !== null ? Entity.fromPartial(object.value) : undefined;
     return message;
   },
 };
@@ -1400,11 +1279,7 @@ export const PingRequest = {
 
   fromJSON(object: any): PingRequest {
     const message = { ...basePingRequest } as PingRequest;
-    if (object.input !== undefined && object.input !== null) {
-      message.input = String(object.input);
-    } else {
-      message.input = '';
-    }
+    message.input = object.input !== undefined && object.input !== null ? String(object.input) : '';
     return message;
   },
 
@@ -1451,11 +1326,7 @@ export const PingResponse = {
 
   fromJSON(object: any): PingResponse {
     const message = { ...basePingResponse } as PingResponse;
-    if (object.output !== undefined && object.output !== null) {
-      message.output = String(object.output);
-    } else {
-      message.output = '';
-    }
+    message.output = object.output !== undefined && object.output !== null ? String(object.output) : '';
     return message;
   },
 
@@ -1581,66 +1452,18 @@ export const Numbers = {
 
   fromJSON(object: any): Numbers {
     const message = { ...baseNumbers } as Numbers;
-    if (object.double !== undefined && object.double !== null) {
-      message.double = Number(object.double);
-    } else {
-      message.double = 0;
-    }
-    if (object.float !== undefined && object.float !== null) {
-      message.float = Number(object.float);
-    } else {
-      message.float = 0;
-    }
-    if (object.int32 !== undefined && object.int32 !== null) {
-      message.int32 = Number(object.int32);
-    } else {
-      message.int32 = 0;
-    }
-    if (object.int64 !== undefined && object.int64 !== null) {
-      message.int64 = Number(object.int64);
-    } else {
-      message.int64 = 0;
-    }
-    if (object.uint32 !== undefined && object.uint32 !== null) {
-      message.uint32 = Number(object.uint32);
-    } else {
-      message.uint32 = 0;
-    }
-    if (object.uint64 !== undefined && object.uint64 !== null) {
-      message.uint64 = Number(object.uint64);
-    } else {
-      message.uint64 = 0;
-    }
-    if (object.sint32 !== undefined && object.sint32 !== null) {
-      message.sint32 = Number(object.sint32);
-    } else {
-      message.sint32 = 0;
-    }
-    if (object.sint64 !== undefined && object.sint64 !== null) {
-      message.sint64 = Number(object.sint64);
-    } else {
-      message.sint64 = 0;
-    }
-    if (object.fixed32 !== undefined && object.fixed32 !== null) {
-      message.fixed32 = Number(object.fixed32);
-    } else {
-      message.fixed32 = 0;
-    }
-    if (object.fixed64 !== undefined && object.fixed64 !== null) {
-      message.fixed64 = Number(object.fixed64);
-    } else {
-      message.fixed64 = 0;
-    }
-    if (object.sfixed32 !== undefined && object.sfixed32 !== null) {
-      message.sfixed32 = Number(object.sfixed32);
-    } else {
-      message.sfixed32 = 0;
-    }
-    if (object.sfixed64 !== undefined && object.sfixed64 !== null) {
-      message.sfixed64 = Number(object.sfixed64);
-    } else {
-      message.sfixed64 = 0;
-    }
+    message.double = object.double !== undefined && object.double !== null ? Number(object.double) : 0;
+    message.float = object.float !== undefined && object.float !== null ? Number(object.float) : 0;
+    message.int32 = object.int32 !== undefined && object.int32 !== null ? Number(object.int32) : 0;
+    message.int64 = object.int64 !== undefined && object.int64 !== null ? Number(object.int64) : 0;
+    message.uint32 = object.uint32 !== undefined && object.uint32 !== null ? Number(object.uint32) : 0;
+    message.uint64 = object.uint64 !== undefined && object.uint64 !== null ? Number(object.uint64) : 0;
+    message.sint32 = object.sint32 !== undefined && object.sint32 !== null ? Number(object.sint32) : 0;
+    message.sint64 = object.sint64 !== undefined && object.sint64 !== null ? Number(object.sint64) : 0;
+    message.fixed32 = object.fixed32 !== undefined && object.fixed32 !== null ? Number(object.fixed32) : 0;
+    message.fixed64 = object.fixed64 !== undefined && object.fixed64 !== null ? Number(object.fixed64) : 0;
+    message.sfixed32 = object.sfixed32 !== undefined && object.sfixed32 !== null ? Number(object.sfixed32) : 0;
+    message.sfixed64 = object.sfixed64 !== undefined && object.sfixed64 !== null ? Number(object.sfixed64) : 0;
     return message;
   },
 

--- a/integration/simple/google/protobuf/timestamp.ts
+++ b/integration/simple/google/protobuf/timestamp.ts
@@ -140,16 +140,8 @@ export const Timestamp = {
 
   fromJSON(object: any): Timestamp {
     const message = { ...baseTimestamp } as Timestamp;
-    if (object.seconds !== undefined && object.seconds !== null) {
-      message.seconds = Number(object.seconds);
-    } else {
-      message.seconds = 0;
-    }
-    if (object.nanos !== undefined && object.nanos !== null) {
-      message.nanos = Number(object.nanos);
-    } else {
-      message.nanos = 0;
-    }
+    message.seconds = object.seconds !== undefined && object.seconds !== null ? Number(object.seconds) : 0;
+    message.nanos = object.nanos !== undefined && object.nanos !== null ? Number(object.nanos) : 0;
     return message;
   },
 

--- a/integration/simple/google/protobuf/wrappers.ts
+++ b/integration/simple/google/protobuf/wrappers.ts
@@ -124,11 +124,7 @@ export const DoubleValue = {
 
   fromJSON(object: any): DoubleValue {
     const message = { ...baseDoubleValue } as DoubleValue;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Number(object.value);
-    } else {
-      message.value = 0;
-    }
+    message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
 
@@ -175,11 +171,7 @@ export const FloatValue = {
 
   fromJSON(object: any): FloatValue {
     const message = { ...baseFloatValue } as FloatValue;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Number(object.value);
-    } else {
-      message.value = 0;
-    }
+    message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
 
@@ -226,11 +218,7 @@ export const Int64Value = {
 
   fromJSON(object: any): Int64Value {
     const message = { ...baseInt64Value } as Int64Value;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Number(object.value);
-    } else {
-      message.value = 0;
-    }
+    message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
 
@@ -277,11 +265,7 @@ export const UInt64Value = {
 
   fromJSON(object: any): UInt64Value {
     const message = { ...baseUInt64Value } as UInt64Value;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Number(object.value);
-    } else {
-      message.value = 0;
-    }
+    message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
 
@@ -328,11 +312,7 @@ export const Int32Value = {
 
   fromJSON(object: any): Int32Value {
     const message = { ...baseInt32Value } as Int32Value;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Number(object.value);
-    } else {
-      message.value = 0;
-    }
+    message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
 
@@ -379,11 +359,7 @@ export const UInt32Value = {
 
   fromJSON(object: any): UInt32Value {
     const message = { ...baseUInt32Value } as UInt32Value;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Number(object.value);
-    } else {
-      message.value = 0;
-    }
+    message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
 
@@ -430,11 +406,7 @@ export const BoolValue = {
 
   fromJSON(object: any): BoolValue {
     const message = { ...baseBoolValue } as BoolValue;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Boolean(object.value);
-    } else {
-      message.value = false;
-    }
+    message.value = object.value !== undefined && object.value !== null ? Boolean(object.value) : false;
     return message;
   },
 
@@ -481,11 +453,7 @@ export const StringValue = {
 
   fromJSON(object: any): StringValue {
     const message = { ...baseStringValue } as StringValue;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = String(object.value);
-    } else {
-      message.value = '';
-    }
+    message.value = object.value !== undefined && object.value !== null ? String(object.value) : '';
     return message;
   },
 
@@ -533,11 +501,8 @@ export const BytesValue = {
 
   fromJSON(object: any): BytesValue {
     const message = { ...baseBytesValue } as BytesValue;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = bytesFromBase64(object.value);
-    } else {
-      message.value = new Uint8Array();
-    }
+    message.value =
+      object.value !== undefined && object.value !== null ? bytesFromBase64(object.value) : new Uint8Array();
     return message;
   },
 

--- a/integration/simple/google/type/date.ts
+++ b/integration/simple/google/type/date.ts
@@ -77,21 +77,9 @@ export const DateMessage = {
 
   fromJSON(object: any): DateMessage {
     const message = { ...baseDateMessage } as DateMessage;
-    if (object.year !== undefined && object.year !== null) {
-      message.year = Number(object.year);
-    } else {
-      message.year = 0;
-    }
-    if (object.month !== undefined && object.month !== null) {
-      message.month = Number(object.month);
-    } else {
-      message.month = 0;
-    }
-    if (object.day !== undefined && object.day !== null) {
-      message.day = Number(object.day);
-    } else {
-      message.day = 0;
-    }
+    message.year = object.year !== undefined && object.year !== null ? Number(object.year) : 0;
+    message.month = object.month !== undefined && object.month !== null ? Number(object.month) : 0;
+    message.day = object.day !== undefined && object.day !== null ? Number(object.day) : 0;
     return message;
   },
 

--- a/integration/simple/import_dir/thing.ts
+++ b/integration/simple/import_dir/thing.ts
@@ -39,11 +39,8 @@ export const ImportedThing = {
 
   fromJSON(object: any): ImportedThing {
     const message = { ...baseImportedThing } as ImportedThing;
-    if (object.createdAt !== undefined && object.createdAt !== null) {
-      message.createdAt = fromJsonTimestamp(object.createdAt);
-    } else {
-      message.createdAt = undefined;
-    }
+    message.createdAt =
+      object.createdAt !== undefined && object.createdAt !== null ? fromJsonTimestamp(object.createdAt) : undefined;
     return message;
   },
 

--- a/integration/simple/simple.ts
+++ b/integration/simple/simple.ts
@@ -410,51 +410,22 @@ export const Simple = {
 
   fromJSON(object: any): Simple {
     const message = { ...baseSimple } as Simple;
-    if (object.name !== undefined && object.name !== null) {
-      message.name = String(object.name);
-    } else {
-      message.name = '';
-    }
-    if (object.age !== undefined && object.age !== null) {
-      message.age = Number(object.age);
-    } else {
-      message.age = 0;
-    }
-    if (object.createdAt !== undefined && object.createdAt !== null) {
-      message.createdAt = fromJsonTimestamp(object.createdAt);
-    } else {
-      message.createdAt = undefined;
-    }
-    if (object.child !== undefined && object.child !== null) {
-      message.child = Child.fromJSON(object.child);
-    } else {
-      message.child = undefined;
-    }
-    if (object.state !== undefined && object.state !== null) {
-      message.state = stateEnumFromJSON(object.state);
-    } else {
-      message.state = 0;
-    }
+    message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
+    message.age = object.age !== undefined && object.age !== null ? Number(object.age) : 0;
+    message.createdAt =
+      object.createdAt !== undefined && object.createdAt !== null ? fromJsonTimestamp(object.createdAt) : undefined;
+    message.child = object.child !== undefined && object.child !== null ? Child.fromJSON(object.child) : undefined;
+    message.state = object.state !== undefined && object.state !== null ? stateEnumFromJSON(object.state) : 0;
     message.grandChildren = (object.grandChildren ?? []).map((e: any) => Child.fromJSON(e));
     message.coins = (object.coins ?? []).map((e: any) => Number(e));
     message.snacks = (object.snacks ?? []).map((e: any) => String(e));
     message.oldStates = (object.oldStates ?? []).map((e: any) => stateEnumFromJSON(e));
-    if (object.thing !== undefined && object.thing !== null) {
-      message.thing = ImportedThing.fromJSON(object.thing);
-    } else {
-      message.thing = undefined;
-    }
+    message.thing =
+      object.thing !== undefined && object.thing !== null ? ImportedThing.fromJSON(object.thing) : undefined;
     message.blobs = (object.blobs ?? []).map((e: any) => bytesFromBase64(e));
-    if (object.birthday !== undefined && object.birthday !== null) {
-      message.birthday = DateMessage.fromJSON(object.birthday);
-    } else {
-      message.birthday = undefined;
-    }
-    if (object.blob !== undefined && object.blob !== null) {
-      message.blob = bytesFromBase64(object.blob);
-    } else {
-      message.blob = new Uint8Array();
-    }
+    message.birthday =
+      object.birthday !== undefined && object.birthday !== null ? DateMessage.fromJSON(object.birthday) : undefined;
+    message.blob = object.blob !== undefined && object.blob !== null ? bytesFromBase64(object.blob) : new Uint8Array();
     return message;
   },
 
@@ -503,27 +474,17 @@ export const Simple = {
     message.name = object.name ?? '';
     message.age = object.age ?? 0;
     message.createdAt = object.createdAt ?? undefined;
-    if (object.child !== undefined && object.child !== null) {
-      message.child = Child.fromPartial(object.child);
-    } else {
-      message.child = undefined;
-    }
+    message.child = object.child !== undefined && object.child !== null ? Child.fromPartial(object.child) : undefined;
     message.state = object.state ?? 0;
     message.grandChildren = (object.grandChildren ?? []).map((e) => Child.fromPartial(e));
     message.coins = (object.coins ?? []).map((e) => e);
     message.snacks = (object.snacks ?? []).map((e) => e);
     message.oldStates = (object.oldStates ?? []).map((e) => e);
-    if (object.thing !== undefined && object.thing !== null) {
-      message.thing = ImportedThing.fromPartial(object.thing);
-    } else {
-      message.thing = undefined;
-    }
+    message.thing =
+      object.thing !== undefined && object.thing !== null ? ImportedThing.fromPartial(object.thing) : undefined;
     message.blobs = (object.blobs ?? []).map((e) => e);
-    if (object.birthday !== undefined && object.birthday !== null) {
-      message.birthday = DateMessage.fromPartial(object.birthday);
-    } else {
-      message.birthday = undefined;
-    }
+    message.birthday =
+      object.birthday !== undefined && object.birthday !== null ? DateMessage.fromPartial(object.birthday) : undefined;
     message.blob = object.blob ?? new Uint8Array();
     return message;
   },
@@ -565,16 +526,8 @@ export const Child = {
 
   fromJSON(object: any): Child {
     const message = { ...baseChild } as Child;
-    if (object.name !== undefined && object.name !== null) {
-      message.name = String(object.name);
-    } else {
-      message.name = '';
-    }
-    if (object.type !== undefined && object.type !== null) {
-      message.type = child_TypeFromJSON(object.type);
-    } else {
-      message.type = 0;
-    }
+    message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
+    message.type = object.type !== undefined && object.type !== null ? child_TypeFromJSON(object.type) : 0;
     return message;
   },
 
@@ -635,21 +588,12 @@ export const Nested = {
 
   fromJSON(object: any): Nested {
     const message = { ...baseNested } as Nested;
-    if (object.name !== undefined && object.name !== null) {
-      message.name = String(object.name);
-    } else {
-      message.name = '';
-    }
-    if (object.message !== undefined && object.message !== null) {
-      message.message = Nested_InnerMessage.fromJSON(object.message);
-    } else {
-      message.message = undefined;
-    }
-    if (object.state !== undefined && object.state !== null) {
-      message.state = nested_InnerEnumFromJSON(object.state);
-    } else {
-      message.state = 0;
-    }
+    message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
+    message.message =
+      object.message !== undefined && object.message !== null
+        ? Nested_InnerMessage.fromJSON(object.message)
+        : undefined;
+    message.state = object.state !== undefined && object.state !== null ? nested_InnerEnumFromJSON(object.state) : 0;
     return message;
   },
 
@@ -665,11 +609,10 @@ export const Nested = {
   fromPartial(object: DeepPartial<Nested>): Nested {
     const message = { ...baseNested } as Nested;
     message.name = object.name ?? '';
-    if (object.message !== undefined && object.message !== null) {
-      message.message = Nested_InnerMessage.fromPartial(object.message);
-    } else {
-      message.message = undefined;
-    }
+    message.message =
+      object.message !== undefined && object.message !== null
+        ? Nested_InnerMessage.fromPartial(object.message)
+        : undefined;
     message.state = object.state ?? 0;
     return message;
   },
@@ -711,16 +654,11 @@ export const Nested_InnerMessage = {
 
   fromJSON(object: any): Nested_InnerMessage {
     const message = { ...baseNested_InnerMessage } as Nested_InnerMessage;
-    if (object.name !== undefined && object.name !== null) {
-      message.name = String(object.name);
-    } else {
-      message.name = '';
-    }
-    if (object.deep !== undefined && object.deep !== null) {
-      message.deep = Nested_InnerMessage_DeepMessage.fromJSON(object.deep);
-    } else {
-      message.deep = undefined;
-    }
+    message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
+    message.deep =
+      object.deep !== undefined && object.deep !== null
+        ? Nested_InnerMessage_DeepMessage.fromJSON(object.deep)
+        : undefined;
     return message;
   },
 
@@ -735,11 +673,10 @@ export const Nested_InnerMessage = {
   fromPartial(object: DeepPartial<Nested_InnerMessage>): Nested_InnerMessage {
     const message = { ...baseNested_InnerMessage } as Nested_InnerMessage;
     message.name = object.name ?? '';
-    if (object.deep !== undefined && object.deep !== null) {
-      message.deep = Nested_InnerMessage_DeepMessage.fromPartial(object.deep);
-    } else {
-      message.deep = undefined;
-    }
+    message.deep =
+      object.deep !== undefined && object.deep !== null
+        ? Nested_InnerMessage_DeepMessage.fromPartial(object.deep)
+        : undefined;
     return message;
   },
 };
@@ -774,11 +711,7 @@ export const Nested_InnerMessage_DeepMessage = {
 
   fromJSON(object: any): Nested_InnerMessage_DeepMessage {
     const message = { ...baseNested_InnerMessage_DeepMessage } as Nested_InnerMessage_DeepMessage;
-    if (object.name !== undefined && object.name !== null) {
-      message.name = String(object.name);
-    } else {
-      message.name = '';
-    }
+    message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
     return message;
   },
 
@@ -831,16 +764,8 @@ export const OneOfMessage = {
 
   fromJSON(object: any): OneOfMessage {
     const message = { ...baseOneOfMessage } as OneOfMessage;
-    if (object.first !== undefined && object.first !== null) {
-      message.first = String(object.first);
-    } else {
-      message.first = undefined;
-    }
-    if (object.last !== undefined && object.last !== null) {
-      message.last = String(object.last);
-    } else {
-      message.last = undefined;
-    }
+    message.first = object.first !== undefined && object.first !== null ? String(object.first) : undefined;
+    message.last = object.last !== undefined && object.last !== null ? String(object.last) : undefined;
     return message;
   },
 
@@ -921,28 +846,12 @@ export const SimpleWithWrappers = {
 
   fromJSON(object: any): SimpleWithWrappers {
     const message = { ...baseSimpleWithWrappers } as SimpleWithWrappers;
-    if (object.name !== undefined && object.name !== null) {
-      message.name = String(object.name);
-    } else {
-      message.name = undefined;
-    }
-    if (object.age !== undefined && object.age !== null) {
-      message.age = Number(object.age);
-    } else {
-      message.age = undefined;
-    }
-    if (object.enabled !== undefined && object.enabled !== null) {
-      message.enabled = Boolean(object.enabled);
-    } else {
-      message.enabled = undefined;
-    }
+    message.name = object.name !== undefined && object.name !== null ? String(object.name) : undefined;
+    message.age = object.age !== undefined && object.age !== null ? Number(object.age) : undefined;
+    message.enabled = object.enabled !== undefined && object.enabled !== null ? Boolean(object.enabled) : undefined;
     message.coins = (object.coins ?? []).map((e: any) => Number(e));
     message.snacks = (object.snacks ?? []).map((e: any) => String(e));
-    if (object.id !== undefined && object.id !== null) {
-      message.id = new Uint8Array(object.id);
-    } else {
-      message.id = undefined;
-    }
+    message.id = object.id !== undefined && object.id !== null ? new Uint8Array(object.id) : undefined;
     return message;
   },
 
@@ -1007,11 +916,7 @@ export const Entity = {
 
   fromJSON(object: any): Entity {
     const message = { ...baseEntity } as Entity;
-    if (object.id !== undefined && object.id !== null) {
-      message.id = Number(object.id);
-    } else {
-      message.id = 0;
-    }
+    message.id = object.id !== undefined && object.id !== null ? Number(object.id) : 0;
     return message;
   },
 
@@ -1284,16 +1189,8 @@ export const SimpleWithMap_EntitiesByIdEntry = {
 
   fromJSON(object: any): SimpleWithMap_EntitiesByIdEntry {
     const message = { ...baseSimpleWithMap_EntitiesByIdEntry } as SimpleWithMap_EntitiesByIdEntry;
-    if (object.key !== undefined && object.key !== null) {
-      message.key = Number(object.key);
-    } else {
-      message.key = 0;
-    }
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Entity.fromJSON(object.value);
-    } else {
-      message.value = undefined;
-    }
+    message.key = object.key !== undefined && object.key !== null ? Number(object.key) : 0;
+    message.value = object.value !== undefined && object.value !== null ? Entity.fromJSON(object.value) : undefined;
     return message;
   },
 
@@ -1307,11 +1204,7 @@ export const SimpleWithMap_EntitiesByIdEntry = {
   fromPartial(object: DeepPartial<SimpleWithMap_EntitiesByIdEntry>): SimpleWithMap_EntitiesByIdEntry {
     const message = { ...baseSimpleWithMap_EntitiesByIdEntry } as SimpleWithMap_EntitiesByIdEntry;
     message.key = object.key ?? 0;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Entity.fromPartial(object.value);
-    } else {
-      message.value = undefined;
-    }
+    message.value = object.value !== undefined && object.value !== null ? Entity.fromPartial(object.value) : undefined;
     return message;
   },
 };
@@ -1352,16 +1245,8 @@ export const SimpleWithMap_NameLookupEntry = {
 
   fromJSON(object: any): SimpleWithMap_NameLookupEntry {
     const message = { ...baseSimpleWithMap_NameLookupEntry } as SimpleWithMap_NameLookupEntry;
-    if (object.key !== undefined && object.key !== null) {
-      message.key = String(object.key);
-    } else {
-      message.key = '';
-    }
-    if (object.value !== undefined && object.value !== null) {
-      message.value = String(object.value);
-    } else {
-      message.value = '';
-    }
+    message.key = object.key !== undefined && object.key !== null ? String(object.key) : '';
+    message.value = object.value !== undefined && object.value !== null ? String(object.value) : '';
     return message;
   },
 
@@ -1416,16 +1301,8 @@ export const SimpleWithMap_IntLookupEntry = {
 
   fromJSON(object: any): SimpleWithMap_IntLookupEntry {
     const message = { ...baseSimpleWithMap_IntLookupEntry } as SimpleWithMap_IntLookupEntry;
-    if (object.key !== undefined && object.key !== null) {
-      message.key = Number(object.key);
-    } else {
-      message.key = 0;
-    }
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Number(object.value);
-    } else {
-      message.value = 0;
-    }
+    message.key = object.key !== undefined && object.key !== null ? Number(object.key) : 0;
+    message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
 
@@ -1480,16 +1357,8 @@ export const SimpleWithMap_MapOfTimestampsEntry = {
 
   fromJSON(object: any): SimpleWithMap_MapOfTimestampsEntry {
     const message = { ...baseSimpleWithMap_MapOfTimestampsEntry } as SimpleWithMap_MapOfTimestampsEntry;
-    if (object.key !== undefined && object.key !== null) {
-      message.key = String(object.key);
-    } else {
-      message.key = '';
-    }
-    if (object.value !== undefined && object.value !== null) {
-      message.value = fromJsonTimestamp(object.value);
-    } else {
-      message.value = undefined;
-    }
+    message.key = object.key !== undefined && object.key !== null ? String(object.key) : '';
+    message.value = object.value !== undefined && object.value !== null ? fromJsonTimestamp(object.value) : undefined;
     return message;
   },
 
@@ -1545,16 +1414,9 @@ export const SimpleWithMap_MapOfBytesEntry = {
 
   fromJSON(object: any): SimpleWithMap_MapOfBytesEntry {
     const message = { ...baseSimpleWithMap_MapOfBytesEntry } as SimpleWithMap_MapOfBytesEntry;
-    if (object.key !== undefined && object.key !== null) {
-      message.key = String(object.key);
-    } else {
-      message.key = '';
-    }
-    if (object.value !== undefined && object.value !== null) {
-      message.value = bytesFromBase64(object.value);
-    } else {
-      message.value = new Uint8Array();
-    }
+    message.key = object.key !== undefined && object.key !== null ? String(object.key) : '';
+    message.value =
+      object.value !== undefined && object.value !== null ? bytesFromBase64(object.value) : new Uint8Array();
     return message;
   },
 
@@ -1610,16 +1472,8 @@ export const SimpleWithMap_MapOfStringValuesEntry = {
 
   fromJSON(object: any): SimpleWithMap_MapOfStringValuesEntry {
     const message = { ...baseSimpleWithMap_MapOfStringValuesEntry } as SimpleWithMap_MapOfStringValuesEntry;
-    if (object.key !== undefined && object.key !== null) {
-      message.key = String(object.key);
-    } else {
-      message.key = '';
-    }
-    if (object.value !== undefined && object.value !== null) {
-      message.value = String(object.value);
-    } else {
-      message.value = undefined;
-    }
+    message.key = object.key !== undefined && object.key !== null ? String(object.key) : '';
+    message.value = object.value !== undefined && object.value !== null ? String(object.value) : undefined;
     return message;
   },
 
@@ -1742,16 +1596,8 @@ export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
 
   fromJSON(object: any): SimpleWithSnakeCaseMap_EntitiesByIdEntry {
     const message = { ...baseSimpleWithSnakeCaseMap_EntitiesByIdEntry } as SimpleWithSnakeCaseMap_EntitiesByIdEntry;
-    if (object.key !== undefined && object.key !== null) {
-      message.key = Number(object.key);
-    } else {
-      message.key = 0;
-    }
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Entity.fromJSON(object.value);
-    } else {
-      message.value = undefined;
-    }
+    message.key = object.key !== undefined && object.key !== null ? Number(object.key) : 0;
+    message.value = object.value !== undefined && object.value !== null ? Entity.fromJSON(object.value) : undefined;
     return message;
   },
 
@@ -1765,11 +1611,7 @@ export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
   fromPartial(object: DeepPartial<SimpleWithSnakeCaseMap_EntitiesByIdEntry>): SimpleWithSnakeCaseMap_EntitiesByIdEntry {
     const message = { ...baseSimpleWithSnakeCaseMap_EntitiesByIdEntry } as SimpleWithSnakeCaseMap_EntitiesByIdEntry;
     message.key = object.key ?? 0;
-    if (object.value !== undefined && object.value !== null) {
-      message.value = Entity.fromPartial(object.value);
-    } else {
-      message.value = undefined;
-    }
+    message.value = object.value !== undefined && object.value !== null ? Entity.fromPartial(object.value) : undefined;
     return message;
   },
 };
@@ -1878,16 +1720,8 @@ export const SimpleWithMapOfEnums_EnumsByIdEntry = {
 
   fromJSON(object: any): SimpleWithMapOfEnums_EnumsByIdEntry {
     const message = { ...baseSimpleWithMapOfEnums_EnumsByIdEntry } as SimpleWithMapOfEnums_EnumsByIdEntry;
-    if (object.key !== undefined && object.key !== null) {
-      message.key = Number(object.key);
-    } else {
-      message.key = 0;
-    }
-    if (object.value !== undefined && object.value !== null) {
-      message.value = stateEnumFromJSON(object.value);
-    } else {
-      message.value = 0;
-    }
+    message.key = object.key !== undefined && object.key !== null ? Number(object.key) : 0;
+    message.value = object.value !== undefined && object.value !== null ? stateEnumFromJSON(object.value) : 0;
     return message;
   },
 
@@ -1936,11 +1770,7 @@ export const PingRequest = {
 
   fromJSON(object: any): PingRequest {
     const message = { ...basePingRequest } as PingRequest;
-    if (object.input !== undefined && object.input !== null) {
-      message.input = String(object.input);
-    } else {
-      message.input = '';
-    }
+    message.input = object.input !== undefined && object.input !== null ? String(object.input) : '';
     return message;
   },
 
@@ -1987,11 +1817,7 @@ export const PingResponse = {
 
   fromJSON(object: any): PingResponse {
     const message = { ...basePingResponse } as PingResponse;
-    if (object.output !== undefined && object.output !== null) {
-      message.output = String(object.output);
-    } else {
-      message.output = '';
-    }
+    message.output = object.output !== undefined && object.output !== null ? String(object.output) : '';
     return message;
   },
 
@@ -2117,66 +1943,18 @@ export const Numbers = {
 
   fromJSON(object: any): Numbers {
     const message = { ...baseNumbers } as Numbers;
-    if (object.double !== undefined && object.double !== null) {
-      message.double = Number(object.double);
-    } else {
-      message.double = 0;
-    }
-    if (object.float !== undefined && object.float !== null) {
-      message.float = Number(object.float);
-    } else {
-      message.float = 0;
-    }
-    if (object.int32 !== undefined && object.int32 !== null) {
-      message.int32 = Number(object.int32);
-    } else {
-      message.int32 = 0;
-    }
-    if (object.int64 !== undefined && object.int64 !== null) {
-      message.int64 = Number(object.int64);
-    } else {
-      message.int64 = 0;
-    }
-    if (object.uint32 !== undefined && object.uint32 !== null) {
-      message.uint32 = Number(object.uint32);
-    } else {
-      message.uint32 = 0;
-    }
-    if (object.uint64 !== undefined && object.uint64 !== null) {
-      message.uint64 = Number(object.uint64);
-    } else {
-      message.uint64 = 0;
-    }
-    if (object.sint32 !== undefined && object.sint32 !== null) {
-      message.sint32 = Number(object.sint32);
-    } else {
-      message.sint32 = 0;
-    }
-    if (object.sint64 !== undefined && object.sint64 !== null) {
-      message.sint64 = Number(object.sint64);
-    } else {
-      message.sint64 = 0;
-    }
-    if (object.fixed32 !== undefined && object.fixed32 !== null) {
-      message.fixed32 = Number(object.fixed32);
-    } else {
-      message.fixed32 = 0;
-    }
-    if (object.fixed64 !== undefined && object.fixed64 !== null) {
-      message.fixed64 = Number(object.fixed64);
-    } else {
-      message.fixed64 = 0;
-    }
-    if (object.sfixed32 !== undefined && object.sfixed32 !== null) {
-      message.sfixed32 = Number(object.sfixed32);
-    } else {
-      message.sfixed32 = 0;
-    }
-    if (object.sfixed64 !== undefined && object.sfixed64 !== null) {
-      message.sfixed64 = Number(object.sfixed64);
-    } else {
-      message.sfixed64 = 0;
-    }
+    message.double = object.double !== undefined && object.double !== null ? Number(object.double) : 0;
+    message.float = object.float !== undefined && object.float !== null ? Number(object.float) : 0;
+    message.int32 = object.int32 !== undefined && object.int32 !== null ? Number(object.int32) : 0;
+    message.int64 = object.int64 !== undefined && object.int64 !== null ? Number(object.int64) : 0;
+    message.uint32 = object.uint32 !== undefined && object.uint32 !== null ? Number(object.uint32) : 0;
+    message.uint64 = object.uint64 !== undefined && object.uint64 !== null ? Number(object.uint64) : 0;
+    message.sint32 = object.sint32 !== undefined && object.sint32 !== null ? Number(object.sint32) : 0;
+    message.sint64 = object.sint64 !== undefined && object.sint64 !== null ? Number(object.sint64) : 0;
+    message.fixed32 = object.fixed32 !== undefined && object.fixed32 !== null ? Number(object.fixed32) : 0;
+    message.fixed64 = object.fixed64 !== undefined && object.fixed64 !== null ? Number(object.fixed64) : 0;
+    message.sfixed32 = object.sfixed32 !== undefined && object.sfixed32 !== null ? Number(object.sfixed32) : 0;
+    message.sfixed64 = object.sfixed64 !== undefined && object.sfixed64 !== null ? Number(object.sfixed64) : 0;
     return message;
   },
 
@@ -2281,41 +2059,16 @@ export const SimpleButOptional = {
 
   fromJSON(object: any): SimpleButOptional {
     const message = { ...baseSimpleButOptional } as SimpleButOptional;
-    if (object.name !== undefined && object.name !== null) {
-      message.name = String(object.name);
-    } else {
-      message.name = undefined;
-    }
-    if (object.age !== undefined && object.age !== null) {
-      message.age = Number(object.age);
-    } else {
-      message.age = undefined;
-    }
-    if (object.createdAt !== undefined && object.createdAt !== null) {
-      message.createdAt = fromJsonTimestamp(object.createdAt);
-    } else {
-      message.createdAt = undefined;
-    }
-    if (object.child !== undefined && object.child !== null) {
-      message.child = Child.fromJSON(object.child);
-    } else {
-      message.child = undefined;
-    }
-    if (object.state !== undefined && object.state !== null) {
-      message.state = stateEnumFromJSON(object.state);
-    } else {
-      message.state = undefined;
-    }
-    if (object.thing !== undefined && object.thing !== null) {
-      message.thing = ImportedThing.fromJSON(object.thing);
-    } else {
-      message.thing = undefined;
-    }
-    if (object.birthday !== undefined && object.birthday !== null) {
-      message.birthday = DateMessage.fromJSON(object.birthday);
-    } else {
-      message.birthday = undefined;
-    }
+    message.name = object.name !== undefined && object.name !== null ? String(object.name) : undefined;
+    message.age = object.age !== undefined && object.age !== null ? Number(object.age) : undefined;
+    message.createdAt =
+      object.createdAt !== undefined && object.createdAt !== null ? fromJsonTimestamp(object.createdAt) : undefined;
+    message.child = object.child !== undefined && object.child !== null ? Child.fromJSON(object.child) : undefined;
+    message.state = object.state !== undefined && object.state !== null ? stateEnumFromJSON(object.state) : undefined;
+    message.thing =
+      object.thing !== undefined && object.thing !== null ? ImportedThing.fromJSON(object.thing) : undefined;
+    message.birthday =
+      object.birthday !== undefined && object.birthday !== null ? DateMessage.fromJSON(object.birthday) : undefined;
     return message;
   },
 
@@ -2338,22 +2091,12 @@ export const SimpleButOptional = {
     message.name = object.name ?? undefined;
     message.age = object.age ?? undefined;
     message.createdAt = object.createdAt ?? undefined;
-    if (object.child !== undefined && object.child !== null) {
-      message.child = Child.fromPartial(object.child);
-    } else {
-      message.child = undefined;
-    }
+    message.child = object.child !== undefined && object.child !== null ? Child.fromPartial(object.child) : undefined;
     message.state = object.state ?? undefined;
-    if (object.thing !== undefined && object.thing !== null) {
-      message.thing = ImportedThing.fromPartial(object.thing);
-    } else {
-      message.thing = undefined;
-    }
-    if (object.birthday !== undefined && object.birthday !== null) {
-      message.birthday = DateMessage.fromPartial(object.birthday);
-    } else {
-      message.birthday = undefined;
-    }
+    message.thing =
+      object.thing !== undefined && object.thing !== null ? ImportedThing.fromPartial(object.thing) : undefined;
+    message.birthday =
+      object.birthday !== undefined && object.birthday !== null ? DateMessage.fromPartial(object.birthday) : undefined;
     return message;
   },
 };

--- a/integration/type-registry/bar/bar.ts
+++ b/integration/type-registry/bar/bar.ts
@@ -43,11 +43,7 @@ export const Bar = {
 
   fromJSON(object: any): Bar {
     const message = { ...baseBar } as Bar;
-    if (object.foo !== undefined && object.foo !== null) {
-      message.foo = Foo.fromJSON(object.foo);
-    } else {
-      message.foo = undefined;
-    }
+    message.foo = object.foo !== undefined && object.foo !== null ? Foo.fromJSON(object.foo) : undefined;
     return message;
   },
 
@@ -59,11 +55,7 @@ export const Bar = {
 
   fromPartial(object: DeepPartial<Bar>): Bar {
     const message = { ...baseBar } as Bar;
-    if (object.foo !== undefined && object.foo !== null) {
-      message.foo = Foo.fromPartial(object.foo);
-    } else {
-      message.foo = undefined;
-    }
+    message.foo = object.foo !== undefined && object.foo !== null ? Foo.fromPartial(object.foo) : undefined;
     return message;
   },
 };

--- a/integration/type-registry/foo.ts
+++ b/integration/type-registry/foo.ts
@@ -48,11 +48,8 @@ export const Foo = {
 
   fromJSON(object: any): Foo {
     const message = { ...baseFoo } as Foo;
-    if (object.timestamp !== undefined && object.timestamp !== null) {
-      message.timestamp = fromJsonTimestamp(object.timestamp);
-    } else {
-      message.timestamp = undefined;
-    }
+    message.timestamp =
+      object.timestamp !== undefined && object.timestamp !== null ? fromJsonTimestamp(object.timestamp) : undefined;
     return message;
   },
 
@@ -103,11 +100,8 @@ export const Foo2 = {
 
   fromJSON(object: any): Foo2 {
     const message = { ...baseFoo2 } as Foo2;
-    if (object.timestamp !== undefined && object.timestamp !== null) {
-      message.timestamp = fromJsonTimestamp(object.timestamp);
-    } else {
-      message.timestamp = undefined;
-    }
+    message.timestamp =
+      object.timestamp !== undefined && object.timestamp !== null ? fromJsonTimestamp(object.timestamp) : undefined;
     return message;
   },
 

--- a/integration/type-registry/google/protobuf/timestamp.ts
+++ b/integration/type-registry/google/protobuf/timestamp.ts
@@ -144,16 +144,8 @@ export const Timestamp = {
 
   fromJSON(object: any): Timestamp {
     const message = { ...baseTimestamp } as Timestamp;
-    if (object.seconds !== undefined && object.seconds !== null) {
-      message.seconds = Number(object.seconds);
-    } else {
-      message.seconds = 0;
-    }
-    if (object.nanos !== undefined && object.nanos !== null) {
-      message.nanos = Number(object.nanos);
-    } else {
-      message.nanos = 0;
-    }
+    message.seconds = object.seconds !== undefined && object.seconds !== null ? Number(object.seconds) : 0;
+    message.nanos = object.nanos !== undefined && object.nanos !== null ? Number(object.nanos) : 0;
     return message;
   },
 

--- a/integration/types-with-underscores/file.ts
+++ b/integration/types-with-underscores/file.ts
@@ -40,11 +40,7 @@ export const Baz = {
 
   fromJSON(object: any): Baz {
     const message = { ...baseBaz } as Baz;
-    if (object.foo !== undefined && object.foo !== null) {
-      message.foo = FooBar.fromJSON(object.foo);
-    } else {
-      message.foo = undefined;
-    }
+    message.foo = object.foo !== undefined && object.foo !== null ? FooBar.fromJSON(object.foo) : undefined;
     return message;
   },
 
@@ -56,11 +52,7 @@ export const Baz = {
 
   fromPartial(object: DeepPartial<Baz>): Baz {
     const message = { ...baseBaz } as Baz;
-    if (object.foo !== undefined && object.foo !== null) {
-      message.foo = FooBar.fromPartial(object.foo);
-    } else {
-      message.foo = undefined;
-    }
+    message.foo = object.foo !== undefined && object.foo !== null ? FooBar.fromPartial(object.foo) : undefined;
     return message;
   },
 };

--- a/integration/use-date-false/google/protobuf/timestamp.ts
+++ b/integration/use-date-false/google/protobuf/timestamp.ts
@@ -140,16 +140,8 @@ export const Timestamp = {
 
   fromJSON(object: any): Timestamp {
     const message = { ...baseTimestamp } as Timestamp;
-    if (object.seconds !== undefined && object.seconds !== null) {
-      message.seconds = Number(object.seconds);
-    } else {
-      message.seconds = 0;
-    }
-    if (object.nanos !== undefined && object.nanos !== null) {
-      message.nanos = Number(object.nanos);
-    } else {
-      message.nanos = 0;
-    }
+    message.seconds = object.seconds !== undefined && object.seconds !== null ? Number(object.seconds) : 0;
+    message.nanos = object.nanos !== undefined && object.nanos !== null ? Number(object.nanos) : 0;
     return message;
   },
 

--- a/integration/use-date-false/metadata.ts
+++ b/integration/use-date-false/metadata.ts
@@ -39,11 +39,8 @@ export const Metadata = {
 
   fromJSON(object: any): Metadata {
     const message = { ...baseMetadata } as Metadata;
-    if (object.lastEdited !== undefined && object.lastEdited !== null) {
-      message.lastEdited = fromJsonTimestamp(object.lastEdited);
-    } else {
-      message.lastEdited = undefined;
-    }
+    message.lastEdited =
+      object.lastEdited !== undefined && object.lastEdited !== null ? fromJsonTimestamp(object.lastEdited) : undefined;
     return message;
   },
 
@@ -55,11 +52,10 @@ export const Metadata = {
 
   fromPartial(object: DeepPartial<Metadata>): Metadata {
     const message = { ...baseMetadata } as Metadata;
-    if (object.lastEdited !== undefined && object.lastEdited !== null) {
-      message.lastEdited = Timestamp.fromPartial(object.lastEdited);
-    } else {
-      message.lastEdited = undefined;
-    }
+    message.lastEdited =
+      object.lastEdited !== undefined && object.lastEdited !== null
+        ? Timestamp.fromPartial(object.lastEdited)
+        : undefined;
     return message;
   },
 };

--- a/integration/use-date-string/google/protobuf/timestamp.ts
+++ b/integration/use-date-string/google/protobuf/timestamp.ts
@@ -140,16 +140,8 @@ export const Timestamp = {
 
   fromJSON(object: any): Timestamp {
     const message = { ...baseTimestamp } as Timestamp;
-    if (object.seconds !== undefined && object.seconds !== null) {
-      message.seconds = Number(object.seconds);
-    } else {
-      message.seconds = 0;
-    }
-    if (object.nanos !== undefined && object.nanos !== null) {
-      message.nanos = Number(object.nanos);
-    } else {
-      message.nanos = 0;
-    }
+    message.seconds = object.seconds !== undefined && object.seconds !== null ? Number(object.seconds) : 0;
+    message.nanos = object.nanos !== undefined && object.nanos !== null ? Number(object.nanos) : 0;
     return message;
   },
 

--- a/integration/use-date-string/use-date-string.ts
+++ b/integration/use-date-string/use-date-string.ts
@@ -77,22 +77,14 @@ export const Todo = {
 
   fromJSON(object: any): Todo {
     const message = { ...baseTodo } as Todo;
-    if (object.id !== undefined && object.id !== null) {
-      message.id = String(object.id);
-    } else {
-      message.id = '';
-    }
-    if (object.timestamp !== undefined && object.timestamp !== null) {
-      message.timestamp = String(object.timestamp);
-    } else {
-      message.timestamp = undefined;
-    }
+    message.id = object.id !== undefined && object.id !== null ? String(object.id) : '';
+    message.timestamp =
+      object.timestamp !== undefined && object.timestamp !== null ? String(object.timestamp) : undefined;
     message.repeatedTimestamp = (object.repeatedTimestamp ?? []).map((e: any) => String(e));
-    if (object.optionalTimestamp !== undefined && object.optionalTimestamp !== null) {
-      message.optionalTimestamp = String(object.optionalTimestamp);
-    } else {
-      message.optionalTimestamp = undefined;
-    }
+    message.optionalTimestamp =
+      object.optionalTimestamp !== undefined && object.optionalTimestamp !== null
+        ? String(object.optionalTimestamp)
+        : undefined;
     message.mapOfTimestamps = {};
     if (object.mapOfTimestamps !== undefined && object.mapOfTimestamps !== null) {
       Object.entries(object.mapOfTimestamps).forEach(([key, value]) => {
@@ -175,16 +167,8 @@ export const Todo_MapOfTimestampsEntry = {
 
   fromJSON(object: any): Todo_MapOfTimestampsEntry {
     const message = { ...baseTodo_MapOfTimestampsEntry } as Todo_MapOfTimestampsEntry;
-    if (object.key !== undefined && object.key !== null) {
-      message.key = String(object.key);
-    } else {
-      message.key = '';
-    }
-    if (object.value !== undefined && object.value !== null) {
-      message.value = String(object.value);
-    } else {
-      message.value = undefined;
-    }
+    message.key = object.key !== undefined && object.key !== null ? String(object.key) : '';
+    message.value = object.value !== undefined && object.value !== null ? String(object.value) : undefined;
     return message;
   },
 

--- a/integration/use-date-true/google/protobuf/timestamp.ts
+++ b/integration/use-date-true/google/protobuf/timestamp.ts
@@ -140,16 +140,8 @@ export const Timestamp = {
 
   fromJSON(object: any): Timestamp {
     const message = { ...baseTimestamp } as Timestamp;
-    if (object.seconds !== undefined && object.seconds !== null) {
-      message.seconds = Number(object.seconds);
-    } else {
-      message.seconds = 0;
-    }
-    if (object.nanos !== undefined && object.nanos !== null) {
-      message.nanos = Number(object.nanos);
-    } else {
-      message.nanos = 0;
-    }
+    message.seconds = object.seconds !== undefined && object.seconds !== null ? Number(object.seconds) : 0;
+    message.nanos = object.nanos !== undefined && object.nanos !== null ? Number(object.nanos) : 0;
     return message;
   },
 

--- a/integration/use-date-true/use-date-true.ts
+++ b/integration/use-date-true/use-date-true.ts
@@ -77,22 +77,14 @@ export const Todo = {
 
   fromJSON(object: any): Todo {
     const message = { ...baseTodo } as Todo;
-    if (object.id !== undefined && object.id !== null) {
-      message.id = String(object.id);
-    } else {
-      message.id = '';
-    }
-    if (object.timestamp !== undefined && object.timestamp !== null) {
-      message.timestamp = fromJsonTimestamp(object.timestamp);
-    } else {
-      message.timestamp = undefined;
-    }
+    message.id = object.id !== undefined && object.id !== null ? String(object.id) : '';
+    message.timestamp =
+      object.timestamp !== undefined && object.timestamp !== null ? fromJsonTimestamp(object.timestamp) : undefined;
     message.repeatedTimestamp = (object.repeatedTimestamp ?? []).map((e: any) => fromJsonTimestamp(e));
-    if (object.optionalTimestamp !== undefined && object.optionalTimestamp !== null) {
-      message.optionalTimestamp = fromJsonTimestamp(object.optionalTimestamp);
-    } else {
-      message.optionalTimestamp = undefined;
-    }
+    message.optionalTimestamp =
+      object.optionalTimestamp !== undefined && object.optionalTimestamp !== null
+        ? fromJsonTimestamp(object.optionalTimestamp)
+        : undefined;
     message.mapOfTimestamps = {};
     if (object.mapOfTimestamps !== undefined && object.mapOfTimestamps !== null) {
       Object.entries(object.mapOfTimestamps).forEach(([key, value]) => {
@@ -175,16 +167,8 @@ export const Todo_MapOfTimestampsEntry = {
 
   fromJSON(object: any): Todo_MapOfTimestampsEntry {
     const message = { ...baseTodo_MapOfTimestampsEntry } as Todo_MapOfTimestampsEntry;
-    if (object.key !== undefined && object.key !== null) {
-      message.key = String(object.key);
-    } else {
-      message.key = '';
-    }
-    if (object.value !== undefined && object.value !== null) {
-      message.value = fromJsonTimestamp(object.value);
-    } else {
-      message.value = undefined;
-    }
+    message.key = object.key !== undefined && object.key !== null ? String(object.key) : '';
+    message.value = object.value !== undefined && object.value !== null ? fromJsonTimestamp(object.value) : undefined;
     return message;
   },
 

--- a/integration/vector-tile/vector_tile.ts
+++ b/integration/vector-tile/vector_tile.ts
@@ -204,41 +204,15 @@ export const Tile_Value = {
 
   fromJSON(object: any): Tile_Value {
     const message = { ...baseTile_Value } as Tile_Value;
-    if (object.stringValue !== undefined && object.stringValue !== null) {
-      message.stringValue = String(object.stringValue);
-    } else {
-      message.stringValue = '';
-    }
-    if (object.floatValue !== undefined && object.floatValue !== null) {
-      message.floatValue = Number(object.floatValue);
-    } else {
-      message.floatValue = 0;
-    }
-    if (object.doubleValue !== undefined && object.doubleValue !== null) {
-      message.doubleValue = Number(object.doubleValue);
-    } else {
-      message.doubleValue = 0;
-    }
-    if (object.intValue !== undefined && object.intValue !== null) {
-      message.intValue = Number(object.intValue);
-    } else {
-      message.intValue = 0;
-    }
-    if (object.uintValue !== undefined && object.uintValue !== null) {
-      message.uintValue = Number(object.uintValue);
-    } else {
-      message.uintValue = 0;
-    }
-    if (object.sintValue !== undefined && object.sintValue !== null) {
-      message.sintValue = Number(object.sintValue);
-    } else {
-      message.sintValue = 0;
-    }
-    if (object.boolValue !== undefined && object.boolValue !== null) {
-      message.boolValue = Boolean(object.boolValue);
-    } else {
-      message.boolValue = false;
-    }
+    message.stringValue =
+      object.stringValue !== undefined && object.stringValue !== null ? String(object.stringValue) : '';
+    message.floatValue = object.floatValue !== undefined && object.floatValue !== null ? Number(object.floatValue) : 0;
+    message.doubleValue =
+      object.doubleValue !== undefined && object.doubleValue !== null ? Number(object.doubleValue) : 0;
+    message.intValue = object.intValue !== undefined && object.intValue !== null ? Number(object.intValue) : 0;
+    message.uintValue = object.uintValue !== undefined && object.uintValue !== null ? Number(object.uintValue) : 0;
+    message.sintValue = object.sintValue !== undefined && object.sintValue !== null ? Number(object.sintValue) : 0;
+    message.boolValue = object.boolValue !== undefined && object.boolValue !== null ? Boolean(object.boolValue) : false;
     return message;
   },
 
@@ -335,17 +309,9 @@ export const Tile_Feature = {
 
   fromJSON(object: any): Tile_Feature {
     const message = { ...baseTile_Feature } as Tile_Feature;
-    if (object.id !== undefined && object.id !== null) {
-      message.id = Number(object.id);
-    } else {
-      message.id = 0;
-    }
+    message.id = object.id !== undefined && object.id !== null ? Number(object.id) : 0;
     message.tags = (object.tags ?? []).map((e: any) => Number(e));
-    if (object.type !== undefined && object.type !== null) {
-      message.type = tile_GeomTypeFromJSON(object.type);
-    } else {
-      message.type = 0;
-    }
+    message.type = object.type !== undefined && object.type !== null ? tile_GeomTypeFromJSON(object.type) : 0;
     message.geometry = (object.geometry ?? []).map((e: any) => Number(e));
     return message;
   },
@@ -440,24 +406,12 @@ export const Tile_Layer = {
 
   fromJSON(object: any): Tile_Layer {
     const message = { ...baseTile_Layer } as Tile_Layer;
-    if (object.version !== undefined && object.version !== null) {
-      message.version = Number(object.version);
-    } else {
-      message.version = 0;
-    }
-    if (object.name !== undefined && object.name !== null) {
-      message.name = String(object.name);
-    } else {
-      message.name = '';
-    }
+    message.version = object.version !== undefined && object.version !== null ? Number(object.version) : 0;
+    message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
     message.features = (object.features ?? []).map((e: any) => Tile_Feature.fromJSON(e));
     message.keys = (object.keys ?? []).map((e: any) => String(e));
     message.values = (object.values ?? []).map((e: any) => Tile_Value.fromJSON(e));
-    if (object.extent !== undefined && object.extent !== null) {
-      message.extent = Number(object.extent);
-    } else {
-      message.extent = 0;
-    }
+    message.extent = object.extent !== undefined && object.extent !== null ? Number(object.extent) : 0;
     return message;
   },
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1212,11 +1212,7 @@ function generateFromPartial(ctx: Context, fullName: string, messageDesc: Descri
       const fallback = isWithinOneOf(field) ? 'undefined' : defaultValue(ctx, field);
       chunks.push(code`message.${fieldName} = ${fallback}`);
       chunks.push(code`}`);
-    } else if (
-      isPrimitive(field) ||
-      (isTimestamp(field) && (options.useDate === DateOption.DATE || options.useDate === DateOption.STRING)) ||
-      isValueType(ctx, field)
-    ) {
+    } else if (readSnippet(`x`).toCodeString() == 'x') {
       // An optimized case of the else below that works when `readSnippet` returns the plain input
       const fallback = isWithinOneOf(field) ? 'undefined' : defaultValue(ctx, field);
       chunks.push(code`message.${fieldName} = object.${fieldName} ?? ${fallback};`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1007,12 +1007,12 @@ function generateFromJson(ctx: Context, fullName: string, messageDesc: Descripto
       `);
       chunks.push(code`}`);
     } else {
-      chunks.push(code`if (object.${fieldName} !== undefined && object.${fieldName} !== null) {`);
-      chunks.push(code`message.${fieldName} = ${readSnippet(`object.${fieldName}`)};`);
-      chunks.push(code`} else {`);
       const fallback = isWithinOneOf(field) ? 'undefined' : defaultValue(ctx, field);
-      chunks.push(code`message.${fieldName} = ${fallback};`);
-      chunks.push(code`}`);
+      chunks.push(code`
+        message.${fieldName} = (object.${fieldName} !== undefined && object.${fieldName} !== null)
+          ? ${readSnippet(`object.${fieldName}`)}
+          : ${fallback};
+      `);
     }
   });
   // and then wrap up the switch/while/return
@@ -1217,12 +1217,12 @@ function generateFromPartial(ctx: Context, fullName: string, messageDesc: Descri
       const fallback = isWithinOneOf(field) ? 'undefined' : defaultValue(ctx, field);
       chunks.push(code`message.${fieldName} = object.${fieldName} ?? ${fallback};`);
     } else {
-      chunks.push(code`if (object.${fieldName} !== undefined && object.${fieldName} !== null) {`);
-      chunks.push(code`message.${fieldName} = ${readSnippet(`object.${fieldName}`)};`);
-      chunks.push(code`} else {`);
       const fallback = isWithinOneOf(field) ? 'undefined' : defaultValue(ctx, field);
-      chunks.push(code`message.${fieldName} = ${fallback};`);
-      chunks.push(code`}`);
+      chunks.push(code`
+        message.${fieldName} = (object.${fieldName} !== undefined && object.${fieldName} !== null)
+          ? ${readSnippet(`object.${fieldName}`)}
+          : ${fallback};
+      `);
     }
   });
 


### PR DESCRIPTION
That's the second step initially proposed in https://github.com/stephenh/ts-proto/issues/371. In cases where the input value needs to be transformed, we [cannot use nullish coalescing](https://stackoverflow.com/questions/69696665/optional-chaining-with-free-functins) or anything new and fancy.

This improves the code output in two ways:
- Less code (that ultimatly reduces the app bundle size for the end user)
- Exactly one assignment per field which I find easier to reason about