### PR TITLE
fix: dockerized protoc aliases

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 *.sh text eol=lf
 parameters.txt text eol=lf
 protoc-gen-dump text eol=lf
+protoc-gen-ts_proto text eol=lf

--- a/aliases.sh
+++ b/aliases.sh
@@ -2,10 +2,23 @@
 PROJECT_ROOT=$(realpath $(dirname "$BASH_SOURCE"))
 PROJECT_ROOT_DOCKER="//ts-proto" # double slash to support git bash on windows
 
-# Alias docker-compose to make it usable from anywhere
+# Alias docker-compose to make it usable from anywhere.
 function _docker-compose() { docker-compose -f $PROJECT_ROOT/docker-compose.yml "$@"; }
 
-function protoc() { _docker-compose run --rm protoc "$@"; }
-function protoc-sh() { _docker-compose run --rm --entrypoint sh -- protoc "$@"; }
+# Dockerized version of protoc.
+function protoc() { _docker-compose run --rm -w //host --entrypoint protoc -- protoc "$@"; }
+
+# Open a shell in the dockerized version of protoc, useful for debugging.
+function protoc-sh() { _docker-compose run --rm -w //host -- protoc "$@"; }
+
+# Rebuild the docker image.
 function protoc-build() { _docker-compose build protoc; }
-function ts-protoc { protoc --plugin=$PROJECT_ROOT_DOCKER/protoc-gen-ts_proto "$@"; }
+
+# Run protoc with the plugin path pre-set.
+function ts-protoc {
+  if [ ! -d "$PROJECT_ROOT/build" ]; then
+    echo "Run 'yarn build' first"
+    return 1
+  fi
+  protoc --plugin=$PROJECT_ROOT_DOCKER/protoc-gen-ts_proto "$@";
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,3 +6,4 @@ services:
       dockerfile: "protoc.Dockerfile"
     volumes:
       - ".:/ts-proto"
+      - "${PWD:-.}:/host"


### PR DESCRIPTION
Restores the dockerized version of `protoc`, for standalone use, as documented under [Readme.md#development](https://github.com/stephenh/ts-proto#development)

`Dockerfile` and `yarn` commands not touched. Added a default _docker-compose_ mount of `$PWD:/host`, this should not affect other uses of the container as the container does not automatically enter this directory, and the project directory is mounted in case $PWD is not set (e.g. when running without TTY)