### PR TITLE
docs: improve readme section on generic service definitions

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -337,7 +337,7 @@ Generated code will be placed in the Gradle build directory.
 
 - With `--ts_proto_opt=outputServices=grpc-js`, ts-proto will output service definitions and server / client stubs in [grpc-js](https://github.com/grpc/grpc-node/tree/master/packages/grpc-js) format.
 
-- With `--ts_proto_opt=outputServices=generic-definitions`, ts-proto will output generic (framework-agnostic) service definitions.
+- With `--ts_proto_opt=outputServices=generic-definitions`, ts-proto will output generic (framework-agnostic) service definitions. These definitions contain descriptors for each method with links to request and response types, which allows to generate server and client stubs at runtime, and also generate strong types for them at compile time. An example of a library that uses this approach is [nice-grpc](https://github.com/deeplay-io/nice-grpc).
 
 - With `--ts_proto_opt=outputServices=false`, or `=none`, ts-proto will output NO service definitions.
 


### PR DESCRIPTION
I added a small description of what the generic definitions are and added a link to [nice-grpc](https://github.com/deeplay-io/nice-grpc) as an example of a library that utilizes this feature.