### PR TITLE
docs: Clarify fromJSON/toJSON format in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -159,7 +159,7 @@ creating a class and calling the right getters/setters.
 
   (Configurable with the `useDate` parameter.)
 
-- `fromJSON`/`toJSON` support the [canonical Protobuf JS](https://developers.google.com/protocol-buffers/docs/proto3#json) format (i.e. timestamps are ISO strings)
+- `fromJSON`/`toJSON` use the [proto3 canonical JSON encoding format](https://developers.google.com/protocol-buffers/docs/proto3#json) (e.g. timestamps are ISO strings), unlike [`protobufjs`](https://github.com/protobufjs/protobuf.js/issues/1304). 
 
 # Auto-Batching / N+1 Prevention
 


### PR DESCRIPTION
On first glance, I thought "Protobuf JS format" meant the `protobufjs` format, which is not spec-compliant. I edited to clarity. I also changed `i.e.` to `e.g.` because the former implies that's the only thing that makes the method spec-compliant. I imagine it correctly encodes all the other types as well, not just `Timestamp`?

![image](https://user-images.githubusercontent.com/251288/146699151-8f41d0b8-65e9-467b-8f98-a75b56846a42.png)
