### PR TITLE
fix: Unwrap google.protobuf.BytesValue to Buffer when env=node

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -422,7 +422,7 @@ export function valueTypeName(ctx: Context, typeName: string): Code | undefined 
     case '.google.protobuf.BoolValue':
       return code`boolean`;
     case '.google.protobuf.BytesValue':
-      return code`Uint8Array`;
+      return ctx.options.env === EnvOption.NODE ? code`Buffer` : code`Uint8Array`;
     case '.google.protobuf.ListValue':
       return code`Array<any>`;
     case '.google.protobuf.Value':


### PR DESCRIPTION
Fixes #368 