### PR TITLE
feat: Improve map reading (fromJSON/fromPartial)

### DIFF
--- a/integration/batching-with-context/batching.ts
+++ b/integration/batching-with-context/batching.ts
@@ -236,10 +236,10 @@ export const BatchMapQueryResponse = {
 
   fromJSON(object: any): BatchMapQueryResponse {
     const message = { ...baseBatchMapQueryResponse } as BatchMapQueryResponse;
-    message.entities = {};
-    Object.entries(object.entities ?? {}).forEach(([key, value]) => {
-      message.entities[key] = Entity.fromJSON(value);
-    });
+    message.entities = Object.entries(object.entities ?? {}).reduce<{ [key: string]: Entity }>((acc, [key, value]) => {
+      acc[key] = Entity.fromJSON(value);
+      return acc;
+    }, {});
     return message;
   },
 
@@ -256,12 +256,12 @@ export const BatchMapQueryResponse = {
 
   fromPartial(object: DeepPartial<BatchMapQueryResponse>): BatchMapQueryResponse {
     const message = { ...baseBatchMapQueryResponse } as BatchMapQueryResponse;
-    message.entities = {};
-    Object.entries(object.entities ?? {}).forEach(([key, value]) => {
+    message.entities = Object.entries(object.entities ?? {}).reduce<{ [key: string]: Entity }>((acc, [key, value]) => {
       if (value !== undefined) {
-        message.entities[key] = Entity.fromPartial(value);
+        acc[key] = Entity.fromPartial(value);
       }
-    });
+      return acc;
+    }, {});
     return message;
   },
 };

--- a/integration/batching-with-context/batching.ts
+++ b/integration/batching-with-context/batching.ts
@@ -237,11 +237,9 @@ export const BatchMapQueryResponse = {
   fromJSON(object: any): BatchMapQueryResponse {
     const message = { ...baseBatchMapQueryResponse } as BatchMapQueryResponse;
     message.entities = {};
-    if (object.entities !== undefined && object.entities !== null) {
-      Object.entries(object.entities).forEach(([key, value]) => {
-        message.entities[key] = Entity.fromJSON(value);
-      });
-    }
+    Object.entries(object.entities ?? {}).forEach(([key, value]) => {
+      message.entities[key] = Entity.fromJSON(value);
+    });
     return message;
   },
 
@@ -259,13 +257,11 @@ export const BatchMapQueryResponse = {
   fromPartial(object: DeepPartial<BatchMapQueryResponse>): BatchMapQueryResponse {
     const message = { ...baseBatchMapQueryResponse } as BatchMapQueryResponse;
     message.entities = {};
-    if (object.entities !== undefined && object.entities !== null) {
-      Object.entries(object.entities).forEach(([key, value]) => {
-        if (value !== undefined) {
-          message.entities[key] = Entity.fromPartial(value);
-        }
-      });
-    }
+    Object.entries(object.entities ?? {}).forEach(([key, value]) => {
+      if (value !== undefined) {
+        message.entities[key] = Entity.fromPartial(value);
+      }
+    });
     return message;
   },
 };

--- a/integration/batching/batching.ts
+++ b/integration/batching/batching.ts
@@ -234,10 +234,10 @@ export const BatchMapQueryResponse = {
 
   fromJSON(object: any): BatchMapQueryResponse {
     const message = { ...baseBatchMapQueryResponse } as BatchMapQueryResponse;
-    message.entities = {};
-    Object.entries(object.entities ?? {}).forEach(([key, value]) => {
-      message.entities[key] = Entity.fromJSON(value);
-    });
+    message.entities = Object.entries(object.entities ?? {}).reduce<{ [key: string]: Entity }>((acc, [key, value]) => {
+      acc[key] = Entity.fromJSON(value);
+      return acc;
+    }, {});
     return message;
   },
 
@@ -254,12 +254,12 @@ export const BatchMapQueryResponse = {
 
   fromPartial(object: DeepPartial<BatchMapQueryResponse>): BatchMapQueryResponse {
     const message = { ...baseBatchMapQueryResponse } as BatchMapQueryResponse;
-    message.entities = {};
-    Object.entries(object.entities ?? {}).forEach(([key, value]) => {
+    message.entities = Object.entries(object.entities ?? {}).reduce<{ [key: string]: Entity }>((acc, [key, value]) => {
       if (value !== undefined) {
-        message.entities[key] = Entity.fromPartial(value);
+        acc[key] = Entity.fromPartial(value);
       }
-    });
+      return acc;
+    }, {});
     return message;
   },
 };

--- a/integration/batching/batching.ts
+++ b/integration/batching/batching.ts
@@ -235,11 +235,9 @@ export const BatchMapQueryResponse = {
   fromJSON(object: any): BatchMapQueryResponse {
     const message = { ...baseBatchMapQueryResponse } as BatchMapQueryResponse;
     message.entities = {};
-    if (object.entities !== undefined && object.entities !== null) {
-      Object.entries(object.entities).forEach(([key, value]) => {
-        message.entities[key] = Entity.fromJSON(value);
-      });
-    }
+    Object.entries(object.entities ?? {}).forEach(([key, value]) => {
+      message.entities[key] = Entity.fromJSON(value);
+    });
     return message;
   },
 
@@ -257,13 +255,11 @@ export const BatchMapQueryResponse = {
   fromPartial(object: DeepPartial<BatchMapQueryResponse>): BatchMapQueryResponse {
     const message = { ...baseBatchMapQueryResponse } as BatchMapQueryResponse;
     message.entities = {};
-    if (object.entities !== undefined && object.entities !== null) {
-      Object.entries(object.entities).forEach(([key, value]) => {
-        if (value !== undefined) {
-          message.entities[key] = Entity.fromPartial(value);
-        }
-      });
-    }
+    Object.entries(object.entities ?? {}).forEach(([key, value]) => {
+      if (value !== undefined) {
+        message.entities[key] = Entity.fromPartial(value);
+      }
+    });
     return message;
   },
 };

--- a/integration/simple-long/simple.ts
+++ b/integration/simple-long/simple.ts
@@ -211,18 +211,27 @@ export const SimpleWithMap = {
 
   fromJSON(object: any): SimpleWithMap {
     const message = { ...baseSimpleWithMap } as SimpleWithMap;
-    message.nameLookup = {};
-    Object.entries(object.nameLookup ?? {}).forEach(([key, value]) => {
-      message.nameLookup[key] = String(value);
-    });
-    message.intLookup = {};
-    Object.entries(object.intLookup ?? {}).forEach(([key, value]) => {
-      message.intLookup[Number(key)] = Number(value);
-    });
-    message.longLookup = {};
-    Object.entries(object.longLookup ?? {}).forEach(([key, value]) => {
-      message.longLookup[key] = Long.fromString(value as string);
-    });
+    message.nameLookup = Object.entries(object.nameLookup ?? {}).reduce<{ [key: string]: string }>(
+      (acc, [key, value]) => {
+        acc[key] = String(value);
+        return acc;
+      },
+      {}
+    );
+    message.intLookup = Object.entries(object.intLookup ?? {}).reduce<{ [key: number]: number }>(
+      (acc, [key, value]) => {
+        acc[Number(key)] = Number(value);
+        return acc;
+      },
+      {}
+    );
+    message.longLookup = Object.entries(object.longLookup ?? {}).reduce<{ [key: string]: Long }>(
+      (acc, [key, value]) => {
+        acc[key] = Long.fromString(value as string);
+        return acc;
+      },
+      {}
+    );
     return message;
   },
 
@@ -251,24 +260,33 @@ export const SimpleWithMap = {
 
   fromPartial(object: DeepPartial<SimpleWithMap>): SimpleWithMap {
     const message = { ...baseSimpleWithMap } as SimpleWithMap;
-    message.nameLookup = {};
-    Object.entries(object.nameLookup ?? {}).forEach(([key, value]) => {
-      if (value !== undefined) {
-        message.nameLookup[key] = String(value);
-      }
-    });
-    message.intLookup = {};
-    Object.entries(object.intLookup ?? {}).forEach(([key, value]) => {
-      if (value !== undefined) {
-        message.intLookup[Number(key)] = Number(value);
-      }
-    });
-    message.longLookup = {};
-    Object.entries(object.longLookup ?? {}).forEach(([key, value]) => {
-      if (value !== undefined) {
-        message.longLookup[key] = Long.fromValue(value);
-      }
-    });
+    message.nameLookup = Object.entries(object.nameLookup ?? {}).reduce<{ [key: string]: string }>(
+      (acc, [key, value]) => {
+        if (value !== undefined) {
+          acc[key] = String(value);
+        }
+        return acc;
+      },
+      {}
+    );
+    message.intLookup = Object.entries(object.intLookup ?? {}).reduce<{ [key: number]: number }>(
+      (acc, [key, value]) => {
+        if (value !== undefined) {
+          acc[Number(key)] = Number(value);
+        }
+        return acc;
+      },
+      {}
+    );
+    message.longLookup = Object.entries(object.longLookup ?? {}).reduce<{ [key: string]: Long }>(
+      (acc, [key, value]) => {
+        if (value !== undefined) {
+          acc[key] = Long.fromValue(value);
+        }
+        return acc;
+      },
+      {}
+    );
     return message;
   },
 };

--- a/integration/simple-long/simple.ts
+++ b/integration/simple-long/simple.ts
@@ -212,23 +212,17 @@ export const SimpleWithMap = {
   fromJSON(object: any): SimpleWithMap {
     const message = { ...baseSimpleWithMap } as SimpleWithMap;
     message.nameLookup = {};
-    if (object.nameLookup !== undefined && object.nameLookup !== null) {
-      Object.entries(object.nameLookup).forEach(([key, value]) => {
-        message.nameLookup[key] = String(value);
-      });
-    }
+    Object.entries(object.nameLookup ?? {}).forEach(([key, value]) => {
+      message.nameLookup[key] = String(value);
+    });
     message.intLookup = {};
-    if (object.intLookup !== undefined && object.intLookup !== null) {
-      Object.entries(object.intLookup).forEach(([key, value]) => {
-        message.intLookup[Number(key)] = Number(value);
-      });
-    }
+    Object.entries(object.intLookup ?? {}).forEach(([key, value]) => {
+      message.intLookup[Number(key)] = Number(value);
+    });
     message.longLookup = {};
-    if (object.longLookup !== undefined && object.longLookup !== null) {
-      Object.entries(object.longLookup).forEach(([key, value]) => {
-        message.longLookup[key] = Long.fromString(value as string);
-      });
-    }
+    Object.entries(object.longLookup ?? {}).forEach(([key, value]) => {
+      message.longLookup[key] = Long.fromString(value as string);
+    });
     return message;
   },
 
@@ -258,29 +252,23 @@ export const SimpleWithMap = {
   fromPartial(object: DeepPartial<SimpleWithMap>): SimpleWithMap {
     const message = { ...baseSimpleWithMap } as SimpleWithMap;
     message.nameLookup = {};
-    if (object.nameLookup !== undefined && object.nameLookup !== null) {
-      Object.entries(object.nameLookup).forEach(([key, value]) => {
-        if (value !== undefined) {
-          message.nameLookup[key] = String(value);
-        }
-      });
-    }
+    Object.entries(object.nameLookup ?? {}).forEach(([key, value]) => {
+      if (value !== undefined) {
+        message.nameLookup[key] = String(value);
+      }
+    });
     message.intLookup = {};
-    if (object.intLookup !== undefined && object.intLookup !== null) {
-      Object.entries(object.intLookup).forEach(([key, value]) => {
-        if (value !== undefined) {
-          message.intLookup[Number(key)] = Number(value);
-        }
-      });
-    }
+    Object.entries(object.intLookup ?? {}).forEach(([key, value]) => {
+      if (value !== undefined) {
+        message.intLookup[Number(key)] = Number(value);
+      }
+    });
     message.longLookup = {};
-    if (object.longLookup !== undefined && object.longLookup !== null) {
-      Object.entries(object.longLookup).forEach(([key, value]) => {
-        if (value !== undefined) {
-          message.longLookup[key] = Long.fromValue(value);
-        }
-      });
-    }
+    Object.entries(object.longLookup ?? {}).forEach(([key, value]) => {
+      if (value !== undefined) {
+        message.longLookup[key] = Long.fromValue(value);
+      }
+    });
     return message;
   },
 };

--- a/integration/simple-optionals/simple.ts
+++ b/integration/simple-optionals/simple.ts
@@ -893,23 +893,17 @@ export const SimpleWithMap = {
   fromJSON(object: any): SimpleWithMap {
     const message = { ...baseSimpleWithMap } as SimpleWithMap;
     message.entitiesById = {};
-    if (object.entitiesById !== undefined && object.entitiesById !== null) {
-      Object.entries(object.entitiesById).forEach(([key, value]) => {
-        message.entitiesById[Number(key)] = Entity.fromJSON(value);
-      });
-    }
+    Object.entries(object.entitiesById ?? {}).forEach(([key, value]) => {
+      message.entitiesById[Number(key)] = Entity.fromJSON(value);
+    });
     message.nameLookup = {};
-    if (object.nameLookup !== undefined && object.nameLookup !== null) {
-      Object.entries(object.nameLookup).forEach(([key, value]) => {
-        message.nameLookup[key] = String(value);
-      });
-    }
+    Object.entries(object.nameLookup ?? {}).forEach(([key, value]) => {
+      message.nameLookup[key] = String(value);
+    });
     message.intLookup = {};
-    if (object.intLookup !== undefined && object.intLookup !== null) {
-      Object.entries(object.intLookup).forEach(([key, value]) => {
-        message.intLookup[Number(key)] = Number(value);
-      });
-    }
+    Object.entries(object.intLookup ?? {}).forEach(([key, value]) => {
+      message.intLookup[Number(key)] = Number(value);
+    });
     return message;
   },
 
@@ -939,29 +933,23 @@ export const SimpleWithMap = {
   fromPartial(object: DeepPartial<SimpleWithMap>): SimpleWithMap {
     const message = { ...baseSimpleWithMap } as SimpleWithMap;
     message.entitiesById = {};
-    if (object.entitiesById !== undefined && object.entitiesById !== null) {
-      Object.entries(object.entitiesById).forEach(([key, value]) => {
-        if (value !== undefined) {
-          message.entitiesById[Number(key)] = Entity.fromPartial(value);
-        }
-      });
-    }
+    Object.entries(object.entitiesById ?? {}).forEach(([key, value]) => {
+      if (value !== undefined) {
+        message.entitiesById[Number(key)] = Entity.fromPartial(value);
+      }
+    });
     message.nameLookup = {};
-    if (object.nameLookup !== undefined && object.nameLookup !== null) {
-      Object.entries(object.nameLookup).forEach(([key, value]) => {
-        if (value !== undefined) {
-          message.nameLookup[key] = String(value);
-        }
-      });
-    }
+    Object.entries(object.nameLookup ?? {}).forEach(([key, value]) => {
+      if (value !== undefined) {
+        message.nameLookup[key] = String(value);
+      }
+    });
     message.intLookup = {};
-    if (object.intLookup !== undefined && object.intLookup !== null) {
-      Object.entries(object.intLookup).forEach(([key, value]) => {
-        if (value !== undefined) {
-          message.intLookup[Number(key)] = Number(value);
-        }
-      });
-    }
+    Object.entries(object.intLookup ?? {}).forEach(([key, value]) => {
+      if (value !== undefined) {
+        message.intLookup[Number(key)] = Number(value);
+      }
+    });
     return message;
   },
 };
@@ -1169,11 +1157,9 @@ export const SimpleWithSnakeCaseMap = {
   fromJSON(object: any): SimpleWithSnakeCaseMap {
     const message = { ...baseSimpleWithSnakeCaseMap } as SimpleWithSnakeCaseMap;
     message.entitiesById = {};
-    if (object.entitiesById !== undefined && object.entitiesById !== null) {
-      Object.entries(object.entitiesById).forEach(([key, value]) => {
-        message.entitiesById[Number(key)] = Entity.fromJSON(value);
-      });
-    }
+    Object.entries(object.entitiesById ?? {}).forEach(([key, value]) => {
+      message.entitiesById[Number(key)] = Entity.fromJSON(value);
+    });
     return message;
   },
 
@@ -1191,13 +1177,11 @@ export const SimpleWithSnakeCaseMap = {
   fromPartial(object: DeepPartial<SimpleWithSnakeCaseMap>): SimpleWithSnakeCaseMap {
     const message = { ...baseSimpleWithSnakeCaseMap } as SimpleWithSnakeCaseMap;
     message.entitiesById = {};
-    if (object.entitiesById !== undefined && object.entitiesById !== null) {
-      Object.entries(object.entitiesById).forEach(([key, value]) => {
-        if (value !== undefined) {
-          message.entitiesById[Number(key)] = Entity.fromPartial(value);
-        }
-      });
-    }
+    Object.entries(object.entitiesById ?? {}).forEach(([key, value]) => {
+      if (value !== undefined) {
+        message.entitiesById[Number(key)] = Entity.fromPartial(value);
+      }
+    });
     return message;
   },
 };

--- a/integration/simple-optionals/simple.ts
+++ b/integration/simple-optionals/simple.ts
@@ -892,18 +892,27 @@ export const SimpleWithMap = {
 
   fromJSON(object: any): SimpleWithMap {
     const message = { ...baseSimpleWithMap } as SimpleWithMap;
-    message.entitiesById = {};
-    Object.entries(object.entitiesById ?? {}).forEach(([key, value]) => {
-      message.entitiesById[Number(key)] = Entity.fromJSON(value);
-    });
-    message.nameLookup = {};
-    Object.entries(object.nameLookup ?? {}).forEach(([key, value]) => {
-      message.nameLookup[key] = String(value);
-    });
-    message.intLookup = {};
-    Object.entries(object.intLookup ?? {}).forEach(([key, value]) => {
-      message.intLookup[Number(key)] = Number(value);
-    });
+    message.entitiesById = Object.entries(object.entitiesById ?? {}).reduce<{ [key: number]: Entity }>(
+      (acc, [key, value]) => {
+        acc[Number(key)] = Entity.fromJSON(value);
+        return acc;
+      },
+      {}
+    );
+    message.nameLookup = Object.entries(object.nameLookup ?? {}).reduce<{ [key: string]: string }>(
+      (acc, [key, value]) => {
+        acc[key] = String(value);
+        return acc;
+      },
+      {}
+    );
+    message.intLookup = Object.entries(object.intLookup ?? {}).reduce<{ [key: number]: number }>(
+      (acc, [key, value]) => {
+        acc[Number(key)] = Number(value);
+        return acc;
+      },
+      {}
+    );
     return message;
   },
 
@@ -932,24 +941,33 @@ export const SimpleWithMap = {
 
   fromPartial(object: DeepPartial<SimpleWithMap>): SimpleWithMap {
     const message = { ...baseSimpleWithMap } as SimpleWithMap;
-    message.entitiesById = {};
-    Object.entries(object.entitiesById ?? {}).forEach(([key, value]) => {
-      if (value !== undefined) {
-        message.entitiesById[Number(key)] = Entity.fromPartial(value);
-      }
-    });
-    message.nameLookup = {};
-    Object.entries(object.nameLookup ?? {}).forEach(([key, value]) => {
-      if (value !== undefined) {
-        message.nameLookup[key] = String(value);
-      }
-    });
-    message.intLookup = {};
-    Object.entries(object.intLookup ?? {}).forEach(([key, value]) => {
-      if (value !== undefined) {
-        message.intLookup[Number(key)] = Number(value);
-      }
-    });
+    message.entitiesById = Object.entries(object.entitiesById ?? {}).reduce<{ [key: number]: Entity }>(
+      (acc, [key, value]) => {
+        if (value !== undefined) {
+          acc[Number(key)] = Entity.fromPartial(value);
+        }
+        return acc;
+      },
+      {}
+    );
+    message.nameLookup = Object.entries(object.nameLookup ?? {}).reduce<{ [key: string]: string }>(
+      (acc, [key, value]) => {
+        if (value !== undefined) {
+          acc[key] = String(value);
+        }
+        return acc;
+      },
+      {}
+    );
+    message.intLookup = Object.entries(object.intLookup ?? {}).reduce<{ [key: number]: number }>(
+      (acc, [key, value]) => {
+        if (value !== undefined) {
+          acc[Number(key)] = Number(value);
+        }
+        return acc;
+      },
+      {}
+    );
     return message;
   },
 };
@@ -1156,10 +1174,13 @@ export const SimpleWithSnakeCaseMap = {
 
   fromJSON(object: any): SimpleWithSnakeCaseMap {
     const message = { ...baseSimpleWithSnakeCaseMap } as SimpleWithSnakeCaseMap;
-    message.entitiesById = {};
-    Object.entries(object.entitiesById ?? {}).forEach(([key, value]) => {
-      message.entitiesById[Number(key)] = Entity.fromJSON(value);
-    });
+    message.entitiesById = Object.entries(object.entitiesById ?? {}).reduce<{ [key: number]: Entity }>(
+      (acc, [key, value]) => {
+        acc[Number(key)] = Entity.fromJSON(value);
+        return acc;
+      },
+      {}
+    );
     return message;
   },
 
@@ -1176,12 +1197,15 @@ export const SimpleWithSnakeCaseMap = {
 
   fromPartial(object: DeepPartial<SimpleWithSnakeCaseMap>): SimpleWithSnakeCaseMap {
     const message = { ...baseSimpleWithSnakeCaseMap } as SimpleWithSnakeCaseMap;
-    message.entitiesById = {};
-    Object.entries(object.entitiesById ?? {}).forEach(([key, value]) => {
-      if (value !== undefined) {
-        message.entitiesById[Number(key)] = Entity.fromPartial(value);
-      }
-    });
+    message.entitiesById = Object.entries(object.entitiesById ?? {}).reduce<{ [key: number]: Entity }>(
+      (acc, [key, value]) => {
+        if (value !== undefined) {
+          acc[Number(key)] = Entity.fromPartial(value);
+        }
+        return acc;
+      },
+      {}
+    );
     return message;
   },
 };

--- a/integration/simple-snake/simple.ts
+++ b/integration/simple-snake/simple.ts
@@ -892,18 +892,27 @@ export const SimpleWithMap = {
 
   fromJSON(object: any): SimpleWithMap {
     const message = { ...baseSimpleWithMap } as SimpleWithMap;
-    message.entitiesById = {};
-    Object.entries(object.entitiesById ?? {}).forEach(([key, value]) => {
-      message.entitiesById[Number(key)] = Entity.fromJSON(value);
-    });
-    message.nameLookup = {};
-    Object.entries(object.nameLookup ?? {}).forEach(([key, value]) => {
-      message.nameLookup[key] = String(value);
-    });
-    message.intLookup = {};
-    Object.entries(object.intLookup ?? {}).forEach(([key, value]) => {
-      message.intLookup[Number(key)] = Number(value);
-    });
+    message.entitiesById = Object.entries(object.entitiesById ?? {}).reduce<{ [key: number]: Entity }>(
+      (acc, [key, value]) => {
+        acc[Number(key)] = Entity.fromJSON(value);
+        return acc;
+      },
+      {}
+    );
+    message.nameLookup = Object.entries(object.nameLookup ?? {}).reduce<{ [key: string]: string }>(
+      (acc, [key, value]) => {
+        acc[key] = String(value);
+        return acc;
+      },
+      {}
+    );
+    message.intLookup = Object.entries(object.intLookup ?? {}).reduce<{ [key: number]: number }>(
+      (acc, [key, value]) => {
+        acc[Number(key)] = Number(value);
+        return acc;
+      },
+      {}
+    );
     return message;
   },
 
@@ -932,24 +941,33 @@ export const SimpleWithMap = {
 
   fromPartial(object: DeepPartial<SimpleWithMap>): SimpleWithMap {
     const message = { ...baseSimpleWithMap } as SimpleWithMap;
-    message.entitiesById = {};
-    Object.entries(object.entitiesById ?? {}).forEach(([key, value]) => {
-      if (value !== undefined) {
-        message.entitiesById[Number(key)] = Entity.fromPartial(value);
-      }
-    });
-    message.nameLookup = {};
-    Object.entries(object.nameLookup ?? {}).forEach(([key, value]) => {
-      if (value !== undefined) {
-        message.nameLookup[key] = String(value);
-      }
-    });
-    message.intLookup = {};
-    Object.entries(object.intLookup ?? {}).forEach(([key, value]) => {
-      if (value !== undefined) {
-        message.intLookup[Number(key)] = Number(value);
-      }
-    });
+    message.entitiesById = Object.entries(object.entitiesById ?? {}).reduce<{ [key: number]: Entity }>(
+      (acc, [key, value]) => {
+        if (value !== undefined) {
+          acc[Number(key)] = Entity.fromPartial(value);
+        }
+        return acc;
+      },
+      {}
+    );
+    message.nameLookup = Object.entries(object.nameLookup ?? {}).reduce<{ [key: string]: string }>(
+      (acc, [key, value]) => {
+        if (value !== undefined) {
+          acc[key] = String(value);
+        }
+        return acc;
+      },
+      {}
+    );
+    message.intLookup = Object.entries(object.intLookup ?? {}).reduce<{ [key: number]: number }>(
+      (acc, [key, value]) => {
+        if (value !== undefined) {
+          acc[Number(key)] = Number(value);
+        }
+        return acc;
+      },
+      {}
+    );
     return message;
   },
 };
@@ -1156,10 +1174,13 @@ export const SimpleWithSnakeCaseMap = {
 
   fromJSON(object: any): SimpleWithSnakeCaseMap {
     const message = { ...baseSimpleWithSnakeCaseMap } as SimpleWithSnakeCaseMap;
-    message.entities_by_id = {};
-    Object.entries(object.entities_by_id ?? {}).forEach(([key, value]) => {
-      message.entities_by_id[Number(key)] = Entity.fromJSON(value);
-    });
+    message.entities_by_id = Object.entries(object.entities_by_id ?? {}).reduce<{ [key: number]: Entity }>(
+      (acc, [key, value]) => {
+        acc[Number(key)] = Entity.fromJSON(value);
+        return acc;
+      },
+      {}
+    );
     return message;
   },
 
@@ -1176,12 +1197,15 @@ export const SimpleWithSnakeCaseMap = {
 
   fromPartial(object: DeepPartial<SimpleWithSnakeCaseMap>): SimpleWithSnakeCaseMap {
     const message = { ...baseSimpleWithSnakeCaseMap } as SimpleWithSnakeCaseMap;
-    message.entities_by_id = {};
-    Object.entries(object.entities_by_id ?? {}).forEach(([key, value]) => {
-      if (value !== undefined) {
-        message.entities_by_id[Number(key)] = Entity.fromPartial(value);
-      }
-    });
+    message.entities_by_id = Object.entries(object.entities_by_id ?? {}).reduce<{ [key: number]: Entity }>(
+      (acc, [key, value]) => {
+        if (value !== undefined) {
+          acc[Number(key)] = Entity.fromPartial(value);
+        }
+        return acc;
+      },
+      {}
+    );
     return message;
   },
 };

--- a/integration/simple-snake/simple.ts
+++ b/integration/simple-snake/simple.ts
@@ -893,23 +893,17 @@ export const SimpleWithMap = {
   fromJSON(object: any): SimpleWithMap {
     const message = { ...baseSimpleWithMap } as SimpleWithMap;
     message.entitiesById = {};
-    if (object.entitiesById !== undefined && object.entitiesById !== null) {
-      Object.entries(object.entitiesById).forEach(([key, value]) => {
-        message.entitiesById[Number(key)] = Entity.fromJSON(value);
-      });
-    }
+    Object.entries(object.entitiesById ?? {}).forEach(([key, value]) => {
+      message.entitiesById[Number(key)] = Entity.fromJSON(value);
+    });
     message.nameLookup = {};
-    if (object.nameLookup !== undefined && object.nameLookup !== null) {
-      Object.entries(object.nameLookup).forEach(([key, value]) => {
-        message.nameLookup[key] = String(value);
-      });
-    }
+    Object.entries(object.nameLookup ?? {}).forEach(([key, value]) => {
+      message.nameLookup[key] = String(value);
+    });
     message.intLookup = {};
-    if (object.intLookup !== undefined && object.intLookup !== null) {
-      Object.entries(object.intLookup).forEach(([key, value]) => {
-        message.intLookup[Number(key)] = Number(value);
-      });
-    }
+    Object.entries(object.intLookup ?? {}).forEach(([key, value]) => {
+      message.intLookup[Number(key)] = Number(value);
+    });
     return message;
   },
 
@@ -939,29 +933,23 @@ export const SimpleWithMap = {
   fromPartial(object: DeepPartial<SimpleWithMap>): SimpleWithMap {
     const message = { ...baseSimpleWithMap } as SimpleWithMap;
     message.entitiesById = {};
-    if (object.entitiesById !== undefined && object.entitiesById !== null) {
-      Object.entries(object.entitiesById).forEach(([key, value]) => {
-        if (value !== undefined) {
-          message.entitiesById[Number(key)] = Entity.fromPartial(value);
-        }
-      });
-    }
+    Object.entries(object.entitiesById ?? {}).forEach(([key, value]) => {
+      if (value !== undefined) {
+        message.entitiesById[Number(key)] = Entity.fromPartial(value);
+      }
+    });
     message.nameLookup = {};
-    if (object.nameLookup !== undefined && object.nameLookup !== null) {
-      Object.entries(object.nameLookup).forEach(([key, value]) => {
-        if (value !== undefined) {
-          message.nameLookup[key] = String(value);
-        }
-      });
-    }
+    Object.entries(object.nameLookup ?? {}).forEach(([key, value]) => {
+      if (value !== undefined) {
+        message.nameLookup[key] = String(value);
+      }
+    });
     message.intLookup = {};
-    if (object.intLookup !== undefined && object.intLookup !== null) {
-      Object.entries(object.intLookup).forEach(([key, value]) => {
-        if (value !== undefined) {
-          message.intLookup[Number(key)] = Number(value);
-        }
-      });
-    }
+    Object.entries(object.intLookup ?? {}).forEach(([key, value]) => {
+      if (value !== undefined) {
+        message.intLookup[Number(key)] = Number(value);
+      }
+    });
     return message;
   },
 };
@@ -1169,11 +1157,9 @@ export const SimpleWithSnakeCaseMap = {
   fromJSON(object: any): SimpleWithSnakeCaseMap {
     const message = { ...baseSimpleWithSnakeCaseMap } as SimpleWithSnakeCaseMap;
     message.entities_by_id = {};
-    if (object.entities_by_id !== undefined && object.entities_by_id !== null) {
-      Object.entries(object.entities_by_id).forEach(([key, value]) => {
-        message.entities_by_id[Number(key)] = Entity.fromJSON(value);
-      });
-    }
+    Object.entries(object.entities_by_id ?? {}).forEach(([key, value]) => {
+      message.entities_by_id[Number(key)] = Entity.fromJSON(value);
+    });
     return message;
   },
 
@@ -1191,13 +1177,11 @@ export const SimpleWithSnakeCaseMap = {
   fromPartial(object: DeepPartial<SimpleWithSnakeCaseMap>): SimpleWithSnakeCaseMap {
     const message = { ...baseSimpleWithSnakeCaseMap } as SimpleWithSnakeCaseMap;
     message.entities_by_id = {};
-    if (object.entities_by_id !== undefined && object.entities_by_id !== null) {
-      Object.entries(object.entities_by_id).forEach(([key, value]) => {
-        if (value !== undefined) {
-          message.entities_by_id[Number(key)] = Entity.fromPartial(value);
-        }
-      });
-    }
+    Object.entries(object.entities_by_id ?? {}).forEach(([key, value]) => {
+      if (value !== undefined) {
+        message.entities_by_id[Number(key)] = Entity.fromPartial(value);
+      }
+    });
     return message;
   },
 };

--- a/integration/simple-unrecognized-enum/simple.ts
+++ b/integration/simple-unrecognized-enum/simple.ts
@@ -884,23 +884,17 @@ export const SimpleWithMap = {
   fromJSON(object: any): SimpleWithMap {
     const message = { ...baseSimpleWithMap } as SimpleWithMap;
     message.entitiesById = {};
-    if (object.entitiesById !== undefined && object.entitiesById !== null) {
-      Object.entries(object.entitiesById).forEach(([key, value]) => {
-        message.entitiesById[Number(key)] = Entity.fromJSON(value);
-      });
-    }
+    Object.entries(object.entitiesById ?? {}).forEach(([key, value]) => {
+      message.entitiesById[Number(key)] = Entity.fromJSON(value);
+    });
     message.nameLookup = {};
-    if (object.nameLookup !== undefined && object.nameLookup !== null) {
-      Object.entries(object.nameLookup).forEach(([key, value]) => {
-        message.nameLookup[key] = String(value);
-      });
-    }
+    Object.entries(object.nameLookup ?? {}).forEach(([key, value]) => {
+      message.nameLookup[key] = String(value);
+    });
     message.intLookup = {};
-    if (object.intLookup !== undefined && object.intLookup !== null) {
-      Object.entries(object.intLookup).forEach(([key, value]) => {
-        message.intLookup[Number(key)] = Number(value);
-      });
-    }
+    Object.entries(object.intLookup ?? {}).forEach(([key, value]) => {
+      message.intLookup[Number(key)] = Number(value);
+    });
     return message;
   },
 
@@ -930,29 +924,23 @@ export const SimpleWithMap = {
   fromPartial(object: DeepPartial<SimpleWithMap>): SimpleWithMap {
     const message = { ...baseSimpleWithMap } as SimpleWithMap;
     message.entitiesById = {};
-    if (object.entitiesById !== undefined && object.entitiesById !== null) {
-      Object.entries(object.entitiesById).forEach(([key, value]) => {
-        if (value !== undefined) {
-          message.entitiesById[Number(key)] = Entity.fromPartial(value);
-        }
-      });
-    }
+    Object.entries(object.entitiesById ?? {}).forEach(([key, value]) => {
+      if (value !== undefined) {
+        message.entitiesById[Number(key)] = Entity.fromPartial(value);
+      }
+    });
     message.nameLookup = {};
-    if (object.nameLookup !== undefined && object.nameLookup !== null) {
-      Object.entries(object.nameLookup).forEach(([key, value]) => {
-        if (value !== undefined) {
-          message.nameLookup[key] = String(value);
-        }
-      });
-    }
+    Object.entries(object.nameLookup ?? {}).forEach(([key, value]) => {
+      if (value !== undefined) {
+        message.nameLookup[key] = String(value);
+      }
+    });
     message.intLookup = {};
-    if (object.intLookup !== undefined && object.intLookup !== null) {
-      Object.entries(object.intLookup).forEach(([key, value]) => {
-        if (value !== undefined) {
-          message.intLookup[Number(key)] = Number(value);
-        }
-      });
-    }
+    Object.entries(object.intLookup ?? {}).forEach(([key, value]) => {
+      if (value !== undefined) {
+        message.intLookup[Number(key)] = Number(value);
+      }
+    });
     return message;
   },
 };
@@ -1160,11 +1148,9 @@ export const SimpleWithSnakeCaseMap = {
   fromJSON(object: any): SimpleWithSnakeCaseMap {
     const message = { ...baseSimpleWithSnakeCaseMap } as SimpleWithSnakeCaseMap;
     message.entitiesById = {};
-    if (object.entitiesById !== undefined && object.entitiesById !== null) {
-      Object.entries(object.entitiesById).forEach(([key, value]) => {
-        message.entitiesById[Number(key)] = Entity.fromJSON(value);
-      });
-    }
+    Object.entries(object.entitiesById ?? {}).forEach(([key, value]) => {
+      message.entitiesById[Number(key)] = Entity.fromJSON(value);
+    });
     return message;
   },
 
@@ -1182,13 +1168,11 @@ export const SimpleWithSnakeCaseMap = {
   fromPartial(object: DeepPartial<SimpleWithSnakeCaseMap>): SimpleWithSnakeCaseMap {
     const message = { ...baseSimpleWithSnakeCaseMap } as SimpleWithSnakeCaseMap;
     message.entitiesById = {};
-    if (object.entitiesById !== undefined && object.entitiesById !== null) {
-      Object.entries(object.entitiesById).forEach(([key, value]) => {
-        if (value !== undefined) {
-          message.entitiesById[Number(key)] = Entity.fromPartial(value);
-        }
-      });
-    }
+    Object.entries(object.entitiesById ?? {}).forEach(([key, value]) => {
+      if (value !== undefined) {
+        message.entitiesById[Number(key)] = Entity.fromPartial(value);
+      }
+    });
     return message;
   },
 };

--- a/integration/simple-unrecognized-enum/simple.ts
+++ b/integration/simple-unrecognized-enum/simple.ts
@@ -883,18 +883,27 @@ export const SimpleWithMap = {
 
   fromJSON(object: any): SimpleWithMap {
     const message = { ...baseSimpleWithMap } as SimpleWithMap;
-    message.entitiesById = {};
-    Object.entries(object.entitiesById ?? {}).forEach(([key, value]) => {
-      message.entitiesById[Number(key)] = Entity.fromJSON(value);
-    });
-    message.nameLookup = {};
-    Object.entries(object.nameLookup ?? {}).forEach(([key, value]) => {
-      message.nameLookup[key] = String(value);
-    });
-    message.intLookup = {};
-    Object.entries(object.intLookup ?? {}).forEach(([key, value]) => {
-      message.intLookup[Number(key)] = Number(value);
-    });
+    message.entitiesById = Object.entries(object.entitiesById ?? {}).reduce<{ [key: number]: Entity }>(
+      (acc, [key, value]) => {
+        acc[Number(key)] = Entity.fromJSON(value);
+        return acc;
+      },
+      {}
+    );
+    message.nameLookup = Object.entries(object.nameLookup ?? {}).reduce<{ [key: string]: string }>(
+      (acc, [key, value]) => {
+        acc[key] = String(value);
+        return acc;
+      },
+      {}
+    );
+    message.intLookup = Object.entries(object.intLookup ?? {}).reduce<{ [key: number]: number }>(
+      (acc, [key, value]) => {
+        acc[Number(key)] = Number(value);
+        return acc;
+      },
+      {}
+    );
     return message;
   },
 
@@ -923,24 +932,33 @@ export const SimpleWithMap = {
 
   fromPartial(object: DeepPartial<SimpleWithMap>): SimpleWithMap {
     const message = { ...baseSimpleWithMap } as SimpleWithMap;
-    message.entitiesById = {};
-    Object.entries(object.entitiesById ?? {}).forEach(([key, value]) => {
-      if (value !== undefined) {
-        message.entitiesById[Number(key)] = Entity.fromPartial(value);
-      }
-    });
-    message.nameLookup = {};
-    Object.entries(object.nameLookup ?? {}).forEach(([key, value]) => {
-      if (value !== undefined) {
-        message.nameLookup[key] = String(value);
-      }
-    });
-    message.intLookup = {};
-    Object.entries(object.intLookup ?? {}).forEach(([key, value]) => {
-      if (value !== undefined) {
-        message.intLookup[Number(key)] = Number(value);
-      }
-    });
+    message.entitiesById = Object.entries(object.entitiesById ?? {}).reduce<{ [key: number]: Entity }>(
+      (acc, [key, value]) => {
+        if (value !== undefined) {
+          acc[Number(key)] = Entity.fromPartial(value);
+        }
+        return acc;
+      },
+      {}
+    );
+    message.nameLookup = Object.entries(object.nameLookup ?? {}).reduce<{ [key: string]: string }>(
+      (acc, [key, value]) => {
+        if (value !== undefined) {
+          acc[key] = String(value);
+        }
+        return acc;
+      },
+      {}
+    );
+    message.intLookup = Object.entries(object.intLookup ?? {}).reduce<{ [key: number]: number }>(
+      (acc, [key, value]) => {
+        if (value !== undefined) {
+          acc[Number(key)] = Number(value);
+        }
+        return acc;
+      },
+      {}
+    );
     return message;
   },
 };
@@ -1147,10 +1165,13 @@ export const SimpleWithSnakeCaseMap = {
 
   fromJSON(object: any): SimpleWithSnakeCaseMap {
     const message = { ...baseSimpleWithSnakeCaseMap } as SimpleWithSnakeCaseMap;
-    message.entitiesById = {};
-    Object.entries(object.entitiesById ?? {}).forEach(([key, value]) => {
-      message.entitiesById[Number(key)] = Entity.fromJSON(value);
-    });
+    message.entitiesById = Object.entries(object.entitiesById ?? {}).reduce<{ [key: number]: Entity }>(
+      (acc, [key, value]) => {
+        acc[Number(key)] = Entity.fromJSON(value);
+        return acc;
+      },
+      {}
+    );
     return message;
   },
 
@@ -1167,12 +1188,15 @@ export const SimpleWithSnakeCaseMap = {
 
   fromPartial(object: DeepPartial<SimpleWithSnakeCaseMap>): SimpleWithSnakeCaseMap {
     const message = { ...baseSimpleWithSnakeCaseMap } as SimpleWithSnakeCaseMap;
-    message.entitiesById = {};
-    Object.entries(object.entitiesById ?? {}).forEach(([key, value]) => {
-      if (value !== undefined) {
-        message.entitiesById[Number(key)] = Entity.fromPartial(value);
-      }
-    });
+    message.entitiesById = Object.entries(object.entitiesById ?? {}).reduce<{ [key: number]: Entity }>(
+      (acc, [key, value]) => {
+        if (value !== undefined) {
+          acc[Number(key)] = Entity.fromPartial(value);
+        }
+        return acc;
+      },
+      {}
+    );
     return message;
   },
 };

--- a/integration/simple/simple.ts
+++ b/integration/simple/simple.ts
@@ -1035,34 +1035,54 @@ export const SimpleWithMap = {
 
   fromJSON(object: any): SimpleWithMap {
     const message = { ...baseSimpleWithMap } as SimpleWithMap;
-    message.entitiesById = {};
-    Object.entries(object.entitiesById ?? {}).forEach(([key, value]) => {
-      message.entitiesById[Number(key)] = Entity.fromJSON(value);
-    });
-    message.nameLookup = {};
-    Object.entries(object.nameLookup ?? {}).forEach(([key, value]) => {
-      message.nameLookup[key] = String(value);
-    });
-    message.intLookup = {};
-    Object.entries(object.intLookup ?? {}).forEach(([key, value]) => {
-      message.intLookup[Number(key)] = Number(value);
-    });
-    message.mapOfTimestamps = {};
-    Object.entries(object.mapOfTimestamps ?? {}).forEach(([key, value]) => {
-      message.mapOfTimestamps[key] = fromJsonTimestamp(value);
-    });
-    message.mapOfBytes = {};
-    Object.entries(object.mapOfBytes ?? {}).forEach(([key, value]) => {
-      message.mapOfBytes[key] = bytesFromBase64(value as string);
-    });
-    message.mapOfStringValues = {};
-    Object.entries(object.mapOfStringValues ?? {}).forEach(([key, value]) => {
-      message.mapOfStringValues[key] = value as string | undefined;
-    });
-    message.longLookup = {};
-    Object.entries(object.longLookup ?? {}).forEach(([key, value]) => {
-      message.longLookup[Number(key)] = Number(value);
-    });
+    message.entitiesById = Object.entries(object.entitiesById ?? {}).reduce<{ [key: number]: Entity }>(
+      (acc, [key, value]) => {
+        acc[Number(key)] = Entity.fromJSON(value);
+        return acc;
+      },
+      {}
+    );
+    message.nameLookup = Object.entries(object.nameLookup ?? {}).reduce<{ [key: string]: string }>(
+      (acc, [key, value]) => {
+        acc[key] = String(value);
+        return acc;
+      },
+      {}
+    );
+    message.intLookup = Object.entries(object.intLookup ?? {}).reduce<{ [key: number]: number }>(
+      (acc, [key, value]) => {
+        acc[Number(key)] = Number(value);
+        return acc;
+      },
+      {}
+    );
+    message.mapOfTimestamps = Object.entries(object.mapOfTimestamps ?? {}).reduce<{ [key: string]: Date }>(
+      (acc, [key, value]) => {
+        acc[key] = fromJsonTimestamp(value);
+        return acc;
+      },
+      {}
+    );
+    message.mapOfBytes = Object.entries(object.mapOfBytes ?? {}).reduce<{ [key: string]: Uint8Array }>(
+      (acc, [key, value]) => {
+        acc[key] = bytesFromBase64(value as string);
+        return acc;
+      },
+      {}
+    );
+    message.mapOfStringValues = Object.entries(object.mapOfStringValues ?? {}).reduce<{
+      [key: string]: string | undefined;
+    }>((acc, [key, value]) => {
+      acc[key] = value as string | undefined;
+      return acc;
+    }, {});
+    message.longLookup = Object.entries(object.longLookup ?? {}).reduce<{ [key: number]: number }>(
+      (acc, [key, value]) => {
+        acc[Number(key)] = Number(value);
+        return acc;
+      },
+      {}
+    );
     return message;
   },
 
@@ -1115,48 +1135,68 @@ export const SimpleWithMap = {
 
   fromPartial(object: DeepPartial<SimpleWithMap>): SimpleWithMap {
     const message = { ...baseSimpleWithMap } as SimpleWithMap;
-    message.entitiesById = {};
-    Object.entries(object.entitiesById ?? {}).forEach(([key, value]) => {
+    message.entitiesById = Object.entries(object.entitiesById ?? {}).reduce<{ [key: number]: Entity }>(
+      (acc, [key, value]) => {
+        if (value !== undefined) {
+          acc[Number(key)] = Entity.fromPartial(value);
+        }
+        return acc;
+      },
+      {}
+    );
+    message.nameLookup = Object.entries(object.nameLookup ?? {}).reduce<{ [key: string]: string }>(
+      (acc, [key, value]) => {
+        if (value !== undefined) {
+          acc[key] = String(value);
+        }
+        return acc;
+      },
+      {}
+    );
+    message.intLookup = Object.entries(object.intLookup ?? {}).reduce<{ [key: number]: number }>(
+      (acc, [key, value]) => {
+        if (value !== undefined) {
+          acc[Number(key)] = Number(value);
+        }
+        return acc;
+      },
+      {}
+    );
+    message.mapOfTimestamps = Object.entries(object.mapOfTimestamps ?? {}).reduce<{ [key: string]: Date }>(
+      (acc, [key, value]) => {
+        if (value !== undefined) {
+          acc[key] = value;
+        }
+        return acc;
+      },
+      {}
+    );
+    message.mapOfBytes = Object.entries(object.mapOfBytes ?? {}).reduce<{ [key: string]: Uint8Array }>(
+      (acc, [key, value]) => {
+        if (value !== undefined) {
+          acc[key] = value;
+        }
+        return acc;
+      },
+      {}
+    );
+    message.mapOfStringValues = Object.entries(object.mapOfStringValues ?? {}).reduce<{
+      [key: string]: string | undefined;
+    }>((acc, [key, value]) => {
       if (value !== undefined) {
-        message.entitiesById[Number(key)] = Entity.fromPartial(value);
+        acc[key] = value;
       }
-    });
-    message.nameLookup = {};
-    Object.entries(object.nameLookup ?? {}).forEach(([key, value]) => {
-      if (value !== undefined) {
-        message.nameLookup[key] = String(value);
-      }
-    });
-    message.intLookup = {};
-    Object.entries(object.intLookup ?? {}).forEach(([key, value]) => {
-      if (value !== undefined) {
-        message.intLookup[Number(key)] = Number(value);
-      }
-    });
-    message.mapOfTimestamps = {};
-    Object.entries(object.mapOfTimestamps ?? {}).forEach(([key, value]) => {
-      if (value !== undefined) {
-        message.mapOfTimestamps[key] = value;
-      }
-    });
-    message.mapOfBytes = {};
-    Object.entries(object.mapOfBytes ?? {}).forEach(([key, value]) => {
-      if (value !== undefined) {
-        message.mapOfBytes[key] = value;
-      }
-    });
-    message.mapOfStringValues = {};
-    Object.entries(object.mapOfStringValues ?? {}).forEach(([key, value]) => {
-      if (value !== undefined) {
-        message.mapOfStringValues[key] = value;
-      }
-    });
-    message.longLookup = {};
-    Object.entries(object.longLookup ?? {}).forEach(([key, value]) => {
-      if (value !== undefined) {
-        message.longLookup[Number(key)] = Number(value);
-      }
-    });
+      return acc;
+    }, {});
+    message.longLookup = Object.entries(object.longLookup ?? {}).reduce<{ [key: number]: number }>(
+      (acc, [key, value]) => {
+        if (value !== undefined) {
+          acc[Number(key)] = Number(value);
+        }
+        return acc;
+      },
+      {}
+    );
     return message;
   },
 };
@@ -1590,10 +1630,13 @@ export const SimpleWithSnakeCaseMap = {
 
   fromJSON(object: any): SimpleWithSnakeCaseMap {
     const message = { ...baseSimpleWithSnakeCaseMap } as SimpleWithSnakeCaseMap;
-    message.entitiesById = {};
-    Object.entries(object.entitiesById ?? {}).forEach(([key, value]) => {
-      message.entitiesById[Number(key)] = Entity.fromJSON(value);
-    });
+    message.entitiesById = Object.entries(object.entitiesById ?? {}).reduce<{ [key: number]: Entity }>(
+      (acc, [key, value]) => {
+        acc[Number(key)] = Entity.fromJSON(value);
+        return acc;
+      },
+      {}
+    );
     return message;
   },
 
@@ -1610,12 +1653,15 @@ export const SimpleWithSnakeCaseMap = {
 
   fromPartial(object: DeepPartial<SimpleWithSnakeCaseMap>): SimpleWithSnakeCaseMap {
     const message = { ...baseSimpleWithSnakeCaseMap } as SimpleWithSnakeCaseMap;
-    message.entitiesById = {};
-    Object.entries(object.entitiesById ?? {}).forEach(([key, value]) => {
-      if (value !== undefined) {
-        message.entitiesById[Number(key)] = Entity.fromPartial(value);
-      }
-    });
+    message.entitiesById = Object.entries(object.entitiesById ?? {}).reduce<{ [key: number]: Entity }>(
+      (acc, [key, value]) => {
+        if (value !== undefined) {
+          acc[Number(key)] = Entity.fromPartial(value);
+        }
+        return acc;
+      },
+      {}
+    );
     return message;
   },
 };
@@ -1710,10 +1756,13 @@ export const SimpleWithMapOfEnums = {
 
   fromJSON(object: any): SimpleWithMapOfEnums {
     const message = { ...baseSimpleWithMapOfEnums } as SimpleWithMapOfEnums;
-    message.enumsById = {};
-    Object.entries(object.enumsById ?? {}).forEach(([key, value]) => {
-      message.enumsById[Number(key)] = value as number;
-    });
+    message.enumsById = Object.entries(object.enumsById ?? {}).reduce<{ [key: number]: StateEnum }>(
+      (acc, [key, value]) => {
+        acc[Number(key)] = value as number;
+        return acc;
+      },
+      {}
+    );
     return message;
   },
 
@@ -1730,12 +1779,15 @@ export const SimpleWithMapOfEnums = {
 
   fromPartial(object: DeepPartial<SimpleWithMapOfEnums>): SimpleWithMapOfEnums {
     const message = { ...baseSimpleWithMapOfEnums } as SimpleWithMapOfEnums;
-    message.enumsById = {};
-    Object.entries(object.enumsById ?? {}).forEach(([key, value]) => {
-      if (value !== undefined) {
-        message.enumsById[Number(key)] = value as number;
-      }
-    });
+    message.enumsById = Object.entries(object.enumsById ?? {}).reduce<{ [key: number]: StateEnum }>(
+      (acc, [key, value]) => {
+        if (value !== undefined) {
+          acc[Number(key)] = value as number;
+        }
+        return acc;
+      },
+      {}
+    );
     return message;
   },
 };

--- a/integration/simple/simple.ts
+++ b/integration/simple/simple.ts
@@ -1036,47 +1036,33 @@ export const SimpleWithMap = {
   fromJSON(object: any): SimpleWithMap {
     const message = { ...baseSimpleWithMap } as SimpleWithMap;
     message.entitiesById = {};
-    if (object.entitiesById !== undefined && object.entitiesById !== null) {
-      Object.entries(object.entitiesById).forEach(([key, value]) => {
-        message.entitiesById[Number(key)] = Entity.fromJSON(value);
-      });
-    }
+    Object.entries(object.entitiesById ?? {}).forEach(([key, value]) => {
+      message.entitiesById[Number(key)] = Entity.fromJSON(value);
+    });
     message.nameLookup = {};
-    if (object.nameLookup !== undefined && object.nameLookup !== null) {
-      Object.entries(object.nameLookup).forEach(([key, value]) => {
-        message.nameLookup[key] = String(value);
-      });
-    }
+    Object.entries(object.nameLookup ?? {}).forEach(([key, value]) => {
+      message.nameLookup[key] = String(value);
+    });
     message.intLookup = {};
-    if (object.intLookup !== undefined && object.intLookup !== null) {
-      Object.entries(object.intLookup).forEach(([key, value]) => {
-        message.intLookup[Number(key)] = Number(value);
-      });
-    }
+    Object.entries(object.intLookup ?? {}).forEach(([key, value]) => {
+      message.intLookup[Number(key)] = Number(value);
+    });
     message.mapOfTimestamps = {};
-    if (object.mapOfTimestamps !== undefined && object.mapOfTimestamps !== null) {
-      Object.entries(object.mapOfTimestamps).forEach(([key, value]) => {
-        message.mapOfTimestamps[key] = fromJsonTimestamp(value);
-      });
-    }
+    Object.entries(object.mapOfTimestamps ?? {}).forEach(([key, value]) => {
+      message.mapOfTimestamps[key] = fromJsonTimestamp(value);
+    });
     message.mapOfBytes = {};
-    if (object.mapOfBytes !== undefined && object.mapOfBytes !== null) {
-      Object.entries(object.mapOfBytes).forEach(([key, value]) => {
-        message.mapOfBytes[key] = bytesFromBase64(value as string);
-      });
-    }
+    Object.entries(object.mapOfBytes ?? {}).forEach(([key, value]) => {
+      message.mapOfBytes[key] = bytesFromBase64(value as string);
+    });
     message.mapOfStringValues = {};
-    if (object.mapOfStringValues !== undefined && object.mapOfStringValues !== null) {
-      Object.entries(object.mapOfStringValues).forEach(([key, value]) => {
-        message.mapOfStringValues[key] = value as string | undefined;
-      });
-    }
+    Object.entries(object.mapOfStringValues ?? {}).forEach(([key, value]) => {
+      message.mapOfStringValues[key] = value as string | undefined;
+    });
     message.longLookup = {};
-    if (object.longLookup !== undefined && object.longLookup !== null) {
-      Object.entries(object.longLookup).forEach(([key, value]) => {
-        message.longLookup[Number(key)] = Number(value);
-      });
-    }
+    Object.entries(object.longLookup ?? {}).forEach(([key, value]) => {
+      message.longLookup[Number(key)] = Number(value);
+    });
     return message;
   },
 
@@ -1130,61 +1116,47 @@ export const SimpleWithMap = {
   fromPartial(object: DeepPartial<SimpleWithMap>): SimpleWithMap {
     const message = { ...baseSimpleWithMap } as SimpleWithMap;
     message.entitiesById = {};
-    if (object.entitiesById !== undefined && object.entitiesById !== null) {
-      Object.entries(object.entitiesById).forEach(([key, value]) => {
-        if (value !== undefined) {
-          message.entitiesById[Number(key)] = Entity.fromPartial(value);
-        }
-      });
-    }
+    Object.entries(object.entitiesById ?? {}).forEach(([key, value]) => {
+      if (value !== undefined) {
+        message.entitiesById[Number(key)] = Entity.fromPartial(value);
+      }
+    });
     message.nameLookup = {};
-    if (object.nameLookup !== undefined && object.nameLookup !== null) {
-      Object.entries(object.nameLookup).forEach(([key, value]) => {
-        if (value !== undefined) {
-          message.nameLookup[key] = String(value);
-        }
-      });
-    }
+    Object.entries(object.nameLookup ?? {}).forEach(([key, value]) => {
+      if (value !== undefined) {
+        message.nameLookup[key] = String(value);
+      }
+    });
     message.intLookup = {};
-    if (object.intLookup !== undefined && object.intLookup !== null) {
-      Object.entries(object.intLookup).forEach(([key, value]) => {
-        if (value !== undefined) {
-          message.intLookup[Number(key)] = Number(value);
-        }
-      });
-    }
+    Object.entries(object.intLookup ?? {}).forEach(([key, value]) => {
+      if (value !== undefined) {
+        message.intLookup[Number(key)] = Number(value);
+      }
+    });
     message.mapOfTimestamps = {};
-    if (object.mapOfTimestamps !== undefined && object.mapOfTimestamps !== null) {
-      Object.entries(object.mapOfTimestamps).forEach(([key, value]) => {
-        if (value !== undefined) {
-          message.mapOfTimestamps[key] = value;
-        }
-      });
-    }
+    Object.entries(object.mapOfTimestamps ?? {}).forEach(([key, value]) => {
+      if (value !== undefined) {
+        message.mapOfTimestamps[key] = value;
+      }
+    });
     message.mapOfBytes = {};
-    if (object.mapOfBytes !== undefined && object.mapOfBytes !== null) {
-      Object.entries(object.mapOfBytes).forEach(([key, value]) => {
-        if (value !== undefined) {
-          message.mapOfBytes[key] = value;
-        }
-      });
-    }
+    Object.entries(object.mapOfBytes ?? {}).forEach(([key, value]) => {
+      if (value !== undefined) {
+        message.mapOfBytes[key] = value;
+      }
+    });
     message.mapOfStringValues = {};
-    if (object.mapOfStringValues !== undefined && object.mapOfStringValues !== null) {
-      Object.entries(object.mapOfStringValues).forEach(([key, value]) => {
-        if (value !== undefined) {
-          message.mapOfStringValues[key] = value;
-        }
-      });
-    }
+    Object.entries(object.mapOfStringValues ?? {}).forEach(([key, value]) => {
+      if (value !== undefined) {
+        message.mapOfStringValues[key] = value;
+      }
+    });
     message.longLookup = {};
-    if (object.longLookup !== undefined && object.longLookup !== null) {
-      Object.entries(object.longLookup).forEach(([key, value]) => {
-        if (value !== undefined) {
-          message.longLookup[Number(key)] = Number(value);
-        }
-      });
-    }
+    Object.entries(object.longLookup ?? {}).forEach(([key, value]) => {
+      if (value !== undefined) {
+        message.longLookup[Number(key)] = Number(value);
+      }
+    });
     return message;
   },
 };
@@ -1619,11 +1591,9 @@ export const SimpleWithSnakeCaseMap = {
   fromJSON(object: any): SimpleWithSnakeCaseMap {
     const message = { ...baseSimpleWithSnakeCaseMap } as SimpleWithSnakeCaseMap;
     message.entitiesById = {};
-    if (object.entitiesById !== undefined && object.entitiesById !== null) {
-      Object.entries(object.entitiesById).forEach(([key, value]) => {
-        message.entitiesById[Number(key)] = Entity.fromJSON(value);
-      });
-    }
+    Object.entries(object.entitiesById ?? {}).forEach(([key, value]) => {
+      message.entitiesById[Number(key)] = Entity.fromJSON(value);
+    });
     return message;
   },
 
@@ -1641,13 +1611,11 @@ export const SimpleWithSnakeCaseMap = {
   fromPartial(object: DeepPartial<SimpleWithSnakeCaseMap>): SimpleWithSnakeCaseMap {
     const message = { ...baseSimpleWithSnakeCaseMap } as SimpleWithSnakeCaseMap;
     message.entitiesById = {};
-    if (object.entitiesById !== undefined && object.entitiesById !== null) {
-      Object.entries(object.entitiesById).forEach(([key, value]) => {
-        if (value !== undefined) {
-          message.entitiesById[Number(key)] = Entity.fromPartial(value);
-        }
-      });
-    }
+    Object.entries(object.entitiesById ?? {}).forEach(([key, value]) => {
+      if (value !== undefined) {
+        message.entitiesById[Number(key)] = Entity.fromPartial(value);
+      }
+    });
     return message;
   },
 };
@@ -1743,11 +1711,9 @@ export const SimpleWithMapOfEnums = {
   fromJSON(object: any): SimpleWithMapOfEnums {
     const message = { ...baseSimpleWithMapOfEnums } as SimpleWithMapOfEnums;
     message.enumsById = {};
-    if (object.enumsById !== undefined && object.enumsById !== null) {
-      Object.entries(object.enumsById).forEach(([key, value]) => {
-        message.enumsById[Number(key)] = value as number;
-      });
-    }
+    Object.entries(object.enumsById ?? {}).forEach(([key, value]) => {
+      message.enumsById[Number(key)] = value as number;
+    });
     return message;
   },
 
@@ -1765,13 +1731,11 @@ export const SimpleWithMapOfEnums = {
   fromPartial(object: DeepPartial<SimpleWithMapOfEnums>): SimpleWithMapOfEnums {
     const message = { ...baseSimpleWithMapOfEnums } as SimpleWithMapOfEnums;
     message.enumsById = {};
-    if (object.enumsById !== undefined && object.enumsById !== null) {
-      Object.entries(object.enumsById).forEach(([key, value]) => {
-        if (value !== undefined) {
-          message.enumsById[Number(key)] = value as number;
-        }
-      });
-    }
+    Object.entries(object.enumsById ?? {}).forEach(([key, value]) => {
+      if (value !== undefined) {
+        message.enumsById[Number(key)] = value as number;
+      }
+    });
     return message;
   },
 };

--- a/integration/struct/google/protobuf/struct.ts
+++ b/integration/struct/google/protobuf/struct.ts
@@ -127,11 +127,9 @@ export const Struct = {
   fromJSON(object: any): Struct {
     const message = { ...baseStruct } as Struct;
     message.fields = {};
-    if (object.fields !== undefined && object.fields !== null) {
-      Object.entries(object.fields).forEach(([key, value]) => {
-        message.fields[key] = value as any | undefined;
-      });
-    }
+    Object.entries(object.fields ?? {}).forEach(([key, value]) => {
+      message.fields[key] = value as any | undefined;
+    });
     return message;
   },
 
@@ -149,13 +147,11 @@ export const Struct = {
   fromPartial(object: DeepPartial<Struct>): Struct {
     const message = { ...baseStruct } as Struct;
     message.fields = {};
-    if (object.fields !== undefined && object.fields !== null) {
-      Object.entries(object.fields).forEach(([key, value]) => {
-        if (value !== undefined) {
-          message.fields[key] = value;
-        }
-      });
-    }
+    Object.entries(object.fields ?? {}).forEach(([key, value]) => {
+      if (value !== undefined) {
+        message.fields[key] = value;
+      }
+    });
     return message;
   },
 };

--- a/integration/struct/google/protobuf/struct.ts
+++ b/integration/struct/google/protobuf/struct.ts
@@ -126,10 +126,13 @@ export const Struct = {
 
   fromJSON(object: any): Struct {
     const message = { ...baseStruct } as Struct;
-    message.fields = {};
-    Object.entries(object.fields ?? {}).forEach(([key, value]) => {
-      message.fields[key] = value as any | undefined;
-    });
+    message.fields = Object.entries(object.fields ?? {}).reduce<{ [key: string]: any | undefined }>(
+      (acc, [key, value]) => {
+        acc[key] = value as any | undefined;
+        return acc;
+      },
+      {}
+    );
     return message;
   },
 
@@ -146,12 +149,15 @@ export const Struct = {
 
   fromPartial(object: DeepPartial<Struct>): Struct {
     const message = { ...baseStruct } as Struct;
-    message.fields = {};
-    Object.entries(object.fields ?? {}).forEach(([key, value]) => {
-      if (value !== undefined) {
-        message.fields[key] = value;
-      }
-    });
+    message.fields = Object.entries(object.fields ?? {}).reduce<{ [key: string]: any | undefined }>(
+      (acc, [key, value]) => {
+        if (value !== undefined) {
+          acc[key] = value;
+        }
+        return acc;
+      },
+      {}
+    );
     return message;
   },
 };

--- a/integration/use-date-string/use-date-string.ts
+++ b/integration/use-date-string/use-date-string.ts
@@ -86,11 +86,9 @@ export const Todo = {
         ? String(object.optionalTimestamp)
         : undefined;
     message.mapOfTimestamps = {};
-    if (object.mapOfTimestamps !== undefined && object.mapOfTimestamps !== null) {
-      Object.entries(object.mapOfTimestamps).forEach(([key, value]) => {
-        message.mapOfTimestamps[key] = String(value);
-      });
-    }
+    Object.entries(object.mapOfTimestamps ?? {}).forEach(([key, value]) => {
+      message.mapOfTimestamps[key] = String(value);
+    });
     return message;
   },
 
@@ -120,13 +118,11 @@ export const Todo = {
     message.repeatedTimestamp = (object.repeatedTimestamp ?? []).map((e) => e);
     message.optionalTimestamp = object.optionalTimestamp ?? undefined;
     message.mapOfTimestamps = {};
-    if (object.mapOfTimestamps !== undefined && object.mapOfTimestamps !== null) {
-      Object.entries(object.mapOfTimestamps).forEach(([key, value]) => {
-        if (value !== undefined) {
-          message.mapOfTimestamps[key] = value;
-        }
-      });
-    }
+    Object.entries(object.mapOfTimestamps ?? {}).forEach(([key, value]) => {
+      if (value !== undefined) {
+        message.mapOfTimestamps[key] = value;
+      }
+    });
     return message;
   },
 };

--- a/integration/use-date-string/use-date-string.ts
+++ b/integration/use-date-string/use-date-string.ts
@@ -85,10 +85,13 @@ export const Todo = {
       object.optionalTimestamp !== undefined && object.optionalTimestamp !== null
         ? String(object.optionalTimestamp)
         : undefined;
-    message.mapOfTimestamps = {};
-    Object.entries(object.mapOfTimestamps ?? {}).forEach(([key, value]) => {
-      message.mapOfTimestamps[key] = String(value);
-    });
+    message.mapOfTimestamps = Object.entries(object.mapOfTimestamps ?? {}).reduce<{ [key: string]: string }>(
+      (acc, [key, value]) => {
+        acc[key] = String(value);
+        return acc;
+      },
+      {}
+    );
     return message;
   },
 
@@ -117,12 +120,15 @@ export const Todo = {
     message.timestamp = object.timestamp ?? undefined;
     message.repeatedTimestamp = (object.repeatedTimestamp ?? []).map((e) => e);
     message.optionalTimestamp = object.optionalTimestamp ?? undefined;
-    message.mapOfTimestamps = {};
-    Object.entries(object.mapOfTimestamps ?? {}).forEach(([key, value]) => {
-      if (value !== undefined) {
-        message.mapOfTimestamps[key] = value;
-      }
-    });
+    message.mapOfTimestamps = Object.entries(object.mapOfTimestamps ?? {}).reduce<{ [key: string]: string }>(
+      (acc, [key, value]) => {
+        if (value !== undefined) {
+          acc[key] = value;
+        }
+        return acc;
+      },
+      {}
+    );
     return message;
   },
 };

--- a/integration/use-date-true/use-date-true.ts
+++ b/integration/use-date-true/use-date-true.ts
@@ -85,10 +85,13 @@ export const Todo = {
       object.optionalTimestamp !== undefined && object.optionalTimestamp !== null
         ? fromJsonTimestamp(object.optionalTimestamp)
         : undefined;
-    message.mapOfTimestamps = {};
-    Object.entries(object.mapOfTimestamps ?? {}).forEach(([key, value]) => {
-      message.mapOfTimestamps[key] = fromJsonTimestamp(value);
-    });
+    message.mapOfTimestamps = Object.entries(object.mapOfTimestamps ?? {}).reduce<{ [key: string]: Date }>(
+      (acc, [key, value]) => {
+        acc[key] = fromJsonTimestamp(value);
+        return acc;
+      },
+      {}
+    );
     return message;
   },
 
@@ -117,12 +120,15 @@ export const Todo = {
     message.timestamp = object.timestamp ?? undefined;
     message.repeatedTimestamp = (object.repeatedTimestamp ?? []).map((e) => e);
     message.optionalTimestamp = object.optionalTimestamp ?? undefined;
-    message.mapOfTimestamps = {};
-    Object.entries(object.mapOfTimestamps ?? {}).forEach(([key, value]) => {
-      if (value !== undefined) {
-        message.mapOfTimestamps[key] = value;
-      }
-    });
+    message.mapOfTimestamps = Object.entries(object.mapOfTimestamps ?? {}).reduce<{ [key: string]: Date }>(
+      (acc, [key, value]) => {
+        if (value !== undefined) {
+          acc[key] = value;
+        }
+        return acc;
+      },
+      {}
+    );
     return message;
   },
 };

--- a/integration/use-date-true/use-date-true.ts
+++ b/integration/use-date-true/use-date-true.ts
@@ -86,11 +86,9 @@ export const Todo = {
         ? fromJsonTimestamp(object.optionalTimestamp)
         : undefined;
     message.mapOfTimestamps = {};
-    if (object.mapOfTimestamps !== undefined && object.mapOfTimestamps !== null) {
-      Object.entries(object.mapOfTimestamps).forEach(([key, value]) => {
-        message.mapOfTimestamps[key] = fromJsonTimestamp(value);
-      });
-    }
+    Object.entries(object.mapOfTimestamps ?? {}).forEach(([key, value]) => {
+      message.mapOfTimestamps[key] = fromJsonTimestamp(value);
+    });
     return message;
   },
 
@@ -120,13 +118,11 @@ export const Todo = {
     message.repeatedTimestamp = (object.repeatedTimestamp ?? []).map((e) => e);
     message.optionalTimestamp = object.optionalTimestamp ?? undefined;
     message.mapOfTimestamps = {};
-    if (object.mapOfTimestamps !== undefined && object.mapOfTimestamps !== null) {
-      Object.entries(object.mapOfTimestamps).forEach(([key, value]) => {
-        if (value !== undefined) {
-          message.mapOfTimestamps[key] = value;
-        }
-      });
-    }
+    Object.entries(object.mapOfTimestamps ?? {}).forEach(([key, value]) => {
+      if (value !== undefined) {
+        message.mapOfTimestamps[key] = value;
+      }
+    });
     return message;
   },
 };

--- a/integration/value/google/protobuf/struct.ts
+++ b/integration/value/google/protobuf/struct.ts
@@ -127,11 +127,9 @@ export const Struct = {
   fromJSON(object: any): Struct {
     const message = { ...baseStruct } as Struct;
     message.fields = {};
-    if (object.fields !== undefined && object.fields !== null) {
-      Object.entries(object.fields).forEach(([key, value]) => {
-        message.fields[key] = value as any | undefined;
-      });
-    }
+    Object.entries(object.fields ?? {}).forEach(([key, value]) => {
+      message.fields[key] = value as any | undefined;
+    });
     return message;
   },
 
@@ -149,13 +147,11 @@ export const Struct = {
   fromPartial(object: DeepPartial<Struct>): Struct {
     const message = { ...baseStruct } as Struct;
     message.fields = {};
-    if (object.fields !== undefined && object.fields !== null) {
-      Object.entries(object.fields).forEach(([key, value]) => {
-        if (value !== undefined) {
-          message.fields[key] = value;
-        }
-      });
-    }
+    Object.entries(object.fields ?? {}).forEach(([key, value]) => {
+      if (value !== undefined) {
+        message.fields[key] = value;
+      }
+    });
     return message;
   },
 };

--- a/integration/value/google/protobuf/struct.ts
+++ b/integration/value/google/protobuf/struct.ts
@@ -126,10 +126,13 @@ export const Struct = {
 
   fromJSON(object: any): Struct {
     const message = { ...baseStruct } as Struct;
-    message.fields = {};
-    Object.entries(object.fields ?? {}).forEach(([key, value]) => {
-      message.fields[key] = value as any | undefined;
-    });
+    message.fields = Object.entries(object.fields ?? {}).reduce<{ [key: string]: any | undefined }>(
+      (acc, [key, value]) => {
+        acc[key] = value as any | undefined;
+        return acc;
+      },
+      {}
+    );
     return message;
   },
 
@@ -146,12 +149,15 @@ export const Struct = {
 
   fromPartial(object: DeepPartial<Struct>): Struct {
     const message = { ...baseStruct } as Struct;
-    message.fields = {};
-    Object.entries(object.fields ?? {}).forEach(([key, value]) => {
-      if (value !== undefined) {
-        message.fields[key] = value;
-      }
-    });
+    message.fields = Object.entries(object.fields ?? {}).reduce<{ [key: string]: any | undefined }>(
+      (acc, [key, value]) => {
+        if (value !== undefined) {
+          acc[key] = value;
+        }
+        return acc;
+      },
+      {}
+    );
     return message;
   },
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -1083,14 +1083,12 @@ function generateFromJson(ctx: Context, fullName: string, messageDesc: Descripto
     if (isRepeated(field)) {
       if (isMapType(ctx, messageDesc, field)) {
         chunks.push(code`message.${fieldName} = {};`);
-        chunks.push(code`if (object.${fieldName} !== undefined && object.${fieldName} !== null) {`);
         const i = maybeCastToNumber(ctx, messageDesc, field, 'key');
         chunks.push(code`
-          Object.entries(object.${fieldName}).forEach(([key, value]) => {
+          Object.entries(object.${fieldName} ?? {}).forEach(([key, value]) => {
             message.${fieldName}[${i}] = ${readSnippet('value')};
           });
         `);
-        chunks.push(code`}`);
       } else if (isAnyValueType(field)) {
         chunks.push(code`
           message.${fieldName} = Array.isArray(object?.${fieldName}) ? [...object.${fieldName}] : [];
@@ -1304,16 +1302,14 @@ function generateFromPartial(ctx: Context, fullName: string, messageDesc: Descri
     if (isRepeated(field)) {
       if (isMapType(ctx, messageDesc, field)) {
         chunks.push(code`message.${fieldName} = {};`);
-        chunks.push(code`if (object.${fieldName} !== undefined && object.${fieldName} !== null) {`);
         const i = maybeCastToNumber(ctx, messageDesc, field, 'key');
         chunks.push(code`
-          Object.entries(object.${fieldName}).forEach(([key, value]) => {
+          Object.entries(object.${fieldName} ?? {}).forEach(([key, value]) => {
             if (value !== undefined) {
               message.${fieldName}[${i}] = ${readSnippet('value')};
             }
           });
         `);
-        chunks.push(code`}`);
       } else {
         chunks.push(code`
           message.${fieldName} = (object.${fieldName} ?? []).map((e) => ${readSnippet('e')});


### PR DESCRIPTION
This follows the same idea as previous PRs for fromJSON/fromPartial: have exactly one assignment per field.

The explicit typing in reduce is necessary to avoid that TS infers `{}` as the output/accumulator type. `${fieldType}` could be replaced with `typeof message.outputField` but then in https://github.com/stephenh/ts-proto/pull/402 the output field might become optional but `${fieldType}` should not change.