### PR TITLE
fix: add service property to client constructor generator

### DIFF
--- a/src/generate-grpc-js.ts
+++ b/src/generate-grpc-js.ts
@@ -229,7 +229,7 @@ function generateClientConstructor(fileDesc: FileDescriptorProto, serviceDesc: S
         credentials: ${ChannelCredentials},
         options?: Partial<${ChannelOptions}>,
       ): ${serviceDesc.name}Client;
-      service: ${serviceDesc.name}Service;
+      service: typeof ${serviceDesc.name}Service;
     }
   `;
 }

--- a/src/generate-grpc-js.ts
+++ b/src/generate-grpc-js.ts
@@ -229,6 +229,7 @@ function generateClientConstructor(fileDesc: FileDescriptorProto, serviceDesc: S
         credentials: ${ChannelCredentials},
         options?: Partial<${ChannelOptions}>,
       ): ${serviceDesc.name}Client;
+      service: ${serviceDesc.name}Service;
     }
   `;
 }


### PR DESCRIPTION
According to [this](https://github.com/grpc/grpc-node/blob/master/packages/grpc-js/src/make-client.ts#L173) client constructor has `service` property which contains `ServiceDefinition`. It can be useful to access it in some cases.