### PR TITLE
perf: optimize object creation in `decode`, `fromJSON` and `fromPartial`

### DIFF
--- a/integration/angular/simple-message.ts
+++ b/integration/angular/simple-message.ts
@@ -8,7 +8,7 @@ export interface SimpleMessage {
   numberField: number;
 }
 
-const baseSimpleMessage: object = { numberField: 0 };
+const createBaseSimpleMessage = (): SimpleMessage => ({ numberField: 0 });
 
 export const SimpleMessage = {
   encode(message: SimpleMessage, writer: Writer = Writer.create()): Writer {
@@ -21,7 +21,7 @@ export const SimpleMessage = {
   decode(input: Reader | Uint8Array, length?: number): SimpleMessage {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimpleMessage } as SimpleMessage;
+    const message = createBaseSimpleMessage();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -37,7 +37,7 @@ export const SimpleMessage = {
   },
 
   fromJSON(object: any): SimpleMessage {
-    const message = { ...baseSimpleMessage } as SimpleMessage;
+    const message = createBaseSimpleMessage();
     message.numberField =
       object.numberField !== undefined && object.numberField !== null ? Number(object.numberField) : 0;
     return message;
@@ -50,7 +50,7 @@ export const SimpleMessage = {
   },
 
   fromPartial<I extends Exact<DeepPartial<SimpleMessage>, I>>(object: I): SimpleMessage {
-    const message = { ...baseSimpleMessage } as SimpleMessage;
+    const message = createBaseSimpleMessage();
     message.numberField = object.numberField ?? 0;
     return message;
   },

--- a/integration/angular/simple-message.ts
+++ b/integration/angular/simple-message.ts
@@ -8,7 +8,9 @@ export interface SimpleMessage {
   numberField: number;
 }
 
-const createBaseSimpleMessage = (): SimpleMessage => ({ numberField: 0 });
+function createBaseSimpleMessage(): SimpleMessage {
+  return { numberField: 0 };
+}
 
 export const SimpleMessage = {
   encode(message: SimpleMessage, writer: Writer = Writer.create()): Writer {

--- a/integration/avoid-import-conflicts/simple.ts
+++ b/integration/avoid-import-conflicts/simple.ts
@@ -58,7 +58,7 @@ export interface SimpleEnums {
   importEnum: SimpleEnum1;
 }
 
-const baseSimple: object = { name: '' };
+const createBaseSimple = (): Simple => ({ name: '' });
 
 export const Simple = {
   encode(message: Simple, writer: Writer = Writer.create()): Writer {
@@ -74,7 +74,7 @@ export const Simple = {
   decode(input: Reader | Uint8Array, length?: number): Simple {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimple } as Simple;
+    const message = createBaseSimple();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -93,7 +93,7 @@ export const Simple = {
   },
 
   fromJSON(object: any): Simple {
-    const message = { ...baseSimple } as Simple;
+    const message = createBaseSimple();
     message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
     message.otherSimple =
       object.otherSimple !== undefined && object.otherSimple !== null
@@ -111,7 +111,7 @@ export const Simple = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Simple>, I>>(object: I): Simple {
-    const message = { ...baseSimple } as Simple;
+    const message = createBaseSimple();
     message.name = object.name ?? '';
     message.otherSimple =
       object.otherSimple !== undefined && object.otherSimple !== null
@@ -121,7 +121,7 @@ export const Simple = {
   },
 };
 
-const baseSimpleEnums: object = { localEnum: 0, importEnum: 0 };
+const createBaseSimpleEnums = (): SimpleEnums => ({ localEnum: 0, importEnum: 0 });
 
 export const SimpleEnums = {
   encode(message: SimpleEnums, writer: Writer = Writer.create()): Writer {
@@ -137,7 +137,7 @@ export const SimpleEnums = {
   decode(input: Reader | Uint8Array, length?: number): SimpleEnums {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimpleEnums } as SimpleEnums;
+    const message = createBaseSimpleEnums();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -156,7 +156,7 @@ export const SimpleEnums = {
   },
 
   fromJSON(object: any): SimpleEnums {
-    const message = { ...baseSimpleEnums } as SimpleEnums;
+    const message = createBaseSimpleEnums();
     message.localEnum =
       object.localEnum !== undefined && object.localEnum !== null ? simpleEnumFromJSON(object.localEnum) : 0;
     message.importEnum =
@@ -172,7 +172,7 @@ export const SimpleEnums = {
   },
 
   fromPartial<I extends Exact<DeepPartial<SimpleEnums>, I>>(object: I): SimpleEnums {
-    const message = { ...baseSimpleEnums } as SimpleEnums;
+    const message = createBaseSimpleEnums();
     message.localEnum = object.localEnum ?? 0;
     message.importEnum = object.importEnum ?? 0;
     return message;

--- a/integration/avoid-import-conflicts/simple.ts
+++ b/integration/avoid-import-conflicts/simple.ts
@@ -58,7 +58,9 @@ export interface SimpleEnums {
   importEnum: SimpleEnum1;
 }
 
-const createBaseSimple = (): Simple => ({ name: '' });
+function createBaseSimple(): Simple {
+  return { name: '', otherSimple: undefined };
+}
 
 export const Simple = {
   encode(message: Simple, writer: Writer = Writer.create()): Writer {
@@ -121,7 +123,9 @@ export const Simple = {
   },
 };
 
-const createBaseSimpleEnums = (): SimpleEnums => ({ localEnum: 0, importEnum: 0 });
+function createBaseSimpleEnums(): SimpleEnums {
+  return { localEnum: 0, importEnum: 0 };
+}
 
 export const SimpleEnums = {
   encode(message: SimpleEnums, writer: Writer = Writer.create()): Writer {

--- a/integration/avoid-import-conflicts/simple2.ts
+++ b/integration/avoid-import-conflicts/simple2.ts
@@ -47,7 +47,9 @@ export interface Simple {
   age: number;
 }
 
-const createBaseSimple = (): Simple => ({ name: '', age: 0 });
+function createBaseSimple(): Simple {
+  return { name: '', age: 0 };
+}
 
 export const Simple = {
   encode(message: Simple, writer: Writer = Writer.create()): Writer {

--- a/integration/avoid-import-conflicts/simple2.ts
+++ b/integration/avoid-import-conflicts/simple2.ts
@@ -47,7 +47,7 @@ export interface Simple {
   age: number;
 }
 
-const baseSimple: object = { name: '', age: 0 };
+const createBaseSimple = (): Simple => ({ name: '', age: 0 });
 
 export const Simple = {
   encode(message: Simple, writer: Writer = Writer.create()): Writer {
@@ -63,7 +63,7 @@ export const Simple = {
   decode(input: Reader | Uint8Array, length?: number): Simple {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimple } as Simple;
+    const message = createBaseSimple();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -82,7 +82,7 @@ export const Simple = {
   },
 
   fromJSON(object: any): Simple {
-    const message = { ...baseSimple } as Simple;
+    const message = createBaseSimple();
     message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
     message.age = object.age !== undefined && object.age !== null ? Number(object.age) : 0;
     return message;
@@ -96,7 +96,7 @@ export const Simple = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Simple>, I>>(object: I): Simple {
-    const message = { ...baseSimple } as Simple;
+    const message = createBaseSimple();
     message.name = object.name ?? '';
     message.age = object.age ?? 0;
     return message;

--- a/integration/barrel-imports/bar.ts
+++ b/integration/barrel-imports/bar.ts
@@ -7,7 +7,9 @@ export interface Bar {
   age: number;
 }
 
-const createBaseBar = (): Bar => ({ name: '', age: 0 });
+function createBaseBar(): Bar {
+  return { name: '', age: 0 };
+}
 
 export const Bar = {
   encode(message: Bar, writer: Writer = Writer.create()): Writer {

--- a/integration/barrel-imports/bar.ts
+++ b/integration/barrel-imports/bar.ts
@@ -7,7 +7,7 @@ export interface Bar {
   age: number;
 }
 
-const baseBar: object = { name: '', age: 0 };
+const createBaseBar = (): Bar => ({ name: '', age: 0 });
 
 export const Bar = {
   encode(message: Bar, writer: Writer = Writer.create()): Writer {
@@ -23,7 +23,7 @@ export const Bar = {
   decode(input: Reader | Uint8Array, length?: number): Bar {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseBar } as Bar;
+    const message = createBaseBar();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -42,7 +42,7 @@ export const Bar = {
   },
 
   fromJSON(object: any): Bar {
-    const message = { ...baseBar } as Bar;
+    const message = createBaseBar();
     message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
     message.age = object.age !== undefined && object.age !== null ? Number(object.age) : 0;
     return message;
@@ -56,7 +56,7 @@ export const Bar = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Bar>, I>>(object: I): Bar {
-    const message = { ...baseBar } as Bar;
+    const message = createBaseBar();
     message.name = object.name ?? '';
     message.age = object.age ?? 0;
     return message;

--- a/integration/barrel-imports/foo.ts
+++ b/integration/barrel-imports/foo.ts
@@ -8,7 +8,7 @@ export interface Foo {
   bar: Bar | undefined;
 }
 
-const baseFoo: object = { name: '' };
+const createBaseFoo = (): Foo => ({ name: '' });
 
 export const Foo = {
   encode(message: Foo, writer: Writer = Writer.create()): Writer {
@@ -24,7 +24,7 @@ export const Foo = {
   decode(input: Reader | Uint8Array, length?: number): Foo {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseFoo } as Foo;
+    const message = createBaseFoo();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -43,7 +43,7 @@ export const Foo = {
   },
 
   fromJSON(object: any): Foo {
-    const message = { ...baseFoo } as Foo;
+    const message = createBaseFoo();
     message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
     message.bar = object.bar !== undefined && object.bar !== null ? Bar.fromJSON(object.bar) : undefined;
     return message;
@@ -57,7 +57,7 @@ export const Foo = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Foo>, I>>(object: I): Foo {
-    const message = { ...baseFoo } as Foo;
+    const message = createBaseFoo();
     message.name = object.name ?? '';
     message.bar = object.bar !== undefined && object.bar !== null ? Bar.fromPartial(object.bar) : undefined;
     return message;

--- a/integration/barrel-imports/foo.ts
+++ b/integration/barrel-imports/foo.ts
@@ -8,7 +8,9 @@ export interface Foo {
   bar: Bar | undefined;
 }
 
-const createBaseFoo = (): Foo => ({ name: '' });
+function createBaseFoo(): Foo {
+  return { name: '', bar: undefined };
+}
 
 export const Foo = {
   encode(message: Foo, writer: Writer = Writer.create()): Writer {

--- a/integration/batching-with-context/batching.ts
+++ b/integration/batching-with-context/batching.ts
@@ -46,7 +46,7 @@ export interface Entity {
   name: string;
 }
 
-const baseBatchQueryRequest: object = { ids: '' };
+const createBaseBatchQueryRequest = (): BatchQueryRequest => ({ ids: '' });
 
 export const BatchQueryRequest = {
   encode(message: BatchQueryRequest, writer: Writer = Writer.create()): Writer {
@@ -59,7 +59,7 @@ export const BatchQueryRequest = {
   decode(input: Reader | Uint8Array, length?: number): BatchQueryRequest {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseBatchQueryRequest } as BatchQueryRequest;
+    const message = createBaseBatchQueryRequest();
     message.ids = [];
     while (reader.pos < end) {
       const tag = reader.uint32();
@@ -76,7 +76,7 @@ export const BatchQueryRequest = {
   },
 
   fromJSON(object: any): BatchQueryRequest {
-    const message = { ...baseBatchQueryRequest } as BatchQueryRequest;
+    const message = createBaseBatchQueryRequest();
     message.ids = (object.ids ?? []).map((e: any) => String(e));
     return message;
   },
@@ -92,13 +92,13 @@ export const BatchQueryRequest = {
   },
 
   fromPartial<I extends Exact<DeepPartial<BatchQueryRequest>, I>>(object: I): BatchQueryRequest {
-    const message = { ...baseBatchQueryRequest } as BatchQueryRequest;
+    const message = createBaseBatchQueryRequest();
     message.ids = object.ids?.map((e) => e) || [];
     return message;
   },
 };
 
-const baseBatchQueryResponse: object = {};
+const createBaseBatchQueryResponse = (): BatchQueryResponse => ({});
 
 export const BatchQueryResponse = {
   encode(message: BatchQueryResponse, writer: Writer = Writer.create()): Writer {
@@ -111,7 +111,7 @@ export const BatchQueryResponse = {
   decode(input: Reader | Uint8Array, length?: number): BatchQueryResponse {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseBatchQueryResponse } as BatchQueryResponse;
+    const message = createBaseBatchQueryResponse();
     message.entities = [];
     while (reader.pos < end) {
       const tag = reader.uint32();
@@ -128,7 +128,7 @@ export const BatchQueryResponse = {
   },
 
   fromJSON(object: any): BatchQueryResponse {
-    const message = { ...baseBatchQueryResponse } as BatchQueryResponse;
+    const message = createBaseBatchQueryResponse();
     message.entities = (object.entities ?? []).map((e: any) => Entity.fromJSON(e));
     return message;
   },
@@ -144,13 +144,13 @@ export const BatchQueryResponse = {
   },
 
   fromPartial<I extends Exact<DeepPartial<BatchQueryResponse>, I>>(object: I): BatchQueryResponse {
-    const message = { ...baseBatchQueryResponse } as BatchQueryResponse;
+    const message = createBaseBatchQueryResponse();
     message.entities = object.entities?.map((e) => Entity.fromPartial(e)) || [];
     return message;
   },
 };
 
-const baseBatchMapQueryRequest: object = { ids: '' };
+const createBaseBatchMapQueryRequest = (): BatchMapQueryRequest => ({ ids: '' });
 
 export const BatchMapQueryRequest = {
   encode(message: BatchMapQueryRequest, writer: Writer = Writer.create()): Writer {
@@ -163,7 +163,7 @@ export const BatchMapQueryRequest = {
   decode(input: Reader | Uint8Array, length?: number): BatchMapQueryRequest {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseBatchMapQueryRequest } as BatchMapQueryRequest;
+    const message = createBaseBatchMapQueryRequest();
     message.ids = [];
     while (reader.pos < end) {
       const tag = reader.uint32();
@@ -180,7 +180,7 @@ export const BatchMapQueryRequest = {
   },
 
   fromJSON(object: any): BatchMapQueryRequest {
-    const message = { ...baseBatchMapQueryRequest } as BatchMapQueryRequest;
+    const message = createBaseBatchMapQueryRequest();
     message.ids = (object.ids ?? []).map((e: any) => String(e));
     return message;
   },
@@ -196,13 +196,13 @@ export const BatchMapQueryRequest = {
   },
 
   fromPartial<I extends Exact<DeepPartial<BatchMapQueryRequest>, I>>(object: I): BatchMapQueryRequest {
-    const message = { ...baseBatchMapQueryRequest } as BatchMapQueryRequest;
+    const message = createBaseBatchMapQueryRequest();
     message.ids = object.ids?.map((e) => e) || [];
     return message;
   },
 };
 
-const baseBatchMapQueryResponse: object = {};
+const createBaseBatchMapQueryResponse = (): BatchMapQueryResponse => ({});
 
 export const BatchMapQueryResponse = {
   encode(message: BatchMapQueryResponse, writer: Writer = Writer.create()): Writer {
@@ -215,7 +215,7 @@ export const BatchMapQueryResponse = {
   decode(input: Reader | Uint8Array, length?: number): BatchMapQueryResponse {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseBatchMapQueryResponse } as BatchMapQueryResponse;
+    const message = createBaseBatchMapQueryResponse();
     message.entities = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
@@ -235,7 +235,7 @@ export const BatchMapQueryResponse = {
   },
 
   fromJSON(object: any): BatchMapQueryResponse {
-    const message = { ...baseBatchMapQueryResponse } as BatchMapQueryResponse;
+    const message = createBaseBatchMapQueryResponse();
     message.entities = Object.entries(object.entities ?? {}).reduce<{ [key: string]: Entity }>((acc, [key, value]) => {
       acc[key] = Entity.fromJSON(value);
       return acc;
@@ -255,7 +255,7 @@ export const BatchMapQueryResponse = {
   },
 
   fromPartial<I extends Exact<DeepPartial<BatchMapQueryResponse>, I>>(object: I): BatchMapQueryResponse {
-    const message = { ...baseBatchMapQueryResponse } as BatchMapQueryResponse;
+    const message = createBaseBatchMapQueryResponse();
     message.entities = Object.entries(object.entities ?? {}).reduce<{ [key: string]: Entity }>((acc, [key, value]) => {
       if (value !== undefined) {
         acc[key] = Entity.fromPartial(value);
@@ -266,7 +266,7 @@ export const BatchMapQueryResponse = {
   },
 };
 
-const baseBatchMapQueryResponse_EntitiesEntry: object = { key: '' };
+const createBaseBatchMapQueryResponse_EntitiesEntry = (): BatchMapQueryResponse_EntitiesEntry => ({ key: '' });
 
 export const BatchMapQueryResponse_EntitiesEntry = {
   encode(message: BatchMapQueryResponse_EntitiesEntry, writer: Writer = Writer.create()): Writer {
@@ -282,7 +282,7 @@ export const BatchMapQueryResponse_EntitiesEntry = {
   decode(input: Reader | Uint8Array, length?: number): BatchMapQueryResponse_EntitiesEntry {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseBatchMapQueryResponse_EntitiesEntry } as BatchMapQueryResponse_EntitiesEntry;
+    const message = createBaseBatchMapQueryResponse_EntitiesEntry();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -301,7 +301,7 @@ export const BatchMapQueryResponse_EntitiesEntry = {
   },
 
   fromJSON(object: any): BatchMapQueryResponse_EntitiesEntry {
-    const message = { ...baseBatchMapQueryResponse_EntitiesEntry } as BatchMapQueryResponse_EntitiesEntry;
+    const message = createBaseBatchMapQueryResponse_EntitiesEntry();
     message.key = object.key !== undefined && object.key !== null ? String(object.key) : '';
     message.value = object.value !== undefined && object.value !== null ? Entity.fromJSON(object.value) : undefined;
     return message;
@@ -317,14 +317,14 @@ export const BatchMapQueryResponse_EntitiesEntry = {
   fromPartial<I extends Exact<DeepPartial<BatchMapQueryResponse_EntitiesEntry>, I>>(
     object: I
   ): BatchMapQueryResponse_EntitiesEntry {
-    const message = { ...baseBatchMapQueryResponse_EntitiesEntry } as BatchMapQueryResponse_EntitiesEntry;
+    const message = createBaseBatchMapQueryResponse_EntitiesEntry();
     message.key = object.key ?? '';
     message.value = object.value !== undefined && object.value !== null ? Entity.fromPartial(object.value) : undefined;
     return message;
   },
 };
 
-const baseGetOnlyMethodRequest: object = { id: '' };
+const createBaseGetOnlyMethodRequest = (): GetOnlyMethodRequest => ({ id: '' });
 
 export const GetOnlyMethodRequest = {
   encode(message: GetOnlyMethodRequest, writer: Writer = Writer.create()): Writer {
@@ -337,7 +337,7 @@ export const GetOnlyMethodRequest = {
   decode(input: Reader | Uint8Array, length?: number): GetOnlyMethodRequest {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseGetOnlyMethodRequest } as GetOnlyMethodRequest;
+    const message = createBaseGetOnlyMethodRequest();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -353,7 +353,7 @@ export const GetOnlyMethodRequest = {
   },
 
   fromJSON(object: any): GetOnlyMethodRequest {
-    const message = { ...baseGetOnlyMethodRequest } as GetOnlyMethodRequest;
+    const message = createBaseGetOnlyMethodRequest();
     message.id = object.id !== undefined && object.id !== null ? String(object.id) : '';
     return message;
   },
@@ -365,13 +365,13 @@ export const GetOnlyMethodRequest = {
   },
 
   fromPartial<I extends Exact<DeepPartial<GetOnlyMethodRequest>, I>>(object: I): GetOnlyMethodRequest {
-    const message = { ...baseGetOnlyMethodRequest } as GetOnlyMethodRequest;
+    const message = createBaseGetOnlyMethodRequest();
     message.id = object.id ?? '';
     return message;
   },
 };
 
-const baseGetOnlyMethodResponse: object = {};
+const createBaseGetOnlyMethodResponse = (): GetOnlyMethodResponse => ({});
 
 export const GetOnlyMethodResponse = {
   encode(message: GetOnlyMethodResponse, writer: Writer = Writer.create()): Writer {
@@ -384,7 +384,7 @@ export const GetOnlyMethodResponse = {
   decode(input: Reader | Uint8Array, length?: number): GetOnlyMethodResponse {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseGetOnlyMethodResponse } as GetOnlyMethodResponse;
+    const message = createBaseGetOnlyMethodResponse();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -400,7 +400,7 @@ export const GetOnlyMethodResponse = {
   },
 
   fromJSON(object: any): GetOnlyMethodResponse {
-    const message = { ...baseGetOnlyMethodResponse } as GetOnlyMethodResponse;
+    const message = createBaseGetOnlyMethodResponse();
     message.entity = object.entity !== undefined && object.entity !== null ? Entity.fromJSON(object.entity) : undefined;
     return message;
   },
@@ -412,14 +412,14 @@ export const GetOnlyMethodResponse = {
   },
 
   fromPartial<I extends Exact<DeepPartial<GetOnlyMethodResponse>, I>>(object: I): GetOnlyMethodResponse {
-    const message = { ...baseGetOnlyMethodResponse } as GetOnlyMethodResponse;
+    const message = createBaseGetOnlyMethodResponse();
     message.entity =
       object.entity !== undefined && object.entity !== null ? Entity.fromPartial(object.entity) : undefined;
     return message;
   },
 };
 
-const baseWriteMethodRequest: object = { id: '' };
+const createBaseWriteMethodRequest = (): WriteMethodRequest => ({ id: '' });
 
 export const WriteMethodRequest = {
   encode(message: WriteMethodRequest, writer: Writer = Writer.create()): Writer {
@@ -432,7 +432,7 @@ export const WriteMethodRequest = {
   decode(input: Reader | Uint8Array, length?: number): WriteMethodRequest {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseWriteMethodRequest } as WriteMethodRequest;
+    const message = createBaseWriteMethodRequest();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -448,7 +448,7 @@ export const WriteMethodRequest = {
   },
 
   fromJSON(object: any): WriteMethodRequest {
-    const message = { ...baseWriteMethodRequest } as WriteMethodRequest;
+    const message = createBaseWriteMethodRequest();
     message.id = object.id !== undefined && object.id !== null ? String(object.id) : '';
     return message;
   },
@@ -460,13 +460,13 @@ export const WriteMethodRequest = {
   },
 
   fromPartial<I extends Exact<DeepPartial<WriteMethodRequest>, I>>(object: I): WriteMethodRequest {
-    const message = { ...baseWriteMethodRequest } as WriteMethodRequest;
+    const message = createBaseWriteMethodRequest();
     message.id = object.id ?? '';
     return message;
   },
 };
 
-const baseWriteMethodResponse: object = {};
+const createBaseWriteMethodResponse = (): WriteMethodResponse => ({});
 
 export const WriteMethodResponse = {
   encode(_: WriteMethodResponse, writer: Writer = Writer.create()): Writer {
@@ -476,7 +476,7 @@ export const WriteMethodResponse = {
   decode(input: Reader | Uint8Array, length?: number): WriteMethodResponse {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseWriteMethodResponse } as WriteMethodResponse;
+    const message = createBaseWriteMethodResponse();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -489,7 +489,7 @@ export const WriteMethodResponse = {
   },
 
   fromJSON(_: any): WriteMethodResponse {
-    const message = { ...baseWriteMethodResponse } as WriteMethodResponse;
+    const message = createBaseWriteMethodResponse();
     return message;
   },
 
@@ -499,12 +499,12 @@ export const WriteMethodResponse = {
   },
 
   fromPartial<I extends Exact<DeepPartial<WriteMethodResponse>, I>>(_: I): WriteMethodResponse {
-    const message = { ...baseWriteMethodResponse } as WriteMethodResponse;
+    const message = createBaseWriteMethodResponse();
     return message;
   },
 };
 
-const baseEntity: object = { id: '', name: '' };
+const createBaseEntity = (): Entity => ({ id: '', name: '' });
 
 export const Entity = {
   encode(message: Entity, writer: Writer = Writer.create()): Writer {
@@ -520,7 +520,7 @@ export const Entity = {
   decode(input: Reader | Uint8Array, length?: number): Entity {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseEntity } as Entity;
+    const message = createBaseEntity();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -539,7 +539,7 @@ export const Entity = {
   },
 
   fromJSON(object: any): Entity {
-    const message = { ...baseEntity } as Entity;
+    const message = createBaseEntity();
     message.id = object.id !== undefined && object.id !== null ? String(object.id) : '';
     message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
     return message;
@@ -553,7 +553,7 @@ export const Entity = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Entity>, I>>(object: I): Entity {
-    const message = { ...baseEntity } as Entity;
+    const message = createBaseEntity();
     message.id = object.id ?? '';
     message.name = object.name ?? '';
     return message;

--- a/integration/batching-with-context/batching.ts
+++ b/integration/batching-with-context/batching.ts
@@ -46,7 +46,9 @@ export interface Entity {
   name: string;
 }
 
-const createBaseBatchQueryRequest = (): BatchQueryRequest => ({ ids: '' });
+function createBaseBatchQueryRequest(): BatchQueryRequest {
+  return { ids: [] };
+}
 
 export const BatchQueryRequest = {
   encode(message: BatchQueryRequest, writer: Writer = Writer.create()): Writer {
@@ -60,7 +62,6 @@ export const BatchQueryRequest = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseBatchQueryRequest();
-    message.ids = [];
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -98,7 +99,9 @@ export const BatchQueryRequest = {
   },
 };
 
-const createBaseBatchQueryResponse = (): BatchQueryResponse => ({});
+function createBaseBatchQueryResponse(): BatchQueryResponse {
+  return { entities: [] };
+}
 
 export const BatchQueryResponse = {
   encode(message: BatchQueryResponse, writer: Writer = Writer.create()): Writer {
@@ -112,7 +115,6 @@ export const BatchQueryResponse = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseBatchQueryResponse();
-    message.entities = [];
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -150,7 +152,9 @@ export const BatchQueryResponse = {
   },
 };
 
-const createBaseBatchMapQueryRequest = (): BatchMapQueryRequest => ({ ids: '' });
+function createBaseBatchMapQueryRequest(): BatchMapQueryRequest {
+  return { ids: [] };
+}
 
 export const BatchMapQueryRequest = {
   encode(message: BatchMapQueryRequest, writer: Writer = Writer.create()): Writer {
@@ -164,7 +168,6 @@ export const BatchMapQueryRequest = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseBatchMapQueryRequest();
-    message.ids = [];
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -202,7 +205,9 @@ export const BatchMapQueryRequest = {
   },
 };
 
-const createBaseBatchMapQueryResponse = (): BatchMapQueryResponse => ({});
+function createBaseBatchMapQueryResponse(): BatchMapQueryResponse {
+  return { entities: {} };
+}
 
 export const BatchMapQueryResponse = {
   encode(message: BatchMapQueryResponse, writer: Writer = Writer.create()): Writer {
@@ -216,7 +221,6 @@ export const BatchMapQueryResponse = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseBatchMapQueryResponse();
-    message.entities = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -266,7 +270,9 @@ export const BatchMapQueryResponse = {
   },
 };
 
-const createBaseBatchMapQueryResponse_EntitiesEntry = (): BatchMapQueryResponse_EntitiesEntry => ({ key: '' });
+function createBaseBatchMapQueryResponse_EntitiesEntry(): BatchMapQueryResponse_EntitiesEntry {
+  return { key: '', value: undefined };
+}
 
 export const BatchMapQueryResponse_EntitiesEntry = {
   encode(message: BatchMapQueryResponse_EntitiesEntry, writer: Writer = Writer.create()): Writer {
@@ -324,7 +330,9 @@ export const BatchMapQueryResponse_EntitiesEntry = {
   },
 };
 
-const createBaseGetOnlyMethodRequest = (): GetOnlyMethodRequest => ({ id: '' });
+function createBaseGetOnlyMethodRequest(): GetOnlyMethodRequest {
+  return { id: '' };
+}
 
 export const GetOnlyMethodRequest = {
   encode(message: GetOnlyMethodRequest, writer: Writer = Writer.create()): Writer {
@@ -371,7 +379,9 @@ export const GetOnlyMethodRequest = {
   },
 };
 
-const createBaseGetOnlyMethodResponse = (): GetOnlyMethodResponse => ({});
+function createBaseGetOnlyMethodResponse(): GetOnlyMethodResponse {
+  return { entity: undefined };
+}
 
 export const GetOnlyMethodResponse = {
   encode(message: GetOnlyMethodResponse, writer: Writer = Writer.create()): Writer {
@@ -419,7 +429,9 @@ export const GetOnlyMethodResponse = {
   },
 };
 
-const createBaseWriteMethodRequest = (): WriteMethodRequest => ({ id: '' });
+function createBaseWriteMethodRequest(): WriteMethodRequest {
+  return { id: '' };
+}
 
 export const WriteMethodRequest = {
   encode(message: WriteMethodRequest, writer: Writer = Writer.create()): Writer {
@@ -466,7 +478,9 @@ export const WriteMethodRequest = {
   },
 };
 
-const createBaseWriteMethodResponse = (): WriteMethodResponse => ({});
+function createBaseWriteMethodResponse(): WriteMethodResponse {
+  return {};
+}
 
 export const WriteMethodResponse = {
   encode(_: WriteMethodResponse, writer: Writer = Writer.create()): Writer {
@@ -504,7 +518,9 @@ export const WriteMethodResponse = {
   },
 };
 
-const createBaseEntity = (): Entity => ({ id: '', name: '' });
+function createBaseEntity(): Entity {
+  return { id: '', name: '' };
+}
 
 export const Entity = {
   encode(message: Entity, writer: Writer = Writer.create()): Writer {

--- a/integration/batching/batching.ts
+++ b/integration/batching/batching.ts
@@ -44,7 +44,9 @@ export interface Entity {
   name: string;
 }
 
-const createBaseBatchQueryRequest = (): BatchQueryRequest => ({ ids: '' });
+function createBaseBatchQueryRequest(): BatchQueryRequest {
+  return { ids: [] };
+}
 
 export const BatchQueryRequest = {
   encode(message: BatchQueryRequest, writer: Writer = Writer.create()): Writer {
@@ -58,7 +60,6 @@ export const BatchQueryRequest = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseBatchQueryRequest();
-    message.ids = [];
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -96,7 +97,9 @@ export const BatchQueryRequest = {
   },
 };
 
-const createBaseBatchQueryResponse = (): BatchQueryResponse => ({});
+function createBaseBatchQueryResponse(): BatchQueryResponse {
+  return { entities: [] };
+}
 
 export const BatchQueryResponse = {
   encode(message: BatchQueryResponse, writer: Writer = Writer.create()): Writer {
@@ -110,7 +113,6 @@ export const BatchQueryResponse = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseBatchQueryResponse();
-    message.entities = [];
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -148,7 +150,9 @@ export const BatchQueryResponse = {
   },
 };
 
-const createBaseBatchMapQueryRequest = (): BatchMapQueryRequest => ({ ids: '' });
+function createBaseBatchMapQueryRequest(): BatchMapQueryRequest {
+  return { ids: [] };
+}
 
 export const BatchMapQueryRequest = {
   encode(message: BatchMapQueryRequest, writer: Writer = Writer.create()): Writer {
@@ -162,7 +166,6 @@ export const BatchMapQueryRequest = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseBatchMapQueryRequest();
-    message.ids = [];
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -200,7 +203,9 @@ export const BatchMapQueryRequest = {
   },
 };
 
-const createBaseBatchMapQueryResponse = (): BatchMapQueryResponse => ({});
+function createBaseBatchMapQueryResponse(): BatchMapQueryResponse {
+  return { entities: {} };
+}
 
 export const BatchMapQueryResponse = {
   encode(message: BatchMapQueryResponse, writer: Writer = Writer.create()): Writer {
@@ -214,7 +219,6 @@ export const BatchMapQueryResponse = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseBatchMapQueryResponse();
-    message.entities = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -264,7 +268,9 @@ export const BatchMapQueryResponse = {
   },
 };
 
-const createBaseBatchMapQueryResponse_EntitiesEntry = (): BatchMapQueryResponse_EntitiesEntry => ({ key: '' });
+function createBaseBatchMapQueryResponse_EntitiesEntry(): BatchMapQueryResponse_EntitiesEntry {
+  return { key: '', value: undefined };
+}
 
 export const BatchMapQueryResponse_EntitiesEntry = {
   encode(message: BatchMapQueryResponse_EntitiesEntry, writer: Writer = Writer.create()): Writer {
@@ -322,7 +328,9 @@ export const BatchMapQueryResponse_EntitiesEntry = {
   },
 };
 
-const createBaseGetOnlyMethodRequest = (): GetOnlyMethodRequest => ({ id: '' });
+function createBaseGetOnlyMethodRequest(): GetOnlyMethodRequest {
+  return { id: '' };
+}
 
 export const GetOnlyMethodRequest = {
   encode(message: GetOnlyMethodRequest, writer: Writer = Writer.create()): Writer {
@@ -369,7 +377,9 @@ export const GetOnlyMethodRequest = {
   },
 };
 
-const createBaseGetOnlyMethodResponse = (): GetOnlyMethodResponse => ({});
+function createBaseGetOnlyMethodResponse(): GetOnlyMethodResponse {
+  return { entity: undefined };
+}
 
 export const GetOnlyMethodResponse = {
   encode(message: GetOnlyMethodResponse, writer: Writer = Writer.create()): Writer {
@@ -417,7 +427,9 @@ export const GetOnlyMethodResponse = {
   },
 };
 
-const createBaseWriteMethodRequest = (): WriteMethodRequest => ({ id: '' });
+function createBaseWriteMethodRequest(): WriteMethodRequest {
+  return { id: '' };
+}
 
 export const WriteMethodRequest = {
   encode(message: WriteMethodRequest, writer: Writer = Writer.create()): Writer {
@@ -464,7 +476,9 @@ export const WriteMethodRequest = {
   },
 };
 
-const createBaseWriteMethodResponse = (): WriteMethodResponse => ({});
+function createBaseWriteMethodResponse(): WriteMethodResponse {
+  return {};
+}
 
 export const WriteMethodResponse = {
   encode(_: WriteMethodResponse, writer: Writer = Writer.create()): Writer {
@@ -502,7 +516,9 @@ export const WriteMethodResponse = {
   },
 };
 
-const createBaseEntity = (): Entity => ({ id: '', name: '' });
+function createBaseEntity(): Entity {
+  return { id: '', name: '' };
+}
 
 export const Entity = {
   encode(message: Entity, writer: Writer = Writer.create()): Writer {

--- a/integration/batching/batching.ts
+++ b/integration/batching/batching.ts
@@ -44,7 +44,7 @@ export interface Entity {
   name: string;
 }
 
-const baseBatchQueryRequest: object = { ids: '' };
+const createBaseBatchQueryRequest = (): BatchQueryRequest => ({ ids: '' });
 
 export const BatchQueryRequest = {
   encode(message: BatchQueryRequest, writer: Writer = Writer.create()): Writer {
@@ -57,7 +57,7 @@ export const BatchQueryRequest = {
   decode(input: Reader | Uint8Array, length?: number): BatchQueryRequest {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseBatchQueryRequest } as BatchQueryRequest;
+    const message = createBaseBatchQueryRequest();
     message.ids = [];
     while (reader.pos < end) {
       const tag = reader.uint32();
@@ -74,7 +74,7 @@ export const BatchQueryRequest = {
   },
 
   fromJSON(object: any): BatchQueryRequest {
-    const message = { ...baseBatchQueryRequest } as BatchQueryRequest;
+    const message = createBaseBatchQueryRequest();
     message.ids = (object.ids ?? []).map((e: any) => String(e));
     return message;
   },
@@ -90,13 +90,13 @@ export const BatchQueryRequest = {
   },
 
   fromPartial<I extends Exact<DeepPartial<BatchQueryRequest>, I>>(object: I): BatchQueryRequest {
-    const message = { ...baseBatchQueryRequest } as BatchQueryRequest;
+    const message = createBaseBatchQueryRequest();
     message.ids = object.ids?.map((e) => e) || [];
     return message;
   },
 };
 
-const baseBatchQueryResponse: object = {};
+const createBaseBatchQueryResponse = (): BatchQueryResponse => ({});
 
 export const BatchQueryResponse = {
   encode(message: BatchQueryResponse, writer: Writer = Writer.create()): Writer {
@@ -109,7 +109,7 @@ export const BatchQueryResponse = {
   decode(input: Reader | Uint8Array, length?: number): BatchQueryResponse {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseBatchQueryResponse } as BatchQueryResponse;
+    const message = createBaseBatchQueryResponse();
     message.entities = [];
     while (reader.pos < end) {
       const tag = reader.uint32();
@@ -126,7 +126,7 @@ export const BatchQueryResponse = {
   },
 
   fromJSON(object: any): BatchQueryResponse {
-    const message = { ...baseBatchQueryResponse } as BatchQueryResponse;
+    const message = createBaseBatchQueryResponse();
     message.entities = (object.entities ?? []).map((e: any) => Entity.fromJSON(e));
     return message;
   },
@@ -142,13 +142,13 @@ export const BatchQueryResponse = {
   },
 
   fromPartial<I extends Exact<DeepPartial<BatchQueryResponse>, I>>(object: I): BatchQueryResponse {
-    const message = { ...baseBatchQueryResponse } as BatchQueryResponse;
+    const message = createBaseBatchQueryResponse();
     message.entities = object.entities?.map((e) => Entity.fromPartial(e)) || [];
     return message;
   },
 };
 
-const baseBatchMapQueryRequest: object = { ids: '' };
+const createBaseBatchMapQueryRequest = (): BatchMapQueryRequest => ({ ids: '' });
 
 export const BatchMapQueryRequest = {
   encode(message: BatchMapQueryRequest, writer: Writer = Writer.create()): Writer {
@@ -161,7 +161,7 @@ export const BatchMapQueryRequest = {
   decode(input: Reader | Uint8Array, length?: number): BatchMapQueryRequest {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseBatchMapQueryRequest } as BatchMapQueryRequest;
+    const message = createBaseBatchMapQueryRequest();
     message.ids = [];
     while (reader.pos < end) {
       const tag = reader.uint32();
@@ -178,7 +178,7 @@ export const BatchMapQueryRequest = {
   },
 
   fromJSON(object: any): BatchMapQueryRequest {
-    const message = { ...baseBatchMapQueryRequest } as BatchMapQueryRequest;
+    const message = createBaseBatchMapQueryRequest();
     message.ids = (object.ids ?? []).map((e: any) => String(e));
     return message;
   },
@@ -194,13 +194,13 @@ export const BatchMapQueryRequest = {
   },
 
   fromPartial<I extends Exact<DeepPartial<BatchMapQueryRequest>, I>>(object: I): BatchMapQueryRequest {
-    const message = { ...baseBatchMapQueryRequest } as BatchMapQueryRequest;
+    const message = createBaseBatchMapQueryRequest();
     message.ids = object.ids?.map((e) => e) || [];
     return message;
   },
 };
 
-const baseBatchMapQueryResponse: object = {};
+const createBaseBatchMapQueryResponse = (): BatchMapQueryResponse => ({});
 
 export const BatchMapQueryResponse = {
   encode(message: BatchMapQueryResponse, writer: Writer = Writer.create()): Writer {
@@ -213,7 +213,7 @@ export const BatchMapQueryResponse = {
   decode(input: Reader | Uint8Array, length?: number): BatchMapQueryResponse {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseBatchMapQueryResponse } as BatchMapQueryResponse;
+    const message = createBaseBatchMapQueryResponse();
     message.entities = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
@@ -233,7 +233,7 @@ export const BatchMapQueryResponse = {
   },
 
   fromJSON(object: any): BatchMapQueryResponse {
-    const message = { ...baseBatchMapQueryResponse } as BatchMapQueryResponse;
+    const message = createBaseBatchMapQueryResponse();
     message.entities = Object.entries(object.entities ?? {}).reduce<{ [key: string]: Entity }>((acc, [key, value]) => {
       acc[key] = Entity.fromJSON(value);
       return acc;
@@ -253,7 +253,7 @@ export const BatchMapQueryResponse = {
   },
 
   fromPartial<I extends Exact<DeepPartial<BatchMapQueryResponse>, I>>(object: I): BatchMapQueryResponse {
-    const message = { ...baseBatchMapQueryResponse } as BatchMapQueryResponse;
+    const message = createBaseBatchMapQueryResponse();
     message.entities = Object.entries(object.entities ?? {}).reduce<{ [key: string]: Entity }>((acc, [key, value]) => {
       if (value !== undefined) {
         acc[key] = Entity.fromPartial(value);
@@ -264,7 +264,7 @@ export const BatchMapQueryResponse = {
   },
 };
 
-const baseBatchMapQueryResponse_EntitiesEntry: object = { key: '' };
+const createBaseBatchMapQueryResponse_EntitiesEntry = (): BatchMapQueryResponse_EntitiesEntry => ({ key: '' });
 
 export const BatchMapQueryResponse_EntitiesEntry = {
   encode(message: BatchMapQueryResponse_EntitiesEntry, writer: Writer = Writer.create()): Writer {
@@ -280,7 +280,7 @@ export const BatchMapQueryResponse_EntitiesEntry = {
   decode(input: Reader | Uint8Array, length?: number): BatchMapQueryResponse_EntitiesEntry {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseBatchMapQueryResponse_EntitiesEntry } as BatchMapQueryResponse_EntitiesEntry;
+    const message = createBaseBatchMapQueryResponse_EntitiesEntry();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -299,7 +299,7 @@ export const BatchMapQueryResponse_EntitiesEntry = {
   },
 
   fromJSON(object: any): BatchMapQueryResponse_EntitiesEntry {
-    const message = { ...baseBatchMapQueryResponse_EntitiesEntry } as BatchMapQueryResponse_EntitiesEntry;
+    const message = createBaseBatchMapQueryResponse_EntitiesEntry();
     message.key = object.key !== undefined && object.key !== null ? String(object.key) : '';
     message.value = object.value !== undefined && object.value !== null ? Entity.fromJSON(object.value) : undefined;
     return message;
@@ -315,14 +315,14 @@ export const BatchMapQueryResponse_EntitiesEntry = {
   fromPartial<I extends Exact<DeepPartial<BatchMapQueryResponse_EntitiesEntry>, I>>(
     object: I
   ): BatchMapQueryResponse_EntitiesEntry {
-    const message = { ...baseBatchMapQueryResponse_EntitiesEntry } as BatchMapQueryResponse_EntitiesEntry;
+    const message = createBaseBatchMapQueryResponse_EntitiesEntry();
     message.key = object.key ?? '';
     message.value = object.value !== undefined && object.value !== null ? Entity.fromPartial(object.value) : undefined;
     return message;
   },
 };
 
-const baseGetOnlyMethodRequest: object = { id: '' };
+const createBaseGetOnlyMethodRequest = (): GetOnlyMethodRequest => ({ id: '' });
 
 export const GetOnlyMethodRequest = {
   encode(message: GetOnlyMethodRequest, writer: Writer = Writer.create()): Writer {
@@ -335,7 +335,7 @@ export const GetOnlyMethodRequest = {
   decode(input: Reader | Uint8Array, length?: number): GetOnlyMethodRequest {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseGetOnlyMethodRequest } as GetOnlyMethodRequest;
+    const message = createBaseGetOnlyMethodRequest();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -351,7 +351,7 @@ export const GetOnlyMethodRequest = {
   },
 
   fromJSON(object: any): GetOnlyMethodRequest {
-    const message = { ...baseGetOnlyMethodRequest } as GetOnlyMethodRequest;
+    const message = createBaseGetOnlyMethodRequest();
     message.id = object.id !== undefined && object.id !== null ? String(object.id) : '';
     return message;
   },
@@ -363,13 +363,13 @@ export const GetOnlyMethodRequest = {
   },
 
   fromPartial<I extends Exact<DeepPartial<GetOnlyMethodRequest>, I>>(object: I): GetOnlyMethodRequest {
-    const message = { ...baseGetOnlyMethodRequest } as GetOnlyMethodRequest;
+    const message = createBaseGetOnlyMethodRequest();
     message.id = object.id ?? '';
     return message;
   },
 };
 
-const baseGetOnlyMethodResponse: object = {};
+const createBaseGetOnlyMethodResponse = (): GetOnlyMethodResponse => ({});
 
 export const GetOnlyMethodResponse = {
   encode(message: GetOnlyMethodResponse, writer: Writer = Writer.create()): Writer {
@@ -382,7 +382,7 @@ export const GetOnlyMethodResponse = {
   decode(input: Reader | Uint8Array, length?: number): GetOnlyMethodResponse {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseGetOnlyMethodResponse } as GetOnlyMethodResponse;
+    const message = createBaseGetOnlyMethodResponse();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -398,7 +398,7 @@ export const GetOnlyMethodResponse = {
   },
 
   fromJSON(object: any): GetOnlyMethodResponse {
-    const message = { ...baseGetOnlyMethodResponse } as GetOnlyMethodResponse;
+    const message = createBaseGetOnlyMethodResponse();
     message.entity = object.entity !== undefined && object.entity !== null ? Entity.fromJSON(object.entity) : undefined;
     return message;
   },
@@ -410,14 +410,14 @@ export const GetOnlyMethodResponse = {
   },
 
   fromPartial<I extends Exact<DeepPartial<GetOnlyMethodResponse>, I>>(object: I): GetOnlyMethodResponse {
-    const message = { ...baseGetOnlyMethodResponse } as GetOnlyMethodResponse;
+    const message = createBaseGetOnlyMethodResponse();
     message.entity =
       object.entity !== undefined && object.entity !== null ? Entity.fromPartial(object.entity) : undefined;
     return message;
   },
 };
 
-const baseWriteMethodRequest: object = { id: '' };
+const createBaseWriteMethodRequest = (): WriteMethodRequest => ({ id: '' });
 
 export const WriteMethodRequest = {
   encode(message: WriteMethodRequest, writer: Writer = Writer.create()): Writer {
@@ -430,7 +430,7 @@ export const WriteMethodRequest = {
   decode(input: Reader | Uint8Array, length?: number): WriteMethodRequest {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseWriteMethodRequest } as WriteMethodRequest;
+    const message = createBaseWriteMethodRequest();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -446,7 +446,7 @@ export const WriteMethodRequest = {
   },
 
   fromJSON(object: any): WriteMethodRequest {
-    const message = { ...baseWriteMethodRequest } as WriteMethodRequest;
+    const message = createBaseWriteMethodRequest();
     message.id = object.id !== undefined && object.id !== null ? String(object.id) : '';
     return message;
   },
@@ -458,13 +458,13 @@ export const WriteMethodRequest = {
   },
 
   fromPartial<I extends Exact<DeepPartial<WriteMethodRequest>, I>>(object: I): WriteMethodRequest {
-    const message = { ...baseWriteMethodRequest } as WriteMethodRequest;
+    const message = createBaseWriteMethodRequest();
     message.id = object.id ?? '';
     return message;
   },
 };
 
-const baseWriteMethodResponse: object = {};
+const createBaseWriteMethodResponse = (): WriteMethodResponse => ({});
 
 export const WriteMethodResponse = {
   encode(_: WriteMethodResponse, writer: Writer = Writer.create()): Writer {
@@ -474,7 +474,7 @@ export const WriteMethodResponse = {
   decode(input: Reader | Uint8Array, length?: number): WriteMethodResponse {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseWriteMethodResponse } as WriteMethodResponse;
+    const message = createBaseWriteMethodResponse();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -487,7 +487,7 @@ export const WriteMethodResponse = {
   },
 
   fromJSON(_: any): WriteMethodResponse {
-    const message = { ...baseWriteMethodResponse } as WriteMethodResponse;
+    const message = createBaseWriteMethodResponse();
     return message;
   },
 
@@ -497,12 +497,12 @@ export const WriteMethodResponse = {
   },
 
   fromPartial<I extends Exact<DeepPartial<WriteMethodResponse>, I>>(_: I): WriteMethodResponse {
-    const message = { ...baseWriteMethodResponse } as WriteMethodResponse;
+    const message = createBaseWriteMethodResponse();
     return message;
   },
 };
 
-const baseEntity: object = { id: '', name: '' };
+const createBaseEntity = (): Entity => ({ id: '', name: '' });
 
 export const Entity = {
   encode(message: Entity, writer: Writer = Writer.create()): Writer {
@@ -518,7 +518,7 @@ export const Entity = {
   decode(input: Reader | Uint8Array, length?: number): Entity {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseEntity } as Entity;
+    const message = createBaseEntity();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -537,7 +537,7 @@ export const Entity = {
   },
 
   fromJSON(object: any): Entity {
-    const message = { ...baseEntity } as Entity;
+    const message = createBaseEntity();
     message.id = object.id !== undefined && object.id !== null ? String(object.id) : '';
     message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
     return message;
@@ -551,7 +551,7 @@ export const Entity = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Entity>, I>>(object: I): Entity {
-    const message = { ...baseEntity } as Entity;
+    const message = createBaseEntity();
     message.id = object.id ?? '';
     message.name = object.name ?? '';
     return message;

--- a/integration/bytes-as-base64/message.ts
+++ b/integration/bytes-as-base64/message.ts
@@ -8,11 +8,11 @@ export interface Message {
   data: Uint8Array;
 }
 
-const baseMessage: object = {};
+const createBaseMessage = (): Message => ({});
 
 export const Message = {
   fromJSON(object: any): Message {
-    const message = { ...baseMessage } as Message;
+    const message = createBaseMessage();
     message.data = object.data !== undefined && object.data !== null ? bytesFromBase64(object.data) : new Uint8Array();
     return message;
   },
@@ -25,7 +25,7 @@ export const Message = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Message>, I>>(object: I): Message {
-    const message = { ...baseMessage } as Message;
+    const message = createBaseMessage();
     message.data = object.data ?? new Uint8Array();
     return message;
   },

--- a/integration/bytes-as-base64/message.ts
+++ b/integration/bytes-as-base64/message.ts
@@ -8,7 +8,9 @@ export interface Message {
   data: Uint8Array;
 }
 
-const createBaseMessage = (): Message => ({});
+function createBaseMessage(): Message {
+  return { data: new Uint8Array() };
+}
 
 export const Message = {
   fromJSON(object: any): Message {

--- a/integration/bytes-node/google/protobuf/wrappers.ts
+++ b/integration/bytes-node/google/protobuf/wrappers.ts
@@ -94,7 +94,9 @@ export interface BytesValue {
   value: Buffer;
 }
 
-const createBaseDoubleValue = (): DoubleValue => ({ value: 0 });
+function createBaseDoubleValue(): DoubleValue {
+  return { value: 0 };
+}
 
 export const DoubleValue = {
   encode(message: DoubleValue, writer: Writer = Writer.create()): Writer {
@@ -141,7 +143,9 @@ export const DoubleValue = {
   },
 };
 
-const createBaseFloatValue = (): FloatValue => ({ value: 0 });
+function createBaseFloatValue(): FloatValue {
+  return { value: 0 };
+}
 
 export const FloatValue = {
   encode(message: FloatValue, writer: Writer = Writer.create()): Writer {
@@ -188,7 +192,9 @@ export const FloatValue = {
   },
 };
 
-const createBaseInt64Value = (): Int64Value => ({ value: 0 });
+function createBaseInt64Value(): Int64Value {
+  return { value: 0 };
+}
 
 export const Int64Value = {
   encode(message: Int64Value, writer: Writer = Writer.create()): Writer {
@@ -235,7 +241,9 @@ export const Int64Value = {
   },
 };
 
-const createBaseUInt64Value = (): UInt64Value => ({ value: 0 });
+function createBaseUInt64Value(): UInt64Value {
+  return { value: 0 };
+}
 
 export const UInt64Value = {
   encode(message: UInt64Value, writer: Writer = Writer.create()): Writer {
@@ -282,7 +290,9 @@ export const UInt64Value = {
   },
 };
 
-const createBaseInt32Value = (): Int32Value => ({ value: 0 });
+function createBaseInt32Value(): Int32Value {
+  return { value: 0 };
+}
 
 export const Int32Value = {
   encode(message: Int32Value, writer: Writer = Writer.create()): Writer {
@@ -329,7 +339,9 @@ export const Int32Value = {
   },
 };
 
-const createBaseUInt32Value = (): UInt32Value => ({ value: 0 });
+function createBaseUInt32Value(): UInt32Value {
+  return { value: 0 };
+}
 
 export const UInt32Value = {
   encode(message: UInt32Value, writer: Writer = Writer.create()): Writer {
@@ -376,7 +388,9 @@ export const UInt32Value = {
   },
 };
 
-const createBaseBoolValue = (): BoolValue => ({ value: false });
+function createBaseBoolValue(): BoolValue {
+  return { value: false };
+}
 
 export const BoolValue = {
   encode(message: BoolValue, writer: Writer = Writer.create()): Writer {
@@ -423,7 +437,9 @@ export const BoolValue = {
   },
 };
 
-const createBaseStringValue = (): StringValue => ({ value: '' });
+function createBaseStringValue(): StringValue {
+  return { value: '' };
+}
 
 export const StringValue = {
   encode(message: StringValue, writer: Writer = Writer.create()): Writer {
@@ -470,7 +486,9 @@ export const StringValue = {
   },
 };
 
-const createBaseBytesValue = (): BytesValue => ({});
+function createBaseBytesValue(): BytesValue {
+  return { value: Buffer.alloc(0) };
+}
 
 export const BytesValue = {
   encode(message: BytesValue, writer: Writer = Writer.create()): Writer {
@@ -484,7 +502,6 @@ export const BytesValue = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseBytesValue();
-    message.value = Buffer.alloc(0);
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {

--- a/integration/bytes-node/google/protobuf/wrappers.ts
+++ b/integration/bytes-node/google/protobuf/wrappers.ts
@@ -94,7 +94,7 @@ export interface BytesValue {
   value: Buffer;
 }
 
-const baseDoubleValue: object = { value: 0 };
+const createBaseDoubleValue = (): DoubleValue => ({ value: 0 });
 
 export const DoubleValue = {
   encode(message: DoubleValue, writer: Writer = Writer.create()): Writer {
@@ -107,7 +107,7 @@ export const DoubleValue = {
   decode(input: Reader | Uint8Array, length?: number): DoubleValue {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseDoubleValue } as DoubleValue;
+    const message = createBaseDoubleValue();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -123,7 +123,7 @@ export const DoubleValue = {
   },
 
   fromJSON(object: any): DoubleValue {
-    const message = { ...baseDoubleValue } as DoubleValue;
+    const message = createBaseDoubleValue();
     message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
@@ -135,13 +135,13 @@ export const DoubleValue = {
   },
 
   fromPartial<I extends Exact<DeepPartial<DoubleValue>, I>>(object: I): DoubleValue {
-    const message = { ...baseDoubleValue } as DoubleValue;
+    const message = createBaseDoubleValue();
     message.value = object.value ?? 0;
     return message;
   },
 };
 
-const baseFloatValue: object = { value: 0 };
+const createBaseFloatValue = (): FloatValue => ({ value: 0 });
 
 export const FloatValue = {
   encode(message: FloatValue, writer: Writer = Writer.create()): Writer {
@@ -154,7 +154,7 @@ export const FloatValue = {
   decode(input: Reader | Uint8Array, length?: number): FloatValue {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseFloatValue } as FloatValue;
+    const message = createBaseFloatValue();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -170,7 +170,7 @@ export const FloatValue = {
   },
 
   fromJSON(object: any): FloatValue {
-    const message = { ...baseFloatValue } as FloatValue;
+    const message = createBaseFloatValue();
     message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
@@ -182,13 +182,13 @@ export const FloatValue = {
   },
 
   fromPartial<I extends Exact<DeepPartial<FloatValue>, I>>(object: I): FloatValue {
-    const message = { ...baseFloatValue } as FloatValue;
+    const message = createBaseFloatValue();
     message.value = object.value ?? 0;
     return message;
   },
 };
 
-const baseInt64Value: object = { value: 0 };
+const createBaseInt64Value = (): Int64Value => ({ value: 0 });
 
 export const Int64Value = {
   encode(message: Int64Value, writer: Writer = Writer.create()): Writer {
@@ -201,7 +201,7 @@ export const Int64Value = {
   decode(input: Reader | Uint8Array, length?: number): Int64Value {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseInt64Value } as Int64Value;
+    const message = createBaseInt64Value();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -217,7 +217,7 @@ export const Int64Value = {
   },
 
   fromJSON(object: any): Int64Value {
-    const message = { ...baseInt64Value } as Int64Value;
+    const message = createBaseInt64Value();
     message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
@@ -229,13 +229,13 @@ export const Int64Value = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Int64Value>, I>>(object: I): Int64Value {
-    const message = { ...baseInt64Value } as Int64Value;
+    const message = createBaseInt64Value();
     message.value = object.value ?? 0;
     return message;
   },
 };
 
-const baseUInt64Value: object = { value: 0 };
+const createBaseUInt64Value = (): UInt64Value => ({ value: 0 });
 
 export const UInt64Value = {
   encode(message: UInt64Value, writer: Writer = Writer.create()): Writer {
@@ -248,7 +248,7 @@ export const UInt64Value = {
   decode(input: Reader | Uint8Array, length?: number): UInt64Value {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseUInt64Value } as UInt64Value;
+    const message = createBaseUInt64Value();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -264,7 +264,7 @@ export const UInt64Value = {
   },
 
   fromJSON(object: any): UInt64Value {
-    const message = { ...baseUInt64Value } as UInt64Value;
+    const message = createBaseUInt64Value();
     message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
@@ -276,13 +276,13 @@ export const UInt64Value = {
   },
 
   fromPartial<I extends Exact<DeepPartial<UInt64Value>, I>>(object: I): UInt64Value {
-    const message = { ...baseUInt64Value } as UInt64Value;
+    const message = createBaseUInt64Value();
     message.value = object.value ?? 0;
     return message;
   },
 };
 
-const baseInt32Value: object = { value: 0 };
+const createBaseInt32Value = (): Int32Value => ({ value: 0 });
 
 export const Int32Value = {
   encode(message: Int32Value, writer: Writer = Writer.create()): Writer {
@@ -295,7 +295,7 @@ export const Int32Value = {
   decode(input: Reader | Uint8Array, length?: number): Int32Value {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseInt32Value } as Int32Value;
+    const message = createBaseInt32Value();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -311,7 +311,7 @@ export const Int32Value = {
   },
 
   fromJSON(object: any): Int32Value {
-    const message = { ...baseInt32Value } as Int32Value;
+    const message = createBaseInt32Value();
     message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
@@ -323,13 +323,13 @@ export const Int32Value = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Int32Value>, I>>(object: I): Int32Value {
-    const message = { ...baseInt32Value } as Int32Value;
+    const message = createBaseInt32Value();
     message.value = object.value ?? 0;
     return message;
   },
 };
 
-const baseUInt32Value: object = { value: 0 };
+const createBaseUInt32Value = (): UInt32Value => ({ value: 0 });
 
 export const UInt32Value = {
   encode(message: UInt32Value, writer: Writer = Writer.create()): Writer {
@@ -342,7 +342,7 @@ export const UInt32Value = {
   decode(input: Reader | Uint8Array, length?: number): UInt32Value {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseUInt32Value } as UInt32Value;
+    const message = createBaseUInt32Value();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -358,7 +358,7 @@ export const UInt32Value = {
   },
 
   fromJSON(object: any): UInt32Value {
-    const message = { ...baseUInt32Value } as UInt32Value;
+    const message = createBaseUInt32Value();
     message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
@@ -370,13 +370,13 @@ export const UInt32Value = {
   },
 
   fromPartial<I extends Exact<DeepPartial<UInt32Value>, I>>(object: I): UInt32Value {
-    const message = { ...baseUInt32Value } as UInt32Value;
+    const message = createBaseUInt32Value();
     message.value = object.value ?? 0;
     return message;
   },
 };
 
-const baseBoolValue: object = { value: false };
+const createBaseBoolValue = (): BoolValue => ({ value: false });
 
 export const BoolValue = {
   encode(message: BoolValue, writer: Writer = Writer.create()): Writer {
@@ -389,7 +389,7 @@ export const BoolValue = {
   decode(input: Reader | Uint8Array, length?: number): BoolValue {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseBoolValue } as BoolValue;
+    const message = createBaseBoolValue();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -405,7 +405,7 @@ export const BoolValue = {
   },
 
   fromJSON(object: any): BoolValue {
-    const message = { ...baseBoolValue } as BoolValue;
+    const message = createBaseBoolValue();
     message.value = object.value !== undefined && object.value !== null ? Boolean(object.value) : false;
     return message;
   },
@@ -417,13 +417,13 @@ export const BoolValue = {
   },
 
   fromPartial<I extends Exact<DeepPartial<BoolValue>, I>>(object: I): BoolValue {
-    const message = { ...baseBoolValue } as BoolValue;
+    const message = createBaseBoolValue();
     message.value = object.value ?? false;
     return message;
   },
 };
 
-const baseStringValue: object = { value: '' };
+const createBaseStringValue = (): StringValue => ({ value: '' });
 
 export const StringValue = {
   encode(message: StringValue, writer: Writer = Writer.create()): Writer {
@@ -436,7 +436,7 @@ export const StringValue = {
   decode(input: Reader | Uint8Array, length?: number): StringValue {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseStringValue } as StringValue;
+    const message = createBaseStringValue();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -452,7 +452,7 @@ export const StringValue = {
   },
 
   fromJSON(object: any): StringValue {
-    const message = { ...baseStringValue } as StringValue;
+    const message = createBaseStringValue();
     message.value = object.value !== undefined && object.value !== null ? String(object.value) : '';
     return message;
   },
@@ -464,13 +464,13 @@ export const StringValue = {
   },
 
   fromPartial<I extends Exact<DeepPartial<StringValue>, I>>(object: I): StringValue {
-    const message = { ...baseStringValue } as StringValue;
+    const message = createBaseStringValue();
     message.value = object.value ?? '';
     return message;
   },
 };
 
-const baseBytesValue: object = {};
+const createBaseBytesValue = (): BytesValue => ({});
 
 export const BytesValue = {
   encode(message: BytesValue, writer: Writer = Writer.create()): Writer {
@@ -483,7 +483,7 @@ export const BytesValue = {
   decode(input: Reader | Uint8Array, length?: number): BytesValue {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseBytesValue } as BytesValue;
+    const message = createBaseBytesValue();
     message.value = Buffer.alloc(0);
     while (reader.pos < end) {
       const tag = reader.uint32();
@@ -500,7 +500,7 @@ export const BytesValue = {
   },
 
   fromJSON(object: any): BytesValue {
-    const message = { ...baseBytesValue } as BytesValue;
+    const message = createBaseBytesValue();
     message.value =
       object.value !== undefined && object.value !== null
         ? Buffer.from(bytesFromBase64(object.value))
@@ -516,7 +516,7 @@ export const BytesValue = {
   },
 
   fromPartial<I extends Exact<DeepPartial<BytesValue>, I>>(object: I): BytesValue {
-    const message = { ...baseBytesValue } as BytesValue;
+    const message = createBaseBytesValue();
     message.value = object.value ?? Buffer.alloc(0);
     return message;
   },

--- a/integration/bytes-node/point.ts
+++ b/integration/bytes-node/point.ts
@@ -10,7 +10,9 @@ export interface Point {
   dataWrapped: Buffer | undefined;
 }
 
-const createBasePoint = (): Point => ({});
+function createBasePoint(): Point {
+  return { data: Buffer.alloc(0), dataWrapped: undefined };
+}
 
 export const Point = {
   encode(message: Point, writer: Writer = Writer.create()): Writer {
@@ -27,7 +29,6 @@ export const Point = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBasePoint();
-    message.data = Buffer.alloc(0);
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {

--- a/integration/bytes-node/point.ts
+++ b/integration/bytes-node/point.ts
@@ -10,7 +10,7 @@ export interface Point {
   dataWrapped: Buffer | undefined;
 }
 
-const basePoint: object = {};
+const createBasePoint = (): Point => ({});
 
 export const Point = {
   encode(message: Point, writer: Writer = Writer.create()): Writer {
@@ -26,7 +26,7 @@ export const Point = {
   decode(input: Reader | Uint8Array, length?: number): Point {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...basePoint } as Point;
+    const message = createBasePoint();
     message.data = Buffer.alloc(0);
     while (reader.pos < end) {
       const tag = reader.uint32();
@@ -46,7 +46,7 @@ export const Point = {
   },
 
   fromJSON(object: any): Point {
-    const message = { ...basePoint } as Point;
+    const message = createBasePoint();
     message.data =
       object.data !== undefined && object.data !== null ? Buffer.from(bytesFromBase64(object.data)) : Buffer.alloc(0);
     message.dataWrapped =
@@ -63,7 +63,7 @@ export const Point = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Point>, I>>(object: I): Point {
-    const message = { ...basePoint } as Point;
+    const message = createBasePoint();
     message.data = object.data ?? Buffer.alloc(0);
     message.dataWrapped = object.dataWrapped ?? undefined;
     return message;

--- a/integration/const-enum/const-enum.ts
+++ b/integration/const-enum/const-enum.ts
@@ -67,7 +67,7 @@ export function dividerData_DividerTypeToNumber(object: DividerData_DividerType)
   }
 }
 
-const baseDividerData: object = { type: DividerData_DividerType.DOUBLE };
+const createBaseDividerData = (): DividerData => ({ type: DividerData_DividerType.DOUBLE });
 
 export const DividerData = {
   encode(message: DividerData, writer: Writer = Writer.create()): Writer {
@@ -80,7 +80,7 @@ export const DividerData = {
   decode(input: Reader | Uint8Array, length?: number): DividerData {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseDividerData } as DividerData;
+    const message = createBaseDividerData();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -96,7 +96,7 @@ export const DividerData = {
   },
 
   fromJSON(object: any): DividerData {
-    const message = { ...baseDividerData } as DividerData;
+    const message = createBaseDividerData();
     message.type =
       object.type !== undefined && object.type !== null
         ? dividerData_DividerTypeFromJSON(object.type)
@@ -111,7 +111,7 @@ export const DividerData = {
   },
 
   fromPartial<I extends Exact<DeepPartial<DividerData>, I>>(object: I): DividerData {
-    const message = { ...baseDividerData } as DividerData;
+    const message = createBaseDividerData();
     message.type = object.type ?? DividerData_DividerType.DOUBLE;
     return message;
   },

--- a/integration/const-enum/const-enum.ts
+++ b/integration/const-enum/const-enum.ts
@@ -67,7 +67,9 @@ export function dividerData_DividerTypeToNumber(object: DividerData_DividerType)
   }
 }
 
-const createBaseDividerData = (): DividerData => ({ type: DividerData_DividerType.DOUBLE });
+function createBaseDividerData(): DividerData {
+  return { type: DividerData_DividerType.DOUBLE };
+}
 
 export const DividerData = {
   encode(message: DividerData, writer: Writer = Writer.create()): Writer {

--- a/integration/enums-as-literals-with-string-enums/enums-as-literals-with-string-enums.ts
+++ b/integration/enums-as-literals-with-string-enums/enums-as-literals-with-string-enums.ts
@@ -69,7 +69,7 @@ export function dividerData_DividerTypeToNumber(object: DividerData_DividerType)
   }
 }
 
-const baseDividerData: object = { type: DividerData_DividerType.DOUBLE };
+const createBaseDividerData = (): DividerData => ({ type: DividerData_DividerType.DOUBLE });
 
 export const DividerData = {
   encode(message: DividerData, writer: Writer = Writer.create()): Writer {
@@ -82,7 +82,7 @@ export const DividerData = {
   decode(input: Reader | Uint8Array, length?: number): DividerData {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseDividerData } as DividerData;
+    const message = createBaseDividerData();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -98,7 +98,7 @@ export const DividerData = {
   },
 
   fromJSON(object: any): DividerData {
-    const message = { ...baseDividerData } as DividerData;
+    const message = createBaseDividerData();
     message.type =
       object.type !== undefined && object.type !== null
         ? dividerData_DividerTypeFromJSON(object.type)
@@ -113,7 +113,7 @@ export const DividerData = {
   },
 
   fromPartial<I extends Exact<DeepPartial<DividerData>, I>>(object: I): DividerData {
-    const message = { ...baseDividerData } as DividerData;
+    const message = createBaseDividerData();
     message.type = object.type ?? DividerData_DividerType.DOUBLE;
     return message;
   },

--- a/integration/enums-as-literals-with-string-enums/enums-as-literals-with-string-enums.ts
+++ b/integration/enums-as-literals-with-string-enums/enums-as-literals-with-string-enums.ts
@@ -69,7 +69,9 @@ export function dividerData_DividerTypeToNumber(object: DividerData_DividerType)
   }
 }
 
-const createBaseDividerData = (): DividerData => ({ type: DividerData_DividerType.DOUBLE });
+function createBaseDividerData(): DividerData {
+  return { type: DividerData_DividerType.DOUBLE };
+}
 
 export const DividerData = {
   encode(message: DividerData, writer: Writer = Writer.create()): Writer {

--- a/integration/enums-as-literals/enums-as-literals.ts
+++ b/integration/enums-as-literals/enums-as-literals.ts
@@ -54,7 +54,7 @@ export function dividerData_DividerTypeToJSON(object: DividerData_DividerType): 
   }
 }
 
-const baseDividerData: object = { type: 0 };
+const createBaseDividerData = (): DividerData => ({ type: 0 });
 
 export const DividerData = {
   encode(message: DividerData, writer: Writer = Writer.create()): Writer {
@@ -67,7 +67,7 @@ export const DividerData = {
   decode(input: Reader | Uint8Array, length?: number): DividerData {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseDividerData } as DividerData;
+    const message = createBaseDividerData();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -83,7 +83,7 @@ export const DividerData = {
   },
 
   fromJSON(object: any): DividerData {
-    const message = { ...baseDividerData } as DividerData;
+    const message = createBaseDividerData();
     message.type = object.type !== undefined && object.type !== null ? dividerData_DividerTypeFromJSON(object.type) : 0;
     return message;
   },
@@ -95,7 +95,7 @@ export const DividerData = {
   },
 
   fromPartial<I extends Exact<DeepPartial<DividerData>, I>>(object: I): DividerData {
-    const message = { ...baseDividerData } as DividerData;
+    const message = createBaseDividerData();
     message.type = object.type ?? 0;
     return message;
   },

--- a/integration/enums-as-literals/enums-as-literals.ts
+++ b/integration/enums-as-literals/enums-as-literals.ts
@@ -54,7 +54,9 @@ export function dividerData_DividerTypeToJSON(object: DividerData_DividerType): 
   }
 }
 
-const createBaseDividerData = (): DividerData => ({ type: 0 });
+function createBaseDividerData(): DividerData {
+  return { type: 0 };
+}
 
 export const DividerData = {
   encode(message: DividerData, writer: Writer = Writer.create()): Writer {

--- a/integration/file-suffix/child.pb.ts
+++ b/integration/file-suffix/child.pb.ts
@@ -40,7 +40,7 @@ export interface Child {
   name: string;
 }
 
-const baseChild: object = { name: '' };
+const createBaseChild = (): Child => ({ name: '' });
 
 export const Child = {
   encode(message: Child, writer: Writer = Writer.create()): Writer {
@@ -53,7 +53,7 @@ export const Child = {
   decode(input: Reader | Uint8Array, length?: number): Child {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseChild } as Child;
+    const message = createBaseChild();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -69,7 +69,7 @@ export const Child = {
   },
 
   fromJSON(object: any): Child {
-    const message = { ...baseChild } as Child;
+    const message = createBaseChild();
     message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
     return message;
   },
@@ -81,7 +81,7 @@ export const Child = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Child>, I>>(object: I): Child {
-    const message = { ...baseChild } as Child;
+    const message = createBaseChild();
     message.name = object.name ?? '';
     return message;
   },

--- a/integration/file-suffix/child.pb.ts
+++ b/integration/file-suffix/child.pb.ts
@@ -40,7 +40,9 @@ export interface Child {
   name: string;
 }
 
-const createBaseChild = (): Child => ({ name: '' });
+function createBaseChild(): Child {
+  return { name: '' };
+}
 
 export const Child = {
   encode(message: Child, writer: Writer = Writer.create()): Writer {

--- a/integration/file-suffix/google/protobuf/timestamp.pb.ts
+++ b/integration/file-suffix/google/protobuf/timestamp.pb.ts
@@ -113,7 +113,9 @@ export interface Timestamp {
   nanos: number;
 }
 
-const createBaseTimestamp = (): Timestamp => ({ seconds: 0, nanos: 0 });
+function createBaseTimestamp(): Timestamp {
+  return { seconds: 0, nanos: 0 };
+}
 
 export const Timestamp = {
   encode(message: Timestamp, writer: Writer = Writer.create()): Writer {

--- a/integration/file-suffix/google/protobuf/timestamp.pb.ts
+++ b/integration/file-suffix/google/protobuf/timestamp.pb.ts
@@ -113,7 +113,7 @@ export interface Timestamp {
   nanos: number;
 }
 
-const baseTimestamp: object = { seconds: 0, nanos: 0 };
+const createBaseTimestamp = (): Timestamp => ({ seconds: 0, nanos: 0 });
 
 export const Timestamp = {
   encode(message: Timestamp, writer: Writer = Writer.create()): Writer {
@@ -129,7 +129,7 @@ export const Timestamp = {
   decode(input: Reader | Uint8Array, length?: number): Timestamp {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseTimestamp } as Timestamp;
+    const message = createBaseTimestamp();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -148,7 +148,7 @@ export const Timestamp = {
   },
 
   fromJSON(object: any): Timestamp {
-    const message = { ...baseTimestamp } as Timestamp;
+    const message = createBaseTimestamp();
     message.seconds = object.seconds !== undefined && object.seconds !== null ? Number(object.seconds) : 0;
     message.nanos = object.nanos !== undefined && object.nanos !== null ? Number(object.nanos) : 0;
     return message;
@@ -162,7 +162,7 @@ export const Timestamp = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Timestamp>, I>>(object: I): Timestamp {
-    const message = { ...baseTimestamp } as Timestamp;
+    const message = createBaseTimestamp();
     message.seconds = object.seconds ?? 0;
     message.nanos = object.nanos ?? 0;
     return message;

--- a/integration/file-suffix/parent.pb.ts
+++ b/integration/file-suffix/parent.pb.ts
@@ -12,7 +12,7 @@ export interface Parent {
   createdAt: Date | undefined;
 }
 
-const baseParent: object = { childEnum: 0 };
+const createBaseParent = (): Parent => ({ childEnum: 0 });
 
 export const Parent = {
   encode(message: Parent, writer: Writer = Writer.create()): Writer {
@@ -31,7 +31,7 @@ export const Parent = {
   decode(input: Reader | Uint8Array, length?: number): Parent {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseParent } as Parent;
+    const message = createBaseParent();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -53,7 +53,7 @@ export const Parent = {
   },
 
   fromJSON(object: any): Parent {
-    const message = { ...baseParent } as Parent;
+    const message = createBaseParent();
     message.child = object.child !== undefined && object.child !== null ? Child.fromJSON(object.child) : undefined;
     message.childEnum =
       object.childEnum !== undefined && object.childEnum !== null ? childEnumFromJSON(object.childEnum) : 0;
@@ -71,7 +71,7 @@ export const Parent = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Parent>, I>>(object: I): Parent {
-    const message = { ...baseParent } as Parent;
+    const message = createBaseParent();
     message.child = object.child !== undefined && object.child !== null ? Child.fromPartial(object.child) : undefined;
     message.childEnum = object.childEnum ?? 0;
     message.createdAt = object.createdAt ?? undefined;

--- a/integration/file-suffix/parent.pb.ts
+++ b/integration/file-suffix/parent.pb.ts
@@ -12,7 +12,9 @@ export interface Parent {
   createdAt: Date | undefined;
 }
 
-const createBaseParent = (): Parent => ({ childEnum: 0 });
+function createBaseParent(): Parent {
+  return { child: undefined, childEnum: 0, createdAt: undefined };
+}
 
 export const Parent = {
   encode(message: Parent, writer: Writer = Writer.create()): Writer {

--- a/integration/generic-service-definitions/simple.ts
+++ b/integration/generic-service-definitions/simple.ts
@@ -8,7 +8,7 @@ export interface TestMessage {
   value: string;
 }
 
-const baseTestMessage: object = { value: '' };
+const createBaseTestMessage = (): TestMessage => ({ value: '' });
 
 export const TestMessage = {
   encode(message: TestMessage, writer: Writer = Writer.create()): Writer {
@@ -21,7 +21,7 @@ export const TestMessage = {
   decode(input: Reader | Uint8Array, length?: number): TestMessage {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseTestMessage } as TestMessage;
+    const message = createBaseTestMessage();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -37,7 +37,7 @@ export const TestMessage = {
   },
 
   fromJSON(object: any): TestMessage {
-    const message = { ...baseTestMessage } as TestMessage;
+    const message = createBaseTestMessage();
     message.value = object.value !== undefined && object.value !== null ? String(object.value) : '';
     return message;
   },
@@ -49,7 +49,7 @@ export const TestMessage = {
   },
 
   fromPartial<I extends Exact<DeepPartial<TestMessage>, I>>(object: I): TestMessage {
-    const message = { ...baseTestMessage } as TestMessage;
+    const message = createBaseTestMessage();
     message.value = object.value ?? '';
     return message;
   },

--- a/integration/generic-service-definitions/simple.ts
+++ b/integration/generic-service-definitions/simple.ts
@@ -8,7 +8,9 @@ export interface TestMessage {
   value: string;
 }
 
-const createBaseTestMessage = (): TestMessage => ({ value: '' });
+function createBaseTestMessage(): TestMessage {
+  return { value: '' };
+}
 
 export const TestMessage = {
   encode(message: TestMessage, writer: Writer = Writer.create()): Writer {

--- a/integration/global-this/global-this.ts
+++ b/integration/global-this/global-this.ts
@@ -12,7 +12,7 @@ export interface Error {
   name: string;
 }
 
-const baseObject: object = { name: '' };
+const createBaseObject = (): Object => ({ name: '' });
 
 export const Object = {
   encode(message: Object, writer: Writer = Writer.create()): Writer {
@@ -25,7 +25,7 @@ export const Object = {
   decode(input: Reader | Uint8Array, length?: number): Object {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseObject } as Object;
+    const message = createBaseObject();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -41,7 +41,7 @@ export const Object = {
   },
 
   fromJSON(object: any): Object {
-    const message = { ...baseObject } as Object;
+    const message = createBaseObject();
     message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
     return message;
   },
@@ -53,13 +53,13 @@ export const Object = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Object>, I>>(object: I): Object {
-    const message = { ...baseObject } as Object;
+    const message = createBaseObject();
     message.name = object.name ?? '';
     return message;
   },
 };
 
-const baseError: object = { name: '' };
+const createBaseError = (): Error => ({ name: '' });
 
 export const Error = {
   encode(message: Error, writer: Writer = Writer.create()): Writer {
@@ -72,7 +72,7 @@ export const Error = {
   decode(input: Reader | Uint8Array, length?: number): Error {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseError } as Error;
+    const message = createBaseError();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -88,7 +88,7 @@ export const Error = {
   },
 
   fromJSON(object: any): Error {
-    const message = { ...baseError } as Error;
+    const message = createBaseError();
     message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
     return message;
   },
@@ -100,7 +100,7 @@ export const Error = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Error>, I>>(object: I): Error {
-    const message = { ...baseError } as Error;
+    const message = createBaseError();
     message.name = object.name ?? '';
     return message;
   },

--- a/integration/global-this/global-this.ts
+++ b/integration/global-this/global-this.ts
@@ -12,7 +12,9 @@ export interface Error {
   name: string;
 }
 
-const createBaseObject = (): Object => ({ name: '' });
+function createBaseObject(): Object {
+  return { name: '' };
+}
 
 export const Object = {
   encode(message: Object, writer: Writer = Writer.create()): Writer {
@@ -59,7 +61,9 @@ export const Object = {
   },
 };
 
-const createBaseError = (): Error => ({ name: '' });
+function createBaseError(): Error {
+  return { name: '' };
+}
 
 export const Error = {
   encode(message: Error, writer: Writer = Writer.create()): Writer {

--- a/integration/grpc-js/google/protobuf/empty.ts
+++ b/integration/grpc-js/google/protobuf/empty.ts
@@ -17,7 +17,9 @@ export const protobufPackage = 'google.protobuf';
  */
 export interface Empty {}
 
-const createBaseEmpty = (): Empty => ({});
+function createBaseEmpty(): Empty {
+  return {};
+}
 
 export const Empty = {
   encode(_: Empty, writer: Writer = Writer.create()): Writer {

--- a/integration/grpc-js/google/protobuf/empty.ts
+++ b/integration/grpc-js/google/protobuf/empty.ts
@@ -17,7 +17,7 @@ export const protobufPackage = 'google.protobuf';
  */
 export interface Empty {}
 
-const baseEmpty: object = {};
+const createBaseEmpty = (): Empty => ({});
 
 export const Empty = {
   encode(_: Empty, writer: Writer = Writer.create()): Writer {
@@ -27,7 +27,7 @@ export const Empty = {
   decode(input: Reader | Uint8Array, length?: number): Empty {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseEmpty } as Empty;
+    const message = createBaseEmpty();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -40,7 +40,7 @@ export const Empty = {
   },
 
   fromJSON(_: any): Empty {
-    const message = { ...baseEmpty } as Empty;
+    const message = createBaseEmpty();
     return message;
   },
 
@@ -50,7 +50,7 @@ export const Empty = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Empty>, I>>(_: I): Empty {
-    const message = { ...baseEmpty } as Empty;
+    const message = createBaseEmpty();
     return message;
   },
 };

--- a/integration/grpc-js/google/protobuf/struct.ts
+++ b/integration/grpc-js/google/protobuf/struct.ts
@@ -90,7 +90,7 @@ export interface ListValue {
   values: any[];
 }
 
-const baseStruct: object = {};
+const createBaseStruct = (): Struct => ({});
 
 export const Struct = {
   encode(message: Struct, writer: Writer = Writer.create()): Writer {
@@ -105,7 +105,7 @@ export const Struct = {
   decode(input: Reader | Uint8Array, length?: number): Struct {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseStruct } as Struct;
+    const message = createBaseStruct();
     message.fields = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
@@ -125,7 +125,7 @@ export const Struct = {
   },
 
   fromJSON(object: any): Struct {
-    const message = { ...baseStruct } as Struct;
+    const message = createBaseStruct();
     message.fields = Object.entries(object.fields ?? {}).reduce<{ [key: string]: any | undefined }>(
       (acc, [key, value]) => {
         acc[key] = value as any | undefined;
@@ -148,7 +148,7 @@ export const Struct = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Struct>, I>>(object: I): Struct {
-    const message = { ...baseStruct } as Struct;
+    const message = createBaseStruct();
     message.fields = Object.entries(object.fields ?? {}).reduce<{ [key: string]: any | undefined }>(
       (acc, [key, value]) => {
         if (value !== undefined) {
@@ -180,7 +180,7 @@ export const Struct = {
   },
 };
 
-const baseStruct_FieldsEntry: object = { key: '' };
+const createBaseStruct_FieldsEntry = (): Struct_FieldsEntry => ({ key: '' });
 
 export const Struct_FieldsEntry = {
   encode(message: Struct_FieldsEntry, writer: Writer = Writer.create()): Writer {
@@ -196,7 +196,7 @@ export const Struct_FieldsEntry = {
   decode(input: Reader | Uint8Array, length?: number): Struct_FieldsEntry {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseStruct_FieldsEntry } as Struct_FieldsEntry;
+    const message = createBaseStruct_FieldsEntry();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -215,7 +215,7 @@ export const Struct_FieldsEntry = {
   },
 
   fromJSON(object: any): Struct_FieldsEntry {
-    const message = { ...baseStruct_FieldsEntry } as Struct_FieldsEntry;
+    const message = createBaseStruct_FieldsEntry();
     message.key = object.key !== undefined && object.key !== null ? String(object.key) : '';
     message.value = object.value;
     return message;
@@ -229,14 +229,14 @@ export const Struct_FieldsEntry = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Struct_FieldsEntry>, I>>(object: I): Struct_FieldsEntry {
-    const message = { ...baseStruct_FieldsEntry } as Struct_FieldsEntry;
+    const message = createBaseStruct_FieldsEntry();
     message.key = object.key ?? '';
     message.value = object.value ?? undefined;
     return message;
   },
 };
 
-const baseValue: object = {};
+const createBaseValue = (): Value => ({});
 
 export const Value = {
   encode(message: Value, writer: Writer = Writer.create()): Writer {
@@ -264,7 +264,7 @@ export const Value = {
   decode(input: Reader | Uint8Array, length?: number): Value {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseValue } as Value;
+    const message = createBaseValue();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -295,7 +295,7 @@ export const Value = {
   },
 
   fromJSON(object: any): Value {
-    const message = { ...baseValue } as Value;
+    const message = createBaseValue();
     message.nullValue =
       object.nullValue !== undefined && object.nullValue !== null ? nullValueFromJSON(object.nullValue) : undefined;
     message.numberValue =
@@ -322,7 +322,7 @@ export const Value = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Value>, I>>(object: I): Value {
-    const message = { ...baseValue } as Value;
+    const message = createBaseValue();
     message.nullValue = object.nullValue ?? undefined;
     message.numberValue = object.numberValue ?? undefined;
     message.stringValue = object.stringValue ?? undefined;
@@ -370,7 +370,7 @@ export const Value = {
   },
 };
 
-const baseListValue: object = {};
+const createBaseListValue = (): ListValue => ({});
 
 export const ListValue = {
   encode(message: ListValue, writer: Writer = Writer.create()): Writer {
@@ -383,7 +383,7 @@ export const ListValue = {
   decode(input: Reader | Uint8Array, length?: number): ListValue {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseListValue } as ListValue;
+    const message = createBaseListValue();
     message.values = [];
     while (reader.pos < end) {
       const tag = reader.uint32();
@@ -400,7 +400,7 @@ export const ListValue = {
   },
 
   fromJSON(object: any): ListValue {
-    const message = { ...baseListValue } as ListValue;
+    const message = createBaseListValue();
     message.values = Array.isArray(object?.values) ? [...object.values] : [];
     return message;
   },
@@ -416,7 +416,7 @@ export const ListValue = {
   },
 
   fromPartial<I extends Exact<DeepPartial<ListValue>, I>>(object: I): ListValue {
-    const message = { ...baseListValue } as ListValue;
+    const message = createBaseListValue();
     message.values = object.values?.map((e) => e) || [];
     return message;
   },

--- a/integration/grpc-js/google/protobuf/struct.ts
+++ b/integration/grpc-js/google/protobuf/struct.ts
@@ -90,7 +90,9 @@ export interface ListValue {
   values: any[];
 }
 
-const createBaseStruct = (): Struct => ({});
+function createBaseStruct(): Struct {
+  return { fields: {} };
+}
 
 export const Struct = {
   encode(message: Struct, writer: Writer = Writer.create()): Writer {
@@ -106,7 +108,6 @@ export const Struct = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseStruct();
-    message.fields = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -180,7 +181,9 @@ export const Struct = {
   },
 };
 
-const createBaseStruct_FieldsEntry = (): Struct_FieldsEntry => ({ key: '' });
+function createBaseStruct_FieldsEntry(): Struct_FieldsEntry {
+  return { key: '', value: undefined };
+}
 
 export const Struct_FieldsEntry = {
   encode(message: Struct_FieldsEntry, writer: Writer = Writer.create()): Writer {
@@ -236,7 +239,16 @@ export const Struct_FieldsEntry = {
   },
 };
 
-const createBaseValue = (): Value => ({});
+function createBaseValue(): Value {
+  return {
+    nullValue: undefined,
+    numberValue: undefined,
+    stringValue: undefined,
+    boolValue: undefined,
+    structValue: undefined,
+    listValue: undefined,
+  };
+}
 
 export const Value = {
   encode(message: Value, writer: Writer = Writer.create()): Writer {
@@ -370,7 +382,9 @@ export const Value = {
   },
 };
 
-const createBaseListValue = (): ListValue => ({});
+function createBaseListValue(): ListValue {
+  return { values: [] };
+}
 
 export const ListValue = {
   encode(message: ListValue, writer: Writer = Writer.create()): Writer {
@@ -384,7 +398,6 @@ export const ListValue = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseListValue();
-    message.values = [];
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {

--- a/integration/grpc-js/google/protobuf/timestamp.ts
+++ b/integration/grpc-js/google/protobuf/timestamp.ts
@@ -113,7 +113,9 @@ export interface Timestamp {
   nanos: number;
 }
 
-const createBaseTimestamp = (): Timestamp => ({ seconds: 0, nanos: 0 });
+function createBaseTimestamp(): Timestamp {
+  return { seconds: 0, nanos: 0 };
+}
 
 export const Timestamp = {
   encode(message: Timestamp, writer: Writer = Writer.create()): Writer {

--- a/integration/grpc-js/google/protobuf/timestamp.ts
+++ b/integration/grpc-js/google/protobuf/timestamp.ts
@@ -113,7 +113,7 @@ export interface Timestamp {
   nanos: number;
 }
 
-const baseTimestamp: object = { seconds: 0, nanos: 0 };
+const createBaseTimestamp = (): Timestamp => ({ seconds: 0, nanos: 0 });
 
 export const Timestamp = {
   encode(message: Timestamp, writer: Writer = Writer.create()): Writer {
@@ -129,7 +129,7 @@ export const Timestamp = {
   decode(input: Reader | Uint8Array, length?: number): Timestamp {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseTimestamp } as Timestamp;
+    const message = createBaseTimestamp();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -148,7 +148,7 @@ export const Timestamp = {
   },
 
   fromJSON(object: any): Timestamp {
-    const message = { ...baseTimestamp } as Timestamp;
+    const message = createBaseTimestamp();
     message.seconds = object.seconds !== undefined && object.seconds !== null ? Number(object.seconds) : 0;
     message.nanos = object.nanos !== undefined && object.nanos !== null ? Number(object.nanos) : 0;
     return message;
@@ -162,7 +162,7 @@ export const Timestamp = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Timestamp>, I>>(object: I): Timestamp {
-    const message = { ...baseTimestamp } as Timestamp;
+    const message = createBaseTimestamp();
     message.seconds = object.seconds ?? 0;
     message.nanos = object.nanos ?? 0;
     return message;

--- a/integration/grpc-js/google/protobuf/wrappers.ts
+++ b/integration/grpc-js/google/protobuf/wrappers.ts
@@ -94,7 +94,9 @@ export interface BytesValue {
   value: Uint8Array;
 }
 
-const createBaseDoubleValue = (): DoubleValue => ({ value: 0 });
+function createBaseDoubleValue(): DoubleValue {
+  return { value: 0 };
+}
 
 export const DoubleValue = {
   encode(message: DoubleValue, writer: Writer = Writer.create()): Writer {
@@ -141,7 +143,9 @@ export const DoubleValue = {
   },
 };
 
-const createBaseFloatValue = (): FloatValue => ({ value: 0 });
+function createBaseFloatValue(): FloatValue {
+  return { value: 0 };
+}
 
 export const FloatValue = {
   encode(message: FloatValue, writer: Writer = Writer.create()): Writer {
@@ -188,7 +192,9 @@ export const FloatValue = {
   },
 };
 
-const createBaseInt64Value = (): Int64Value => ({ value: 0 });
+function createBaseInt64Value(): Int64Value {
+  return { value: 0 };
+}
 
 export const Int64Value = {
   encode(message: Int64Value, writer: Writer = Writer.create()): Writer {
@@ -235,7 +241,9 @@ export const Int64Value = {
   },
 };
 
-const createBaseUInt64Value = (): UInt64Value => ({ value: 0 });
+function createBaseUInt64Value(): UInt64Value {
+  return { value: 0 };
+}
 
 export const UInt64Value = {
   encode(message: UInt64Value, writer: Writer = Writer.create()): Writer {
@@ -282,7 +290,9 @@ export const UInt64Value = {
   },
 };
 
-const createBaseInt32Value = (): Int32Value => ({ value: 0 });
+function createBaseInt32Value(): Int32Value {
+  return { value: 0 };
+}
 
 export const Int32Value = {
   encode(message: Int32Value, writer: Writer = Writer.create()): Writer {
@@ -329,7 +339,9 @@ export const Int32Value = {
   },
 };
 
-const createBaseUInt32Value = (): UInt32Value => ({ value: 0 });
+function createBaseUInt32Value(): UInt32Value {
+  return { value: 0 };
+}
 
 export const UInt32Value = {
   encode(message: UInt32Value, writer: Writer = Writer.create()): Writer {
@@ -376,7 +388,9 @@ export const UInt32Value = {
   },
 };
 
-const createBaseBoolValue = (): BoolValue => ({ value: false });
+function createBaseBoolValue(): BoolValue {
+  return { value: false };
+}
 
 export const BoolValue = {
   encode(message: BoolValue, writer: Writer = Writer.create()): Writer {
@@ -423,7 +437,9 @@ export const BoolValue = {
   },
 };
 
-const createBaseStringValue = (): StringValue => ({ value: '' });
+function createBaseStringValue(): StringValue {
+  return { value: '' };
+}
 
 export const StringValue = {
   encode(message: StringValue, writer: Writer = Writer.create()): Writer {
@@ -470,7 +486,9 @@ export const StringValue = {
   },
 };
 
-const createBaseBytesValue = (): BytesValue => ({});
+function createBaseBytesValue(): BytesValue {
+  return { value: new Uint8Array() };
+}
 
 export const BytesValue = {
   encode(message: BytesValue, writer: Writer = Writer.create()): Writer {
@@ -484,7 +502,6 @@ export const BytesValue = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseBytesValue();
-    message.value = new Uint8Array();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {

--- a/integration/grpc-js/google/protobuf/wrappers.ts
+++ b/integration/grpc-js/google/protobuf/wrappers.ts
@@ -94,7 +94,7 @@ export interface BytesValue {
   value: Uint8Array;
 }
 
-const baseDoubleValue: object = { value: 0 };
+const createBaseDoubleValue = (): DoubleValue => ({ value: 0 });
 
 export const DoubleValue = {
   encode(message: DoubleValue, writer: Writer = Writer.create()): Writer {
@@ -107,7 +107,7 @@ export const DoubleValue = {
   decode(input: Reader | Uint8Array, length?: number): DoubleValue {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseDoubleValue } as DoubleValue;
+    const message = createBaseDoubleValue();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -123,7 +123,7 @@ export const DoubleValue = {
   },
 
   fromJSON(object: any): DoubleValue {
-    const message = { ...baseDoubleValue } as DoubleValue;
+    const message = createBaseDoubleValue();
     message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
@@ -135,13 +135,13 @@ export const DoubleValue = {
   },
 
   fromPartial<I extends Exact<DeepPartial<DoubleValue>, I>>(object: I): DoubleValue {
-    const message = { ...baseDoubleValue } as DoubleValue;
+    const message = createBaseDoubleValue();
     message.value = object.value ?? 0;
     return message;
   },
 };
 
-const baseFloatValue: object = { value: 0 };
+const createBaseFloatValue = (): FloatValue => ({ value: 0 });
 
 export const FloatValue = {
   encode(message: FloatValue, writer: Writer = Writer.create()): Writer {
@@ -154,7 +154,7 @@ export const FloatValue = {
   decode(input: Reader | Uint8Array, length?: number): FloatValue {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseFloatValue } as FloatValue;
+    const message = createBaseFloatValue();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -170,7 +170,7 @@ export const FloatValue = {
   },
 
   fromJSON(object: any): FloatValue {
-    const message = { ...baseFloatValue } as FloatValue;
+    const message = createBaseFloatValue();
     message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
@@ -182,13 +182,13 @@ export const FloatValue = {
   },
 
   fromPartial<I extends Exact<DeepPartial<FloatValue>, I>>(object: I): FloatValue {
-    const message = { ...baseFloatValue } as FloatValue;
+    const message = createBaseFloatValue();
     message.value = object.value ?? 0;
     return message;
   },
 };
 
-const baseInt64Value: object = { value: 0 };
+const createBaseInt64Value = (): Int64Value => ({ value: 0 });
 
 export const Int64Value = {
   encode(message: Int64Value, writer: Writer = Writer.create()): Writer {
@@ -201,7 +201,7 @@ export const Int64Value = {
   decode(input: Reader | Uint8Array, length?: number): Int64Value {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseInt64Value } as Int64Value;
+    const message = createBaseInt64Value();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -217,7 +217,7 @@ export const Int64Value = {
   },
 
   fromJSON(object: any): Int64Value {
-    const message = { ...baseInt64Value } as Int64Value;
+    const message = createBaseInt64Value();
     message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
@@ -229,13 +229,13 @@ export const Int64Value = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Int64Value>, I>>(object: I): Int64Value {
-    const message = { ...baseInt64Value } as Int64Value;
+    const message = createBaseInt64Value();
     message.value = object.value ?? 0;
     return message;
   },
 };
 
-const baseUInt64Value: object = { value: 0 };
+const createBaseUInt64Value = (): UInt64Value => ({ value: 0 });
 
 export const UInt64Value = {
   encode(message: UInt64Value, writer: Writer = Writer.create()): Writer {
@@ -248,7 +248,7 @@ export const UInt64Value = {
   decode(input: Reader | Uint8Array, length?: number): UInt64Value {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseUInt64Value } as UInt64Value;
+    const message = createBaseUInt64Value();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -264,7 +264,7 @@ export const UInt64Value = {
   },
 
   fromJSON(object: any): UInt64Value {
-    const message = { ...baseUInt64Value } as UInt64Value;
+    const message = createBaseUInt64Value();
     message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
@@ -276,13 +276,13 @@ export const UInt64Value = {
   },
 
   fromPartial<I extends Exact<DeepPartial<UInt64Value>, I>>(object: I): UInt64Value {
-    const message = { ...baseUInt64Value } as UInt64Value;
+    const message = createBaseUInt64Value();
     message.value = object.value ?? 0;
     return message;
   },
 };
 
-const baseInt32Value: object = { value: 0 };
+const createBaseInt32Value = (): Int32Value => ({ value: 0 });
 
 export const Int32Value = {
   encode(message: Int32Value, writer: Writer = Writer.create()): Writer {
@@ -295,7 +295,7 @@ export const Int32Value = {
   decode(input: Reader | Uint8Array, length?: number): Int32Value {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseInt32Value } as Int32Value;
+    const message = createBaseInt32Value();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -311,7 +311,7 @@ export const Int32Value = {
   },
 
   fromJSON(object: any): Int32Value {
-    const message = { ...baseInt32Value } as Int32Value;
+    const message = createBaseInt32Value();
     message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
@@ -323,13 +323,13 @@ export const Int32Value = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Int32Value>, I>>(object: I): Int32Value {
-    const message = { ...baseInt32Value } as Int32Value;
+    const message = createBaseInt32Value();
     message.value = object.value ?? 0;
     return message;
   },
 };
 
-const baseUInt32Value: object = { value: 0 };
+const createBaseUInt32Value = (): UInt32Value => ({ value: 0 });
 
 export const UInt32Value = {
   encode(message: UInt32Value, writer: Writer = Writer.create()): Writer {
@@ -342,7 +342,7 @@ export const UInt32Value = {
   decode(input: Reader | Uint8Array, length?: number): UInt32Value {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseUInt32Value } as UInt32Value;
+    const message = createBaseUInt32Value();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -358,7 +358,7 @@ export const UInt32Value = {
   },
 
   fromJSON(object: any): UInt32Value {
-    const message = { ...baseUInt32Value } as UInt32Value;
+    const message = createBaseUInt32Value();
     message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
@@ -370,13 +370,13 @@ export const UInt32Value = {
   },
 
   fromPartial<I extends Exact<DeepPartial<UInt32Value>, I>>(object: I): UInt32Value {
-    const message = { ...baseUInt32Value } as UInt32Value;
+    const message = createBaseUInt32Value();
     message.value = object.value ?? 0;
     return message;
   },
 };
 
-const baseBoolValue: object = { value: false };
+const createBaseBoolValue = (): BoolValue => ({ value: false });
 
 export const BoolValue = {
   encode(message: BoolValue, writer: Writer = Writer.create()): Writer {
@@ -389,7 +389,7 @@ export const BoolValue = {
   decode(input: Reader | Uint8Array, length?: number): BoolValue {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseBoolValue } as BoolValue;
+    const message = createBaseBoolValue();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -405,7 +405,7 @@ export const BoolValue = {
   },
 
   fromJSON(object: any): BoolValue {
-    const message = { ...baseBoolValue } as BoolValue;
+    const message = createBaseBoolValue();
     message.value = object.value !== undefined && object.value !== null ? Boolean(object.value) : false;
     return message;
   },
@@ -417,13 +417,13 @@ export const BoolValue = {
   },
 
   fromPartial<I extends Exact<DeepPartial<BoolValue>, I>>(object: I): BoolValue {
-    const message = { ...baseBoolValue } as BoolValue;
+    const message = createBaseBoolValue();
     message.value = object.value ?? false;
     return message;
   },
 };
 
-const baseStringValue: object = { value: '' };
+const createBaseStringValue = (): StringValue => ({ value: '' });
 
 export const StringValue = {
   encode(message: StringValue, writer: Writer = Writer.create()): Writer {
@@ -436,7 +436,7 @@ export const StringValue = {
   decode(input: Reader | Uint8Array, length?: number): StringValue {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseStringValue } as StringValue;
+    const message = createBaseStringValue();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -452,7 +452,7 @@ export const StringValue = {
   },
 
   fromJSON(object: any): StringValue {
-    const message = { ...baseStringValue } as StringValue;
+    const message = createBaseStringValue();
     message.value = object.value !== undefined && object.value !== null ? String(object.value) : '';
     return message;
   },
@@ -464,13 +464,13 @@ export const StringValue = {
   },
 
   fromPartial<I extends Exact<DeepPartial<StringValue>, I>>(object: I): StringValue {
-    const message = { ...baseStringValue } as StringValue;
+    const message = createBaseStringValue();
     message.value = object.value ?? '';
     return message;
   },
 };
 
-const baseBytesValue: object = {};
+const createBaseBytesValue = (): BytesValue => ({});
 
 export const BytesValue = {
   encode(message: BytesValue, writer: Writer = Writer.create()): Writer {
@@ -483,7 +483,7 @@ export const BytesValue = {
   decode(input: Reader | Uint8Array, length?: number): BytesValue {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseBytesValue } as BytesValue;
+    const message = createBaseBytesValue();
     message.value = new Uint8Array();
     while (reader.pos < end) {
       const tag = reader.uint32();
@@ -500,7 +500,7 @@ export const BytesValue = {
   },
 
   fromJSON(object: any): BytesValue {
-    const message = { ...baseBytesValue } as BytesValue;
+    const message = createBaseBytesValue();
     message.value =
       object.value !== undefined && object.value !== null ? bytesFromBase64(object.value) : new Uint8Array();
     return message;
@@ -514,7 +514,7 @@ export const BytesValue = {
   },
 
   fromPartial<I extends Exact<DeepPartial<BytesValue>, I>>(object: I): BytesValue {
-    const message = { ...baseBytesValue } as BytesValue;
+    const message = createBaseBytesValue();
     message.value = object.value ?? new Uint8Array();
     return message;
   },

--- a/integration/grpc-js/simple.ts
+++ b/integration/grpc-js/simple.ts
@@ -40,7 +40,7 @@ export interface TestMessage {
   timestamp: Date | undefined;
 }
 
-const baseTestMessage: object = {};
+const createBaseTestMessage = (): TestMessage => ({});
 
 export const TestMessage = {
   encode(message: TestMessage, writer: Writer = Writer.create()): Writer {
@@ -53,7 +53,7 @@ export const TestMessage = {
   decode(input: Reader | Uint8Array, length?: number): TestMessage {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseTestMessage } as TestMessage;
+    const message = createBaseTestMessage();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -69,7 +69,7 @@ export const TestMessage = {
   },
 
   fromJSON(object: any): TestMessage {
-    const message = { ...baseTestMessage } as TestMessage;
+    const message = createBaseTestMessage();
     message.timestamp =
       object.timestamp !== undefined && object.timestamp !== null ? fromJsonTimestamp(object.timestamp) : undefined;
     return message;
@@ -82,7 +82,7 @@ export const TestMessage = {
   },
 
   fromPartial<I extends Exact<DeepPartial<TestMessage>, I>>(object: I): TestMessage {
-    const message = { ...baseTestMessage } as TestMessage;
+    const message = createBaseTestMessage();
     message.timestamp = object.timestamp ?? undefined;
     return message;
   },

--- a/integration/grpc-js/simple.ts
+++ b/integration/grpc-js/simple.ts
@@ -40,7 +40,9 @@ export interface TestMessage {
   timestamp: Date | undefined;
 }
 
-const createBaseTestMessage = (): TestMessage => ({});
+function createBaseTestMessage(): TestMessage {
+  return { timestamp: undefined };
+}
 
 export const TestMessage = {
   encode(message: TestMessage, writer: Writer = Writer.create()): Writer {

--- a/integration/grpc-web-go-server/example.ts
+++ b/integration/grpc-web-go-server/example.ts
@@ -92,7 +92,7 @@ export interface DashAPICredsDeleteReq {
 
 export interface Empty {}
 
-const baseDashFlash: object = { msg: '', type: 0 };
+const createBaseDashFlash = (): DashFlash => ({ msg: '', type: 0 });
 
 export const DashFlash = {
   encode(message: DashFlash, writer: Writer = Writer.create()): Writer {
@@ -108,7 +108,7 @@ export const DashFlash = {
   decode(input: Reader | Uint8Array, length?: number): DashFlash {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseDashFlash } as DashFlash;
+    const message = createBaseDashFlash();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -127,7 +127,7 @@ export const DashFlash = {
   },
 
   fromJSON(object: any): DashFlash {
-    const message = { ...baseDashFlash } as DashFlash;
+    const message = createBaseDashFlash();
     message.msg = object.msg !== undefined && object.msg !== null ? String(object.msg) : '';
     message.type = object.type !== undefined && object.type !== null ? dashFlash_TypeFromJSON(object.type) : 0;
     return message;
@@ -141,14 +141,14 @@ export const DashFlash = {
   },
 
   fromPartial<I extends Exact<DeepPartial<DashFlash>, I>>(object: I): DashFlash {
-    const message = { ...baseDashFlash } as DashFlash;
+    const message = createBaseDashFlash();
     message.msg = object.msg ?? '';
     message.type = object.type ?? 0;
     return message;
   },
 };
 
-const baseDashUserSettingsState: object = { email: '' };
+const createBaseDashUserSettingsState = (): DashUserSettingsState => ({ email: '' });
 
 export const DashUserSettingsState = {
   encode(message: DashUserSettingsState, writer: Writer = Writer.create()): Writer {
@@ -167,7 +167,7 @@ export const DashUserSettingsState = {
   decode(input: Reader | Uint8Array, length?: number): DashUserSettingsState {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseDashUserSettingsState } as DashUserSettingsState;
+    const message = createBaseDashUserSettingsState();
     message.flashes = [];
     while (reader.pos < end) {
       const tag = reader.uint32();
@@ -190,7 +190,7 @@ export const DashUserSettingsState = {
   },
 
   fromJSON(object: any): DashUserSettingsState {
-    const message = { ...baseDashUserSettingsState } as DashUserSettingsState;
+    const message = createBaseDashUserSettingsState();
     message.email = object.email !== undefined && object.email !== null ? String(object.email) : '';
     message.urls =
       object.urls !== undefined && object.urls !== null ? DashUserSettingsState_URLs.fromJSON(object.urls) : undefined;
@@ -212,7 +212,7 @@ export const DashUserSettingsState = {
   },
 
   fromPartial<I extends Exact<DeepPartial<DashUserSettingsState>, I>>(object: I): DashUserSettingsState {
-    const message = { ...baseDashUserSettingsState } as DashUserSettingsState;
+    const message = createBaseDashUserSettingsState();
     message.email = object.email ?? '';
     message.urls =
       object.urls !== undefined && object.urls !== null
@@ -223,7 +223,10 @@ export const DashUserSettingsState = {
   },
 };
 
-const baseDashUserSettingsState_URLs: object = { connectGoogle: '', connectGithub: '' };
+const createBaseDashUserSettingsState_URLs = (): DashUserSettingsState_URLs => ({
+  connectGoogle: '',
+  connectGithub: '',
+});
 
 export const DashUserSettingsState_URLs = {
   encode(message: DashUserSettingsState_URLs, writer: Writer = Writer.create()): Writer {
@@ -239,7 +242,7 @@ export const DashUserSettingsState_URLs = {
   decode(input: Reader | Uint8Array, length?: number): DashUserSettingsState_URLs {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseDashUserSettingsState_URLs } as DashUserSettingsState_URLs;
+    const message = createBaseDashUserSettingsState_URLs();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -258,7 +261,7 @@ export const DashUserSettingsState_URLs = {
   },
 
   fromJSON(object: any): DashUserSettingsState_URLs {
-    const message = { ...baseDashUserSettingsState_URLs } as DashUserSettingsState_URLs;
+    const message = createBaseDashUserSettingsState_URLs();
     message.connectGoogle =
       object.connectGoogle !== undefined && object.connectGoogle !== null ? String(object.connectGoogle) : '';
     message.connectGithub =
@@ -274,14 +277,14 @@ export const DashUserSettingsState_URLs = {
   },
 
   fromPartial<I extends Exact<DeepPartial<DashUserSettingsState_URLs>, I>>(object: I): DashUserSettingsState_URLs {
-    const message = { ...baseDashUserSettingsState_URLs } as DashUserSettingsState_URLs;
+    const message = createBaseDashUserSettingsState_URLs();
     message.connectGoogle = object.connectGoogle ?? '';
     message.connectGithub = object.connectGithub ?? '';
     return message;
   },
 };
 
-const baseDashCred: object = { description: '', metadata: '', token: '', id: '' };
+const createBaseDashCred = (): DashCred => ({ description: '', metadata: '', token: '', id: '' });
 
 export const DashCred = {
   encode(message: DashCred, writer: Writer = Writer.create()): Writer {
@@ -303,7 +306,7 @@ export const DashCred = {
   decode(input: Reader | Uint8Array, length?: number): DashCred {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseDashCred } as DashCred;
+    const message = createBaseDashCred();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -328,7 +331,7 @@ export const DashCred = {
   },
 
   fromJSON(object: any): DashCred {
-    const message = { ...baseDashCred } as DashCred;
+    const message = createBaseDashCred();
     message.description =
       object.description !== undefined && object.description !== null ? String(object.description) : '';
     message.metadata = object.metadata !== undefined && object.metadata !== null ? String(object.metadata) : '';
@@ -347,7 +350,7 @@ export const DashCred = {
   },
 
   fromPartial<I extends Exact<DeepPartial<DashCred>, I>>(object: I): DashCred {
-    const message = { ...baseDashCred } as DashCred;
+    const message = createBaseDashCred();
     message.description = object.description ?? '';
     message.metadata = object.metadata ?? '';
     message.token = object.token ?? '';
@@ -356,7 +359,7 @@ export const DashCred = {
   },
 };
 
-const baseDashAPICredsCreateReq: object = { description: '', metadata: '' };
+const createBaseDashAPICredsCreateReq = (): DashAPICredsCreateReq => ({ description: '', metadata: '' });
 
 export const DashAPICredsCreateReq = {
   encode(message: DashAPICredsCreateReq, writer: Writer = Writer.create()): Writer {
@@ -372,7 +375,7 @@ export const DashAPICredsCreateReq = {
   decode(input: Reader | Uint8Array, length?: number): DashAPICredsCreateReq {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseDashAPICredsCreateReq } as DashAPICredsCreateReq;
+    const message = createBaseDashAPICredsCreateReq();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -391,7 +394,7 @@ export const DashAPICredsCreateReq = {
   },
 
   fromJSON(object: any): DashAPICredsCreateReq {
-    const message = { ...baseDashAPICredsCreateReq } as DashAPICredsCreateReq;
+    const message = createBaseDashAPICredsCreateReq();
     message.description =
       object.description !== undefined && object.description !== null ? String(object.description) : '';
     message.metadata = object.metadata !== undefined && object.metadata !== null ? String(object.metadata) : '';
@@ -406,14 +409,19 @@ export const DashAPICredsCreateReq = {
   },
 
   fromPartial<I extends Exact<DeepPartial<DashAPICredsCreateReq>, I>>(object: I): DashAPICredsCreateReq {
-    const message = { ...baseDashAPICredsCreateReq } as DashAPICredsCreateReq;
+    const message = createBaseDashAPICredsCreateReq();
     message.description = object.description ?? '';
     message.metadata = object.metadata ?? '';
     return message;
   },
 };
 
-const baseDashAPICredsUpdateReq: object = { credSid: '', description: '', metadata: '', id: '' };
+const createBaseDashAPICredsUpdateReq = (): DashAPICredsUpdateReq => ({
+  credSid: '',
+  description: '',
+  metadata: '',
+  id: '',
+});
 
 export const DashAPICredsUpdateReq = {
   encode(message: DashAPICredsUpdateReq, writer: Writer = Writer.create()): Writer {
@@ -435,7 +443,7 @@ export const DashAPICredsUpdateReq = {
   decode(input: Reader | Uint8Array, length?: number): DashAPICredsUpdateReq {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseDashAPICredsUpdateReq } as DashAPICredsUpdateReq;
+    const message = createBaseDashAPICredsUpdateReq();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -460,7 +468,7 @@ export const DashAPICredsUpdateReq = {
   },
 
   fromJSON(object: any): DashAPICredsUpdateReq {
-    const message = { ...baseDashAPICredsUpdateReq } as DashAPICredsUpdateReq;
+    const message = createBaseDashAPICredsUpdateReq();
     message.credSid = object.credSid !== undefined && object.credSid !== null ? String(object.credSid) : '';
     message.description =
       object.description !== undefined && object.description !== null ? String(object.description) : '';
@@ -479,7 +487,7 @@ export const DashAPICredsUpdateReq = {
   },
 
   fromPartial<I extends Exact<DeepPartial<DashAPICredsUpdateReq>, I>>(object: I): DashAPICredsUpdateReq {
-    const message = { ...baseDashAPICredsUpdateReq } as DashAPICredsUpdateReq;
+    const message = createBaseDashAPICredsUpdateReq();
     message.credSid = object.credSid ?? '';
     message.description = object.description ?? '';
     message.metadata = object.metadata ?? '';
@@ -488,7 +496,7 @@ export const DashAPICredsUpdateReq = {
   },
 };
 
-const baseDashAPICredsDeleteReq: object = { credSid: '', id: '' };
+const createBaseDashAPICredsDeleteReq = (): DashAPICredsDeleteReq => ({ credSid: '', id: '' });
 
 export const DashAPICredsDeleteReq = {
   encode(message: DashAPICredsDeleteReq, writer: Writer = Writer.create()): Writer {
@@ -504,7 +512,7 @@ export const DashAPICredsDeleteReq = {
   decode(input: Reader | Uint8Array, length?: number): DashAPICredsDeleteReq {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseDashAPICredsDeleteReq } as DashAPICredsDeleteReq;
+    const message = createBaseDashAPICredsDeleteReq();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -523,7 +531,7 @@ export const DashAPICredsDeleteReq = {
   },
 
   fromJSON(object: any): DashAPICredsDeleteReq {
-    const message = { ...baseDashAPICredsDeleteReq } as DashAPICredsDeleteReq;
+    const message = createBaseDashAPICredsDeleteReq();
     message.credSid = object.credSid !== undefined && object.credSid !== null ? String(object.credSid) : '';
     message.id = object.id !== undefined && object.id !== null ? String(object.id) : '';
     return message;
@@ -537,14 +545,14 @@ export const DashAPICredsDeleteReq = {
   },
 
   fromPartial<I extends Exact<DeepPartial<DashAPICredsDeleteReq>, I>>(object: I): DashAPICredsDeleteReq {
-    const message = { ...baseDashAPICredsDeleteReq } as DashAPICredsDeleteReq;
+    const message = createBaseDashAPICredsDeleteReq();
     message.credSid = object.credSid ?? '';
     message.id = object.id ?? '';
     return message;
   },
 };
 
-const baseEmpty: object = {};
+const createBaseEmpty = (): Empty => ({});
 
 export const Empty = {
   encode(_: Empty, writer: Writer = Writer.create()): Writer {
@@ -554,7 +562,7 @@ export const Empty = {
   decode(input: Reader | Uint8Array, length?: number): Empty {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseEmpty } as Empty;
+    const message = createBaseEmpty();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -567,7 +575,7 @@ export const Empty = {
   },
 
   fromJSON(_: any): Empty {
-    const message = { ...baseEmpty } as Empty;
+    const message = createBaseEmpty();
     return message;
   },
 
@@ -577,7 +585,7 @@ export const Empty = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Empty>, I>>(_: I): Empty {
-    const message = { ...baseEmpty } as Empty;
+    const message = createBaseEmpty();
     return message;
   },
 };

--- a/integration/grpc-web-go-server/example.ts
+++ b/integration/grpc-web-go-server/example.ts
@@ -92,7 +92,9 @@ export interface DashAPICredsDeleteReq {
 
 export interface Empty {}
 
-const createBaseDashFlash = (): DashFlash => ({ msg: '', type: 0 });
+function createBaseDashFlash(): DashFlash {
+  return { msg: '', type: 0 };
+}
 
 export const DashFlash = {
   encode(message: DashFlash, writer: Writer = Writer.create()): Writer {
@@ -148,7 +150,9 @@ export const DashFlash = {
   },
 };
 
-const createBaseDashUserSettingsState = (): DashUserSettingsState => ({ email: '' });
+function createBaseDashUserSettingsState(): DashUserSettingsState {
+  return { email: '', urls: undefined, flashes: [] };
+}
 
 export const DashUserSettingsState = {
   encode(message: DashUserSettingsState, writer: Writer = Writer.create()): Writer {
@@ -168,7 +172,6 @@ export const DashUserSettingsState = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseDashUserSettingsState();
-    message.flashes = [];
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -223,10 +226,9 @@ export const DashUserSettingsState = {
   },
 };
 
-const createBaseDashUserSettingsState_URLs = (): DashUserSettingsState_URLs => ({
-  connectGoogle: '',
-  connectGithub: '',
-});
+function createBaseDashUserSettingsState_URLs(): DashUserSettingsState_URLs {
+  return { connectGoogle: '', connectGithub: '' };
+}
 
 export const DashUserSettingsState_URLs = {
   encode(message: DashUserSettingsState_URLs, writer: Writer = Writer.create()): Writer {
@@ -284,7 +286,9 @@ export const DashUserSettingsState_URLs = {
   },
 };
 
-const createBaseDashCred = (): DashCred => ({ description: '', metadata: '', token: '', id: '' });
+function createBaseDashCred(): DashCred {
+  return { description: '', metadata: '', token: '', id: '' };
+}
 
 export const DashCred = {
   encode(message: DashCred, writer: Writer = Writer.create()): Writer {
@@ -359,7 +363,9 @@ export const DashCred = {
   },
 };
 
-const createBaseDashAPICredsCreateReq = (): DashAPICredsCreateReq => ({ description: '', metadata: '' });
+function createBaseDashAPICredsCreateReq(): DashAPICredsCreateReq {
+  return { description: '', metadata: '' };
+}
 
 export const DashAPICredsCreateReq = {
   encode(message: DashAPICredsCreateReq, writer: Writer = Writer.create()): Writer {
@@ -416,12 +422,9 @@ export const DashAPICredsCreateReq = {
   },
 };
 
-const createBaseDashAPICredsUpdateReq = (): DashAPICredsUpdateReq => ({
-  credSid: '',
-  description: '',
-  metadata: '',
-  id: '',
-});
+function createBaseDashAPICredsUpdateReq(): DashAPICredsUpdateReq {
+  return { credSid: '', description: '', metadata: '', id: '' };
+}
 
 export const DashAPICredsUpdateReq = {
   encode(message: DashAPICredsUpdateReq, writer: Writer = Writer.create()): Writer {
@@ -496,7 +499,9 @@ export const DashAPICredsUpdateReq = {
   },
 };
 
-const createBaseDashAPICredsDeleteReq = (): DashAPICredsDeleteReq => ({ credSid: '', id: '' });
+function createBaseDashAPICredsDeleteReq(): DashAPICredsDeleteReq {
+  return { credSid: '', id: '' };
+}
 
 export const DashAPICredsDeleteReq = {
   encode(message: DashAPICredsDeleteReq, writer: Writer = Writer.create()): Writer {
@@ -552,7 +557,9 @@ export const DashAPICredsDeleteReq = {
   },
 };
 
-const createBaseEmpty = (): Empty => ({});
+function createBaseEmpty(): Empty {
+  return {};
+}
 
 export const Empty = {
   encode(_: Empty, writer: Writer = Writer.create()): Writer {

--- a/integration/grpc-web-no-streaming-observable/example.ts
+++ b/integration/grpc-web-no-streaming-observable/example.ts
@@ -70,7 +70,9 @@ export interface DashUserSettingsState_URLs {
 
 export interface Empty {}
 
-const createBaseDashFlash = (): DashFlash => ({ msg: '', type: 0 });
+function createBaseDashFlash(): DashFlash {
+  return { msg: '', type: 0 };
+}
 
 export const DashFlash = {
   encode(message: DashFlash, writer: Writer = Writer.create()): Writer {
@@ -126,7 +128,9 @@ export const DashFlash = {
   },
 };
 
-const createBaseDashUserSettingsState = (): DashUserSettingsState => ({ email: '' });
+function createBaseDashUserSettingsState(): DashUserSettingsState {
+  return { email: '', urls: undefined, flashes: [] };
+}
 
 export const DashUserSettingsState = {
   encode(message: DashUserSettingsState, writer: Writer = Writer.create()): Writer {
@@ -146,7 +150,6 @@ export const DashUserSettingsState = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseDashUserSettingsState();
-    message.flashes = [];
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -201,10 +204,9 @@ export const DashUserSettingsState = {
   },
 };
 
-const createBaseDashUserSettingsState_URLs = (): DashUserSettingsState_URLs => ({
-  connectGoogle: '',
-  connectGithub: '',
-});
+function createBaseDashUserSettingsState_URLs(): DashUserSettingsState_URLs {
+  return { connectGoogle: '', connectGithub: '' };
+}
 
 export const DashUserSettingsState_URLs = {
   encode(message: DashUserSettingsState_URLs, writer: Writer = Writer.create()): Writer {
@@ -262,7 +264,9 @@ export const DashUserSettingsState_URLs = {
   },
 };
 
-const createBaseEmpty = (): Empty => ({});
+function createBaseEmpty(): Empty {
+  return {};
+}
 
 export const Empty = {
   encode(_: Empty, writer: Writer = Writer.create()): Writer {

--- a/integration/grpc-web-no-streaming-observable/example.ts
+++ b/integration/grpc-web-no-streaming-observable/example.ts
@@ -70,7 +70,7 @@ export interface DashUserSettingsState_URLs {
 
 export interface Empty {}
 
-const baseDashFlash: object = { msg: '', type: 0 };
+const createBaseDashFlash = (): DashFlash => ({ msg: '', type: 0 });
 
 export const DashFlash = {
   encode(message: DashFlash, writer: Writer = Writer.create()): Writer {
@@ -86,7 +86,7 @@ export const DashFlash = {
   decode(input: Reader | Uint8Array, length?: number): DashFlash {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseDashFlash } as DashFlash;
+    const message = createBaseDashFlash();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -105,7 +105,7 @@ export const DashFlash = {
   },
 
   fromJSON(object: any): DashFlash {
-    const message = { ...baseDashFlash } as DashFlash;
+    const message = createBaseDashFlash();
     message.msg = object.msg !== undefined && object.msg !== null ? String(object.msg) : '';
     message.type = object.type !== undefined && object.type !== null ? dashFlash_TypeFromJSON(object.type) : 0;
     return message;
@@ -119,14 +119,14 @@ export const DashFlash = {
   },
 
   fromPartial<I extends Exact<DeepPartial<DashFlash>, I>>(object: I): DashFlash {
-    const message = { ...baseDashFlash } as DashFlash;
+    const message = createBaseDashFlash();
     message.msg = object.msg ?? '';
     message.type = object.type ?? 0;
     return message;
   },
 };
 
-const baseDashUserSettingsState: object = { email: '' };
+const createBaseDashUserSettingsState = (): DashUserSettingsState => ({ email: '' });
 
 export const DashUserSettingsState = {
   encode(message: DashUserSettingsState, writer: Writer = Writer.create()): Writer {
@@ -145,7 +145,7 @@ export const DashUserSettingsState = {
   decode(input: Reader | Uint8Array, length?: number): DashUserSettingsState {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseDashUserSettingsState } as DashUserSettingsState;
+    const message = createBaseDashUserSettingsState();
     message.flashes = [];
     while (reader.pos < end) {
       const tag = reader.uint32();
@@ -168,7 +168,7 @@ export const DashUserSettingsState = {
   },
 
   fromJSON(object: any): DashUserSettingsState {
-    const message = { ...baseDashUserSettingsState } as DashUserSettingsState;
+    const message = createBaseDashUserSettingsState();
     message.email = object.email !== undefined && object.email !== null ? String(object.email) : '';
     message.urls =
       object.urls !== undefined && object.urls !== null ? DashUserSettingsState_URLs.fromJSON(object.urls) : undefined;
@@ -190,7 +190,7 @@ export const DashUserSettingsState = {
   },
 
   fromPartial<I extends Exact<DeepPartial<DashUserSettingsState>, I>>(object: I): DashUserSettingsState {
-    const message = { ...baseDashUserSettingsState } as DashUserSettingsState;
+    const message = createBaseDashUserSettingsState();
     message.email = object.email ?? '';
     message.urls =
       object.urls !== undefined && object.urls !== null
@@ -201,7 +201,10 @@ export const DashUserSettingsState = {
   },
 };
 
-const baseDashUserSettingsState_URLs: object = { connectGoogle: '', connectGithub: '' };
+const createBaseDashUserSettingsState_URLs = (): DashUserSettingsState_URLs => ({
+  connectGoogle: '',
+  connectGithub: '',
+});
 
 export const DashUserSettingsState_URLs = {
   encode(message: DashUserSettingsState_URLs, writer: Writer = Writer.create()): Writer {
@@ -217,7 +220,7 @@ export const DashUserSettingsState_URLs = {
   decode(input: Reader | Uint8Array, length?: number): DashUserSettingsState_URLs {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseDashUserSettingsState_URLs } as DashUserSettingsState_URLs;
+    const message = createBaseDashUserSettingsState_URLs();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -236,7 +239,7 @@ export const DashUserSettingsState_URLs = {
   },
 
   fromJSON(object: any): DashUserSettingsState_URLs {
-    const message = { ...baseDashUserSettingsState_URLs } as DashUserSettingsState_URLs;
+    const message = createBaseDashUserSettingsState_URLs();
     message.connectGoogle =
       object.connectGoogle !== undefined && object.connectGoogle !== null ? String(object.connectGoogle) : '';
     message.connectGithub =
@@ -252,14 +255,14 @@ export const DashUserSettingsState_URLs = {
   },
 
   fromPartial<I extends Exact<DeepPartial<DashUserSettingsState_URLs>, I>>(object: I): DashUserSettingsState_URLs {
-    const message = { ...baseDashUserSettingsState_URLs } as DashUserSettingsState_URLs;
+    const message = createBaseDashUserSettingsState_URLs();
     message.connectGoogle = object.connectGoogle ?? '';
     message.connectGithub = object.connectGithub ?? '';
     return message;
   },
 };
 
-const baseEmpty: object = {};
+const createBaseEmpty = (): Empty => ({});
 
 export const Empty = {
   encode(_: Empty, writer: Writer = Writer.create()): Writer {
@@ -269,7 +272,7 @@ export const Empty = {
   decode(input: Reader | Uint8Array, length?: number): Empty {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseEmpty } as Empty;
+    const message = createBaseEmpty();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -282,7 +285,7 @@ export const Empty = {
   },
 
   fromJSON(_: any): Empty {
-    const message = { ...baseEmpty } as Empty;
+    const message = createBaseEmpty();
     return message;
   },
 
@@ -292,7 +295,7 @@ export const Empty = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Empty>, I>>(_: I): Empty {
-    const message = { ...baseEmpty } as Empty;
+    const message = createBaseEmpty();
     return message;
   },
 };

--- a/integration/grpc-web-no-streaming/example.ts
+++ b/integration/grpc-web-no-streaming/example.ts
@@ -68,7 +68,7 @@ export interface DashUserSettingsState_URLs {
 
 export interface Empty {}
 
-const baseDashFlash: object = { msg: '', type: 0 };
+const createBaseDashFlash = (): DashFlash => ({ msg: '', type: 0 });
 
 export const DashFlash = {
   encode(message: DashFlash, writer: Writer = Writer.create()): Writer {
@@ -84,7 +84,7 @@ export const DashFlash = {
   decode(input: Reader | Uint8Array, length?: number): DashFlash {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseDashFlash } as DashFlash;
+    const message = createBaseDashFlash();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -103,7 +103,7 @@ export const DashFlash = {
   },
 
   fromJSON(object: any): DashFlash {
-    const message = { ...baseDashFlash } as DashFlash;
+    const message = createBaseDashFlash();
     message.msg = object.msg !== undefined && object.msg !== null ? String(object.msg) : '';
     message.type = object.type !== undefined && object.type !== null ? dashFlash_TypeFromJSON(object.type) : 0;
     return message;
@@ -117,14 +117,14 @@ export const DashFlash = {
   },
 
   fromPartial<I extends Exact<DeepPartial<DashFlash>, I>>(object: I): DashFlash {
-    const message = { ...baseDashFlash } as DashFlash;
+    const message = createBaseDashFlash();
     message.msg = object.msg ?? '';
     message.type = object.type ?? 0;
     return message;
   },
 };
 
-const baseDashUserSettingsState: object = { email: '' };
+const createBaseDashUserSettingsState = (): DashUserSettingsState => ({ email: '' });
 
 export const DashUserSettingsState = {
   encode(message: DashUserSettingsState, writer: Writer = Writer.create()): Writer {
@@ -143,7 +143,7 @@ export const DashUserSettingsState = {
   decode(input: Reader | Uint8Array, length?: number): DashUserSettingsState {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseDashUserSettingsState } as DashUserSettingsState;
+    const message = createBaseDashUserSettingsState();
     message.flashes = [];
     while (reader.pos < end) {
       const tag = reader.uint32();
@@ -166,7 +166,7 @@ export const DashUserSettingsState = {
   },
 
   fromJSON(object: any): DashUserSettingsState {
-    const message = { ...baseDashUserSettingsState } as DashUserSettingsState;
+    const message = createBaseDashUserSettingsState();
     message.email = object.email !== undefined && object.email !== null ? String(object.email) : '';
     message.urls =
       object.urls !== undefined && object.urls !== null ? DashUserSettingsState_URLs.fromJSON(object.urls) : undefined;
@@ -188,7 +188,7 @@ export const DashUserSettingsState = {
   },
 
   fromPartial<I extends Exact<DeepPartial<DashUserSettingsState>, I>>(object: I): DashUserSettingsState {
-    const message = { ...baseDashUserSettingsState } as DashUserSettingsState;
+    const message = createBaseDashUserSettingsState();
     message.email = object.email ?? '';
     message.urls =
       object.urls !== undefined && object.urls !== null
@@ -199,7 +199,10 @@ export const DashUserSettingsState = {
   },
 };
 
-const baseDashUserSettingsState_URLs: object = { connectGoogle: '', connectGithub: '' };
+const createBaseDashUserSettingsState_URLs = (): DashUserSettingsState_URLs => ({
+  connectGoogle: '',
+  connectGithub: '',
+});
 
 export const DashUserSettingsState_URLs = {
   encode(message: DashUserSettingsState_URLs, writer: Writer = Writer.create()): Writer {
@@ -215,7 +218,7 @@ export const DashUserSettingsState_URLs = {
   decode(input: Reader | Uint8Array, length?: number): DashUserSettingsState_URLs {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseDashUserSettingsState_URLs } as DashUserSettingsState_URLs;
+    const message = createBaseDashUserSettingsState_URLs();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -234,7 +237,7 @@ export const DashUserSettingsState_URLs = {
   },
 
   fromJSON(object: any): DashUserSettingsState_URLs {
-    const message = { ...baseDashUserSettingsState_URLs } as DashUserSettingsState_URLs;
+    const message = createBaseDashUserSettingsState_URLs();
     message.connectGoogle =
       object.connectGoogle !== undefined && object.connectGoogle !== null ? String(object.connectGoogle) : '';
     message.connectGithub =
@@ -250,14 +253,14 @@ export const DashUserSettingsState_URLs = {
   },
 
   fromPartial<I extends Exact<DeepPartial<DashUserSettingsState_URLs>, I>>(object: I): DashUserSettingsState_URLs {
-    const message = { ...baseDashUserSettingsState_URLs } as DashUserSettingsState_URLs;
+    const message = createBaseDashUserSettingsState_URLs();
     message.connectGoogle = object.connectGoogle ?? '';
     message.connectGithub = object.connectGithub ?? '';
     return message;
   },
 };
 
-const baseEmpty: object = {};
+const createBaseEmpty = (): Empty => ({});
 
 export const Empty = {
   encode(_: Empty, writer: Writer = Writer.create()): Writer {
@@ -267,7 +270,7 @@ export const Empty = {
   decode(input: Reader | Uint8Array, length?: number): Empty {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseEmpty } as Empty;
+    const message = createBaseEmpty();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -280,7 +283,7 @@ export const Empty = {
   },
 
   fromJSON(_: any): Empty {
-    const message = { ...baseEmpty } as Empty;
+    const message = createBaseEmpty();
     return message;
   },
 
@@ -290,7 +293,7 @@ export const Empty = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Empty>, I>>(_: I): Empty {
-    const message = { ...baseEmpty } as Empty;
+    const message = createBaseEmpty();
     return message;
   },
 };

--- a/integration/grpc-web-no-streaming/example.ts
+++ b/integration/grpc-web-no-streaming/example.ts
@@ -68,7 +68,9 @@ export interface DashUserSettingsState_URLs {
 
 export interface Empty {}
 
-const createBaseDashFlash = (): DashFlash => ({ msg: '', type: 0 });
+function createBaseDashFlash(): DashFlash {
+  return { msg: '', type: 0 };
+}
 
 export const DashFlash = {
   encode(message: DashFlash, writer: Writer = Writer.create()): Writer {
@@ -124,7 +126,9 @@ export const DashFlash = {
   },
 };
 
-const createBaseDashUserSettingsState = (): DashUserSettingsState => ({ email: '' });
+function createBaseDashUserSettingsState(): DashUserSettingsState {
+  return { email: '', urls: undefined, flashes: [] };
+}
 
 export const DashUserSettingsState = {
   encode(message: DashUserSettingsState, writer: Writer = Writer.create()): Writer {
@@ -144,7 +148,6 @@ export const DashUserSettingsState = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseDashUserSettingsState();
-    message.flashes = [];
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -199,10 +202,9 @@ export const DashUserSettingsState = {
   },
 };
 
-const createBaseDashUserSettingsState_URLs = (): DashUserSettingsState_URLs => ({
-  connectGoogle: '',
-  connectGithub: '',
-});
+function createBaseDashUserSettingsState_URLs(): DashUserSettingsState_URLs {
+  return { connectGoogle: '', connectGithub: '' };
+}
 
 export const DashUserSettingsState_URLs = {
   encode(message: DashUserSettingsState_URLs, writer: Writer = Writer.create()): Writer {
@@ -260,7 +262,9 @@ export const DashUserSettingsState_URLs = {
   },
 };
 
-const createBaseEmpty = (): Empty => ({});
+function createBaseEmpty(): Empty {
+  return {};
+}
 
 export const Empty = {
   encode(_: Empty, writer: Writer = Writer.create()): Writer {

--- a/integration/grpc-web/example.ts
+++ b/integration/grpc-web/example.ts
@@ -94,7 +94,9 @@ export interface DashAPICredsDeleteReq {
 
 export interface Empty {}
 
-const createBaseDashFlash = (): DashFlash => ({ msg: '', type: 0 });
+function createBaseDashFlash(): DashFlash {
+  return { msg: '', type: 0 };
+}
 
 export const DashFlash = {
   encode(message: DashFlash, writer: Writer = Writer.create()): Writer {
@@ -150,7 +152,9 @@ export const DashFlash = {
   },
 };
 
-const createBaseDashUserSettingsState = (): DashUserSettingsState => ({ email: '' });
+function createBaseDashUserSettingsState(): DashUserSettingsState {
+  return { email: '', urls: undefined, flashes: [] };
+}
 
 export const DashUserSettingsState = {
   encode(message: DashUserSettingsState, writer: Writer = Writer.create()): Writer {
@@ -170,7 +174,6 @@ export const DashUserSettingsState = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseDashUserSettingsState();
-    message.flashes = [];
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -225,10 +228,9 @@ export const DashUserSettingsState = {
   },
 };
 
-const createBaseDashUserSettingsState_URLs = (): DashUserSettingsState_URLs => ({
-  connectGoogle: '',
-  connectGithub: '',
-});
+function createBaseDashUserSettingsState_URLs(): DashUserSettingsState_URLs {
+  return { connectGoogle: '', connectGithub: '' };
+}
 
 export const DashUserSettingsState_URLs = {
   encode(message: DashUserSettingsState_URLs, writer: Writer = Writer.create()): Writer {
@@ -286,7 +288,9 @@ export const DashUserSettingsState_URLs = {
   },
 };
 
-const createBaseDashCred = (): DashCred => ({ description: '', metadata: '', token: '', id: '' });
+function createBaseDashCred(): DashCred {
+  return { description: '', metadata: '', token: '', id: '' };
+}
 
 export const DashCred = {
   encode(message: DashCred, writer: Writer = Writer.create()): Writer {
@@ -361,7 +365,9 @@ export const DashCred = {
   },
 };
 
-const createBaseDashAPICredsCreateReq = (): DashAPICredsCreateReq => ({ description: '', metadata: '' });
+function createBaseDashAPICredsCreateReq(): DashAPICredsCreateReq {
+  return { description: '', metadata: '' };
+}
 
 export const DashAPICredsCreateReq = {
   encode(message: DashAPICredsCreateReq, writer: Writer = Writer.create()): Writer {
@@ -418,12 +424,9 @@ export const DashAPICredsCreateReq = {
   },
 };
 
-const createBaseDashAPICredsUpdateReq = (): DashAPICredsUpdateReq => ({
-  credSid: '',
-  description: '',
-  metadata: '',
-  id: '',
-});
+function createBaseDashAPICredsUpdateReq(): DashAPICredsUpdateReq {
+  return { credSid: '', description: '', metadata: '', id: '' };
+}
 
 export const DashAPICredsUpdateReq = {
   encode(message: DashAPICredsUpdateReq, writer: Writer = Writer.create()): Writer {
@@ -498,7 +501,9 @@ export const DashAPICredsUpdateReq = {
   },
 };
 
-const createBaseDashAPICredsDeleteReq = (): DashAPICredsDeleteReq => ({ credSid: '', id: '' });
+function createBaseDashAPICredsDeleteReq(): DashAPICredsDeleteReq {
+  return { credSid: '', id: '' };
+}
 
 export const DashAPICredsDeleteReq = {
   encode(message: DashAPICredsDeleteReq, writer: Writer = Writer.create()): Writer {
@@ -554,7 +559,9 @@ export const DashAPICredsDeleteReq = {
   },
 };
 
-const createBaseEmpty = (): Empty => ({});
+function createBaseEmpty(): Empty {
+  return {};
+}
 
 export const Empty = {
   encode(_: Empty, writer: Writer = Writer.create()): Writer {

--- a/integration/grpc-web/example.ts
+++ b/integration/grpc-web/example.ts
@@ -94,7 +94,7 @@ export interface DashAPICredsDeleteReq {
 
 export interface Empty {}
 
-const baseDashFlash: object = { msg: '', type: 0 };
+const createBaseDashFlash = (): DashFlash => ({ msg: '', type: 0 });
 
 export const DashFlash = {
   encode(message: DashFlash, writer: Writer = Writer.create()): Writer {
@@ -110,7 +110,7 @@ export const DashFlash = {
   decode(input: Reader | Uint8Array, length?: number): DashFlash {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseDashFlash } as DashFlash;
+    const message = createBaseDashFlash();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -129,7 +129,7 @@ export const DashFlash = {
   },
 
   fromJSON(object: any): DashFlash {
-    const message = { ...baseDashFlash } as DashFlash;
+    const message = createBaseDashFlash();
     message.msg = object.msg !== undefined && object.msg !== null ? String(object.msg) : '';
     message.type = object.type !== undefined && object.type !== null ? dashFlash_TypeFromJSON(object.type) : 0;
     return message;
@@ -143,14 +143,14 @@ export const DashFlash = {
   },
 
   fromPartial<I extends Exact<DeepPartial<DashFlash>, I>>(object: I): DashFlash {
-    const message = { ...baseDashFlash } as DashFlash;
+    const message = createBaseDashFlash();
     message.msg = object.msg ?? '';
     message.type = object.type ?? 0;
     return message;
   },
 };
 
-const baseDashUserSettingsState: object = { email: '' };
+const createBaseDashUserSettingsState = (): DashUserSettingsState => ({ email: '' });
 
 export const DashUserSettingsState = {
   encode(message: DashUserSettingsState, writer: Writer = Writer.create()): Writer {
@@ -169,7 +169,7 @@ export const DashUserSettingsState = {
   decode(input: Reader | Uint8Array, length?: number): DashUserSettingsState {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseDashUserSettingsState } as DashUserSettingsState;
+    const message = createBaseDashUserSettingsState();
     message.flashes = [];
     while (reader.pos < end) {
       const tag = reader.uint32();
@@ -192,7 +192,7 @@ export const DashUserSettingsState = {
   },
 
   fromJSON(object: any): DashUserSettingsState {
-    const message = { ...baseDashUserSettingsState } as DashUserSettingsState;
+    const message = createBaseDashUserSettingsState();
     message.email = object.email !== undefined && object.email !== null ? String(object.email) : '';
     message.urls =
       object.urls !== undefined && object.urls !== null ? DashUserSettingsState_URLs.fromJSON(object.urls) : undefined;
@@ -214,7 +214,7 @@ export const DashUserSettingsState = {
   },
 
   fromPartial<I extends Exact<DeepPartial<DashUserSettingsState>, I>>(object: I): DashUserSettingsState {
-    const message = { ...baseDashUserSettingsState } as DashUserSettingsState;
+    const message = createBaseDashUserSettingsState();
     message.email = object.email ?? '';
     message.urls =
       object.urls !== undefined && object.urls !== null
@@ -225,7 +225,10 @@ export const DashUserSettingsState = {
   },
 };
 
-const baseDashUserSettingsState_URLs: object = { connectGoogle: '', connectGithub: '' };
+const createBaseDashUserSettingsState_URLs = (): DashUserSettingsState_URLs => ({
+  connectGoogle: '',
+  connectGithub: '',
+});
 
 export const DashUserSettingsState_URLs = {
   encode(message: DashUserSettingsState_URLs, writer: Writer = Writer.create()): Writer {
@@ -241,7 +244,7 @@ export const DashUserSettingsState_URLs = {
   decode(input: Reader | Uint8Array, length?: number): DashUserSettingsState_URLs {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseDashUserSettingsState_URLs } as DashUserSettingsState_URLs;
+    const message = createBaseDashUserSettingsState_URLs();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -260,7 +263,7 @@ export const DashUserSettingsState_URLs = {
   },
 
   fromJSON(object: any): DashUserSettingsState_URLs {
-    const message = { ...baseDashUserSettingsState_URLs } as DashUserSettingsState_URLs;
+    const message = createBaseDashUserSettingsState_URLs();
     message.connectGoogle =
       object.connectGoogle !== undefined && object.connectGoogle !== null ? String(object.connectGoogle) : '';
     message.connectGithub =
@@ -276,14 +279,14 @@ export const DashUserSettingsState_URLs = {
   },
 
   fromPartial<I extends Exact<DeepPartial<DashUserSettingsState_URLs>, I>>(object: I): DashUserSettingsState_URLs {
-    const message = { ...baseDashUserSettingsState_URLs } as DashUserSettingsState_URLs;
+    const message = createBaseDashUserSettingsState_URLs();
     message.connectGoogle = object.connectGoogle ?? '';
     message.connectGithub = object.connectGithub ?? '';
     return message;
   },
 };
 
-const baseDashCred: object = { description: '', metadata: '', token: '', id: '' };
+const createBaseDashCred = (): DashCred => ({ description: '', metadata: '', token: '', id: '' });
 
 export const DashCred = {
   encode(message: DashCred, writer: Writer = Writer.create()): Writer {
@@ -305,7 +308,7 @@ export const DashCred = {
   decode(input: Reader | Uint8Array, length?: number): DashCred {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseDashCred } as DashCred;
+    const message = createBaseDashCred();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -330,7 +333,7 @@ export const DashCred = {
   },
 
   fromJSON(object: any): DashCred {
-    const message = { ...baseDashCred } as DashCred;
+    const message = createBaseDashCred();
     message.description =
       object.description !== undefined && object.description !== null ? String(object.description) : '';
     message.metadata = object.metadata !== undefined && object.metadata !== null ? String(object.metadata) : '';
@@ -349,7 +352,7 @@ export const DashCred = {
   },
 
   fromPartial<I extends Exact<DeepPartial<DashCred>, I>>(object: I): DashCred {
-    const message = { ...baseDashCred } as DashCred;
+    const message = createBaseDashCred();
     message.description = object.description ?? '';
     message.metadata = object.metadata ?? '';
     message.token = object.token ?? '';
@@ -358,7 +361,7 @@ export const DashCred = {
   },
 };
 
-const baseDashAPICredsCreateReq: object = { description: '', metadata: '' };
+const createBaseDashAPICredsCreateReq = (): DashAPICredsCreateReq => ({ description: '', metadata: '' });
 
 export const DashAPICredsCreateReq = {
   encode(message: DashAPICredsCreateReq, writer: Writer = Writer.create()): Writer {
@@ -374,7 +377,7 @@ export const DashAPICredsCreateReq = {
   decode(input: Reader | Uint8Array, length?: number): DashAPICredsCreateReq {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseDashAPICredsCreateReq } as DashAPICredsCreateReq;
+    const message = createBaseDashAPICredsCreateReq();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -393,7 +396,7 @@ export const DashAPICredsCreateReq = {
   },
 
   fromJSON(object: any): DashAPICredsCreateReq {
-    const message = { ...baseDashAPICredsCreateReq } as DashAPICredsCreateReq;
+    const message = createBaseDashAPICredsCreateReq();
     message.description =
       object.description !== undefined && object.description !== null ? String(object.description) : '';
     message.metadata = object.metadata !== undefined && object.metadata !== null ? String(object.metadata) : '';
@@ -408,14 +411,19 @@ export const DashAPICredsCreateReq = {
   },
 
   fromPartial<I extends Exact<DeepPartial<DashAPICredsCreateReq>, I>>(object: I): DashAPICredsCreateReq {
-    const message = { ...baseDashAPICredsCreateReq } as DashAPICredsCreateReq;
+    const message = createBaseDashAPICredsCreateReq();
     message.description = object.description ?? '';
     message.metadata = object.metadata ?? '';
     return message;
   },
 };
 
-const baseDashAPICredsUpdateReq: object = { credSid: '', description: '', metadata: '', id: '' };
+const createBaseDashAPICredsUpdateReq = (): DashAPICredsUpdateReq => ({
+  credSid: '',
+  description: '',
+  metadata: '',
+  id: '',
+});
 
 export const DashAPICredsUpdateReq = {
   encode(message: DashAPICredsUpdateReq, writer: Writer = Writer.create()): Writer {
@@ -437,7 +445,7 @@ export const DashAPICredsUpdateReq = {
   decode(input: Reader | Uint8Array, length?: number): DashAPICredsUpdateReq {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseDashAPICredsUpdateReq } as DashAPICredsUpdateReq;
+    const message = createBaseDashAPICredsUpdateReq();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -462,7 +470,7 @@ export const DashAPICredsUpdateReq = {
   },
 
   fromJSON(object: any): DashAPICredsUpdateReq {
-    const message = { ...baseDashAPICredsUpdateReq } as DashAPICredsUpdateReq;
+    const message = createBaseDashAPICredsUpdateReq();
     message.credSid = object.credSid !== undefined && object.credSid !== null ? String(object.credSid) : '';
     message.description =
       object.description !== undefined && object.description !== null ? String(object.description) : '';
@@ -481,7 +489,7 @@ export const DashAPICredsUpdateReq = {
   },
 
   fromPartial<I extends Exact<DeepPartial<DashAPICredsUpdateReq>, I>>(object: I): DashAPICredsUpdateReq {
-    const message = { ...baseDashAPICredsUpdateReq } as DashAPICredsUpdateReq;
+    const message = createBaseDashAPICredsUpdateReq();
     message.credSid = object.credSid ?? '';
     message.description = object.description ?? '';
     message.metadata = object.metadata ?? '';
@@ -490,7 +498,7 @@ export const DashAPICredsUpdateReq = {
   },
 };
 
-const baseDashAPICredsDeleteReq: object = { credSid: '', id: '' };
+const createBaseDashAPICredsDeleteReq = (): DashAPICredsDeleteReq => ({ credSid: '', id: '' });
 
 export const DashAPICredsDeleteReq = {
   encode(message: DashAPICredsDeleteReq, writer: Writer = Writer.create()): Writer {
@@ -506,7 +514,7 @@ export const DashAPICredsDeleteReq = {
   decode(input: Reader | Uint8Array, length?: number): DashAPICredsDeleteReq {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseDashAPICredsDeleteReq } as DashAPICredsDeleteReq;
+    const message = createBaseDashAPICredsDeleteReq();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -525,7 +533,7 @@ export const DashAPICredsDeleteReq = {
   },
 
   fromJSON(object: any): DashAPICredsDeleteReq {
-    const message = { ...baseDashAPICredsDeleteReq } as DashAPICredsDeleteReq;
+    const message = createBaseDashAPICredsDeleteReq();
     message.credSid = object.credSid !== undefined && object.credSid !== null ? String(object.credSid) : '';
     message.id = object.id !== undefined && object.id !== null ? String(object.id) : '';
     return message;
@@ -539,14 +547,14 @@ export const DashAPICredsDeleteReq = {
   },
 
   fromPartial<I extends Exact<DeepPartial<DashAPICredsDeleteReq>, I>>(object: I): DashAPICredsDeleteReq {
-    const message = { ...baseDashAPICredsDeleteReq } as DashAPICredsDeleteReq;
+    const message = createBaseDashAPICredsDeleteReq();
     message.credSid = object.credSid ?? '';
     message.id = object.id ?? '';
     return message;
   },
 };
 
-const baseEmpty: object = {};
+const createBaseEmpty = (): Empty => ({});
 
 export const Empty = {
   encode(_: Empty, writer: Writer = Writer.create()): Writer {
@@ -556,7 +564,7 @@ export const Empty = {
   decode(input: Reader | Uint8Array, length?: number): Empty {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseEmpty } as Empty;
+    const message = createBaseEmpty();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -569,7 +577,7 @@ export const Empty = {
   },
 
   fromJSON(_: any): Empty {
-    const message = { ...baseEmpty } as Empty;
+    const message = createBaseEmpty();
     return message;
   },
 
@@ -579,7 +587,7 @@ export const Empty = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Empty>, I>>(_: I): Empty {
-    const message = { ...baseEmpty } as Empty;
+    const message = createBaseEmpty();
     return message;
   },
 };

--- a/integration/lower-case-svc-methods/math.ts
+++ b/integration/lower-case-svc-methods/math.ts
@@ -19,7 +19,9 @@ export interface Numbers {
   num: number[];
 }
 
-const createBaseNumPair = (): NumPair => ({ num1: 0, num2: 0 });
+function createBaseNumPair(): NumPair {
+  return { num1: 0, num2: 0 };
+}
 
 export const NumPair = {
   encode(message: NumPair, writer: Writer = Writer.create()): Writer {
@@ -75,7 +77,9 @@ export const NumPair = {
   },
 };
 
-const createBaseNumSingle = (): NumSingle => ({ num: 0 });
+function createBaseNumSingle(): NumSingle {
+  return { num: 0 };
+}
 
 export const NumSingle = {
   encode(message: NumSingle, writer: Writer = Writer.create()): Writer {
@@ -122,7 +126,9 @@ export const NumSingle = {
   },
 };
 
-const createBaseNumbers = (): Numbers => ({ num: 0 });
+function createBaseNumbers(): Numbers {
+  return { num: [] };
+}
 
 export const Numbers = {
   encode(message: Numbers, writer: Writer = Writer.create()): Writer {
@@ -138,7 +144,6 @@ export const Numbers = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseNumbers();
-    message.num = [];
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {

--- a/integration/lower-case-svc-methods/math.ts
+++ b/integration/lower-case-svc-methods/math.ts
@@ -19,7 +19,7 @@ export interface Numbers {
   num: number[];
 }
 
-const baseNumPair: object = { num1: 0, num2: 0 };
+const createBaseNumPair = (): NumPair => ({ num1: 0, num2: 0 });
 
 export const NumPair = {
   encode(message: NumPair, writer: Writer = Writer.create()): Writer {
@@ -35,7 +35,7 @@ export const NumPair = {
   decode(input: Reader | Uint8Array, length?: number): NumPair {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseNumPair } as NumPair;
+    const message = createBaseNumPair();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -54,7 +54,7 @@ export const NumPair = {
   },
 
   fromJSON(object: any): NumPair {
-    const message = { ...baseNumPair } as NumPair;
+    const message = createBaseNumPair();
     message.num1 = object.num1 !== undefined && object.num1 !== null ? Number(object.num1) : 0;
     message.num2 = object.num2 !== undefined && object.num2 !== null ? Number(object.num2) : 0;
     return message;
@@ -68,14 +68,14 @@ export const NumPair = {
   },
 
   fromPartial<I extends Exact<DeepPartial<NumPair>, I>>(object: I): NumPair {
-    const message = { ...baseNumPair } as NumPair;
+    const message = createBaseNumPair();
     message.num1 = object.num1 ?? 0;
     message.num2 = object.num2 ?? 0;
     return message;
   },
 };
 
-const baseNumSingle: object = { num: 0 };
+const createBaseNumSingle = (): NumSingle => ({ num: 0 });
 
 export const NumSingle = {
   encode(message: NumSingle, writer: Writer = Writer.create()): Writer {
@@ -88,7 +88,7 @@ export const NumSingle = {
   decode(input: Reader | Uint8Array, length?: number): NumSingle {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseNumSingle } as NumSingle;
+    const message = createBaseNumSingle();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -104,7 +104,7 @@ export const NumSingle = {
   },
 
   fromJSON(object: any): NumSingle {
-    const message = { ...baseNumSingle } as NumSingle;
+    const message = createBaseNumSingle();
     message.num = object.num !== undefined && object.num !== null ? Number(object.num) : 0;
     return message;
   },
@@ -116,13 +116,13 @@ export const NumSingle = {
   },
 
   fromPartial<I extends Exact<DeepPartial<NumSingle>, I>>(object: I): NumSingle {
-    const message = { ...baseNumSingle } as NumSingle;
+    const message = createBaseNumSingle();
     message.num = object.num ?? 0;
     return message;
   },
 };
 
-const baseNumbers: object = { num: 0 };
+const createBaseNumbers = (): Numbers => ({ num: 0 });
 
 export const Numbers = {
   encode(message: Numbers, writer: Writer = Writer.create()): Writer {
@@ -137,7 +137,7 @@ export const Numbers = {
   decode(input: Reader | Uint8Array, length?: number): Numbers {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseNumbers } as Numbers;
+    const message = createBaseNumbers();
     message.num = [];
     while (reader.pos < end) {
       const tag = reader.uint32();
@@ -161,7 +161,7 @@ export const Numbers = {
   },
 
   fromJSON(object: any): Numbers {
-    const message = { ...baseNumbers } as Numbers;
+    const message = createBaseNumbers();
     message.num = (object.num ?? []).map((e: any) => Number(e));
     return message;
   },
@@ -177,7 +177,7 @@ export const Numbers = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Numbers>, I>>(object: I): Numbers {
-    const message = { ...baseNumbers } as Numbers;
+    const message = createBaseNumbers();
     message.num = object.num?.map((e) => e) || [];
     return message;
   },

--- a/integration/meta-typings/google/protobuf/timestamp.ts
+++ b/integration/meta-typings/google/protobuf/timestamp.ts
@@ -114,7 +114,7 @@ export interface Timestamp {
   nanos: number;
 }
 
-const baseTimestamp: object = { seconds: 0, nanos: 0 };
+const createBaseTimestamp = (): Timestamp => ({ seconds: 0, nanos: 0 });
 
 export const Timestamp = {
   encode(message: Timestamp, writer: Writer = Writer.create()): Writer {
@@ -130,7 +130,7 @@ export const Timestamp = {
   decode(input: Reader | Uint8Array, length?: number): Timestamp {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseTimestamp } as Timestamp;
+    const message = createBaseTimestamp();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {

--- a/integration/meta-typings/google/protobuf/timestamp.ts
+++ b/integration/meta-typings/google/protobuf/timestamp.ts
@@ -114,7 +114,9 @@ export interface Timestamp {
   nanos: number;
 }
 
-const createBaseTimestamp = (): Timestamp => ({ seconds: 0, nanos: 0 });
+function createBaseTimestamp(): Timestamp {
+  return { seconds: 0, nanos: 0 };
+}
 
 export const Timestamp = {
   encode(message: Timestamp, writer: Writer = Writer.create()): Writer {

--- a/integration/meta-typings/google/protobuf/wrappers.ts
+++ b/integration/meta-typings/google/protobuf/wrappers.ts
@@ -95,7 +95,9 @@ export interface BytesValue {
   value: Uint8Array;
 }
 
-const createBaseDoubleValue = (): DoubleValue => ({ value: 0 });
+function createBaseDoubleValue(): DoubleValue {
+  return { value: 0 };
+}
 
 export const DoubleValue = {
   encode(message: DoubleValue, writer: Writer = Writer.create()): Writer {
@@ -124,7 +126,9 @@ export const DoubleValue = {
   },
 };
 
-const createBaseFloatValue = (): FloatValue => ({ value: 0 });
+function createBaseFloatValue(): FloatValue {
+  return { value: 0 };
+}
 
 export const FloatValue = {
   encode(message: FloatValue, writer: Writer = Writer.create()): Writer {
@@ -153,7 +157,9 @@ export const FloatValue = {
   },
 };
 
-const createBaseInt64Value = (): Int64Value => ({ value: 0 });
+function createBaseInt64Value(): Int64Value {
+  return { value: 0 };
+}
 
 export const Int64Value = {
   encode(message: Int64Value, writer: Writer = Writer.create()): Writer {
@@ -182,7 +188,9 @@ export const Int64Value = {
   },
 };
 
-const createBaseUInt64Value = (): UInt64Value => ({ value: 0 });
+function createBaseUInt64Value(): UInt64Value {
+  return { value: 0 };
+}
 
 export const UInt64Value = {
   encode(message: UInt64Value, writer: Writer = Writer.create()): Writer {
@@ -211,7 +219,9 @@ export const UInt64Value = {
   },
 };
 
-const createBaseInt32Value = (): Int32Value => ({ value: 0 });
+function createBaseInt32Value(): Int32Value {
+  return { value: 0 };
+}
 
 export const Int32Value = {
   encode(message: Int32Value, writer: Writer = Writer.create()): Writer {
@@ -240,7 +250,9 @@ export const Int32Value = {
   },
 };
 
-const createBaseUInt32Value = (): UInt32Value => ({ value: 0 });
+function createBaseUInt32Value(): UInt32Value {
+  return { value: 0 };
+}
 
 export const UInt32Value = {
   encode(message: UInt32Value, writer: Writer = Writer.create()): Writer {
@@ -269,7 +281,9 @@ export const UInt32Value = {
   },
 };
 
-const createBaseBoolValue = (): BoolValue => ({ value: false });
+function createBaseBoolValue(): BoolValue {
+  return { value: false };
+}
 
 export const BoolValue = {
   encode(message: BoolValue, writer: Writer = Writer.create()): Writer {
@@ -298,7 +312,9 @@ export const BoolValue = {
   },
 };
 
-const createBaseStringValue = (): StringValue => ({ value: '' });
+function createBaseStringValue(): StringValue {
+  return { value: '' };
+}
 
 export const StringValue = {
   encode(message: StringValue, writer: Writer = Writer.create()): Writer {
@@ -327,7 +343,9 @@ export const StringValue = {
   },
 };
 
-const createBaseBytesValue = (): BytesValue => ({});
+function createBaseBytesValue(): BytesValue {
+  return { value: new Uint8Array() };
+}
 
 export const BytesValue = {
   encode(message: BytesValue, writer: Writer = Writer.create()): Writer {
@@ -341,7 +359,6 @@ export const BytesValue = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseBytesValue();
-    message.value = new Uint8Array();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {

--- a/integration/meta-typings/google/protobuf/wrappers.ts
+++ b/integration/meta-typings/google/protobuf/wrappers.ts
@@ -95,7 +95,7 @@ export interface BytesValue {
   value: Uint8Array;
 }
 
-const baseDoubleValue: object = { value: 0 };
+const createBaseDoubleValue = (): DoubleValue => ({ value: 0 });
 
 export const DoubleValue = {
   encode(message: DoubleValue, writer: Writer = Writer.create()): Writer {
@@ -108,7 +108,7 @@ export const DoubleValue = {
   decode(input: Reader | Uint8Array, length?: number): DoubleValue {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseDoubleValue } as DoubleValue;
+    const message = createBaseDoubleValue();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -124,7 +124,7 @@ export const DoubleValue = {
   },
 };
 
-const baseFloatValue: object = { value: 0 };
+const createBaseFloatValue = (): FloatValue => ({ value: 0 });
 
 export const FloatValue = {
   encode(message: FloatValue, writer: Writer = Writer.create()): Writer {
@@ -137,7 +137,7 @@ export const FloatValue = {
   decode(input: Reader | Uint8Array, length?: number): FloatValue {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseFloatValue } as FloatValue;
+    const message = createBaseFloatValue();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -153,7 +153,7 @@ export const FloatValue = {
   },
 };
 
-const baseInt64Value: object = { value: 0 };
+const createBaseInt64Value = (): Int64Value => ({ value: 0 });
 
 export const Int64Value = {
   encode(message: Int64Value, writer: Writer = Writer.create()): Writer {
@@ -166,7 +166,7 @@ export const Int64Value = {
   decode(input: Reader | Uint8Array, length?: number): Int64Value {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseInt64Value } as Int64Value;
+    const message = createBaseInt64Value();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -182,7 +182,7 @@ export const Int64Value = {
   },
 };
 
-const baseUInt64Value: object = { value: 0 };
+const createBaseUInt64Value = (): UInt64Value => ({ value: 0 });
 
 export const UInt64Value = {
   encode(message: UInt64Value, writer: Writer = Writer.create()): Writer {
@@ -195,7 +195,7 @@ export const UInt64Value = {
   decode(input: Reader | Uint8Array, length?: number): UInt64Value {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseUInt64Value } as UInt64Value;
+    const message = createBaseUInt64Value();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -211,7 +211,7 @@ export const UInt64Value = {
   },
 };
 
-const baseInt32Value: object = { value: 0 };
+const createBaseInt32Value = (): Int32Value => ({ value: 0 });
 
 export const Int32Value = {
   encode(message: Int32Value, writer: Writer = Writer.create()): Writer {
@@ -224,7 +224,7 @@ export const Int32Value = {
   decode(input: Reader | Uint8Array, length?: number): Int32Value {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseInt32Value } as Int32Value;
+    const message = createBaseInt32Value();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -240,7 +240,7 @@ export const Int32Value = {
   },
 };
 
-const baseUInt32Value: object = { value: 0 };
+const createBaseUInt32Value = (): UInt32Value => ({ value: 0 });
 
 export const UInt32Value = {
   encode(message: UInt32Value, writer: Writer = Writer.create()): Writer {
@@ -253,7 +253,7 @@ export const UInt32Value = {
   decode(input: Reader | Uint8Array, length?: number): UInt32Value {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseUInt32Value } as UInt32Value;
+    const message = createBaseUInt32Value();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -269,7 +269,7 @@ export const UInt32Value = {
   },
 };
 
-const baseBoolValue: object = { value: false };
+const createBaseBoolValue = (): BoolValue => ({ value: false });
 
 export const BoolValue = {
   encode(message: BoolValue, writer: Writer = Writer.create()): Writer {
@@ -282,7 +282,7 @@ export const BoolValue = {
   decode(input: Reader | Uint8Array, length?: number): BoolValue {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseBoolValue } as BoolValue;
+    const message = createBaseBoolValue();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -298,7 +298,7 @@ export const BoolValue = {
   },
 };
 
-const baseStringValue: object = { value: '' };
+const createBaseStringValue = (): StringValue => ({ value: '' });
 
 export const StringValue = {
   encode(message: StringValue, writer: Writer = Writer.create()): Writer {
@@ -311,7 +311,7 @@ export const StringValue = {
   decode(input: Reader | Uint8Array, length?: number): StringValue {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseStringValue } as StringValue;
+    const message = createBaseStringValue();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -327,7 +327,7 @@ export const StringValue = {
   },
 };
 
-const baseBytesValue: object = {};
+const createBaseBytesValue = (): BytesValue => ({});
 
 export const BytesValue = {
   encode(message: BytesValue, writer: Writer = Writer.create()): Writer {
@@ -340,7 +340,7 @@ export const BytesValue = {
   decode(input: Reader | Uint8Array, length?: number): BytesValue {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseBytesValue } as BytesValue;
+    const message = createBaseBytesValue();
     message.value = new Uint8Array();
     while (reader.pos < end) {
       const tag = reader.uint32();

--- a/integration/meta-typings/google/type/date.ts
+++ b/integration/meta-typings/google/type/date.ts
@@ -36,7 +36,9 @@ export interface DateMessage {
   day: number;
 }
 
-const createBaseDateMessage = (): DateMessage => ({ year: 0, month: 0, day: 0 });
+function createBaseDateMessage(): DateMessage {
+  return { year: 0, month: 0, day: 0 };
+}
 
 export const DateMessage = {
   encode(message: DateMessage, writer: Writer = Writer.create()): Writer {

--- a/integration/meta-typings/google/type/date.ts
+++ b/integration/meta-typings/google/type/date.ts
@@ -36,7 +36,7 @@ export interface DateMessage {
   day: number;
 }
 
-const baseDateMessage: object = { year: 0, month: 0, day: 0 };
+const createBaseDateMessage = (): DateMessage => ({ year: 0, month: 0, day: 0 });
 
 export const DateMessage = {
   encode(message: DateMessage, writer: Writer = Writer.create()): Writer {
@@ -55,7 +55,7 @@ export const DateMessage = {
   decode(input: Reader | Uint8Array, length?: number): DateMessage {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseDateMessage } as DateMessage;
+    const message = createBaseDateMessage();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {

--- a/integration/meta-typings/import_dir/thing.ts
+++ b/integration/meta-typings/import_dir/thing.ts
@@ -10,7 +10,9 @@ export interface ImportedThing {
   createdAt: Date | undefined;
 }
 
-const createBaseImportedThing = (): ImportedThing => ({});
+function createBaseImportedThing(): ImportedThing {
+  return { createdAt: undefined };
+}
 
 export const ImportedThing = {
   encode(message: ImportedThing, writer: Writer = Writer.create()): Writer {

--- a/integration/meta-typings/import_dir/thing.ts
+++ b/integration/meta-typings/import_dir/thing.ts
@@ -10,7 +10,7 @@ export interface ImportedThing {
   createdAt: Date | undefined;
 }
 
-const baseImportedThing: object = {};
+const createBaseImportedThing = (): ImportedThing => ({});
 
 export const ImportedThing = {
   encode(message: ImportedThing, writer: Writer = Writer.create()): Writer {
@@ -23,7 +23,7 @@ export const ImportedThing = {
   decode(input: Reader | Uint8Array, length?: number): ImportedThing {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseImportedThing } as ImportedThing;
+    const message = createBaseImportedThing();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {

--- a/integration/meta-typings/simple.ts
+++ b/integration/meta-typings/simple.ts
@@ -185,7 +185,23 @@ export interface SimpleButOptional {
 
 export interface Empty {}
 
-const createBaseSimple = (): Simple => ({ name: '', age: 0, state: 0, coins: 0, snacks: '', oldStates: 0 });
+function createBaseSimple(): Simple {
+  return {
+    name: '',
+    age: 0,
+    createdAt: undefined,
+    child: undefined,
+    state: 0,
+    grandChildren: [],
+    coins: [],
+    snacks: [],
+    oldStates: [],
+    thing: undefined,
+    blobs: [],
+    birthday: undefined,
+    blob: new Uint8Array(),
+  };
+}
 
 export const Simple = {
   encode(message: Simple, writer: Writer = Writer.create()): Writer {
@@ -239,12 +255,6 @@ export const Simple = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseSimple();
-    message.grandChildren = [];
-    message.coins = [];
-    message.snacks = [];
-    message.oldStates = [];
-    message.blobs = [];
-    message.blob = new Uint8Array();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -310,7 +320,9 @@ export const Simple = {
   },
 };
 
-const createBaseChild = (): Child => ({ name: '', type: 0 });
+function createBaseChild(): Child {
+  return { name: '', type: 0 };
+}
 
 export const Child = {
   encode(message: Child, writer: Writer = Writer.create()): Writer {
@@ -345,7 +357,9 @@ export const Child = {
   },
 };
 
-const createBaseNested = (): Nested => ({ name: '', state: 0 });
+function createBaseNested(): Nested {
+  return { name: '', message: undefined, state: 0 };
+}
 
 export const Nested = {
   encode(message: Nested, writer: Writer = Writer.create()): Writer {
@@ -386,7 +400,9 @@ export const Nested = {
   },
 };
 
-const createBaseNested_InnerMessage = (): Nested_InnerMessage => ({ name: '' });
+function createBaseNested_InnerMessage(): Nested_InnerMessage {
+  return { name: '', deep: undefined };
+}
 
 export const Nested_InnerMessage = {
   encode(message: Nested_InnerMessage, writer: Writer = Writer.create()): Writer {
@@ -421,7 +437,9 @@ export const Nested_InnerMessage = {
   },
 };
 
-const createBaseNested_InnerMessage_DeepMessage = (): Nested_InnerMessage_DeepMessage => ({ name: '' });
+function createBaseNested_InnerMessage_DeepMessage(): Nested_InnerMessage_DeepMessage {
+  return { name: '' };
+}
 
 export const Nested_InnerMessage_DeepMessage = {
   encode(message: Nested_InnerMessage_DeepMessage, writer: Writer = Writer.create()): Writer {
@@ -450,7 +468,9 @@ export const Nested_InnerMessage_DeepMessage = {
   },
 };
 
-const createBaseOneOfMessage = (): OneOfMessage => ({});
+function createBaseOneOfMessage(): OneOfMessage {
+  return { first: undefined, last: undefined };
+}
 
 export const OneOfMessage = {
   encode(message: OneOfMessage, writer: Writer = Writer.create()): Writer {
@@ -485,7 +505,9 @@ export const OneOfMessage = {
   },
 };
 
-const createBaseSimpleWithWrappers = (): SimpleWithWrappers => ({});
+function createBaseSimpleWithWrappers(): SimpleWithWrappers {
+  return { name: undefined, age: undefined, enabled: undefined, coins: [], snacks: [] };
+}
 
 export const SimpleWithWrappers = {
   encode(message: SimpleWithWrappers, writer: Writer = Writer.create()): Writer {
@@ -511,8 +533,6 @@ export const SimpleWithWrappers = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseSimpleWithWrappers();
-    message.coins = [];
-    message.snacks = [];
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -540,7 +560,9 @@ export const SimpleWithWrappers = {
   },
 };
 
-const createBaseEntity = (): Entity => ({ id: 0 });
+function createBaseEntity(): Entity {
+  return { id: 0 };
+}
 
 export const Entity = {
   encode(message: Entity, writer: Writer = Writer.create()): Writer {
@@ -569,7 +591,9 @@ export const Entity = {
   },
 };
 
-const createBaseSimpleWithMap = (): SimpleWithMap => ({});
+function createBaseSimpleWithMap(): SimpleWithMap {
+  return { entitiesById: {}, nameLookup: {}, intLookup: {}, mapOfTimestamps: {}, mapOfBytes: {} };
+}
 
 export const SimpleWithMap = {
   encode(message: SimpleWithMap, writer: Writer = Writer.create()): Writer {
@@ -595,11 +619,6 @@ export const SimpleWithMap = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseSimpleWithMap();
-    message.entitiesById = {};
-    message.nameLookup = {};
-    message.intLookup = {};
-    message.mapOfTimestamps = {};
-    message.mapOfBytes = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -642,7 +661,9 @@ export const SimpleWithMap = {
   },
 };
 
-const createBaseSimpleWithMap_EntitiesByIdEntry = (): SimpleWithMap_EntitiesByIdEntry => ({ key: 0 });
+function createBaseSimpleWithMap_EntitiesByIdEntry(): SimpleWithMap_EntitiesByIdEntry {
+  return { key: 0, value: undefined };
+}
 
 export const SimpleWithMap_EntitiesByIdEntry = {
   encode(message: SimpleWithMap_EntitiesByIdEntry, writer: Writer = Writer.create()): Writer {
@@ -677,7 +698,9 @@ export const SimpleWithMap_EntitiesByIdEntry = {
   },
 };
 
-const createBaseSimpleWithMap_NameLookupEntry = (): SimpleWithMap_NameLookupEntry => ({ key: '', value: '' });
+function createBaseSimpleWithMap_NameLookupEntry(): SimpleWithMap_NameLookupEntry {
+  return { key: '', value: '' };
+}
 
 export const SimpleWithMap_NameLookupEntry = {
   encode(message: SimpleWithMap_NameLookupEntry, writer: Writer = Writer.create()): Writer {
@@ -712,7 +735,9 @@ export const SimpleWithMap_NameLookupEntry = {
   },
 };
 
-const createBaseSimpleWithMap_IntLookupEntry = (): SimpleWithMap_IntLookupEntry => ({ key: 0, value: 0 });
+function createBaseSimpleWithMap_IntLookupEntry(): SimpleWithMap_IntLookupEntry {
+  return { key: 0, value: 0 };
+}
 
 export const SimpleWithMap_IntLookupEntry = {
   encode(message: SimpleWithMap_IntLookupEntry, writer: Writer = Writer.create()): Writer {
@@ -747,7 +772,9 @@ export const SimpleWithMap_IntLookupEntry = {
   },
 };
 
-const createBaseSimpleWithMap_MapOfTimestampsEntry = (): SimpleWithMap_MapOfTimestampsEntry => ({ key: '' });
+function createBaseSimpleWithMap_MapOfTimestampsEntry(): SimpleWithMap_MapOfTimestampsEntry {
+  return { key: '', value: undefined };
+}
 
 export const SimpleWithMap_MapOfTimestampsEntry = {
   encode(message: SimpleWithMap_MapOfTimestampsEntry, writer: Writer = Writer.create()): Writer {
@@ -782,7 +809,9 @@ export const SimpleWithMap_MapOfTimestampsEntry = {
   },
 };
 
-const createBaseSimpleWithMap_MapOfBytesEntry = (): SimpleWithMap_MapOfBytesEntry => ({ key: '' });
+function createBaseSimpleWithMap_MapOfBytesEntry(): SimpleWithMap_MapOfBytesEntry {
+  return { key: '', value: new Uint8Array() };
+}
 
 export const SimpleWithMap_MapOfBytesEntry = {
   encode(message: SimpleWithMap_MapOfBytesEntry, writer: Writer = Writer.create()): Writer {
@@ -799,7 +828,6 @@ export const SimpleWithMap_MapOfBytesEntry = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseSimpleWithMap_MapOfBytesEntry();
-    message.value = new Uint8Array();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -818,7 +846,9 @@ export const SimpleWithMap_MapOfBytesEntry = {
   },
 };
 
-const createBaseSimpleWithSnakeCaseMap = (): SimpleWithSnakeCaseMap => ({});
+function createBaseSimpleWithSnakeCaseMap(): SimpleWithSnakeCaseMap {
+  return { entitiesById: {} };
+}
 
 export const SimpleWithSnakeCaseMap = {
   encode(message: SimpleWithSnakeCaseMap, writer: Writer = Writer.create()): Writer {
@@ -832,7 +862,6 @@ export const SimpleWithSnakeCaseMap = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseSimpleWithSnakeCaseMap();
-    message.entitiesById = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -851,7 +880,9 @@ export const SimpleWithSnakeCaseMap = {
   },
 };
 
-const createBaseSimpleWithSnakeCaseMap_EntitiesByIdEntry = (): SimpleWithSnakeCaseMap_EntitiesByIdEntry => ({ key: 0 });
+function createBaseSimpleWithSnakeCaseMap_EntitiesByIdEntry(): SimpleWithSnakeCaseMap_EntitiesByIdEntry {
+  return { key: 0, value: undefined };
+}
 
 export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
   encode(message: SimpleWithSnakeCaseMap_EntitiesByIdEntry, writer: Writer = Writer.create()): Writer {
@@ -886,7 +917,9 @@ export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
   },
 };
 
-const createBaseSimpleWithMapOfEnums = (): SimpleWithMapOfEnums => ({});
+function createBaseSimpleWithMapOfEnums(): SimpleWithMapOfEnums {
+  return { enumsById: {} };
+}
 
 export const SimpleWithMapOfEnums = {
   encode(message: SimpleWithMapOfEnums, writer: Writer = Writer.create()): Writer {
@@ -900,7 +933,6 @@ export const SimpleWithMapOfEnums = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseSimpleWithMapOfEnums();
-    message.enumsById = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -919,7 +951,9 @@ export const SimpleWithMapOfEnums = {
   },
 };
 
-const createBaseSimpleWithMapOfEnums_EnumsByIdEntry = (): SimpleWithMapOfEnums_EnumsByIdEntry => ({ key: 0, value: 0 });
+function createBaseSimpleWithMapOfEnums_EnumsByIdEntry(): SimpleWithMapOfEnums_EnumsByIdEntry {
+  return { key: 0, value: 0 };
+}
 
 export const SimpleWithMapOfEnums_EnumsByIdEntry = {
   encode(message: SimpleWithMapOfEnums_EnumsByIdEntry, writer: Writer = Writer.create()): Writer {
@@ -954,7 +988,9 @@ export const SimpleWithMapOfEnums_EnumsByIdEntry = {
   },
 };
 
-const createBasePingRequest = (): PingRequest => ({ input: '' });
+function createBasePingRequest(): PingRequest {
+  return { input: '' };
+}
 
 export const PingRequest = {
   encode(message: PingRequest, writer: Writer = Writer.create()): Writer {
@@ -983,7 +1019,9 @@ export const PingRequest = {
   },
 };
 
-const createBasePingResponse = (): PingResponse => ({ output: '' });
+function createBasePingResponse(): PingResponse {
+  return { output: '' };
+}
 
 export const PingResponse = {
   encode(message: PingResponse, writer: Writer = Writer.create()): Writer {
@@ -1012,20 +1050,22 @@ export const PingResponse = {
   },
 };
 
-const createBaseNumbers = (): Numbers => ({
-  double: 0,
-  float: 0,
-  int32: 0,
-  int64: 0,
-  uint32: 0,
-  uint64: 0,
-  sint32: 0,
-  sint64: 0,
-  fixed32: 0,
-  fixed64: 0,
-  sfixed32: 0,
-  sfixed64: 0,
-});
+function createBaseNumbers(): Numbers {
+  return {
+    double: 0,
+    float: 0,
+    int32: 0,
+    int64: 0,
+    uint32: 0,
+    uint64: 0,
+    sint32: 0,
+    sint64: 0,
+    fixed32: 0,
+    fixed64: 0,
+    sfixed32: 0,
+    sfixed64: 0,
+  };
+}
 
 export const Numbers = {
   encode(message: Numbers, writer: Writer = Writer.create()): Writer {
@@ -1120,7 +1160,17 @@ export const Numbers = {
   },
 };
 
-const createBaseSimpleButOptional = (): SimpleButOptional => ({});
+function createBaseSimpleButOptional(): SimpleButOptional {
+  return {
+    name: undefined,
+    age: undefined,
+    createdAt: undefined,
+    child: undefined,
+    state: undefined,
+    thing: undefined,
+    birthday: undefined,
+  };
+}
 
 export const SimpleButOptional = {
   encode(message: SimpleButOptional, writer: Writer = Writer.create()): Writer {
@@ -1185,7 +1235,9 @@ export const SimpleButOptional = {
   },
 };
 
-const createBaseEmpty = (): Empty => ({});
+function createBaseEmpty(): Empty {
+  return {};
+}
 
 export const Empty = {
   encode(_: Empty, writer: Writer = Writer.create()): Writer {

--- a/integration/meta-typings/simple.ts
+++ b/integration/meta-typings/simple.ts
@@ -185,7 +185,7 @@ export interface SimpleButOptional {
 
 export interface Empty {}
 
-const baseSimple: object = { name: '', age: 0, state: 0, coins: 0, snacks: '', oldStates: 0 };
+const createBaseSimple = (): Simple => ({ name: '', age: 0, state: 0, coins: 0, snacks: '', oldStates: 0 });
 
 export const Simple = {
   encode(message: Simple, writer: Writer = Writer.create()): Writer {
@@ -238,7 +238,7 @@ export const Simple = {
   decode(input: Reader | Uint8Array, length?: number): Simple {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimple } as Simple;
+    const message = createBaseSimple();
     message.grandChildren = [];
     message.coins = [];
     message.snacks = [];
@@ -310,7 +310,7 @@ export const Simple = {
   },
 };
 
-const baseChild: object = { name: '', type: 0 };
+const createBaseChild = (): Child => ({ name: '', type: 0 });
 
 export const Child = {
   encode(message: Child, writer: Writer = Writer.create()): Writer {
@@ -326,7 +326,7 @@ export const Child = {
   decode(input: Reader | Uint8Array, length?: number): Child {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseChild } as Child;
+    const message = createBaseChild();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -345,7 +345,7 @@ export const Child = {
   },
 };
 
-const baseNested: object = { name: '', state: 0 };
+const createBaseNested = (): Nested => ({ name: '', state: 0 });
 
 export const Nested = {
   encode(message: Nested, writer: Writer = Writer.create()): Writer {
@@ -364,7 +364,7 @@ export const Nested = {
   decode(input: Reader | Uint8Array, length?: number): Nested {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseNested } as Nested;
+    const message = createBaseNested();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -386,7 +386,7 @@ export const Nested = {
   },
 };
 
-const baseNested_InnerMessage: object = { name: '' };
+const createBaseNested_InnerMessage = (): Nested_InnerMessage => ({ name: '' });
 
 export const Nested_InnerMessage = {
   encode(message: Nested_InnerMessage, writer: Writer = Writer.create()): Writer {
@@ -402,7 +402,7 @@ export const Nested_InnerMessage = {
   decode(input: Reader | Uint8Array, length?: number): Nested_InnerMessage {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseNested_InnerMessage } as Nested_InnerMessage;
+    const message = createBaseNested_InnerMessage();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -421,7 +421,7 @@ export const Nested_InnerMessage = {
   },
 };
 
-const baseNested_InnerMessage_DeepMessage: object = { name: '' };
+const createBaseNested_InnerMessage_DeepMessage = (): Nested_InnerMessage_DeepMessage => ({ name: '' });
 
 export const Nested_InnerMessage_DeepMessage = {
   encode(message: Nested_InnerMessage_DeepMessage, writer: Writer = Writer.create()): Writer {
@@ -434,7 +434,7 @@ export const Nested_InnerMessage_DeepMessage = {
   decode(input: Reader | Uint8Array, length?: number): Nested_InnerMessage_DeepMessage {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseNested_InnerMessage_DeepMessage } as Nested_InnerMessage_DeepMessage;
+    const message = createBaseNested_InnerMessage_DeepMessage();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -450,7 +450,7 @@ export const Nested_InnerMessage_DeepMessage = {
   },
 };
 
-const baseOneOfMessage: object = {};
+const createBaseOneOfMessage = (): OneOfMessage => ({});
 
 export const OneOfMessage = {
   encode(message: OneOfMessage, writer: Writer = Writer.create()): Writer {
@@ -466,7 +466,7 @@ export const OneOfMessage = {
   decode(input: Reader | Uint8Array, length?: number): OneOfMessage {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseOneOfMessage } as OneOfMessage;
+    const message = createBaseOneOfMessage();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -485,7 +485,7 @@ export const OneOfMessage = {
   },
 };
 
-const baseSimpleWithWrappers: object = {};
+const createBaseSimpleWithWrappers = (): SimpleWithWrappers => ({});
 
 export const SimpleWithWrappers = {
   encode(message: SimpleWithWrappers, writer: Writer = Writer.create()): Writer {
@@ -510,7 +510,7 @@ export const SimpleWithWrappers = {
   decode(input: Reader | Uint8Array, length?: number): SimpleWithWrappers {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimpleWithWrappers } as SimpleWithWrappers;
+    const message = createBaseSimpleWithWrappers();
     message.coins = [];
     message.snacks = [];
     while (reader.pos < end) {
@@ -540,7 +540,7 @@ export const SimpleWithWrappers = {
   },
 };
 
-const baseEntity: object = { id: 0 };
+const createBaseEntity = (): Entity => ({ id: 0 });
 
 export const Entity = {
   encode(message: Entity, writer: Writer = Writer.create()): Writer {
@@ -553,7 +553,7 @@ export const Entity = {
   decode(input: Reader | Uint8Array, length?: number): Entity {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseEntity } as Entity;
+    const message = createBaseEntity();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -569,7 +569,7 @@ export const Entity = {
   },
 };
 
-const baseSimpleWithMap: object = {};
+const createBaseSimpleWithMap = (): SimpleWithMap => ({});
 
 export const SimpleWithMap = {
   encode(message: SimpleWithMap, writer: Writer = Writer.create()): Writer {
@@ -594,7 +594,7 @@ export const SimpleWithMap = {
   decode(input: Reader | Uint8Array, length?: number): SimpleWithMap {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimpleWithMap } as SimpleWithMap;
+    const message = createBaseSimpleWithMap();
     message.entitiesById = {};
     message.nameLookup = {};
     message.intLookup = {};
@@ -642,7 +642,7 @@ export const SimpleWithMap = {
   },
 };
 
-const baseSimpleWithMap_EntitiesByIdEntry: object = { key: 0 };
+const createBaseSimpleWithMap_EntitiesByIdEntry = (): SimpleWithMap_EntitiesByIdEntry => ({ key: 0 });
 
 export const SimpleWithMap_EntitiesByIdEntry = {
   encode(message: SimpleWithMap_EntitiesByIdEntry, writer: Writer = Writer.create()): Writer {
@@ -658,7 +658,7 @@ export const SimpleWithMap_EntitiesByIdEntry = {
   decode(input: Reader | Uint8Array, length?: number): SimpleWithMap_EntitiesByIdEntry {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimpleWithMap_EntitiesByIdEntry } as SimpleWithMap_EntitiesByIdEntry;
+    const message = createBaseSimpleWithMap_EntitiesByIdEntry();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -677,7 +677,7 @@ export const SimpleWithMap_EntitiesByIdEntry = {
   },
 };
 
-const baseSimpleWithMap_NameLookupEntry: object = { key: '', value: '' };
+const createBaseSimpleWithMap_NameLookupEntry = (): SimpleWithMap_NameLookupEntry => ({ key: '', value: '' });
 
 export const SimpleWithMap_NameLookupEntry = {
   encode(message: SimpleWithMap_NameLookupEntry, writer: Writer = Writer.create()): Writer {
@@ -693,7 +693,7 @@ export const SimpleWithMap_NameLookupEntry = {
   decode(input: Reader | Uint8Array, length?: number): SimpleWithMap_NameLookupEntry {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimpleWithMap_NameLookupEntry } as SimpleWithMap_NameLookupEntry;
+    const message = createBaseSimpleWithMap_NameLookupEntry();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -712,7 +712,7 @@ export const SimpleWithMap_NameLookupEntry = {
   },
 };
 
-const baseSimpleWithMap_IntLookupEntry: object = { key: 0, value: 0 };
+const createBaseSimpleWithMap_IntLookupEntry = (): SimpleWithMap_IntLookupEntry => ({ key: 0, value: 0 });
 
 export const SimpleWithMap_IntLookupEntry = {
   encode(message: SimpleWithMap_IntLookupEntry, writer: Writer = Writer.create()): Writer {
@@ -728,7 +728,7 @@ export const SimpleWithMap_IntLookupEntry = {
   decode(input: Reader | Uint8Array, length?: number): SimpleWithMap_IntLookupEntry {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimpleWithMap_IntLookupEntry } as SimpleWithMap_IntLookupEntry;
+    const message = createBaseSimpleWithMap_IntLookupEntry();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -747,7 +747,7 @@ export const SimpleWithMap_IntLookupEntry = {
   },
 };
 
-const baseSimpleWithMap_MapOfTimestampsEntry: object = { key: '' };
+const createBaseSimpleWithMap_MapOfTimestampsEntry = (): SimpleWithMap_MapOfTimestampsEntry => ({ key: '' });
 
 export const SimpleWithMap_MapOfTimestampsEntry = {
   encode(message: SimpleWithMap_MapOfTimestampsEntry, writer: Writer = Writer.create()): Writer {
@@ -763,7 +763,7 @@ export const SimpleWithMap_MapOfTimestampsEntry = {
   decode(input: Reader | Uint8Array, length?: number): SimpleWithMap_MapOfTimestampsEntry {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimpleWithMap_MapOfTimestampsEntry } as SimpleWithMap_MapOfTimestampsEntry;
+    const message = createBaseSimpleWithMap_MapOfTimestampsEntry();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -782,7 +782,7 @@ export const SimpleWithMap_MapOfTimestampsEntry = {
   },
 };
 
-const baseSimpleWithMap_MapOfBytesEntry: object = { key: '' };
+const createBaseSimpleWithMap_MapOfBytesEntry = (): SimpleWithMap_MapOfBytesEntry => ({ key: '' });
 
 export const SimpleWithMap_MapOfBytesEntry = {
   encode(message: SimpleWithMap_MapOfBytesEntry, writer: Writer = Writer.create()): Writer {
@@ -798,7 +798,7 @@ export const SimpleWithMap_MapOfBytesEntry = {
   decode(input: Reader | Uint8Array, length?: number): SimpleWithMap_MapOfBytesEntry {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimpleWithMap_MapOfBytesEntry } as SimpleWithMap_MapOfBytesEntry;
+    const message = createBaseSimpleWithMap_MapOfBytesEntry();
     message.value = new Uint8Array();
     while (reader.pos < end) {
       const tag = reader.uint32();
@@ -818,7 +818,7 @@ export const SimpleWithMap_MapOfBytesEntry = {
   },
 };
 
-const baseSimpleWithSnakeCaseMap: object = {};
+const createBaseSimpleWithSnakeCaseMap = (): SimpleWithSnakeCaseMap => ({});
 
 export const SimpleWithSnakeCaseMap = {
   encode(message: SimpleWithSnakeCaseMap, writer: Writer = Writer.create()): Writer {
@@ -831,7 +831,7 @@ export const SimpleWithSnakeCaseMap = {
   decode(input: Reader | Uint8Array, length?: number): SimpleWithSnakeCaseMap {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimpleWithSnakeCaseMap } as SimpleWithSnakeCaseMap;
+    const message = createBaseSimpleWithSnakeCaseMap();
     message.entitiesById = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
@@ -851,7 +851,7 @@ export const SimpleWithSnakeCaseMap = {
   },
 };
 
-const baseSimpleWithSnakeCaseMap_EntitiesByIdEntry: object = { key: 0 };
+const createBaseSimpleWithSnakeCaseMap_EntitiesByIdEntry = (): SimpleWithSnakeCaseMap_EntitiesByIdEntry => ({ key: 0 });
 
 export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
   encode(message: SimpleWithSnakeCaseMap_EntitiesByIdEntry, writer: Writer = Writer.create()): Writer {
@@ -867,7 +867,7 @@ export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
   decode(input: Reader | Uint8Array, length?: number): SimpleWithSnakeCaseMap_EntitiesByIdEntry {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimpleWithSnakeCaseMap_EntitiesByIdEntry } as SimpleWithSnakeCaseMap_EntitiesByIdEntry;
+    const message = createBaseSimpleWithSnakeCaseMap_EntitiesByIdEntry();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -886,7 +886,7 @@ export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
   },
 };
 
-const baseSimpleWithMapOfEnums: object = {};
+const createBaseSimpleWithMapOfEnums = (): SimpleWithMapOfEnums => ({});
 
 export const SimpleWithMapOfEnums = {
   encode(message: SimpleWithMapOfEnums, writer: Writer = Writer.create()): Writer {
@@ -899,7 +899,7 @@ export const SimpleWithMapOfEnums = {
   decode(input: Reader | Uint8Array, length?: number): SimpleWithMapOfEnums {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimpleWithMapOfEnums } as SimpleWithMapOfEnums;
+    const message = createBaseSimpleWithMapOfEnums();
     message.enumsById = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
@@ -919,7 +919,7 @@ export const SimpleWithMapOfEnums = {
   },
 };
 
-const baseSimpleWithMapOfEnums_EnumsByIdEntry: object = { key: 0, value: 0 };
+const createBaseSimpleWithMapOfEnums_EnumsByIdEntry = (): SimpleWithMapOfEnums_EnumsByIdEntry => ({ key: 0, value: 0 });
 
 export const SimpleWithMapOfEnums_EnumsByIdEntry = {
   encode(message: SimpleWithMapOfEnums_EnumsByIdEntry, writer: Writer = Writer.create()): Writer {
@@ -935,7 +935,7 @@ export const SimpleWithMapOfEnums_EnumsByIdEntry = {
   decode(input: Reader | Uint8Array, length?: number): SimpleWithMapOfEnums_EnumsByIdEntry {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimpleWithMapOfEnums_EnumsByIdEntry } as SimpleWithMapOfEnums_EnumsByIdEntry;
+    const message = createBaseSimpleWithMapOfEnums_EnumsByIdEntry();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -954,7 +954,7 @@ export const SimpleWithMapOfEnums_EnumsByIdEntry = {
   },
 };
 
-const basePingRequest: object = { input: '' };
+const createBasePingRequest = (): PingRequest => ({ input: '' });
 
 export const PingRequest = {
   encode(message: PingRequest, writer: Writer = Writer.create()): Writer {
@@ -967,7 +967,7 @@ export const PingRequest = {
   decode(input: Reader | Uint8Array, length?: number): PingRequest {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...basePingRequest } as PingRequest;
+    const message = createBasePingRequest();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -983,7 +983,7 @@ export const PingRequest = {
   },
 };
 
-const basePingResponse: object = { output: '' };
+const createBasePingResponse = (): PingResponse => ({ output: '' });
 
 export const PingResponse = {
   encode(message: PingResponse, writer: Writer = Writer.create()): Writer {
@@ -996,7 +996,7 @@ export const PingResponse = {
   decode(input: Reader | Uint8Array, length?: number): PingResponse {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...basePingResponse } as PingResponse;
+    const message = createBasePingResponse();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -1012,7 +1012,7 @@ export const PingResponse = {
   },
 };
 
-const baseNumbers: object = {
+const createBaseNumbers = (): Numbers => ({
   double: 0,
   float: 0,
   int32: 0,
@@ -1025,7 +1025,7 @@ const baseNumbers: object = {
   fixed64: 0,
   sfixed32: 0,
   sfixed64: 0,
-};
+});
 
 export const Numbers = {
   encode(message: Numbers, writer: Writer = Writer.create()): Writer {
@@ -1071,7 +1071,7 @@ export const Numbers = {
   decode(input: Reader | Uint8Array, length?: number): Numbers {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseNumbers } as Numbers;
+    const message = createBaseNumbers();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -1120,7 +1120,7 @@ export const Numbers = {
   },
 };
 
-const baseSimpleButOptional: object = {};
+const createBaseSimpleButOptional = (): SimpleButOptional => ({});
 
 export const SimpleButOptional = {
   encode(message: SimpleButOptional, writer: Writer = Writer.create()): Writer {
@@ -1151,7 +1151,7 @@ export const SimpleButOptional = {
   decode(input: Reader | Uint8Array, length?: number): SimpleButOptional {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimpleButOptional } as SimpleButOptional;
+    const message = createBaseSimpleButOptional();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -1185,7 +1185,7 @@ export const SimpleButOptional = {
   },
 };
 
-const baseEmpty: object = {};
+const createBaseEmpty = (): Empty => ({});
 
 export const Empty = {
   encode(_: Empty, writer: Writer = Writer.create()): Writer {
@@ -1195,7 +1195,7 @@ export const Empty = {
   decode(input: Reader | Uint8Array, length?: number): Empty {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseEmpty } as Empty;
+    const message = createBaseEmpty();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {

--- a/integration/no-proto-package/no-proto-package.ts
+++ b/integration/no-proto-package/no-proto-package.ts
@@ -12,7 +12,9 @@ export interface User {
 
 export interface Empty {}
 
-const createBaseUser = (): User => ({ name: '' });
+function createBaseUser(): User {
+  return { name: '' };
+}
 
 export const User = {
   encode(message: User, writer: Writer = Writer.create()): Writer {
@@ -59,7 +61,9 @@ export const User = {
   },
 };
 
-const createBaseEmpty = (): Empty => ({});
+function createBaseEmpty(): Empty {
+  return {};
+}
 
 export const Empty = {
   encode(_: Empty, writer: Writer = Writer.create()): Writer {

--- a/integration/no-proto-package/no-proto-package.ts
+++ b/integration/no-proto-package/no-proto-package.ts
@@ -12,7 +12,7 @@ export interface User {
 
 export interface Empty {}
 
-const baseUser: object = { name: '' };
+const createBaseUser = (): User => ({ name: '' });
 
 export const User = {
   encode(message: User, writer: Writer = Writer.create()): Writer {
@@ -25,7 +25,7 @@ export const User = {
   decode(input: Reader | Uint8Array, length?: number): User {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseUser } as User;
+    const message = createBaseUser();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -41,7 +41,7 @@ export const User = {
   },
 
   fromJSON(object: any): User {
-    const message = { ...baseUser } as User;
+    const message = createBaseUser();
     message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
     return message;
   },
@@ -53,13 +53,13 @@ export const User = {
   },
 
   fromPartial<I extends Exact<DeepPartial<User>, I>>(object: I): User {
-    const message = { ...baseUser } as User;
+    const message = createBaseUser();
     message.name = object.name ?? '';
     return message;
   },
 };
 
-const baseEmpty: object = {};
+const createBaseEmpty = (): Empty => ({});
 
 export const Empty = {
   encode(_: Empty, writer: Writer = Writer.create()): Writer {
@@ -69,7 +69,7 @@ export const Empty = {
   decode(input: Reader | Uint8Array, length?: number): Empty {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseEmpty } as Empty;
+    const message = createBaseEmpty();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -82,7 +82,7 @@ export const Empty = {
   },
 
   fromJSON(_: any): Empty {
-    const message = { ...baseEmpty } as Empty;
+    const message = createBaseEmpty();
     return message;
   },
 
@@ -92,7 +92,7 @@ export const Empty = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Empty>, I>>(_: I): Empty {
-    const message = { ...baseEmpty } as Empty;
+    const message = createBaseEmpty();
     return message;
   },
 };

--- a/integration/oneof-properties/oneof.ts
+++ b/integration/oneof-properties/oneof.ts
@@ -72,7 +72,7 @@ export interface PleaseChoose_Submessage {
   name: string;
 }
 
-const basePleaseChoose: object = { name: '', age: 0 };
+const createBasePleaseChoose = (): PleaseChoose => ({ name: '', age: 0 });
 
 export const PleaseChoose = {
   encode(message: PleaseChoose, writer: Writer = Writer.create()): Writer {
@@ -115,7 +115,7 @@ export const PleaseChoose = {
   decode(input: Reader | Uint8Array, length?: number): PleaseChoose {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...basePleaseChoose } as PleaseChoose;
+    const message = createBasePleaseChoose();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -161,7 +161,7 @@ export const PleaseChoose = {
   },
 
   fromJSON(object: any): PleaseChoose {
-    const message = { ...basePleaseChoose } as PleaseChoose;
+    const message = createBasePleaseChoose();
     message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
     message.aNumber = object.aNumber !== undefined && object.aNumber !== null ? Number(object.aNumber) : undefined;
     message.aString = object.aString !== undefined && object.aString !== null ? String(object.aString) : undefined;
@@ -202,7 +202,7 @@ export const PleaseChoose = {
   },
 
   fromPartial<I extends Exact<DeepPartial<PleaseChoose>, I>>(object: I): PleaseChoose {
-    const message = { ...basePleaseChoose } as PleaseChoose;
+    const message = createBasePleaseChoose();
     message.name = object.name ?? '';
     message.aNumber = object.aNumber ?? undefined;
     message.aString = object.aString ?? undefined;
@@ -221,7 +221,7 @@ export const PleaseChoose = {
   },
 };
 
-const basePleaseChoose_Submessage: object = { name: '' };
+const createBasePleaseChoose_Submessage = (): PleaseChoose_Submessage => ({ name: '' });
 
 export const PleaseChoose_Submessage = {
   encode(message: PleaseChoose_Submessage, writer: Writer = Writer.create()): Writer {
@@ -234,7 +234,7 @@ export const PleaseChoose_Submessage = {
   decode(input: Reader | Uint8Array, length?: number): PleaseChoose_Submessage {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...basePleaseChoose_Submessage } as PleaseChoose_Submessage;
+    const message = createBasePleaseChoose_Submessage();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -250,7 +250,7 @@ export const PleaseChoose_Submessage = {
   },
 
   fromJSON(object: any): PleaseChoose_Submessage {
-    const message = { ...basePleaseChoose_Submessage } as PleaseChoose_Submessage;
+    const message = createBasePleaseChoose_Submessage();
     message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
     return message;
   },
@@ -262,7 +262,7 @@ export const PleaseChoose_Submessage = {
   },
 
   fromPartial<I extends Exact<DeepPartial<PleaseChoose_Submessage>, I>>(object: I): PleaseChoose_Submessage {
-    const message = { ...basePleaseChoose_Submessage } as PleaseChoose_Submessage;
+    const message = createBasePleaseChoose_Submessage();
     message.name = object.name ?? '';
     return message;
   },

--- a/integration/oneof-properties/oneof.ts
+++ b/integration/oneof-properties/oneof.ts
@@ -72,7 +72,21 @@ export interface PleaseChoose_Submessage {
   name: string;
 }
 
-const createBasePleaseChoose = (): PleaseChoose => ({ name: '', age: 0 });
+function createBasePleaseChoose(): PleaseChoose {
+  return {
+    name: '',
+    aNumber: undefined,
+    aString: undefined,
+    aMessage: undefined,
+    aBool: undefined,
+    bunchaBytes: undefined,
+    anEnum: undefined,
+    age: 0,
+    either: undefined,
+    or: undefined,
+    thirdOption: undefined,
+  };
+}
 
 export const PleaseChoose = {
   encode(message: PleaseChoose, writer: Writer = Writer.create()): Writer {
@@ -221,7 +235,9 @@ export const PleaseChoose = {
   },
 };
 
-const createBasePleaseChoose_Submessage = (): PleaseChoose_Submessage => ({ name: '' });
+function createBasePleaseChoose_Submessage(): PleaseChoose_Submessage {
+  return { name: '' };
+}
 
 export const PleaseChoose_Submessage = {
   encode(message: PleaseChoose_Submessage, writer: Writer = Writer.create()): Writer {

--- a/integration/oneof-unions/oneof.ts
+++ b/integration/oneof-unions/oneof.ts
@@ -69,7 +69,7 @@ export interface SimpleButOptional {
   age?: number | undefined;
 }
 
-const basePleaseChoose: object = { name: '', age: 0 };
+const createBasePleaseChoose = (): PleaseChoose => ({ name: '', age: 0 });
 
 export const PleaseChoose = {
   encode(message: PleaseChoose, writer: Writer = Writer.create()): Writer {
@@ -115,7 +115,7 @@ export const PleaseChoose = {
   decode(input: Reader | Uint8Array, length?: number): PleaseChoose {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...basePleaseChoose } as PleaseChoose;
+    const message = createBasePleaseChoose();
     message.signature = new Uint8Array();
     while (reader.pos < end) {
       const tag = reader.uint32();
@@ -165,7 +165,7 @@ export const PleaseChoose = {
   },
 
   fromJSON(object: any): PleaseChoose {
-    const message = { ...basePleaseChoose } as PleaseChoose;
+    const message = createBasePleaseChoose();
     message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
     if (object.aNumber !== undefined && object.aNumber !== null) {
       message.choice = { $case: 'aNumber', aNumber: Number(object.aNumber) };
@@ -226,7 +226,7 @@ export const PleaseChoose = {
   },
 
   fromPartial<I extends Exact<DeepPartial<PleaseChoose>, I>>(object: I): PleaseChoose {
-    const message = { ...basePleaseChoose } as PleaseChoose;
+    const message = createBasePleaseChoose();
     message.name = object.name ?? '';
     if (object.choice?.$case === 'aNumber' && object.choice?.aNumber !== undefined && object.choice?.aNumber !== null) {
       message.choice = { $case: 'aNumber', aNumber: object.choice.aNumber };
@@ -277,7 +277,7 @@ export const PleaseChoose = {
   },
 };
 
-const basePleaseChoose_Submessage: object = { name: '' };
+const createBasePleaseChoose_Submessage = (): PleaseChoose_Submessage => ({ name: '' });
 
 export const PleaseChoose_Submessage = {
   encode(message: PleaseChoose_Submessage, writer: Writer = Writer.create()): Writer {
@@ -290,7 +290,7 @@ export const PleaseChoose_Submessage = {
   decode(input: Reader | Uint8Array, length?: number): PleaseChoose_Submessage {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...basePleaseChoose_Submessage } as PleaseChoose_Submessage;
+    const message = createBasePleaseChoose_Submessage();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -306,7 +306,7 @@ export const PleaseChoose_Submessage = {
   },
 
   fromJSON(object: any): PleaseChoose_Submessage {
-    const message = { ...basePleaseChoose_Submessage } as PleaseChoose_Submessage;
+    const message = createBasePleaseChoose_Submessage();
     message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
     return message;
   },
@@ -318,13 +318,13 @@ export const PleaseChoose_Submessage = {
   },
 
   fromPartial<I extends Exact<DeepPartial<PleaseChoose_Submessage>, I>>(object: I): PleaseChoose_Submessage {
-    const message = { ...basePleaseChoose_Submessage } as PleaseChoose_Submessage;
+    const message = createBasePleaseChoose_Submessage();
     message.name = object.name ?? '';
     return message;
   },
 };
 
-const baseSimpleButOptional: object = {};
+const createBaseSimpleButOptional = (): SimpleButOptional => ({});
 
 export const SimpleButOptional = {
   encode(message: SimpleButOptional, writer: Writer = Writer.create()): Writer {
@@ -340,7 +340,7 @@ export const SimpleButOptional = {
   decode(input: Reader | Uint8Array, length?: number): SimpleButOptional {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimpleButOptional } as SimpleButOptional;
+    const message = createBaseSimpleButOptional();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -359,7 +359,7 @@ export const SimpleButOptional = {
   },
 
   fromJSON(object: any): SimpleButOptional {
-    const message = { ...baseSimpleButOptional } as SimpleButOptional;
+    const message = createBaseSimpleButOptional();
     message.name = object.name !== undefined && object.name !== null ? String(object.name) : undefined;
     message.age = object.age !== undefined && object.age !== null ? Number(object.age) : undefined;
     return message;
@@ -373,7 +373,7 @@ export const SimpleButOptional = {
   },
 
   fromPartial<I extends Exact<DeepPartial<SimpleButOptional>, I>>(object: I): SimpleButOptional {
-    const message = { ...baseSimpleButOptional } as SimpleButOptional;
+    const message = createBaseSimpleButOptional();
     message.name = object.name ?? undefined;
     message.age = object.age ?? undefined;
     return message;

--- a/integration/oneof-unions/oneof.ts
+++ b/integration/oneof-unions/oneof.ts
@@ -69,7 +69,9 @@ export interface SimpleButOptional {
   age?: number | undefined;
 }
 
-const createBasePleaseChoose = (): PleaseChoose => ({ name: '', age: 0 });
+function createBasePleaseChoose(): PleaseChoose {
+  return { name: '', choice: undefined, age: 0, eitherOr: undefined, signature: new Uint8Array() };
+}
 
 export const PleaseChoose = {
   encode(message: PleaseChoose, writer: Writer = Writer.create()): Writer {
@@ -116,7 +118,6 @@ export const PleaseChoose = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBasePleaseChoose();
-    message.signature = new Uint8Array();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -277,7 +278,9 @@ export const PleaseChoose = {
   },
 };
 
-const createBasePleaseChoose_Submessage = (): PleaseChoose_Submessage => ({ name: '' });
+function createBasePleaseChoose_Submessage(): PleaseChoose_Submessage {
+  return { name: '' };
+}
 
 export const PleaseChoose_Submessage = {
   encode(message: PleaseChoose_Submessage, writer: Writer = Writer.create()): Writer {
@@ -324,7 +327,9 @@ export const PleaseChoose_Submessage = {
   },
 };
 
-const createBaseSimpleButOptional = (): SimpleButOptional => ({});
+function createBaseSimpleButOptional(): SimpleButOptional {
+  return { name: undefined, age: undefined };
+}
 
 export const SimpleButOptional = {
   encode(message: SimpleButOptional, writer: Writer = Writer.create()): Writer {

--- a/integration/point/point.ts
+++ b/integration/point/point.ts
@@ -14,7 +14,9 @@ export interface Area {
   se: Point | undefined;
 }
 
-const createBasePoint = (): Point => ({ lat: 0, lng: 0 });
+function createBasePoint(): Point {
+  return { lat: 0, lng: 0 };
+}
 
 export const Point = {
   encode(message: Point, writer: Writer = Writer.create()): Writer {
@@ -70,7 +72,9 @@ export const Point = {
   },
 };
 
-const createBaseArea = (): Area => ({});
+function createBaseArea(): Area {
+  return { nw: undefined, se: undefined };
+}
 
 export const Area = {
   encode(message: Area, writer: Writer = Writer.create()): Writer {

--- a/integration/point/point.ts
+++ b/integration/point/point.ts
@@ -14,7 +14,7 @@ export interface Area {
   se: Point | undefined;
 }
 
-const basePoint: object = { lat: 0, lng: 0 };
+const createBasePoint = (): Point => ({ lat: 0, lng: 0 });
 
 export const Point = {
   encode(message: Point, writer: Writer = Writer.create()): Writer {
@@ -30,7 +30,7 @@ export const Point = {
   decode(input: Reader | Uint8Array, length?: number): Point {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...basePoint } as Point;
+    const message = createBasePoint();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -49,7 +49,7 @@ export const Point = {
   },
 
   fromJSON(object: any): Point {
-    const message = { ...basePoint } as Point;
+    const message = createBasePoint();
     message.lat = object.lat !== undefined && object.lat !== null ? Number(object.lat) : 0;
     message.lng = object.lng !== undefined && object.lng !== null ? Number(object.lng) : 0;
     return message;
@@ -63,14 +63,14 @@ export const Point = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Point>, I>>(object: I): Point {
-    const message = { ...basePoint } as Point;
+    const message = createBasePoint();
     message.lat = object.lat ?? 0;
     message.lng = object.lng ?? 0;
     return message;
   },
 };
 
-const baseArea: object = {};
+const createBaseArea = (): Area => ({});
 
 export const Area = {
   encode(message: Area, writer: Writer = Writer.create()): Writer {
@@ -86,7 +86,7 @@ export const Area = {
   decode(input: Reader | Uint8Array, length?: number): Area {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseArea } as Area;
+    const message = createBaseArea();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -105,7 +105,7 @@ export const Area = {
   },
 
   fromJSON(object: any): Area {
-    const message = { ...baseArea } as Area;
+    const message = createBaseArea();
     message.nw = object.nw !== undefined && object.nw !== null ? Point.fromJSON(object.nw) : undefined;
     message.se = object.se !== undefined && object.se !== null ? Point.fromJSON(object.se) : undefined;
     return message;
@@ -119,7 +119,7 @@ export const Area = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Area>, I>>(object: I): Area {
-    const message = { ...baseArea } as Area;
+    const message = createBaseArea();
     message.nw = object.nw !== undefined && object.nw !== null ? Point.fromPartial(object.nw) : undefined;
     message.se = object.se !== undefined && object.se !== null ? Point.fromPartial(object.se) : undefined;
     return message;

--- a/integration/return-observable/observable.ts
+++ b/integration/return-observable/observable.ts
@@ -13,7 +13,7 @@ export interface ProduceReply {
   result: string;
 }
 
-const baseProduceRequest: object = { ingredients: '' };
+const createBaseProduceRequest = (): ProduceRequest => ({ ingredients: '' });
 
 export const ProduceRequest = {
   encode(message: ProduceRequest, writer: Writer = Writer.create()): Writer {
@@ -26,7 +26,7 @@ export const ProduceRequest = {
   decode(input: Reader | Uint8Array, length?: number): ProduceRequest {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseProduceRequest } as ProduceRequest;
+    const message = createBaseProduceRequest();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -42,7 +42,7 @@ export const ProduceRequest = {
   },
 
   fromJSON(object: any): ProduceRequest {
-    const message = { ...baseProduceRequest } as ProduceRequest;
+    const message = createBaseProduceRequest();
     message.ingredients =
       object.ingredients !== undefined && object.ingredients !== null ? String(object.ingredients) : '';
     return message;
@@ -55,13 +55,13 @@ export const ProduceRequest = {
   },
 
   fromPartial<I extends Exact<DeepPartial<ProduceRequest>, I>>(object: I): ProduceRequest {
-    const message = { ...baseProduceRequest } as ProduceRequest;
+    const message = createBaseProduceRequest();
     message.ingredients = object.ingredients ?? '';
     return message;
   },
 };
 
-const baseProduceReply: object = { result: '' };
+const createBaseProduceReply = (): ProduceReply => ({ result: '' });
 
 export const ProduceReply = {
   encode(message: ProduceReply, writer: Writer = Writer.create()): Writer {
@@ -74,7 +74,7 @@ export const ProduceReply = {
   decode(input: Reader | Uint8Array, length?: number): ProduceReply {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseProduceReply } as ProduceReply;
+    const message = createBaseProduceReply();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -90,7 +90,7 @@ export const ProduceReply = {
   },
 
   fromJSON(object: any): ProduceReply {
-    const message = { ...baseProduceReply } as ProduceReply;
+    const message = createBaseProduceReply();
     message.result = object.result !== undefined && object.result !== null ? String(object.result) : '';
     return message;
   },
@@ -102,7 +102,7 @@ export const ProduceReply = {
   },
 
   fromPartial<I extends Exact<DeepPartial<ProduceReply>, I>>(object: I): ProduceReply {
-    const message = { ...baseProduceReply } as ProduceReply;
+    const message = createBaseProduceReply();
     message.result = object.result ?? '';
     return message;
   },

--- a/integration/return-observable/observable.ts
+++ b/integration/return-observable/observable.ts
@@ -13,7 +13,9 @@ export interface ProduceReply {
   result: string;
 }
 
-const createBaseProduceRequest = (): ProduceRequest => ({ ingredients: '' });
+function createBaseProduceRequest(): ProduceRequest {
+  return { ingredients: '' };
+}
 
 export const ProduceRequest = {
   encode(message: ProduceRequest, writer: Writer = Writer.create()): Writer {
@@ -61,7 +63,9 @@ export const ProduceRequest = {
   },
 };
 
-const createBaseProduceReply = (): ProduceReply => ({ result: '' });
+function createBaseProduceReply(): ProduceReply {
+  return { result: '' };
+}
 
 export const ProduceReply = {
   encode(message: ProduceReply, writer: Writer = Writer.create()): Writer {

--- a/integration/simple-deprecated-fields/simple.ts
+++ b/integration/simple-deprecated-fields/simple.ts
@@ -32,7 +32,7 @@ export interface Child {
   name: string;
 }
 
-const baseSimple: object = { name: '', age: 0, testField: '', testNotDeprecated: '' };
+const createBaseSimple = (): Simple => ({ name: '', age: 0, testField: '', testNotDeprecated: '' });
 
 export const Simple = {
   encode(message: Simple, writer: Writer = Writer.create()): Writer {
@@ -57,7 +57,7 @@ export const Simple = {
   decode(input: Reader | Uint8Array, length?: number): Simple {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimple } as Simple;
+    const message = createBaseSimple();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -85,7 +85,7 @@ export const Simple = {
   },
 
   fromJSON(object: any): Simple {
-    const message = { ...baseSimple } as Simple;
+    const message = createBaseSimple();
     message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
     message.age = object.age !== undefined && object.age !== null ? Number(object.age) : 0;
     message.child = object.child !== undefined && object.child !== null ? Child.fromJSON(object.child) : undefined;
@@ -108,7 +108,7 @@ export const Simple = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Simple>, I>>(object: I): Simple {
-    const message = { ...baseSimple } as Simple;
+    const message = createBaseSimple();
     message.name = object.name ?? '';
     message.age = object.age ?? 0;
     message.child = object.child !== undefined && object.child !== null ? Child.fromPartial(object.child) : undefined;
@@ -118,7 +118,7 @@ export const Simple = {
   },
 };
 
-const baseChild: object = { name: '' };
+const createBaseChild = (): Child => ({ name: '' });
 
 export const Child = {
   encode(message: Child, writer: Writer = Writer.create()): Writer {
@@ -131,7 +131,7 @@ export const Child = {
   decode(input: Reader | Uint8Array, length?: number): Child {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseChild } as Child;
+    const message = createBaseChild();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -147,7 +147,7 @@ export const Child = {
   },
 
   fromJSON(object: any): Child {
-    const message = { ...baseChild } as Child;
+    const message = createBaseChild();
     message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
     return message;
   },
@@ -159,7 +159,7 @@ export const Child = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Child>, I>>(object: I): Child {
-    const message = { ...baseChild } as Child;
+    const message = createBaseChild();
     message.name = object.name ?? '';
     return message;
   },

--- a/integration/simple-deprecated-fields/simple.ts
+++ b/integration/simple-deprecated-fields/simple.ts
@@ -32,7 +32,9 @@ export interface Child {
   name: string;
 }
 
-const createBaseSimple = (): Simple => ({ name: '', age: 0, testField: '', testNotDeprecated: '' });
+function createBaseSimple(): Simple {
+  return { name: '', age: 0, child: undefined, testField: '', testNotDeprecated: '' };
+}
 
 export const Simple = {
   encode(message: Simple, writer: Writer = Writer.create()): Writer {
@@ -118,7 +120,9 @@ export const Simple = {
   },
 };
 
-const createBaseChild = (): Child => ({ name: '' });
+function createBaseChild(): Child {
+  return { name: '' };
+}
 
 export const Child = {
   encode(message: Child, writer: Writer = Writer.create()): Writer {

--- a/integration/simple-esmodule-interop/simple.ts
+++ b/integration/simple-esmodule-interop/simple.ts
@@ -24,7 +24,7 @@ export interface Numbers {
   sfixed64: number;
 }
 
-const baseSimple: object = { name: '', age: 0 };
+const createBaseSimple = (): Simple => ({ name: '', age: 0 });
 
 export const Simple = {
   encode(message: Simple, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
@@ -40,7 +40,7 @@ export const Simple = {
   decode(input: _m0.Reader | Uint8Array, length?: number): Simple {
     const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimple } as Simple;
+    const message = createBaseSimple();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -59,7 +59,7 @@ export const Simple = {
   },
 
   fromJSON(object: any): Simple {
-    const message = { ...baseSimple } as Simple;
+    const message = createBaseSimple();
     message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
     message.age = object.age !== undefined && object.age !== null ? Number(object.age) : 0;
     return message;
@@ -73,14 +73,14 @@ export const Simple = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Simple>, I>>(object: I): Simple {
-    const message = { ...baseSimple } as Simple;
+    const message = createBaseSimple();
     message.name = object.name ?? '';
     message.age = object.age ?? 0;
     return message;
   },
 };
 
-const baseNumbers: object = {
+const createBaseNumbers = (): Numbers => ({
   double: 0,
   float: 0,
   int32: 0,
@@ -93,7 +93,7 @@ const baseNumbers: object = {
   fixed64: 0,
   sfixed32: 0,
   sfixed64: 0,
-};
+});
 
 export const Numbers = {
   encode(message: Numbers, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
@@ -139,7 +139,7 @@ export const Numbers = {
   decode(input: _m0.Reader | Uint8Array, length?: number): Numbers {
     const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseNumbers } as Numbers;
+    const message = createBaseNumbers();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -188,7 +188,7 @@ export const Numbers = {
   },
 
   fromJSON(object: any): Numbers {
-    const message = { ...baseNumbers } as Numbers;
+    const message = createBaseNumbers();
     message.double = object.double !== undefined && object.double !== null ? Number(object.double) : 0;
     message.float = object.float !== undefined && object.float !== null ? Number(object.float) : 0;
     message.int32 = object.int32 !== undefined && object.int32 !== null ? Number(object.int32) : 0;
@@ -222,7 +222,7 @@ export const Numbers = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Numbers>, I>>(object: I): Numbers {
-    const message = { ...baseNumbers } as Numbers;
+    const message = createBaseNumbers();
     message.double = object.double ?? 0;
     message.float = object.float ?? 0;
     message.int32 = object.int32 ?? 0;

--- a/integration/simple-esmodule-interop/simple.ts
+++ b/integration/simple-esmodule-interop/simple.ts
@@ -24,7 +24,9 @@ export interface Numbers {
   sfixed64: number;
 }
 
-const createBaseSimple = (): Simple => ({ name: '', age: 0 });
+function createBaseSimple(): Simple {
+  return { name: '', age: 0 };
+}
 
 export const Simple = {
   encode(message: Simple, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
@@ -80,20 +82,22 @@ export const Simple = {
   },
 };
 
-const createBaseNumbers = (): Numbers => ({
-  double: 0,
-  float: 0,
-  int32: 0,
-  int64: 0,
-  uint32: 0,
-  uint64: 0,
-  sint32: 0,
-  sint64: 0,
-  fixed32: 0,
-  fixed64: 0,
-  sfixed32: 0,
-  sfixed64: 0,
-});
+function createBaseNumbers(): Numbers {
+  return {
+    double: 0,
+    float: 0,
+    int32: 0,
+    int64: 0,
+    uint32: 0,
+    uint64: 0,
+    sint32: 0,
+    sint64: 0,
+    fixed32: 0,
+    fixed64: 0,
+    sfixed32: 0,
+    sfixed64: 0,
+  };
+}
 
 export const Numbers = {
   encode(message: Numbers, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {

--- a/integration/simple-json-name/google/protobuf/timestamp.ts
+++ b/integration/simple-json-name/google/protobuf/timestamp.ts
@@ -113,7 +113,9 @@ export interface Timestamp {
   nanos: number;
 }
 
-const createBaseTimestamp = (): Timestamp => ({ seconds: 0, nanos: 0 });
+function createBaseTimestamp(): Timestamp {
+  return { seconds: 0, nanos: 0 };
+}
 
 export const Timestamp = {
   encode(message: Timestamp, writer: Writer = Writer.create()): Writer {

--- a/integration/simple-json-name/google/protobuf/timestamp.ts
+++ b/integration/simple-json-name/google/protobuf/timestamp.ts
@@ -113,7 +113,7 @@ export interface Timestamp {
   nanos: number;
 }
 
-const baseTimestamp: object = { seconds: 0, nanos: 0 };
+const createBaseTimestamp = (): Timestamp => ({ seconds: 0, nanos: 0 });
 
 export const Timestamp = {
   encode(message: Timestamp, writer: Writer = Writer.create()): Writer {
@@ -129,7 +129,7 @@ export const Timestamp = {
   decode(input: Reader | Uint8Array, length?: number): Timestamp {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseTimestamp } as Timestamp;
+    const message = createBaseTimestamp();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -148,7 +148,7 @@ export const Timestamp = {
   },
 
   fromJSON(object: any): Timestamp {
-    const message = { ...baseTimestamp } as Timestamp;
+    const message = createBaseTimestamp();
     message.seconds = object.seconds !== undefined && object.seconds !== null ? Number(object.seconds) : 0;
     message.nanos = object.nanos !== undefined && object.nanos !== null ? Number(object.nanos) : 0;
     return message;
@@ -162,7 +162,7 @@ export const Timestamp = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Timestamp>, I>>(object: I): Timestamp {
-    const message = { ...baseTimestamp } as Timestamp;
+    const message = createBaseTimestamp();
     message.seconds = object.seconds ?? 0;
     message.nanos = object.nanos ?? 0;
     return message;

--- a/integration/simple-json-name/simple.ts
+++ b/integration/simple-json-name/simple.ts
@@ -11,7 +11,9 @@ export interface Simple {
   createdAt?: Date | undefined;
 }
 
-const createBaseSimple = (): Simple => ({ name: '' });
+function createBaseSimple(): Simple {
+  return { name: '', age: undefined, createdAt: undefined };
+}
 
 export const Simple = {
   encode(message: Simple, writer: Writer = Writer.create()): Writer {

--- a/integration/simple-json-name/simple.ts
+++ b/integration/simple-json-name/simple.ts
@@ -11,7 +11,7 @@ export interface Simple {
   createdAt?: Date | undefined;
 }
 
-const baseSimple: object = { name: '' };
+const createBaseSimple = (): Simple => ({ name: '' });
 
 export const Simple = {
   encode(message: Simple, writer: Writer = Writer.create()): Writer {
@@ -30,7 +30,7 @@ export const Simple = {
   decode(input: Reader | Uint8Array, length?: number): Simple {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimple } as Simple;
+    const message = createBaseSimple();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -52,7 +52,7 @@ export const Simple = {
   },
 
   fromJSON(object: any): Simple {
-    const message = { ...baseSimple } as Simple;
+    const message = createBaseSimple();
     message.name = object.other_name !== undefined && object.other_name !== null ? String(object.other_name) : '';
     message.age = object.other_age !== undefined && object.other_age !== null ? Number(object.other_age) : undefined;
     message.createdAt =
@@ -69,7 +69,7 @@ export const Simple = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Simple>, I>>(object: I): Simple {
-    const message = { ...baseSimple } as Simple;
+    const message = createBaseSimple();
     message.name = object.name ?? '';
     message.age = object.age ?? undefined;
     message.createdAt = object.createdAt ?? undefined;

--- a/integration/simple-long-string/google/protobuf/timestamp.ts
+++ b/integration/simple-long-string/google/protobuf/timestamp.ts
@@ -113,7 +113,9 @@ export interface Timestamp {
   nanos: number;
 }
 
-const createBaseTimestamp = (): Timestamp => ({ seconds: '0', nanos: 0 });
+function createBaseTimestamp(): Timestamp {
+  return { seconds: '0', nanos: 0 };
+}
 
 export const Timestamp = {
   encode(message: Timestamp, writer: Writer = Writer.create()): Writer {

--- a/integration/simple-long-string/google/protobuf/timestamp.ts
+++ b/integration/simple-long-string/google/protobuf/timestamp.ts
@@ -113,7 +113,7 @@ export interface Timestamp {
   nanos: number;
 }
 
-const baseTimestamp: object = { seconds: '0', nanos: 0 };
+const createBaseTimestamp = (): Timestamp => ({ seconds: '0', nanos: 0 });
 
 export const Timestamp = {
   encode(message: Timestamp, writer: Writer = Writer.create()): Writer {
@@ -129,7 +129,7 @@ export const Timestamp = {
   decode(input: Reader | Uint8Array, length?: number): Timestamp {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseTimestamp } as Timestamp;
+    const message = createBaseTimestamp();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -148,7 +148,7 @@ export const Timestamp = {
   },
 
   fromJSON(object: any): Timestamp {
-    const message = { ...baseTimestamp } as Timestamp;
+    const message = createBaseTimestamp();
     message.seconds = object.seconds !== undefined && object.seconds !== null ? String(object.seconds) : '0';
     message.nanos = object.nanos !== undefined && object.nanos !== null ? Number(object.nanos) : 0;
     return message;
@@ -162,7 +162,7 @@ export const Timestamp = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Timestamp>, I>>(object: I): Timestamp {
-    const message = { ...baseTimestamp } as Timestamp;
+    const message = createBaseTimestamp();
     message.seconds = object.seconds ?? '0';
     message.nanos = object.nanos ?? 0;
     return message;

--- a/integration/simple-long-string/google/protobuf/wrappers.ts
+++ b/integration/simple-long-string/google/protobuf/wrappers.ts
@@ -94,7 +94,7 @@ export interface BytesValue {
   value: Uint8Array;
 }
 
-const baseDoubleValue: object = { value: 0 };
+const createBaseDoubleValue = (): DoubleValue => ({ value: 0 });
 
 export const DoubleValue = {
   encode(message: DoubleValue, writer: Writer = Writer.create()): Writer {
@@ -107,7 +107,7 @@ export const DoubleValue = {
   decode(input: Reader | Uint8Array, length?: number): DoubleValue {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseDoubleValue } as DoubleValue;
+    const message = createBaseDoubleValue();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -123,7 +123,7 @@ export const DoubleValue = {
   },
 
   fromJSON(object: any): DoubleValue {
-    const message = { ...baseDoubleValue } as DoubleValue;
+    const message = createBaseDoubleValue();
     message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
@@ -135,13 +135,13 @@ export const DoubleValue = {
   },
 
   fromPartial<I extends Exact<DeepPartial<DoubleValue>, I>>(object: I): DoubleValue {
-    const message = { ...baseDoubleValue } as DoubleValue;
+    const message = createBaseDoubleValue();
     message.value = object.value ?? 0;
     return message;
   },
 };
 
-const baseFloatValue: object = { value: 0 };
+const createBaseFloatValue = (): FloatValue => ({ value: 0 });
 
 export const FloatValue = {
   encode(message: FloatValue, writer: Writer = Writer.create()): Writer {
@@ -154,7 +154,7 @@ export const FloatValue = {
   decode(input: Reader | Uint8Array, length?: number): FloatValue {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseFloatValue } as FloatValue;
+    const message = createBaseFloatValue();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -170,7 +170,7 @@ export const FloatValue = {
   },
 
   fromJSON(object: any): FloatValue {
-    const message = { ...baseFloatValue } as FloatValue;
+    const message = createBaseFloatValue();
     message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
@@ -182,13 +182,13 @@ export const FloatValue = {
   },
 
   fromPartial<I extends Exact<DeepPartial<FloatValue>, I>>(object: I): FloatValue {
-    const message = { ...baseFloatValue } as FloatValue;
+    const message = createBaseFloatValue();
     message.value = object.value ?? 0;
     return message;
   },
 };
 
-const baseInt64Value: object = { value: '0' };
+const createBaseInt64Value = (): Int64Value => ({ value: '0' });
 
 export const Int64Value = {
   encode(message: Int64Value, writer: Writer = Writer.create()): Writer {
@@ -201,7 +201,7 @@ export const Int64Value = {
   decode(input: Reader | Uint8Array, length?: number): Int64Value {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseInt64Value } as Int64Value;
+    const message = createBaseInt64Value();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -217,7 +217,7 @@ export const Int64Value = {
   },
 
   fromJSON(object: any): Int64Value {
-    const message = { ...baseInt64Value } as Int64Value;
+    const message = createBaseInt64Value();
     message.value = object.value !== undefined && object.value !== null ? String(object.value) : '0';
     return message;
   },
@@ -229,13 +229,13 @@ export const Int64Value = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Int64Value>, I>>(object: I): Int64Value {
-    const message = { ...baseInt64Value } as Int64Value;
+    const message = createBaseInt64Value();
     message.value = object.value ?? '0';
     return message;
   },
 };
 
-const baseUInt64Value: object = { value: '0' };
+const createBaseUInt64Value = (): UInt64Value => ({ value: '0' });
 
 export const UInt64Value = {
   encode(message: UInt64Value, writer: Writer = Writer.create()): Writer {
@@ -248,7 +248,7 @@ export const UInt64Value = {
   decode(input: Reader | Uint8Array, length?: number): UInt64Value {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseUInt64Value } as UInt64Value;
+    const message = createBaseUInt64Value();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -264,7 +264,7 @@ export const UInt64Value = {
   },
 
   fromJSON(object: any): UInt64Value {
-    const message = { ...baseUInt64Value } as UInt64Value;
+    const message = createBaseUInt64Value();
     message.value = object.value !== undefined && object.value !== null ? String(object.value) : '0';
     return message;
   },
@@ -276,13 +276,13 @@ export const UInt64Value = {
   },
 
   fromPartial<I extends Exact<DeepPartial<UInt64Value>, I>>(object: I): UInt64Value {
-    const message = { ...baseUInt64Value } as UInt64Value;
+    const message = createBaseUInt64Value();
     message.value = object.value ?? '0';
     return message;
   },
 };
 
-const baseInt32Value: object = { value: 0 };
+const createBaseInt32Value = (): Int32Value => ({ value: 0 });
 
 export const Int32Value = {
   encode(message: Int32Value, writer: Writer = Writer.create()): Writer {
@@ -295,7 +295,7 @@ export const Int32Value = {
   decode(input: Reader | Uint8Array, length?: number): Int32Value {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseInt32Value } as Int32Value;
+    const message = createBaseInt32Value();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -311,7 +311,7 @@ export const Int32Value = {
   },
 
   fromJSON(object: any): Int32Value {
-    const message = { ...baseInt32Value } as Int32Value;
+    const message = createBaseInt32Value();
     message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
@@ -323,13 +323,13 @@ export const Int32Value = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Int32Value>, I>>(object: I): Int32Value {
-    const message = { ...baseInt32Value } as Int32Value;
+    const message = createBaseInt32Value();
     message.value = object.value ?? 0;
     return message;
   },
 };
 
-const baseUInt32Value: object = { value: 0 };
+const createBaseUInt32Value = (): UInt32Value => ({ value: 0 });
 
 export const UInt32Value = {
   encode(message: UInt32Value, writer: Writer = Writer.create()): Writer {
@@ -342,7 +342,7 @@ export const UInt32Value = {
   decode(input: Reader | Uint8Array, length?: number): UInt32Value {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseUInt32Value } as UInt32Value;
+    const message = createBaseUInt32Value();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -358,7 +358,7 @@ export const UInt32Value = {
   },
 
   fromJSON(object: any): UInt32Value {
-    const message = { ...baseUInt32Value } as UInt32Value;
+    const message = createBaseUInt32Value();
     message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
@@ -370,13 +370,13 @@ export const UInt32Value = {
   },
 
   fromPartial<I extends Exact<DeepPartial<UInt32Value>, I>>(object: I): UInt32Value {
-    const message = { ...baseUInt32Value } as UInt32Value;
+    const message = createBaseUInt32Value();
     message.value = object.value ?? 0;
     return message;
   },
 };
 
-const baseBoolValue: object = { value: false };
+const createBaseBoolValue = (): BoolValue => ({ value: false });
 
 export const BoolValue = {
   encode(message: BoolValue, writer: Writer = Writer.create()): Writer {
@@ -389,7 +389,7 @@ export const BoolValue = {
   decode(input: Reader | Uint8Array, length?: number): BoolValue {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseBoolValue } as BoolValue;
+    const message = createBaseBoolValue();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -405,7 +405,7 @@ export const BoolValue = {
   },
 
   fromJSON(object: any): BoolValue {
-    const message = { ...baseBoolValue } as BoolValue;
+    const message = createBaseBoolValue();
     message.value = object.value !== undefined && object.value !== null ? Boolean(object.value) : false;
     return message;
   },
@@ -417,13 +417,13 @@ export const BoolValue = {
   },
 
   fromPartial<I extends Exact<DeepPartial<BoolValue>, I>>(object: I): BoolValue {
-    const message = { ...baseBoolValue } as BoolValue;
+    const message = createBaseBoolValue();
     message.value = object.value ?? false;
     return message;
   },
 };
 
-const baseStringValue: object = { value: '' };
+const createBaseStringValue = (): StringValue => ({ value: '' });
 
 export const StringValue = {
   encode(message: StringValue, writer: Writer = Writer.create()): Writer {
@@ -436,7 +436,7 @@ export const StringValue = {
   decode(input: Reader | Uint8Array, length?: number): StringValue {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseStringValue } as StringValue;
+    const message = createBaseStringValue();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -452,7 +452,7 @@ export const StringValue = {
   },
 
   fromJSON(object: any): StringValue {
-    const message = { ...baseStringValue } as StringValue;
+    const message = createBaseStringValue();
     message.value = object.value !== undefined && object.value !== null ? String(object.value) : '';
     return message;
   },
@@ -464,13 +464,13 @@ export const StringValue = {
   },
 
   fromPartial<I extends Exact<DeepPartial<StringValue>, I>>(object: I): StringValue {
-    const message = { ...baseStringValue } as StringValue;
+    const message = createBaseStringValue();
     message.value = object.value ?? '';
     return message;
   },
 };
 
-const baseBytesValue: object = {};
+const createBaseBytesValue = (): BytesValue => ({});
 
 export const BytesValue = {
   encode(message: BytesValue, writer: Writer = Writer.create()): Writer {
@@ -483,7 +483,7 @@ export const BytesValue = {
   decode(input: Reader | Uint8Array, length?: number): BytesValue {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseBytesValue } as BytesValue;
+    const message = createBaseBytesValue();
     message.value = new Uint8Array();
     while (reader.pos < end) {
       const tag = reader.uint32();
@@ -500,7 +500,7 @@ export const BytesValue = {
   },
 
   fromJSON(object: any): BytesValue {
-    const message = { ...baseBytesValue } as BytesValue;
+    const message = createBaseBytesValue();
     message.value =
       object.value !== undefined && object.value !== null ? bytesFromBase64(object.value) : new Uint8Array();
     return message;
@@ -514,7 +514,7 @@ export const BytesValue = {
   },
 
   fromPartial<I extends Exact<DeepPartial<BytesValue>, I>>(object: I): BytesValue {
-    const message = { ...baseBytesValue } as BytesValue;
+    const message = createBaseBytesValue();
     message.value = object.value ?? new Uint8Array();
     return message;
   },

--- a/integration/simple-long-string/google/protobuf/wrappers.ts
+++ b/integration/simple-long-string/google/protobuf/wrappers.ts
@@ -94,7 +94,9 @@ export interface BytesValue {
   value: Uint8Array;
 }
 
-const createBaseDoubleValue = (): DoubleValue => ({ value: 0 });
+function createBaseDoubleValue(): DoubleValue {
+  return { value: 0 };
+}
 
 export const DoubleValue = {
   encode(message: DoubleValue, writer: Writer = Writer.create()): Writer {
@@ -141,7 +143,9 @@ export const DoubleValue = {
   },
 };
 
-const createBaseFloatValue = (): FloatValue => ({ value: 0 });
+function createBaseFloatValue(): FloatValue {
+  return { value: 0 };
+}
 
 export const FloatValue = {
   encode(message: FloatValue, writer: Writer = Writer.create()): Writer {
@@ -188,7 +192,9 @@ export const FloatValue = {
   },
 };
 
-const createBaseInt64Value = (): Int64Value => ({ value: '0' });
+function createBaseInt64Value(): Int64Value {
+  return { value: '0' };
+}
 
 export const Int64Value = {
   encode(message: Int64Value, writer: Writer = Writer.create()): Writer {
@@ -235,7 +241,9 @@ export const Int64Value = {
   },
 };
 
-const createBaseUInt64Value = (): UInt64Value => ({ value: '0' });
+function createBaseUInt64Value(): UInt64Value {
+  return { value: '0' };
+}
 
 export const UInt64Value = {
   encode(message: UInt64Value, writer: Writer = Writer.create()): Writer {
@@ -282,7 +290,9 @@ export const UInt64Value = {
   },
 };
 
-const createBaseInt32Value = (): Int32Value => ({ value: 0 });
+function createBaseInt32Value(): Int32Value {
+  return { value: 0 };
+}
 
 export const Int32Value = {
   encode(message: Int32Value, writer: Writer = Writer.create()): Writer {
@@ -329,7 +339,9 @@ export const Int32Value = {
   },
 };
 
-const createBaseUInt32Value = (): UInt32Value => ({ value: 0 });
+function createBaseUInt32Value(): UInt32Value {
+  return { value: 0 };
+}
 
 export const UInt32Value = {
   encode(message: UInt32Value, writer: Writer = Writer.create()): Writer {
@@ -376,7 +388,9 @@ export const UInt32Value = {
   },
 };
 
-const createBaseBoolValue = (): BoolValue => ({ value: false });
+function createBaseBoolValue(): BoolValue {
+  return { value: false };
+}
 
 export const BoolValue = {
   encode(message: BoolValue, writer: Writer = Writer.create()): Writer {
@@ -423,7 +437,9 @@ export const BoolValue = {
   },
 };
 
-const createBaseStringValue = (): StringValue => ({ value: '' });
+function createBaseStringValue(): StringValue {
+  return { value: '' };
+}
 
 export const StringValue = {
   encode(message: StringValue, writer: Writer = Writer.create()): Writer {
@@ -470,7 +486,9 @@ export const StringValue = {
   },
 };
 
-const createBaseBytesValue = (): BytesValue => ({});
+function createBaseBytesValue(): BytesValue {
+  return { value: new Uint8Array() };
+}
 
 export const BytesValue = {
   encode(message: BytesValue, writer: Writer = Writer.create()): Writer {
@@ -484,7 +502,6 @@ export const BytesValue = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseBytesValue();
-    message.value = new Uint8Array();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {

--- a/integration/simple-long-string/simple.ts
+++ b/integration/simple-long-string/simple.ts
@@ -23,20 +23,24 @@ export interface Numbers {
   timestamp: Date | undefined;
 }
 
-const createBaseNumbers = (): Numbers => ({
-  double: 0,
-  float: 0,
-  int32: 0,
-  int64: '0',
-  uint32: 0,
-  uint64: '0',
-  sint32: 0,
-  sint64: '0',
-  fixed32: 0,
-  fixed64: '0',
-  sfixed32: 0,
-  sfixed64: '0',
-});
+function createBaseNumbers(): Numbers {
+  return {
+    double: 0,
+    float: 0,
+    int32: 0,
+    int64: '0',
+    uint32: 0,
+    uint64: '0',
+    sint32: 0,
+    sint64: '0',
+    fixed32: 0,
+    fixed64: '0',
+    sfixed32: 0,
+    sfixed64: '0',
+    guint64: undefined,
+    timestamp: undefined,
+  };
+}
 
 export const Numbers = {
   encode(message: Numbers, writer: Writer = Writer.create()): Writer {

--- a/integration/simple-long-string/simple.ts
+++ b/integration/simple-long-string/simple.ts
@@ -23,7 +23,7 @@ export interface Numbers {
   timestamp: Date | undefined;
 }
 
-const baseNumbers: object = {
+const createBaseNumbers = (): Numbers => ({
   double: 0,
   float: 0,
   int32: 0,
@@ -36,7 +36,7 @@ const baseNumbers: object = {
   fixed64: '0',
   sfixed32: 0,
   sfixed64: '0',
-};
+});
 
 export const Numbers = {
   encode(message: Numbers, writer: Writer = Writer.create()): Writer {
@@ -88,7 +88,7 @@ export const Numbers = {
   decode(input: Reader | Uint8Array, length?: number): Numbers {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseNumbers } as Numbers;
+    const message = createBaseNumbers();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -143,7 +143,7 @@ export const Numbers = {
   },
 
   fromJSON(object: any): Numbers {
-    const message = { ...baseNumbers } as Numbers;
+    const message = createBaseNumbers();
     message.double = object.double !== undefined && object.double !== null ? Number(object.double) : 0;
     message.float = object.float !== undefined && object.float !== null ? Number(object.float) : 0;
     message.int32 = object.int32 !== undefined && object.int32 !== null ? Number(object.int32) : 0;
@@ -182,7 +182,7 @@ export const Numbers = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Numbers>, I>>(object: I): Numbers {
-    const message = { ...baseNumbers } as Numbers;
+    const message = createBaseNumbers();
     message.double = object.double ?? 0;
     message.float = object.float ?? 0;
     message.int32 = object.int32 ?? 0;

--- a/integration/simple-long/google/protobuf/wrappers.ts
+++ b/integration/simple-long/google/protobuf/wrappers.ts
@@ -94,7 +94,9 @@ export interface BytesValue {
   value: Uint8Array;
 }
 
-const createBaseDoubleValue = (): DoubleValue => ({ value: 0 });
+function createBaseDoubleValue(): DoubleValue {
+  return { value: 0 };
+}
 
 export const DoubleValue = {
   encode(message: DoubleValue, writer: Writer = Writer.create()): Writer {
@@ -141,7 +143,9 @@ export const DoubleValue = {
   },
 };
 
-const createBaseFloatValue = (): FloatValue => ({ value: 0 });
+function createBaseFloatValue(): FloatValue {
+  return { value: 0 };
+}
 
 export const FloatValue = {
   encode(message: FloatValue, writer: Writer = Writer.create()): Writer {
@@ -188,7 +192,9 @@ export const FloatValue = {
   },
 };
 
-const createBaseInt64Value = (): Int64Value => ({ value: Long.ZERO });
+function createBaseInt64Value(): Int64Value {
+  return { value: Long.ZERO };
+}
 
 export const Int64Value = {
   encode(message: Int64Value, writer: Writer = Writer.create()): Writer {
@@ -235,7 +241,9 @@ export const Int64Value = {
   },
 };
 
-const createBaseUInt64Value = (): UInt64Value => ({ value: Long.UZERO });
+function createBaseUInt64Value(): UInt64Value {
+  return { value: Long.UZERO };
+}
 
 export const UInt64Value = {
   encode(message: UInt64Value, writer: Writer = Writer.create()): Writer {
@@ -282,7 +290,9 @@ export const UInt64Value = {
   },
 };
 
-const createBaseInt32Value = (): Int32Value => ({ value: 0 });
+function createBaseInt32Value(): Int32Value {
+  return { value: 0 };
+}
 
 export const Int32Value = {
   encode(message: Int32Value, writer: Writer = Writer.create()): Writer {
@@ -329,7 +339,9 @@ export const Int32Value = {
   },
 };
 
-const createBaseUInt32Value = (): UInt32Value => ({ value: 0 });
+function createBaseUInt32Value(): UInt32Value {
+  return { value: 0 };
+}
 
 export const UInt32Value = {
   encode(message: UInt32Value, writer: Writer = Writer.create()): Writer {
@@ -376,7 +388,9 @@ export const UInt32Value = {
   },
 };
 
-const createBaseBoolValue = (): BoolValue => ({ value: false });
+function createBaseBoolValue(): BoolValue {
+  return { value: false };
+}
 
 export const BoolValue = {
   encode(message: BoolValue, writer: Writer = Writer.create()): Writer {
@@ -423,7 +437,9 @@ export const BoolValue = {
   },
 };
 
-const createBaseStringValue = (): StringValue => ({ value: '' });
+function createBaseStringValue(): StringValue {
+  return { value: '' };
+}
 
 export const StringValue = {
   encode(message: StringValue, writer: Writer = Writer.create()): Writer {
@@ -470,7 +486,9 @@ export const StringValue = {
   },
 };
 
-const createBaseBytesValue = (): BytesValue => ({});
+function createBaseBytesValue(): BytesValue {
+  return { value: new Uint8Array() };
+}
 
 export const BytesValue = {
   encode(message: BytesValue, writer: Writer = Writer.create()): Writer {
@@ -484,7 +502,6 @@ export const BytesValue = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseBytesValue();
-    message.value = new Uint8Array();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {

--- a/integration/simple-long/google/protobuf/wrappers.ts
+++ b/integration/simple-long/google/protobuf/wrappers.ts
@@ -94,7 +94,7 @@ export interface BytesValue {
   value: Uint8Array;
 }
 
-const baseDoubleValue: object = { value: 0 };
+const createBaseDoubleValue = (): DoubleValue => ({ value: 0 });
 
 export const DoubleValue = {
   encode(message: DoubleValue, writer: Writer = Writer.create()): Writer {
@@ -107,7 +107,7 @@ export const DoubleValue = {
   decode(input: Reader | Uint8Array, length?: number): DoubleValue {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseDoubleValue } as DoubleValue;
+    const message = createBaseDoubleValue();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -123,7 +123,7 @@ export const DoubleValue = {
   },
 
   fromJSON(object: any): DoubleValue {
-    const message = { ...baseDoubleValue } as DoubleValue;
+    const message = createBaseDoubleValue();
     message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
@@ -135,13 +135,13 @@ export const DoubleValue = {
   },
 
   fromPartial<I extends Exact<DeepPartial<DoubleValue>, I>>(object: I): DoubleValue {
-    const message = { ...baseDoubleValue } as DoubleValue;
+    const message = createBaseDoubleValue();
     message.value = object.value ?? 0;
     return message;
   },
 };
 
-const baseFloatValue: object = { value: 0 };
+const createBaseFloatValue = (): FloatValue => ({ value: 0 });
 
 export const FloatValue = {
   encode(message: FloatValue, writer: Writer = Writer.create()): Writer {
@@ -154,7 +154,7 @@ export const FloatValue = {
   decode(input: Reader | Uint8Array, length?: number): FloatValue {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseFloatValue } as FloatValue;
+    const message = createBaseFloatValue();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -170,7 +170,7 @@ export const FloatValue = {
   },
 
   fromJSON(object: any): FloatValue {
-    const message = { ...baseFloatValue } as FloatValue;
+    const message = createBaseFloatValue();
     message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
@@ -182,13 +182,13 @@ export const FloatValue = {
   },
 
   fromPartial<I extends Exact<DeepPartial<FloatValue>, I>>(object: I): FloatValue {
-    const message = { ...baseFloatValue } as FloatValue;
+    const message = createBaseFloatValue();
     message.value = object.value ?? 0;
     return message;
   },
 };
 
-const baseInt64Value: object = { value: Long.ZERO };
+const createBaseInt64Value = (): Int64Value => ({ value: Long.ZERO });
 
 export const Int64Value = {
   encode(message: Int64Value, writer: Writer = Writer.create()): Writer {
@@ -201,7 +201,7 @@ export const Int64Value = {
   decode(input: Reader | Uint8Array, length?: number): Int64Value {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseInt64Value } as Int64Value;
+    const message = createBaseInt64Value();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -217,7 +217,7 @@ export const Int64Value = {
   },
 
   fromJSON(object: any): Int64Value {
-    const message = { ...baseInt64Value } as Int64Value;
+    const message = createBaseInt64Value();
     message.value = object.value !== undefined && object.value !== null ? Long.fromString(object.value) : Long.ZERO;
     return message;
   },
@@ -229,13 +229,13 @@ export const Int64Value = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Int64Value>, I>>(object: I): Int64Value {
-    const message = { ...baseInt64Value } as Int64Value;
+    const message = createBaseInt64Value();
     message.value = object.value !== undefined && object.value !== null ? Long.fromValue(object.value) : Long.ZERO;
     return message;
   },
 };
 
-const baseUInt64Value: object = { value: Long.UZERO };
+const createBaseUInt64Value = (): UInt64Value => ({ value: Long.UZERO });
 
 export const UInt64Value = {
   encode(message: UInt64Value, writer: Writer = Writer.create()): Writer {
@@ -248,7 +248,7 @@ export const UInt64Value = {
   decode(input: Reader | Uint8Array, length?: number): UInt64Value {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseUInt64Value } as UInt64Value;
+    const message = createBaseUInt64Value();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -264,7 +264,7 @@ export const UInt64Value = {
   },
 
   fromJSON(object: any): UInt64Value {
-    const message = { ...baseUInt64Value } as UInt64Value;
+    const message = createBaseUInt64Value();
     message.value = object.value !== undefined && object.value !== null ? Long.fromString(object.value) : Long.UZERO;
     return message;
   },
@@ -276,13 +276,13 @@ export const UInt64Value = {
   },
 
   fromPartial<I extends Exact<DeepPartial<UInt64Value>, I>>(object: I): UInt64Value {
-    const message = { ...baseUInt64Value } as UInt64Value;
+    const message = createBaseUInt64Value();
     message.value = object.value !== undefined && object.value !== null ? Long.fromValue(object.value) : Long.UZERO;
     return message;
   },
 };
 
-const baseInt32Value: object = { value: 0 };
+const createBaseInt32Value = (): Int32Value => ({ value: 0 });
 
 export const Int32Value = {
   encode(message: Int32Value, writer: Writer = Writer.create()): Writer {
@@ -295,7 +295,7 @@ export const Int32Value = {
   decode(input: Reader | Uint8Array, length?: number): Int32Value {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseInt32Value } as Int32Value;
+    const message = createBaseInt32Value();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -311,7 +311,7 @@ export const Int32Value = {
   },
 
   fromJSON(object: any): Int32Value {
-    const message = { ...baseInt32Value } as Int32Value;
+    const message = createBaseInt32Value();
     message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
@@ -323,13 +323,13 @@ export const Int32Value = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Int32Value>, I>>(object: I): Int32Value {
-    const message = { ...baseInt32Value } as Int32Value;
+    const message = createBaseInt32Value();
     message.value = object.value ?? 0;
     return message;
   },
 };
 
-const baseUInt32Value: object = { value: 0 };
+const createBaseUInt32Value = (): UInt32Value => ({ value: 0 });
 
 export const UInt32Value = {
   encode(message: UInt32Value, writer: Writer = Writer.create()): Writer {
@@ -342,7 +342,7 @@ export const UInt32Value = {
   decode(input: Reader | Uint8Array, length?: number): UInt32Value {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseUInt32Value } as UInt32Value;
+    const message = createBaseUInt32Value();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -358,7 +358,7 @@ export const UInt32Value = {
   },
 
   fromJSON(object: any): UInt32Value {
-    const message = { ...baseUInt32Value } as UInt32Value;
+    const message = createBaseUInt32Value();
     message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
@@ -370,13 +370,13 @@ export const UInt32Value = {
   },
 
   fromPartial<I extends Exact<DeepPartial<UInt32Value>, I>>(object: I): UInt32Value {
-    const message = { ...baseUInt32Value } as UInt32Value;
+    const message = createBaseUInt32Value();
     message.value = object.value ?? 0;
     return message;
   },
 };
 
-const baseBoolValue: object = { value: false };
+const createBaseBoolValue = (): BoolValue => ({ value: false });
 
 export const BoolValue = {
   encode(message: BoolValue, writer: Writer = Writer.create()): Writer {
@@ -389,7 +389,7 @@ export const BoolValue = {
   decode(input: Reader | Uint8Array, length?: number): BoolValue {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseBoolValue } as BoolValue;
+    const message = createBaseBoolValue();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -405,7 +405,7 @@ export const BoolValue = {
   },
 
   fromJSON(object: any): BoolValue {
-    const message = { ...baseBoolValue } as BoolValue;
+    const message = createBaseBoolValue();
     message.value = object.value !== undefined && object.value !== null ? Boolean(object.value) : false;
     return message;
   },
@@ -417,13 +417,13 @@ export const BoolValue = {
   },
 
   fromPartial<I extends Exact<DeepPartial<BoolValue>, I>>(object: I): BoolValue {
-    const message = { ...baseBoolValue } as BoolValue;
+    const message = createBaseBoolValue();
     message.value = object.value ?? false;
     return message;
   },
 };
 
-const baseStringValue: object = { value: '' };
+const createBaseStringValue = (): StringValue => ({ value: '' });
 
 export const StringValue = {
   encode(message: StringValue, writer: Writer = Writer.create()): Writer {
@@ -436,7 +436,7 @@ export const StringValue = {
   decode(input: Reader | Uint8Array, length?: number): StringValue {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseStringValue } as StringValue;
+    const message = createBaseStringValue();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -452,7 +452,7 @@ export const StringValue = {
   },
 
   fromJSON(object: any): StringValue {
-    const message = { ...baseStringValue } as StringValue;
+    const message = createBaseStringValue();
     message.value = object.value !== undefined && object.value !== null ? String(object.value) : '';
     return message;
   },
@@ -464,13 +464,13 @@ export const StringValue = {
   },
 
   fromPartial<I extends Exact<DeepPartial<StringValue>, I>>(object: I): StringValue {
-    const message = { ...baseStringValue } as StringValue;
+    const message = createBaseStringValue();
     message.value = object.value ?? '';
     return message;
   },
 };
 
-const baseBytesValue: object = {};
+const createBaseBytesValue = (): BytesValue => ({});
 
 export const BytesValue = {
   encode(message: BytesValue, writer: Writer = Writer.create()): Writer {
@@ -483,7 +483,7 @@ export const BytesValue = {
   decode(input: Reader | Uint8Array, length?: number): BytesValue {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseBytesValue } as BytesValue;
+    const message = createBaseBytesValue();
     message.value = new Uint8Array();
     while (reader.pos < end) {
       const tag = reader.uint32();
@@ -500,7 +500,7 @@ export const BytesValue = {
   },
 
   fromJSON(object: any): BytesValue {
-    const message = { ...baseBytesValue } as BytesValue;
+    const message = createBaseBytesValue();
     message.value =
       object.value !== undefined && object.value !== null ? bytesFromBase64(object.value) : new Uint8Array();
     return message;
@@ -514,7 +514,7 @@ export const BytesValue = {
   },
 
   fromPartial<I extends Exact<DeepPartial<BytesValue>, I>>(object: I): BytesValue {
-    const message = { ...baseBytesValue } as BytesValue;
+    const message = createBaseBytesValue();
     message.value = object.value ?? new Uint8Array();
     return message;
   },

--- a/integration/simple-long/simple.ts
+++ b/integration/simple-long/simple.ts
@@ -53,7 +53,9 @@ export interface Numbers {
   manyUint64: Long[];
 }
 
-const createBaseSimpleWithWrappers = (): SimpleWithWrappers => ({});
+function createBaseSimpleWithWrappers(): SimpleWithWrappers {
+  return { name: undefined, age: undefined, enabled: undefined, bananas: undefined, coins: [], snacks: [] };
+}
 
 export const SimpleWithWrappers = {
   encode(message: SimpleWithWrappers, writer: Writer = Writer.create()): Writer {
@@ -82,8 +84,6 @@ export const SimpleWithWrappers = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseSimpleWithWrappers();
-    message.coins = [];
-    message.snacks = [];
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -157,7 +157,9 @@ export const SimpleWithWrappers = {
   },
 };
 
-const createBaseSimpleWithMap = (): SimpleWithMap => ({});
+function createBaseSimpleWithMap(): SimpleWithMap {
+  return { nameLookup: {}, intLookup: {}, longLookup: {} };
+}
 
 export const SimpleWithMap = {
   encode(message: SimpleWithMap, writer: Writer = Writer.create()): Writer {
@@ -177,9 +179,6 @@ export const SimpleWithMap = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseSimpleWithMap();
-    message.nameLookup = {};
-    message.intLookup = {};
-    message.longLookup = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -291,7 +290,9 @@ export const SimpleWithMap = {
   },
 };
 
-const createBaseSimpleWithMap_NameLookupEntry = (): SimpleWithMap_NameLookupEntry => ({ key: '', value: '' });
+function createBaseSimpleWithMap_NameLookupEntry(): SimpleWithMap_NameLookupEntry {
+  return { key: '', value: '' };
+}
 
 export const SimpleWithMap_NameLookupEntry = {
   encode(message: SimpleWithMap_NameLookupEntry, writer: Writer = Writer.create()): Writer {
@@ -349,7 +350,9 @@ export const SimpleWithMap_NameLookupEntry = {
   },
 };
 
-const createBaseSimpleWithMap_IntLookupEntry = (): SimpleWithMap_IntLookupEntry => ({ key: 0, value: 0 });
+function createBaseSimpleWithMap_IntLookupEntry(): SimpleWithMap_IntLookupEntry {
+  return { key: 0, value: 0 };
+}
 
 export const SimpleWithMap_IntLookupEntry = {
   encode(message: SimpleWithMap_IntLookupEntry, writer: Writer = Writer.create()): Writer {
@@ -405,7 +408,9 @@ export const SimpleWithMap_IntLookupEntry = {
   },
 };
 
-const createBaseSimpleWithMap_LongLookupEntry = (): SimpleWithMap_LongLookupEntry => ({ key: '', value: Long.ZERO });
+function createBaseSimpleWithMap_LongLookupEntry(): SimpleWithMap_LongLookupEntry {
+  return { key: '', value: Long.ZERO };
+}
 
 export const SimpleWithMap_LongLookupEntry = {
   encode(message: SimpleWithMap_LongLookupEntry, writer: Writer = Writer.create()): Writer {
@@ -463,21 +468,23 @@ export const SimpleWithMap_LongLookupEntry = {
   },
 };
 
-const createBaseNumbers = (): Numbers => ({
-  double: 0,
-  float: 0,
-  int32: 0,
-  int64: Long.ZERO,
-  uint32: 0,
-  uint64: Long.UZERO,
-  sint32: 0,
-  sint64: Long.ZERO,
-  fixed32: 0,
-  fixed64: Long.UZERO,
-  sfixed32: 0,
-  sfixed64: Long.ZERO,
-  manyUint64: Long.UZERO,
-});
+function createBaseNumbers(): Numbers {
+  return {
+    double: 0,
+    float: 0,
+    int32: 0,
+    int64: Long.ZERO,
+    uint32: 0,
+    uint64: Long.UZERO,
+    sint32: 0,
+    sint64: Long.ZERO,
+    fixed32: 0,
+    fixed64: Long.UZERO,
+    sfixed32: 0,
+    sfixed64: Long.ZERO,
+    manyUint64: [],
+  };
+}
 
 export const Numbers = {
   encode(message: Numbers, writer: Writer = Writer.create()): Writer {
@@ -529,7 +536,6 @@ export const Numbers = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseNumbers();
-    message.manyUint64 = [];
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {

--- a/integration/simple-long/simple.ts
+++ b/integration/simple-long/simple.ts
@@ -53,7 +53,7 @@ export interface Numbers {
   manyUint64: Long[];
 }
 
-const baseSimpleWithWrappers: object = {};
+const createBaseSimpleWithWrappers = (): SimpleWithWrappers => ({});
 
 export const SimpleWithWrappers = {
   encode(message: SimpleWithWrappers, writer: Writer = Writer.create()): Writer {
@@ -81,7 +81,7 @@ export const SimpleWithWrappers = {
   decode(input: Reader | Uint8Array, length?: number): SimpleWithWrappers {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimpleWithWrappers } as SimpleWithWrappers;
+    const message = createBaseSimpleWithWrappers();
     message.coins = [];
     message.snacks = [];
     while (reader.pos < end) {
@@ -114,7 +114,7 @@ export const SimpleWithWrappers = {
   },
 
   fromJSON(object: any): SimpleWithWrappers {
-    const message = { ...baseSimpleWithWrappers } as SimpleWithWrappers;
+    const message = createBaseSimpleWithWrappers();
     message.name = object.name !== undefined && object.name !== null ? String(object.name) : undefined;
     message.age = object.age !== undefined && object.age !== null ? Number(object.age) : undefined;
     message.enabled = object.enabled !== undefined && object.enabled !== null ? Boolean(object.enabled) : undefined;
@@ -145,7 +145,7 @@ export const SimpleWithWrappers = {
   },
 
   fromPartial<I extends Exact<DeepPartial<SimpleWithWrappers>, I>>(object: I): SimpleWithWrappers {
-    const message = { ...baseSimpleWithWrappers } as SimpleWithWrappers;
+    const message = createBaseSimpleWithWrappers();
     message.name = object.name ?? undefined;
     message.age = object.age ?? undefined;
     message.enabled = object.enabled ?? undefined;
@@ -157,7 +157,7 @@ export const SimpleWithWrappers = {
   },
 };
 
-const baseSimpleWithMap: object = {};
+const createBaseSimpleWithMap = (): SimpleWithMap => ({});
 
 export const SimpleWithMap = {
   encode(message: SimpleWithMap, writer: Writer = Writer.create()): Writer {
@@ -176,7 +176,7 @@ export const SimpleWithMap = {
   decode(input: Reader | Uint8Array, length?: number): SimpleWithMap {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimpleWithMap } as SimpleWithMap;
+    const message = createBaseSimpleWithMap();
     message.nameLookup = {};
     message.intLookup = {};
     message.longLookup = {};
@@ -210,7 +210,7 @@ export const SimpleWithMap = {
   },
 
   fromJSON(object: any): SimpleWithMap {
-    const message = { ...baseSimpleWithMap } as SimpleWithMap;
+    const message = createBaseSimpleWithMap();
     message.nameLookup = Object.entries(object.nameLookup ?? {}).reduce<{ [key: string]: string }>(
       (acc, [key, value]) => {
         acc[key] = String(value);
@@ -259,7 +259,7 @@ export const SimpleWithMap = {
   },
 
   fromPartial<I extends Exact<DeepPartial<SimpleWithMap>, I>>(object: I): SimpleWithMap {
-    const message = { ...baseSimpleWithMap } as SimpleWithMap;
+    const message = createBaseSimpleWithMap();
     message.nameLookup = Object.entries(object.nameLookup ?? {}).reduce<{ [key: string]: string }>(
       (acc, [key, value]) => {
         if (value !== undefined) {
@@ -291,7 +291,7 @@ export const SimpleWithMap = {
   },
 };
 
-const baseSimpleWithMap_NameLookupEntry: object = { key: '', value: '' };
+const createBaseSimpleWithMap_NameLookupEntry = (): SimpleWithMap_NameLookupEntry => ({ key: '', value: '' });
 
 export const SimpleWithMap_NameLookupEntry = {
   encode(message: SimpleWithMap_NameLookupEntry, writer: Writer = Writer.create()): Writer {
@@ -307,7 +307,7 @@ export const SimpleWithMap_NameLookupEntry = {
   decode(input: Reader | Uint8Array, length?: number): SimpleWithMap_NameLookupEntry {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimpleWithMap_NameLookupEntry } as SimpleWithMap_NameLookupEntry;
+    const message = createBaseSimpleWithMap_NameLookupEntry();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -326,7 +326,7 @@ export const SimpleWithMap_NameLookupEntry = {
   },
 
   fromJSON(object: any): SimpleWithMap_NameLookupEntry {
-    const message = { ...baseSimpleWithMap_NameLookupEntry } as SimpleWithMap_NameLookupEntry;
+    const message = createBaseSimpleWithMap_NameLookupEntry();
     message.key = object.key !== undefined && object.key !== null ? String(object.key) : '';
     message.value = object.value !== undefined && object.value !== null ? String(object.value) : '';
     return message;
@@ -342,14 +342,14 @@ export const SimpleWithMap_NameLookupEntry = {
   fromPartial<I extends Exact<DeepPartial<SimpleWithMap_NameLookupEntry>, I>>(
     object: I
   ): SimpleWithMap_NameLookupEntry {
-    const message = { ...baseSimpleWithMap_NameLookupEntry } as SimpleWithMap_NameLookupEntry;
+    const message = createBaseSimpleWithMap_NameLookupEntry();
     message.key = object.key ?? '';
     message.value = object.value ?? '';
     return message;
   },
 };
 
-const baseSimpleWithMap_IntLookupEntry: object = { key: 0, value: 0 };
+const createBaseSimpleWithMap_IntLookupEntry = (): SimpleWithMap_IntLookupEntry => ({ key: 0, value: 0 });
 
 export const SimpleWithMap_IntLookupEntry = {
   encode(message: SimpleWithMap_IntLookupEntry, writer: Writer = Writer.create()): Writer {
@@ -365,7 +365,7 @@ export const SimpleWithMap_IntLookupEntry = {
   decode(input: Reader | Uint8Array, length?: number): SimpleWithMap_IntLookupEntry {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimpleWithMap_IntLookupEntry } as SimpleWithMap_IntLookupEntry;
+    const message = createBaseSimpleWithMap_IntLookupEntry();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -384,7 +384,7 @@ export const SimpleWithMap_IntLookupEntry = {
   },
 
   fromJSON(object: any): SimpleWithMap_IntLookupEntry {
-    const message = { ...baseSimpleWithMap_IntLookupEntry } as SimpleWithMap_IntLookupEntry;
+    const message = createBaseSimpleWithMap_IntLookupEntry();
     message.key = object.key !== undefined && object.key !== null ? Number(object.key) : 0;
     message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
@@ -398,14 +398,14 @@ export const SimpleWithMap_IntLookupEntry = {
   },
 
   fromPartial<I extends Exact<DeepPartial<SimpleWithMap_IntLookupEntry>, I>>(object: I): SimpleWithMap_IntLookupEntry {
-    const message = { ...baseSimpleWithMap_IntLookupEntry } as SimpleWithMap_IntLookupEntry;
+    const message = createBaseSimpleWithMap_IntLookupEntry();
     message.key = object.key ?? 0;
     message.value = object.value ?? 0;
     return message;
   },
 };
 
-const baseSimpleWithMap_LongLookupEntry: object = { key: '', value: Long.ZERO };
+const createBaseSimpleWithMap_LongLookupEntry = (): SimpleWithMap_LongLookupEntry => ({ key: '', value: Long.ZERO });
 
 export const SimpleWithMap_LongLookupEntry = {
   encode(message: SimpleWithMap_LongLookupEntry, writer: Writer = Writer.create()): Writer {
@@ -421,7 +421,7 @@ export const SimpleWithMap_LongLookupEntry = {
   decode(input: Reader | Uint8Array, length?: number): SimpleWithMap_LongLookupEntry {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimpleWithMap_LongLookupEntry } as SimpleWithMap_LongLookupEntry;
+    const message = createBaseSimpleWithMap_LongLookupEntry();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -440,7 +440,7 @@ export const SimpleWithMap_LongLookupEntry = {
   },
 
   fromJSON(object: any): SimpleWithMap_LongLookupEntry {
-    const message = { ...baseSimpleWithMap_LongLookupEntry } as SimpleWithMap_LongLookupEntry;
+    const message = createBaseSimpleWithMap_LongLookupEntry();
     message.key = object.key !== undefined && object.key !== null ? String(object.key) : '';
     message.value = object.value !== undefined && object.value !== null ? Long.fromString(object.value) : Long.ZERO;
     return message;
@@ -456,14 +456,14 @@ export const SimpleWithMap_LongLookupEntry = {
   fromPartial<I extends Exact<DeepPartial<SimpleWithMap_LongLookupEntry>, I>>(
     object: I
   ): SimpleWithMap_LongLookupEntry {
-    const message = { ...baseSimpleWithMap_LongLookupEntry } as SimpleWithMap_LongLookupEntry;
+    const message = createBaseSimpleWithMap_LongLookupEntry();
     message.key = object.key ?? '';
     message.value = object.value !== undefined && object.value !== null ? Long.fromValue(object.value) : Long.ZERO;
     return message;
   },
 };
 
-const baseNumbers: object = {
+const createBaseNumbers = (): Numbers => ({
   double: 0,
   float: 0,
   int32: 0,
@@ -477,7 +477,7 @@ const baseNumbers: object = {
   sfixed32: 0,
   sfixed64: Long.ZERO,
   manyUint64: Long.UZERO,
-};
+});
 
 export const Numbers = {
   encode(message: Numbers, writer: Writer = Writer.create()): Writer {
@@ -528,7 +528,7 @@ export const Numbers = {
   decode(input: Reader | Uint8Array, length?: number): Numbers {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseNumbers } as Numbers;
+    const message = createBaseNumbers();
     message.manyUint64 = [];
     while (reader.pos < end) {
       const tag = reader.uint32();
@@ -588,7 +588,7 @@ export const Numbers = {
   },
 
   fromJSON(object: any): Numbers {
-    const message = { ...baseNumbers } as Numbers;
+    const message = createBaseNumbers();
     message.double = object.double !== undefined && object.double !== null ? Number(object.double) : 0;
     message.float = object.float !== undefined && object.float !== null ? Number(object.float) : 0;
     message.int32 = object.int32 !== undefined && object.int32 !== null ? Number(object.int32) : 0;
@@ -631,7 +631,7 @@ export const Numbers = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Numbers>, I>>(object: I): Numbers {
-    const message = { ...baseNumbers } as Numbers;
+    const message = createBaseNumbers();
     message.double = object.double ?? 0;
     message.float = object.float ?? 0;
     message.int32 = object.int32 ?? 0;

--- a/integration/simple-optionals/google/protobuf/timestamp.ts
+++ b/integration/simple-optionals/google/protobuf/timestamp.ts
@@ -113,7 +113,9 @@ export interface Timestamp {
   nanos: number;
 }
 
-const createBaseTimestamp = (): Timestamp => ({ seconds: 0, nanos: 0 });
+function createBaseTimestamp(): Timestamp {
+  return { seconds: 0, nanos: 0 };
+}
 
 export const Timestamp = {
   encode(message: Timestamp, writer: Writer = Writer.create()): Writer {

--- a/integration/simple-optionals/google/protobuf/timestamp.ts
+++ b/integration/simple-optionals/google/protobuf/timestamp.ts
@@ -113,7 +113,7 @@ export interface Timestamp {
   nanos: number;
 }
 
-const baseTimestamp: object = { seconds: 0, nanos: 0 };
+const createBaseTimestamp = (): Timestamp => ({ seconds: 0, nanos: 0 });
 
 export const Timestamp = {
   encode(message: Timestamp, writer: Writer = Writer.create()): Writer {
@@ -129,7 +129,7 @@ export const Timestamp = {
   decode(input: Reader | Uint8Array, length?: number): Timestamp {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseTimestamp } as Timestamp;
+    const message = createBaseTimestamp();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -148,7 +148,7 @@ export const Timestamp = {
   },
 
   fromJSON(object: any): Timestamp {
-    const message = { ...baseTimestamp } as Timestamp;
+    const message = createBaseTimestamp();
     message.seconds = object.seconds !== undefined && object.seconds !== null ? Number(object.seconds) : 0;
     message.nanos = object.nanos !== undefined && object.nanos !== null ? Number(object.nanos) : 0;
     return message;
@@ -162,7 +162,7 @@ export const Timestamp = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Timestamp>, I>>(object: I): Timestamp {
-    const message = { ...baseTimestamp } as Timestamp;
+    const message = createBaseTimestamp();
     message.seconds = object.seconds ?? 0;
     message.nanos = object.nanos ?? 0;
     return message;

--- a/integration/simple-optionals/google/protobuf/wrappers.ts
+++ b/integration/simple-optionals/google/protobuf/wrappers.ts
@@ -94,7 +94,9 @@ export interface BytesValue {
   value: Uint8Array;
 }
 
-const createBaseDoubleValue = (): DoubleValue => ({ value: 0 });
+function createBaseDoubleValue(): DoubleValue {
+  return { value: 0 };
+}
 
 export const DoubleValue = {
   encode(message: DoubleValue, writer: Writer = Writer.create()): Writer {
@@ -141,7 +143,9 @@ export const DoubleValue = {
   },
 };
 
-const createBaseFloatValue = (): FloatValue => ({ value: 0 });
+function createBaseFloatValue(): FloatValue {
+  return { value: 0 };
+}
 
 export const FloatValue = {
   encode(message: FloatValue, writer: Writer = Writer.create()): Writer {
@@ -188,7 +192,9 @@ export const FloatValue = {
   },
 };
 
-const createBaseInt64Value = (): Int64Value => ({ value: 0 });
+function createBaseInt64Value(): Int64Value {
+  return { value: 0 };
+}
 
 export const Int64Value = {
   encode(message: Int64Value, writer: Writer = Writer.create()): Writer {
@@ -235,7 +241,9 @@ export const Int64Value = {
   },
 };
 
-const createBaseUInt64Value = (): UInt64Value => ({ value: 0 });
+function createBaseUInt64Value(): UInt64Value {
+  return { value: 0 };
+}
 
 export const UInt64Value = {
   encode(message: UInt64Value, writer: Writer = Writer.create()): Writer {
@@ -282,7 +290,9 @@ export const UInt64Value = {
   },
 };
 
-const createBaseInt32Value = (): Int32Value => ({ value: 0 });
+function createBaseInt32Value(): Int32Value {
+  return { value: 0 };
+}
 
 export const Int32Value = {
   encode(message: Int32Value, writer: Writer = Writer.create()): Writer {
@@ -329,7 +339,9 @@ export const Int32Value = {
   },
 };
 
-const createBaseUInt32Value = (): UInt32Value => ({ value: 0 });
+function createBaseUInt32Value(): UInt32Value {
+  return { value: 0 };
+}
 
 export const UInt32Value = {
   encode(message: UInt32Value, writer: Writer = Writer.create()): Writer {
@@ -376,7 +388,9 @@ export const UInt32Value = {
   },
 };
 
-const createBaseBoolValue = (): BoolValue => ({ value: false });
+function createBaseBoolValue(): BoolValue {
+  return { value: false };
+}
 
 export const BoolValue = {
   encode(message: BoolValue, writer: Writer = Writer.create()): Writer {
@@ -423,7 +437,9 @@ export const BoolValue = {
   },
 };
 
-const createBaseStringValue = (): StringValue => ({ value: '' });
+function createBaseStringValue(): StringValue {
+  return { value: '' };
+}
 
 export const StringValue = {
   encode(message: StringValue, writer: Writer = Writer.create()): Writer {
@@ -470,7 +486,9 @@ export const StringValue = {
   },
 };
 
-const createBaseBytesValue = (): BytesValue => ({});
+function createBaseBytesValue(): BytesValue {
+  return { value: new Uint8Array() };
+}
 
 export const BytesValue = {
   encode(message: BytesValue, writer: Writer = Writer.create()): Writer {
@@ -484,7 +502,6 @@ export const BytesValue = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseBytesValue();
-    message.value = new Uint8Array();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {

--- a/integration/simple-optionals/google/protobuf/wrappers.ts
+++ b/integration/simple-optionals/google/protobuf/wrappers.ts
@@ -94,7 +94,7 @@ export interface BytesValue {
   value: Uint8Array;
 }
 
-const baseDoubleValue: object = { value: 0 };
+const createBaseDoubleValue = (): DoubleValue => ({ value: 0 });
 
 export const DoubleValue = {
   encode(message: DoubleValue, writer: Writer = Writer.create()): Writer {
@@ -107,7 +107,7 @@ export const DoubleValue = {
   decode(input: Reader | Uint8Array, length?: number): DoubleValue {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseDoubleValue } as DoubleValue;
+    const message = createBaseDoubleValue();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -123,7 +123,7 @@ export const DoubleValue = {
   },
 
   fromJSON(object: any): DoubleValue {
-    const message = { ...baseDoubleValue } as DoubleValue;
+    const message = createBaseDoubleValue();
     message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
@@ -135,13 +135,13 @@ export const DoubleValue = {
   },
 
   fromPartial<I extends Exact<DeepPartial<DoubleValue>, I>>(object: I): DoubleValue {
-    const message = { ...baseDoubleValue } as DoubleValue;
+    const message = createBaseDoubleValue();
     message.value = object.value ?? 0;
     return message;
   },
 };
 
-const baseFloatValue: object = { value: 0 };
+const createBaseFloatValue = (): FloatValue => ({ value: 0 });
 
 export const FloatValue = {
   encode(message: FloatValue, writer: Writer = Writer.create()): Writer {
@@ -154,7 +154,7 @@ export const FloatValue = {
   decode(input: Reader | Uint8Array, length?: number): FloatValue {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseFloatValue } as FloatValue;
+    const message = createBaseFloatValue();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -170,7 +170,7 @@ export const FloatValue = {
   },
 
   fromJSON(object: any): FloatValue {
-    const message = { ...baseFloatValue } as FloatValue;
+    const message = createBaseFloatValue();
     message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
@@ -182,13 +182,13 @@ export const FloatValue = {
   },
 
   fromPartial<I extends Exact<DeepPartial<FloatValue>, I>>(object: I): FloatValue {
-    const message = { ...baseFloatValue } as FloatValue;
+    const message = createBaseFloatValue();
     message.value = object.value ?? 0;
     return message;
   },
 };
 
-const baseInt64Value: object = { value: 0 };
+const createBaseInt64Value = (): Int64Value => ({ value: 0 });
 
 export const Int64Value = {
   encode(message: Int64Value, writer: Writer = Writer.create()): Writer {
@@ -201,7 +201,7 @@ export const Int64Value = {
   decode(input: Reader | Uint8Array, length?: number): Int64Value {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseInt64Value } as Int64Value;
+    const message = createBaseInt64Value();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -217,7 +217,7 @@ export const Int64Value = {
   },
 
   fromJSON(object: any): Int64Value {
-    const message = { ...baseInt64Value } as Int64Value;
+    const message = createBaseInt64Value();
     message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
@@ -229,13 +229,13 @@ export const Int64Value = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Int64Value>, I>>(object: I): Int64Value {
-    const message = { ...baseInt64Value } as Int64Value;
+    const message = createBaseInt64Value();
     message.value = object.value ?? 0;
     return message;
   },
 };
 
-const baseUInt64Value: object = { value: 0 };
+const createBaseUInt64Value = (): UInt64Value => ({ value: 0 });
 
 export const UInt64Value = {
   encode(message: UInt64Value, writer: Writer = Writer.create()): Writer {
@@ -248,7 +248,7 @@ export const UInt64Value = {
   decode(input: Reader | Uint8Array, length?: number): UInt64Value {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseUInt64Value } as UInt64Value;
+    const message = createBaseUInt64Value();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -264,7 +264,7 @@ export const UInt64Value = {
   },
 
   fromJSON(object: any): UInt64Value {
-    const message = { ...baseUInt64Value } as UInt64Value;
+    const message = createBaseUInt64Value();
     message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
@@ -276,13 +276,13 @@ export const UInt64Value = {
   },
 
   fromPartial<I extends Exact<DeepPartial<UInt64Value>, I>>(object: I): UInt64Value {
-    const message = { ...baseUInt64Value } as UInt64Value;
+    const message = createBaseUInt64Value();
     message.value = object.value ?? 0;
     return message;
   },
 };
 
-const baseInt32Value: object = { value: 0 };
+const createBaseInt32Value = (): Int32Value => ({ value: 0 });
 
 export const Int32Value = {
   encode(message: Int32Value, writer: Writer = Writer.create()): Writer {
@@ -295,7 +295,7 @@ export const Int32Value = {
   decode(input: Reader | Uint8Array, length?: number): Int32Value {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseInt32Value } as Int32Value;
+    const message = createBaseInt32Value();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -311,7 +311,7 @@ export const Int32Value = {
   },
 
   fromJSON(object: any): Int32Value {
-    const message = { ...baseInt32Value } as Int32Value;
+    const message = createBaseInt32Value();
     message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
@@ -323,13 +323,13 @@ export const Int32Value = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Int32Value>, I>>(object: I): Int32Value {
-    const message = { ...baseInt32Value } as Int32Value;
+    const message = createBaseInt32Value();
     message.value = object.value ?? 0;
     return message;
   },
 };
 
-const baseUInt32Value: object = { value: 0 };
+const createBaseUInt32Value = (): UInt32Value => ({ value: 0 });
 
 export const UInt32Value = {
   encode(message: UInt32Value, writer: Writer = Writer.create()): Writer {
@@ -342,7 +342,7 @@ export const UInt32Value = {
   decode(input: Reader | Uint8Array, length?: number): UInt32Value {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseUInt32Value } as UInt32Value;
+    const message = createBaseUInt32Value();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -358,7 +358,7 @@ export const UInt32Value = {
   },
 
   fromJSON(object: any): UInt32Value {
-    const message = { ...baseUInt32Value } as UInt32Value;
+    const message = createBaseUInt32Value();
     message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
@@ -370,13 +370,13 @@ export const UInt32Value = {
   },
 
   fromPartial<I extends Exact<DeepPartial<UInt32Value>, I>>(object: I): UInt32Value {
-    const message = { ...baseUInt32Value } as UInt32Value;
+    const message = createBaseUInt32Value();
     message.value = object.value ?? 0;
     return message;
   },
 };
 
-const baseBoolValue: object = { value: false };
+const createBaseBoolValue = (): BoolValue => ({ value: false });
 
 export const BoolValue = {
   encode(message: BoolValue, writer: Writer = Writer.create()): Writer {
@@ -389,7 +389,7 @@ export const BoolValue = {
   decode(input: Reader | Uint8Array, length?: number): BoolValue {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseBoolValue } as BoolValue;
+    const message = createBaseBoolValue();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -405,7 +405,7 @@ export const BoolValue = {
   },
 
   fromJSON(object: any): BoolValue {
-    const message = { ...baseBoolValue } as BoolValue;
+    const message = createBaseBoolValue();
     message.value = object.value !== undefined && object.value !== null ? Boolean(object.value) : false;
     return message;
   },
@@ -417,13 +417,13 @@ export const BoolValue = {
   },
 
   fromPartial<I extends Exact<DeepPartial<BoolValue>, I>>(object: I): BoolValue {
-    const message = { ...baseBoolValue } as BoolValue;
+    const message = createBaseBoolValue();
     message.value = object.value ?? false;
     return message;
   },
 };
 
-const baseStringValue: object = { value: '' };
+const createBaseStringValue = (): StringValue => ({ value: '' });
 
 export const StringValue = {
   encode(message: StringValue, writer: Writer = Writer.create()): Writer {
@@ -436,7 +436,7 @@ export const StringValue = {
   decode(input: Reader | Uint8Array, length?: number): StringValue {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseStringValue } as StringValue;
+    const message = createBaseStringValue();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -452,7 +452,7 @@ export const StringValue = {
   },
 
   fromJSON(object: any): StringValue {
-    const message = { ...baseStringValue } as StringValue;
+    const message = createBaseStringValue();
     message.value = object.value !== undefined && object.value !== null ? String(object.value) : '';
     return message;
   },
@@ -464,13 +464,13 @@ export const StringValue = {
   },
 
   fromPartial<I extends Exact<DeepPartial<StringValue>, I>>(object: I): StringValue {
-    const message = { ...baseStringValue } as StringValue;
+    const message = createBaseStringValue();
     message.value = object.value ?? '';
     return message;
   },
 };
 
-const baseBytesValue: object = {};
+const createBaseBytesValue = (): BytesValue => ({});
 
 export const BytesValue = {
   encode(message: BytesValue, writer: Writer = Writer.create()): Writer {
@@ -483,7 +483,7 @@ export const BytesValue = {
   decode(input: Reader | Uint8Array, length?: number): BytesValue {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseBytesValue } as BytesValue;
+    const message = createBaseBytesValue();
     message.value = new Uint8Array();
     while (reader.pos < end) {
       const tag = reader.uint32();
@@ -500,7 +500,7 @@ export const BytesValue = {
   },
 
   fromJSON(object: any): BytesValue {
-    const message = { ...baseBytesValue } as BytesValue;
+    const message = createBaseBytesValue();
     message.value =
       object.value !== undefined && object.value !== null ? bytesFromBase64(object.value) : new Uint8Array();
     return message;
@@ -514,7 +514,7 @@ export const BytesValue = {
   },
 
   fromPartial<I extends Exact<DeepPartial<BytesValue>, I>>(object: I): BytesValue {
-    const message = { ...baseBytesValue } as BytesValue;
+    const message = createBaseBytesValue();
     message.value = object.value ?? new Uint8Array();
     return message;
   },

--- a/integration/simple-optionals/import_dir/thing.ts
+++ b/integration/simple-optionals/import_dir/thing.ts
@@ -9,7 +9,7 @@ export interface ImportedThing {
   createdAt?: Date;
 }
 
-const baseImportedThing: object = {};
+const createBaseImportedThing = (): ImportedThing => ({});
 
 export const ImportedThing = {
   encode(message: ImportedThing, writer: Writer = Writer.create()): Writer {
@@ -22,7 +22,7 @@ export const ImportedThing = {
   decode(input: Reader | Uint8Array, length?: number): ImportedThing {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseImportedThing } as ImportedThing;
+    const message = createBaseImportedThing();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -38,7 +38,7 @@ export const ImportedThing = {
   },
 
   fromJSON(object: any): ImportedThing {
-    const message = { ...baseImportedThing } as ImportedThing;
+    const message = createBaseImportedThing();
     message.createdAt =
       object.createdAt !== undefined && object.createdAt !== null ? fromJsonTimestamp(object.createdAt) : undefined;
     return message;
@@ -51,7 +51,7 @@ export const ImportedThing = {
   },
 
   fromPartial<I extends Exact<DeepPartial<ImportedThing>, I>>(object: I): ImportedThing {
-    const message = { ...baseImportedThing } as ImportedThing;
+    const message = createBaseImportedThing();
     message.createdAt = object.createdAt ?? undefined;
     return message;
   },

--- a/integration/simple-optionals/import_dir/thing.ts
+++ b/integration/simple-optionals/import_dir/thing.ts
@@ -9,7 +9,9 @@ export interface ImportedThing {
   createdAt?: Date;
 }
 
-const createBaseImportedThing = (): ImportedThing => ({});
+function createBaseImportedThing(): ImportedThing {
+  return { createdAt: undefined };
+}
 
 export const ImportedThing = {
   encode(message: ImportedThing, writer: Writer = Writer.create()): Writer {

--- a/integration/simple-optionals/simple.ts
+++ b/integration/simple-optionals/simple.ts
@@ -235,7 +235,20 @@ export interface Numbers {
   sfixed64: number;
 }
 
-const createBaseSimple = (): Simple => ({ name: '', age: 0, state: 0, coins: 0, snacks: '', oldStates: 0 });
+function createBaseSimple(): Simple {
+  return {
+    name: '',
+    age: 0,
+    createdAt: undefined,
+    child: undefined,
+    state: 0,
+    grandChildren: [],
+    coins: [],
+    snacks: [],
+    oldStates: [],
+    thing: undefined,
+  };
+}
 
 export const Simple = {
   encode(message: Simple, writer: Writer = Writer.create()): Writer {
@@ -280,10 +293,6 @@ export const Simple = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseSimple();
-    message.grandChildren = [];
-    message.coins = [];
-    message.snacks = [];
-    message.oldStates = [];
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -404,7 +413,9 @@ export const Simple = {
   },
 };
 
-const createBaseChild = (): Child => ({ name: '', type: 0 });
+function createBaseChild(): Child {
+  return { name: '', type: 0 };
+}
 
 export const Child = {
   encode(message: Child, writer: Writer = Writer.create()): Writer {
@@ -460,7 +471,9 @@ export const Child = {
   },
 };
 
-const createBaseNested = (): Nested => ({ name: '', state: 0 });
+function createBaseNested(): Nested {
+  return { name: '', message: undefined, state: 0 };
+}
 
 export const Nested = {
   encode(message: Nested, writer: Writer = Writer.create()): Writer {
@@ -532,7 +545,9 @@ export const Nested = {
   },
 };
 
-const createBaseNested_InnerMessage = (): Nested_InnerMessage => ({ name: '' });
+function createBaseNested_InnerMessage(): Nested_InnerMessage {
+  return { name: '', deep: undefined };
+}
 
 export const Nested_InnerMessage = {
   encode(message: Nested_InnerMessage, writer: Writer = Writer.create()): Writer {
@@ -595,7 +610,9 @@ export const Nested_InnerMessage = {
   },
 };
 
-const createBaseNested_InnerMessage_DeepMessage = (): Nested_InnerMessage_DeepMessage => ({ name: '' });
+function createBaseNested_InnerMessage_DeepMessage(): Nested_InnerMessage_DeepMessage {
+  return { name: '' };
+}
 
 export const Nested_InnerMessage_DeepMessage = {
   encode(message: Nested_InnerMessage_DeepMessage, writer: Writer = Writer.create()): Writer {
@@ -644,7 +661,9 @@ export const Nested_InnerMessage_DeepMessage = {
   },
 };
 
-const createBaseOneOfMessage = (): OneOfMessage => ({});
+function createBaseOneOfMessage(): OneOfMessage {
+  return { first: undefined, last: undefined };
+}
 
 export const OneOfMessage = {
   encode(message: OneOfMessage, writer: Writer = Writer.create()): Writer {
@@ -700,7 +719,9 @@ export const OneOfMessage = {
   },
 };
 
-const createBaseSimpleWithWrappers = (): SimpleWithWrappers => ({});
+function createBaseSimpleWithWrappers(): SimpleWithWrappers {
+  return { name: undefined, age: undefined, enabled: undefined, coins: [], snacks: [] };
+}
 
 export const SimpleWithWrappers = {
   encode(message: SimpleWithWrappers, writer: Writer = Writer.create()): Writer {
@@ -726,8 +747,6 @@ export const SimpleWithWrappers = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseSimpleWithWrappers();
-    message.coins = [];
-    message.snacks = [];
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -793,7 +812,9 @@ export const SimpleWithWrappers = {
   },
 };
 
-const createBaseEntity = (): Entity => ({ id: 0 });
+function createBaseEntity(): Entity {
+  return { id: 0 };
+}
 
 export const Entity = {
   encode(message: Entity, writer: Writer = Writer.create()): Writer {
@@ -840,7 +861,9 @@ export const Entity = {
   },
 };
 
-const createBaseSimpleWithMap = (): SimpleWithMap => ({});
+function createBaseSimpleWithMap(): SimpleWithMap {
+  return { entitiesById: {}, nameLookup: {}, intLookup: {} };
+}
 
 export const SimpleWithMap = {
   encode(message: SimpleWithMap, writer: Writer = Writer.create()): Writer {
@@ -860,9 +883,6 @@ export const SimpleWithMap = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseSimpleWithMap();
-    message.entitiesById = {};
-    message.nameLookup = {};
-    message.intLookup = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -974,7 +994,9 @@ export const SimpleWithMap = {
   },
 };
 
-const createBaseSimpleWithMap_EntitiesByIdEntry = (): SimpleWithMap_EntitiesByIdEntry => ({ key: 0 });
+function createBaseSimpleWithMap_EntitiesByIdEntry(): SimpleWithMap_EntitiesByIdEntry {
+  return { key: 0, value: undefined };
+}
 
 export const SimpleWithMap_EntitiesByIdEntry = {
   encode(message: SimpleWithMap_EntitiesByIdEntry, writer: Writer = Writer.create()): Writer {
@@ -1032,7 +1054,9 @@ export const SimpleWithMap_EntitiesByIdEntry = {
   },
 };
 
-const createBaseSimpleWithMap_NameLookupEntry = (): SimpleWithMap_NameLookupEntry => ({ key: '', value: '' });
+function createBaseSimpleWithMap_NameLookupEntry(): SimpleWithMap_NameLookupEntry {
+  return { key: '', value: '' };
+}
 
 export const SimpleWithMap_NameLookupEntry = {
   encode(message: SimpleWithMap_NameLookupEntry, writer: Writer = Writer.create()): Writer {
@@ -1090,7 +1114,9 @@ export const SimpleWithMap_NameLookupEntry = {
   },
 };
 
-const createBaseSimpleWithMap_IntLookupEntry = (): SimpleWithMap_IntLookupEntry => ({ key: 0, value: 0 });
+function createBaseSimpleWithMap_IntLookupEntry(): SimpleWithMap_IntLookupEntry {
+  return { key: 0, value: 0 };
+}
 
 export const SimpleWithMap_IntLookupEntry = {
   encode(message: SimpleWithMap_IntLookupEntry, writer: Writer = Writer.create()): Writer {
@@ -1146,7 +1172,9 @@ export const SimpleWithMap_IntLookupEntry = {
   },
 };
 
-const createBaseSimpleWithSnakeCaseMap = (): SimpleWithSnakeCaseMap => ({});
+function createBaseSimpleWithSnakeCaseMap(): SimpleWithSnakeCaseMap {
+  return { entitiesById: {} };
+}
 
 export const SimpleWithSnakeCaseMap = {
   encode(message: SimpleWithSnakeCaseMap, writer: Writer = Writer.create()): Writer {
@@ -1160,7 +1188,6 @@ export const SimpleWithSnakeCaseMap = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseSimpleWithSnakeCaseMap();
-    message.entitiesById = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -1216,7 +1243,9 @@ export const SimpleWithSnakeCaseMap = {
   },
 };
 
-const createBaseSimpleWithSnakeCaseMap_EntitiesByIdEntry = (): SimpleWithSnakeCaseMap_EntitiesByIdEntry => ({ key: 0 });
+function createBaseSimpleWithSnakeCaseMap_EntitiesByIdEntry(): SimpleWithSnakeCaseMap_EntitiesByIdEntry {
+  return { key: 0, value: undefined };
+}
 
 export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
   encode(message: SimpleWithSnakeCaseMap_EntitiesByIdEntry, writer: Writer = Writer.create()): Writer {
@@ -1274,7 +1303,9 @@ export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
   },
 };
 
-const createBasePingRequest = (): PingRequest => ({ input: '' });
+function createBasePingRequest(): PingRequest {
+  return { input: '' };
+}
 
 export const PingRequest = {
   encode(message: PingRequest, writer: Writer = Writer.create()): Writer {
@@ -1321,7 +1352,9 @@ export const PingRequest = {
   },
 };
 
-const createBasePingResponse = (): PingResponse => ({ output: '' });
+function createBasePingResponse(): PingResponse {
+  return { output: '' };
+}
 
 export const PingResponse = {
   encode(message: PingResponse, writer: Writer = Writer.create()): Writer {
@@ -1368,20 +1401,22 @@ export const PingResponse = {
   },
 };
 
-const createBaseNumbers = (): Numbers => ({
-  double: 0,
-  float: 0,
-  int32: 0,
-  int64: 0,
-  uint32: 0,
-  uint64: 0,
-  sint32: 0,
-  sint64: 0,
-  fixed32: 0,
-  fixed64: 0,
-  sfixed32: 0,
-  sfixed64: 0,
-});
+function createBaseNumbers(): Numbers {
+  return {
+    double: 0,
+    float: 0,
+    int32: 0,
+    int64: 0,
+    uint32: 0,
+    uint64: 0,
+    sint32: 0,
+    sint64: 0,
+    fixed32: 0,
+    fixed64: 0,
+    sfixed32: 0,
+    sfixed64: 0,
+  };
+}
 
 export const Numbers = {
   encode(message: Numbers, writer: Writer = Writer.create()): Writer {

--- a/integration/simple-optionals/simple.ts
+++ b/integration/simple-optionals/simple.ts
@@ -235,7 +235,7 @@ export interface Numbers {
   sfixed64: number;
 }
 
-const baseSimple: object = { name: '', age: 0, state: 0, coins: 0, snacks: '', oldStates: 0 };
+const createBaseSimple = (): Simple => ({ name: '', age: 0, state: 0, coins: 0, snacks: '', oldStates: 0 });
 
 export const Simple = {
   encode(message: Simple, writer: Writer = Writer.create()): Writer {
@@ -279,7 +279,7 @@ export const Simple = {
   decode(input: Reader | Uint8Array, length?: number): Simple {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimple } as Simple;
+    const message = createBaseSimple();
     message.grandChildren = [];
     message.coins = [];
     message.snacks = [];
@@ -340,7 +340,7 @@ export const Simple = {
   },
 
   fromJSON(object: any): Simple {
-    const message = { ...baseSimple } as Simple;
+    const message = createBaseSimple();
     message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
     message.age = object.age !== undefined && object.age !== null ? Number(object.age) : 0;
     message.createdAt =
@@ -388,7 +388,7 @@ export const Simple = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Simple>, I>>(object: I): Simple {
-    const message = { ...baseSimple } as Simple;
+    const message = createBaseSimple();
     message.name = object.name ?? '';
     message.age = object.age ?? 0;
     message.createdAt = object.createdAt ?? undefined;
@@ -404,7 +404,7 @@ export const Simple = {
   },
 };
 
-const baseChild: object = { name: '', type: 0 };
+const createBaseChild = (): Child => ({ name: '', type: 0 });
 
 export const Child = {
   encode(message: Child, writer: Writer = Writer.create()): Writer {
@@ -420,7 +420,7 @@ export const Child = {
   decode(input: Reader | Uint8Array, length?: number): Child {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseChild } as Child;
+    const message = createBaseChild();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -439,7 +439,7 @@ export const Child = {
   },
 
   fromJSON(object: any): Child {
-    const message = { ...baseChild } as Child;
+    const message = createBaseChild();
     message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
     message.type = object.type !== undefined && object.type !== null ? child_TypeFromJSON(object.type) : 0;
     return message;
@@ -453,14 +453,14 @@ export const Child = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Child>, I>>(object: I): Child {
-    const message = { ...baseChild } as Child;
+    const message = createBaseChild();
     message.name = object.name ?? '';
     message.type = object.type ?? 0;
     return message;
   },
 };
 
-const baseNested: object = { name: '', state: 0 };
+const createBaseNested = (): Nested => ({ name: '', state: 0 });
 
 export const Nested = {
   encode(message: Nested, writer: Writer = Writer.create()): Writer {
@@ -479,7 +479,7 @@ export const Nested = {
   decode(input: Reader | Uint8Array, length?: number): Nested {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseNested } as Nested;
+    const message = createBaseNested();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -501,7 +501,7 @@ export const Nested = {
   },
 
   fromJSON(object: any): Nested {
-    const message = { ...baseNested } as Nested;
+    const message = createBaseNested();
     message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
     message.message =
       object.message !== undefined && object.message !== null
@@ -521,7 +521,7 @@ export const Nested = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Nested>, I>>(object: I): Nested {
-    const message = { ...baseNested } as Nested;
+    const message = createBaseNested();
     message.name = object.name ?? '';
     message.message =
       object.message !== undefined && object.message !== null
@@ -532,7 +532,7 @@ export const Nested = {
   },
 };
 
-const baseNested_InnerMessage: object = { name: '' };
+const createBaseNested_InnerMessage = (): Nested_InnerMessage => ({ name: '' });
 
 export const Nested_InnerMessage = {
   encode(message: Nested_InnerMessage, writer: Writer = Writer.create()): Writer {
@@ -548,7 +548,7 @@ export const Nested_InnerMessage = {
   decode(input: Reader | Uint8Array, length?: number): Nested_InnerMessage {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseNested_InnerMessage } as Nested_InnerMessage;
+    const message = createBaseNested_InnerMessage();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -567,7 +567,7 @@ export const Nested_InnerMessage = {
   },
 
   fromJSON(object: any): Nested_InnerMessage {
-    const message = { ...baseNested_InnerMessage } as Nested_InnerMessage;
+    const message = createBaseNested_InnerMessage();
     message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
     message.deep =
       object.deep !== undefined && object.deep !== null
@@ -585,7 +585,7 @@ export const Nested_InnerMessage = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Nested_InnerMessage>, I>>(object: I): Nested_InnerMessage {
-    const message = { ...baseNested_InnerMessage } as Nested_InnerMessage;
+    const message = createBaseNested_InnerMessage();
     message.name = object.name ?? '';
     message.deep =
       object.deep !== undefined && object.deep !== null
@@ -595,7 +595,7 @@ export const Nested_InnerMessage = {
   },
 };
 
-const baseNested_InnerMessage_DeepMessage: object = { name: '' };
+const createBaseNested_InnerMessage_DeepMessage = (): Nested_InnerMessage_DeepMessage => ({ name: '' });
 
 export const Nested_InnerMessage_DeepMessage = {
   encode(message: Nested_InnerMessage_DeepMessage, writer: Writer = Writer.create()): Writer {
@@ -608,7 +608,7 @@ export const Nested_InnerMessage_DeepMessage = {
   decode(input: Reader | Uint8Array, length?: number): Nested_InnerMessage_DeepMessage {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseNested_InnerMessage_DeepMessage } as Nested_InnerMessage_DeepMessage;
+    const message = createBaseNested_InnerMessage_DeepMessage();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -624,7 +624,7 @@ export const Nested_InnerMessage_DeepMessage = {
   },
 
   fromJSON(object: any): Nested_InnerMessage_DeepMessage {
-    const message = { ...baseNested_InnerMessage_DeepMessage } as Nested_InnerMessage_DeepMessage;
+    const message = createBaseNested_InnerMessage_DeepMessage();
     message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
     return message;
   },
@@ -638,13 +638,13 @@ export const Nested_InnerMessage_DeepMessage = {
   fromPartial<I extends Exact<DeepPartial<Nested_InnerMessage_DeepMessage>, I>>(
     object: I
   ): Nested_InnerMessage_DeepMessage {
-    const message = { ...baseNested_InnerMessage_DeepMessage } as Nested_InnerMessage_DeepMessage;
+    const message = createBaseNested_InnerMessage_DeepMessage();
     message.name = object.name ?? '';
     return message;
   },
 };
 
-const baseOneOfMessage: object = {};
+const createBaseOneOfMessage = (): OneOfMessage => ({});
 
 export const OneOfMessage = {
   encode(message: OneOfMessage, writer: Writer = Writer.create()): Writer {
@@ -660,7 +660,7 @@ export const OneOfMessage = {
   decode(input: Reader | Uint8Array, length?: number): OneOfMessage {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseOneOfMessage } as OneOfMessage;
+    const message = createBaseOneOfMessage();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -679,7 +679,7 @@ export const OneOfMessage = {
   },
 
   fromJSON(object: any): OneOfMessage {
-    const message = { ...baseOneOfMessage } as OneOfMessage;
+    const message = createBaseOneOfMessage();
     message.first = object.first !== undefined && object.first !== null ? String(object.first) : undefined;
     message.last = object.last !== undefined && object.last !== null ? String(object.last) : undefined;
     return message;
@@ -693,14 +693,14 @@ export const OneOfMessage = {
   },
 
   fromPartial<I extends Exact<DeepPartial<OneOfMessage>, I>>(object: I): OneOfMessage {
-    const message = { ...baseOneOfMessage } as OneOfMessage;
+    const message = createBaseOneOfMessage();
     message.first = object.first ?? undefined;
     message.last = object.last ?? undefined;
     return message;
   },
 };
 
-const baseSimpleWithWrappers: object = {};
+const createBaseSimpleWithWrappers = (): SimpleWithWrappers => ({});
 
 export const SimpleWithWrappers = {
   encode(message: SimpleWithWrappers, writer: Writer = Writer.create()): Writer {
@@ -725,7 +725,7 @@ export const SimpleWithWrappers = {
   decode(input: Reader | Uint8Array, length?: number): SimpleWithWrappers {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimpleWithWrappers } as SimpleWithWrappers;
+    const message = createBaseSimpleWithWrappers();
     message.coins = [];
     message.snacks = [];
     while (reader.pos < end) {
@@ -755,7 +755,7 @@ export const SimpleWithWrappers = {
   },
 
   fromJSON(object: any): SimpleWithWrappers {
-    const message = { ...baseSimpleWithWrappers } as SimpleWithWrappers;
+    const message = createBaseSimpleWithWrappers();
     message.name = object.name !== undefined && object.name !== null ? String(object.name) : undefined;
     message.age = object.age !== undefined && object.age !== null ? Number(object.age) : undefined;
     message.enabled = object.enabled !== undefined && object.enabled !== null ? Boolean(object.enabled) : undefined;
@@ -783,7 +783,7 @@ export const SimpleWithWrappers = {
   },
 
   fromPartial<I extends Exact<DeepPartial<SimpleWithWrappers>, I>>(object: I): SimpleWithWrappers {
-    const message = { ...baseSimpleWithWrappers } as SimpleWithWrappers;
+    const message = createBaseSimpleWithWrappers();
     message.name = object.name ?? undefined;
     message.age = object.age ?? undefined;
     message.enabled = object.enabled ?? undefined;
@@ -793,7 +793,7 @@ export const SimpleWithWrappers = {
   },
 };
 
-const baseEntity: object = { id: 0 };
+const createBaseEntity = (): Entity => ({ id: 0 });
 
 export const Entity = {
   encode(message: Entity, writer: Writer = Writer.create()): Writer {
@@ -806,7 +806,7 @@ export const Entity = {
   decode(input: Reader | Uint8Array, length?: number): Entity {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseEntity } as Entity;
+    const message = createBaseEntity();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -822,7 +822,7 @@ export const Entity = {
   },
 
   fromJSON(object: any): Entity {
-    const message = { ...baseEntity } as Entity;
+    const message = createBaseEntity();
     message.id = object.id !== undefined && object.id !== null ? Number(object.id) : 0;
     return message;
   },
@@ -834,13 +834,13 @@ export const Entity = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Entity>, I>>(object: I): Entity {
-    const message = { ...baseEntity } as Entity;
+    const message = createBaseEntity();
     message.id = object.id ?? 0;
     return message;
   },
 };
 
-const baseSimpleWithMap: object = {};
+const createBaseSimpleWithMap = (): SimpleWithMap => ({});
 
 export const SimpleWithMap = {
   encode(message: SimpleWithMap, writer: Writer = Writer.create()): Writer {
@@ -859,7 +859,7 @@ export const SimpleWithMap = {
   decode(input: Reader | Uint8Array, length?: number): SimpleWithMap {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimpleWithMap } as SimpleWithMap;
+    const message = createBaseSimpleWithMap();
     message.entitiesById = {};
     message.nameLookup = {};
     message.intLookup = {};
@@ -893,7 +893,7 @@ export const SimpleWithMap = {
   },
 
   fromJSON(object: any): SimpleWithMap {
-    const message = { ...baseSimpleWithMap } as SimpleWithMap;
+    const message = createBaseSimpleWithMap();
     message.entitiesById = Object.entries(object.entitiesById ?? {}).reduce<{ [key: number]: Entity }>(
       (acc, [key, value]) => {
         acc[Number(key)] = Entity.fromJSON(value);
@@ -942,7 +942,7 @@ export const SimpleWithMap = {
   },
 
   fromPartial<I extends Exact<DeepPartial<SimpleWithMap>, I>>(object: I): SimpleWithMap {
-    const message = { ...baseSimpleWithMap } as SimpleWithMap;
+    const message = createBaseSimpleWithMap();
     message.entitiesById = Object.entries(object.entitiesById ?? {}).reduce<{ [key: number]: Entity }>(
       (acc, [key, value]) => {
         if (value !== undefined) {
@@ -974,7 +974,7 @@ export const SimpleWithMap = {
   },
 };
 
-const baseSimpleWithMap_EntitiesByIdEntry: object = { key: 0 };
+const createBaseSimpleWithMap_EntitiesByIdEntry = (): SimpleWithMap_EntitiesByIdEntry => ({ key: 0 });
 
 export const SimpleWithMap_EntitiesByIdEntry = {
   encode(message: SimpleWithMap_EntitiesByIdEntry, writer: Writer = Writer.create()): Writer {
@@ -990,7 +990,7 @@ export const SimpleWithMap_EntitiesByIdEntry = {
   decode(input: Reader | Uint8Array, length?: number): SimpleWithMap_EntitiesByIdEntry {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimpleWithMap_EntitiesByIdEntry } as SimpleWithMap_EntitiesByIdEntry;
+    const message = createBaseSimpleWithMap_EntitiesByIdEntry();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -1009,7 +1009,7 @@ export const SimpleWithMap_EntitiesByIdEntry = {
   },
 
   fromJSON(object: any): SimpleWithMap_EntitiesByIdEntry {
-    const message = { ...baseSimpleWithMap_EntitiesByIdEntry } as SimpleWithMap_EntitiesByIdEntry;
+    const message = createBaseSimpleWithMap_EntitiesByIdEntry();
     message.key = object.key !== undefined && object.key !== null ? Number(object.key) : 0;
     message.value = object.value !== undefined && object.value !== null ? Entity.fromJSON(object.value) : undefined;
     return message;
@@ -1025,14 +1025,14 @@ export const SimpleWithMap_EntitiesByIdEntry = {
   fromPartial<I extends Exact<DeepPartial<SimpleWithMap_EntitiesByIdEntry>, I>>(
     object: I
   ): SimpleWithMap_EntitiesByIdEntry {
-    const message = { ...baseSimpleWithMap_EntitiesByIdEntry } as SimpleWithMap_EntitiesByIdEntry;
+    const message = createBaseSimpleWithMap_EntitiesByIdEntry();
     message.key = object.key ?? 0;
     message.value = object.value !== undefined && object.value !== null ? Entity.fromPartial(object.value) : undefined;
     return message;
   },
 };
 
-const baseSimpleWithMap_NameLookupEntry: object = { key: '', value: '' };
+const createBaseSimpleWithMap_NameLookupEntry = (): SimpleWithMap_NameLookupEntry => ({ key: '', value: '' });
 
 export const SimpleWithMap_NameLookupEntry = {
   encode(message: SimpleWithMap_NameLookupEntry, writer: Writer = Writer.create()): Writer {
@@ -1048,7 +1048,7 @@ export const SimpleWithMap_NameLookupEntry = {
   decode(input: Reader | Uint8Array, length?: number): SimpleWithMap_NameLookupEntry {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimpleWithMap_NameLookupEntry } as SimpleWithMap_NameLookupEntry;
+    const message = createBaseSimpleWithMap_NameLookupEntry();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -1067,7 +1067,7 @@ export const SimpleWithMap_NameLookupEntry = {
   },
 
   fromJSON(object: any): SimpleWithMap_NameLookupEntry {
-    const message = { ...baseSimpleWithMap_NameLookupEntry } as SimpleWithMap_NameLookupEntry;
+    const message = createBaseSimpleWithMap_NameLookupEntry();
     message.key = object.key !== undefined && object.key !== null ? String(object.key) : '';
     message.value = object.value !== undefined && object.value !== null ? String(object.value) : '';
     return message;
@@ -1083,14 +1083,14 @@ export const SimpleWithMap_NameLookupEntry = {
   fromPartial<I extends Exact<DeepPartial<SimpleWithMap_NameLookupEntry>, I>>(
     object: I
   ): SimpleWithMap_NameLookupEntry {
-    const message = { ...baseSimpleWithMap_NameLookupEntry } as SimpleWithMap_NameLookupEntry;
+    const message = createBaseSimpleWithMap_NameLookupEntry();
     message.key = object.key ?? '';
     message.value = object.value ?? '';
     return message;
   },
 };
 
-const baseSimpleWithMap_IntLookupEntry: object = { key: 0, value: 0 };
+const createBaseSimpleWithMap_IntLookupEntry = (): SimpleWithMap_IntLookupEntry => ({ key: 0, value: 0 });
 
 export const SimpleWithMap_IntLookupEntry = {
   encode(message: SimpleWithMap_IntLookupEntry, writer: Writer = Writer.create()): Writer {
@@ -1106,7 +1106,7 @@ export const SimpleWithMap_IntLookupEntry = {
   decode(input: Reader | Uint8Array, length?: number): SimpleWithMap_IntLookupEntry {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimpleWithMap_IntLookupEntry } as SimpleWithMap_IntLookupEntry;
+    const message = createBaseSimpleWithMap_IntLookupEntry();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -1125,7 +1125,7 @@ export const SimpleWithMap_IntLookupEntry = {
   },
 
   fromJSON(object: any): SimpleWithMap_IntLookupEntry {
-    const message = { ...baseSimpleWithMap_IntLookupEntry } as SimpleWithMap_IntLookupEntry;
+    const message = createBaseSimpleWithMap_IntLookupEntry();
     message.key = object.key !== undefined && object.key !== null ? Number(object.key) : 0;
     message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
@@ -1139,14 +1139,14 @@ export const SimpleWithMap_IntLookupEntry = {
   },
 
   fromPartial<I extends Exact<DeepPartial<SimpleWithMap_IntLookupEntry>, I>>(object: I): SimpleWithMap_IntLookupEntry {
-    const message = { ...baseSimpleWithMap_IntLookupEntry } as SimpleWithMap_IntLookupEntry;
+    const message = createBaseSimpleWithMap_IntLookupEntry();
     message.key = object.key ?? 0;
     message.value = object.value ?? 0;
     return message;
   },
 };
 
-const baseSimpleWithSnakeCaseMap: object = {};
+const createBaseSimpleWithSnakeCaseMap = (): SimpleWithSnakeCaseMap => ({});
 
 export const SimpleWithSnakeCaseMap = {
   encode(message: SimpleWithSnakeCaseMap, writer: Writer = Writer.create()): Writer {
@@ -1159,7 +1159,7 @@ export const SimpleWithSnakeCaseMap = {
   decode(input: Reader | Uint8Array, length?: number): SimpleWithSnakeCaseMap {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimpleWithSnakeCaseMap } as SimpleWithSnakeCaseMap;
+    const message = createBaseSimpleWithSnakeCaseMap();
     message.entitiesById = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
@@ -1179,7 +1179,7 @@ export const SimpleWithSnakeCaseMap = {
   },
 
   fromJSON(object: any): SimpleWithSnakeCaseMap {
-    const message = { ...baseSimpleWithSnakeCaseMap } as SimpleWithSnakeCaseMap;
+    const message = createBaseSimpleWithSnakeCaseMap();
     message.entitiesById = Object.entries(object.entitiesById ?? {}).reduce<{ [key: number]: Entity }>(
       (acc, [key, value]) => {
         acc[Number(key)] = Entity.fromJSON(value);
@@ -1202,7 +1202,7 @@ export const SimpleWithSnakeCaseMap = {
   },
 
   fromPartial<I extends Exact<DeepPartial<SimpleWithSnakeCaseMap>, I>>(object: I): SimpleWithSnakeCaseMap {
-    const message = { ...baseSimpleWithSnakeCaseMap } as SimpleWithSnakeCaseMap;
+    const message = createBaseSimpleWithSnakeCaseMap();
     message.entitiesById = Object.entries(object.entitiesById ?? {}).reduce<{ [key: number]: Entity }>(
       (acc, [key, value]) => {
         if (value !== undefined) {
@@ -1216,7 +1216,7 @@ export const SimpleWithSnakeCaseMap = {
   },
 };
 
-const baseSimpleWithSnakeCaseMap_EntitiesByIdEntry: object = { key: 0 };
+const createBaseSimpleWithSnakeCaseMap_EntitiesByIdEntry = (): SimpleWithSnakeCaseMap_EntitiesByIdEntry => ({ key: 0 });
 
 export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
   encode(message: SimpleWithSnakeCaseMap_EntitiesByIdEntry, writer: Writer = Writer.create()): Writer {
@@ -1232,7 +1232,7 @@ export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
   decode(input: Reader | Uint8Array, length?: number): SimpleWithSnakeCaseMap_EntitiesByIdEntry {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimpleWithSnakeCaseMap_EntitiesByIdEntry } as SimpleWithSnakeCaseMap_EntitiesByIdEntry;
+    const message = createBaseSimpleWithSnakeCaseMap_EntitiesByIdEntry();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -1251,7 +1251,7 @@ export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
   },
 
   fromJSON(object: any): SimpleWithSnakeCaseMap_EntitiesByIdEntry {
-    const message = { ...baseSimpleWithSnakeCaseMap_EntitiesByIdEntry } as SimpleWithSnakeCaseMap_EntitiesByIdEntry;
+    const message = createBaseSimpleWithSnakeCaseMap_EntitiesByIdEntry();
     message.key = object.key !== undefined && object.key !== null ? Number(object.key) : 0;
     message.value = object.value !== undefined && object.value !== null ? Entity.fromJSON(object.value) : undefined;
     return message;
@@ -1267,14 +1267,14 @@ export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
   fromPartial<I extends Exact<DeepPartial<SimpleWithSnakeCaseMap_EntitiesByIdEntry>, I>>(
     object: I
   ): SimpleWithSnakeCaseMap_EntitiesByIdEntry {
-    const message = { ...baseSimpleWithSnakeCaseMap_EntitiesByIdEntry } as SimpleWithSnakeCaseMap_EntitiesByIdEntry;
+    const message = createBaseSimpleWithSnakeCaseMap_EntitiesByIdEntry();
     message.key = object.key ?? 0;
     message.value = object.value !== undefined && object.value !== null ? Entity.fromPartial(object.value) : undefined;
     return message;
   },
 };
 
-const basePingRequest: object = { input: '' };
+const createBasePingRequest = (): PingRequest => ({ input: '' });
 
 export const PingRequest = {
   encode(message: PingRequest, writer: Writer = Writer.create()): Writer {
@@ -1287,7 +1287,7 @@ export const PingRequest = {
   decode(input: Reader | Uint8Array, length?: number): PingRequest {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...basePingRequest } as PingRequest;
+    const message = createBasePingRequest();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -1303,7 +1303,7 @@ export const PingRequest = {
   },
 
   fromJSON(object: any): PingRequest {
-    const message = { ...basePingRequest } as PingRequest;
+    const message = createBasePingRequest();
     message.input = object.input !== undefined && object.input !== null ? String(object.input) : '';
     return message;
   },
@@ -1315,13 +1315,13 @@ export const PingRequest = {
   },
 
   fromPartial<I extends Exact<DeepPartial<PingRequest>, I>>(object: I): PingRequest {
-    const message = { ...basePingRequest } as PingRequest;
+    const message = createBasePingRequest();
     message.input = object.input ?? '';
     return message;
   },
 };
 
-const basePingResponse: object = { output: '' };
+const createBasePingResponse = (): PingResponse => ({ output: '' });
 
 export const PingResponse = {
   encode(message: PingResponse, writer: Writer = Writer.create()): Writer {
@@ -1334,7 +1334,7 @@ export const PingResponse = {
   decode(input: Reader | Uint8Array, length?: number): PingResponse {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...basePingResponse } as PingResponse;
+    const message = createBasePingResponse();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -1350,7 +1350,7 @@ export const PingResponse = {
   },
 
   fromJSON(object: any): PingResponse {
-    const message = { ...basePingResponse } as PingResponse;
+    const message = createBasePingResponse();
     message.output = object.output !== undefined && object.output !== null ? String(object.output) : '';
     return message;
   },
@@ -1362,13 +1362,13 @@ export const PingResponse = {
   },
 
   fromPartial<I extends Exact<DeepPartial<PingResponse>, I>>(object: I): PingResponse {
-    const message = { ...basePingResponse } as PingResponse;
+    const message = createBasePingResponse();
     message.output = object.output ?? '';
     return message;
   },
 };
 
-const baseNumbers: object = {
+const createBaseNumbers = (): Numbers => ({
   double: 0,
   float: 0,
   int32: 0,
@@ -1381,7 +1381,7 @@ const baseNumbers: object = {
   fixed64: 0,
   sfixed32: 0,
   sfixed64: 0,
-};
+});
 
 export const Numbers = {
   encode(message: Numbers, writer: Writer = Writer.create()): Writer {
@@ -1427,7 +1427,7 @@ export const Numbers = {
   decode(input: Reader | Uint8Array, length?: number): Numbers {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseNumbers } as Numbers;
+    const message = createBaseNumbers();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -1476,7 +1476,7 @@ export const Numbers = {
   },
 
   fromJSON(object: any): Numbers {
-    const message = { ...baseNumbers } as Numbers;
+    const message = createBaseNumbers();
     message.double = object.double !== undefined && object.double !== null ? Number(object.double) : 0;
     message.float = object.float !== undefined && object.float !== null ? Number(object.float) : 0;
     message.int32 = object.int32 !== undefined && object.int32 !== null ? Number(object.int32) : 0;
@@ -1510,7 +1510,7 @@ export const Numbers = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Numbers>, I>>(object: I): Numbers {
-    const message = { ...baseNumbers } as Numbers;
+    const message = createBaseNumbers();
     message.double = object.double ?? 0;
     message.float = object.float ?? 0;
     message.int32 = object.int32 ?? 0;

--- a/integration/simple-optionals/thing.ts
+++ b/integration/simple-optionals/thing.ts
@@ -9,7 +9,7 @@ export interface ImportedThing {
   createdAt?: Date;
 }
 
-const baseImportedThing: object = {};
+const createBaseImportedThing = (): ImportedThing => ({});
 
 export const ImportedThing = {
   encode(message: ImportedThing, writer: Writer = Writer.create()): Writer {
@@ -22,7 +22,7 @@ export const ImportedThing = {
   decode(input: Reader | Uint8Array, length?: number): ImportedThing {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseImportedThing } as ImportedThing;
+    const message = createBaseImportedThing();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -38,7 +38,7 @@ export const ImportedThing = {
   },
 
   fromJSON(object: any): ImportedThing {
-    const message = { ...baseImportedThing } as ImportedThing;
+    const message = createBaseImportedThing();
     message.createdAt =
       object.createdAt !== undefined && object.createdAt !== null ? fromJsonTimestamp(object.createdAt) : undefined;
     return message;
@@ -51,7 +51,7 @@ export const ImportedThing = {
   },
 
   fromPartial<I extends Exact<DeepPartial<ImportedThing>, I>>(object: I): ImportedThing {
-    const message = { ...baseImportedThing } as ImportedThing;
+    const message = createBaseImportedThing();
     message.createdAt = object.createdAt ?? undefined;
     return message;
   },

--- a/integration/simple-optionals/thing.ts
+++ b/integration/simple-optionals/thing.ts
@@ -9,7 +9,9 @@ export interface ImportedThing {
   createdAt?: Date;
 }
 
-const createBaseImportedThing = (): ImportedThing => ({});
+function createBaseImportedThing(): ImportedThing {
+  return { createdAt: undefined };
+}
 
 export const ImportedThing = {
   encode(message: ImportedThing, writer: Writer = Writer.create()): Writer {

--- a/integration/simple-proto2/simple.ts
+++ b/integration/simple-proto2/simple.ts
@@ -40,7 +40,7 @@ export interface Issue56 {
   test: EnumWithoutZero;
 }
 
-const baseIssue56: object = { test: 1 };
+const createBaseIssue56 = (): Issue56 => ({ test: 1 });
 
 export const Issue56 = {
   encode(message: Issue56, writer: Writer = Writer.create()): Writer {
@@ -53,7 +53,7 @@ export const Issue56 = {
   decode(input: Reader | Uint8Array, length?: number): Issue56 {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseIssue56 } as Issue56;
+    const message = createBaseIssue56();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -69,7 +69,7 @@ export const Issue56 = {
   },
 
   fromJSON(object: any): Issue56 {
-    const message = { ...baseIssue56 } as Issue56;
+    const message = createBaseIssue56();
     message.test = object.test !== undefined && object.test !== null ? enumWithoutZeroFromJSON(object.test) : 1;
     return message;
   },
@@ -81,7 +81,7 @@ export const Issue56 = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Issue56>, I>>(object: I): Issue56 {
-    const message = { ...baseIssue56 } as Issue56;
+    const message = createBaseIssue56();
     message.test = object.test ?? 1;
     return message;
   },

--- a/integration/simple-proto2/simple.ts
+++ b/integration/simple-proto2/simple.ts
@@ -40,7 +40,9 @@ export interface Issue56 {
   test: EnumWithoutZero;
 }
 
-const createBaseIssue56 = (): Issue56 => ({ test: 1 });
+function createBaseIssue56(): Issue56 {
+  return { test: 1 };
+}
 
 export const Issue56 = {
   encode(message: Issue56, writer: Writer = Writer.create()): Writer {

--- a/integration/simple-snake/google/protobuf/timestamp.ts
+++ b/integration/simple-snake/google/protobuf/timestamp.ts
@@ -113,7 +113,9 @@ export interface Timestamp {
   nanos: number;
 }
 
-const createBaseTimestamp = (): Timestamp => ({ seconds: 0, nanos: 0 });
+function createBaseTimestamp(): Timestamp {
+  return { seconds: 0, nanos: 0 };
+}
 
 export const Timestamp = {
   encode(message: Timestamp, writer: Writer = Writer.create()): Writer {

--- a/integration/simple-snake/google/protobuf/timestamp.ts
+++ b/integration/simple-snake/google/protobuf/timestamp.ts
@@ -113,7 +113,7 @@ export interface Timestamp {
   nanos: number;
 }
 
-const baseTimestamp: object = { seconds: 0, nanos: 0 };
+const createBaseTimestamp = (): Timestamp => ({ seconds: 0, nanos: 0 });
 
 export const Timestamp = {
   encode(message: Timestamp, writer: Writer = Writer.create()): Writer {
@@ -129,7 +129,7 @@ export const Timestamp = {
   decode(input: Reader | Uint8Array, length?: number): Timestamp {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseTimestamp } as Timestamp;
+    const message = createBaseTimestamp();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -148,7 +148,7 @@ export const Timestamp = {
   },
 
   fromJSON(object: any): Timestamp {
-    const message = { ...baseTimestamp } as Timestamp;
+    const message = createBaseTimestamp();
     message.seconds = object.seconds !== undefined && object.seconds !== null ? Number(object.seconds) : 0;
     message.nanos = object.nanos !== undefined && object.nanos !== null ? Number(object.nanos) : 0;
     return message;
@@ -162,7 +162,7 @@ export const Timestamp = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Timestamp>, I>>(object: I): Timestamp {
-    const message = { ...baseTimestamp } as Timestamp;
+    const message = createBaseTimestamp();
     message.seconds = object.seconds ?? 0;
     message.nanos = object.nanos ?? 0;
     return message;

--- a/integration/simple-snake/google/protobuf/wrappers.ts
+++ b/integration/simple-snake/google/protobuf/wrappers.ts
@@ -94,7 +94,9 @@ export interface BytesValue {
   value: Uint8Array;
 }
 
-const createBaseDoubleValue = (): DoubleValue => ({ value: 0 });
+function createBaseDoubleValue(): DoubleValue {
+  return { value: 0 };
+}
 
 export const DoubleValue = {
   encode(message: DoubleValue, writer: Writer = Writer.create()): Writer {
@@ -141,7 +143,9 @@ export const DoubleValue = {
   },
 };
 
-const createBaseFloatValue = (): FloatValue => ({ value: 0 });
+function createBaseFloatValue(): FloatValue {
+  return { value: 0 };
+}
 
 export const FloatValue = {
   encode(message: FloatValue, writer: Writer = Writer.create()): Writer {
@@ -188,7 +192,9 @@ export const FloatValue = {
   },
 };
 
-const createBaseInt64Value = (): Int64Value => ({ value: 0 });
+function createBaseInt64Value(): Int64Value {
+  return { value: 0 };
+}
 
 export const Int64Value = {
   encode(message: Int64Value, writer: Writer = Writer.create()): Writer {
@@ -235,7 +241,9 @@ export const Int64Value = {
   },
 };
 
-const createBaseUInt64Value = (): UInt64Value => ({ value: 0 });
+function createBaseUInt64Value(): UInt64Value {
+  return { value: 0 };
+}
 
 export const UInt64Value = {
   encode(message: UInt64Value, writer: Writer = Writer.create()): Writer {
@@ -282,7 +290,9 @@ export const UInt64Value = {
   },
 };
 
-const createBaseInt32Value = (): Int32Value => ({ value: 0 });
+function createBaseInt32Value(): Int32Value {
+  return { value: 0 };
+}
 
 export const Int32Value = {
   encode(message: Int32Value, writer: Writer = Writer.create()): Writer {
@@ -329,7 +339,9 @@ export const Int32Value = {
   },
 };
 
-const createBaseUInt32Value = (): UInt32Value => ({ value: 0 });
+function createBaseUInt32Value(): UInt32Value {
+  return { value: 0 };
+}
 
 export const UInt32Value = {
   encode(message: UInt32Value, writer: Writer = Writer.create()): Writer {
@@ -376,7 +388,9 @@ export const UInt32Value = {
   },
 };
 
-const createBaseBoolValue = (): BoolValue => ({ value: false });
+function createBaseBoolValue(): BoolValue {
+  return { value: false };
+}
 
 export const BoolValue = {
   encode(message: BoolValue, writer: Writer = Writer.create()): Writer {
@@ -423,7 +437,9 @@ export const BoolValue = {
   },
 };
 
-const createBaseStringValue = (): StringValue => ({ value: '' });
+function createBaseStringValue(): StringValue {
+  return { value: '' };
+}
 
 export const StringValue = {
   encode(message: StringValue, writer: Writer = Writer.create()): Writer {
@@ -470,7 +486,9 @@ export const StringValue = {
   },
 };
 
-const createBaseBytesValue = (): BytesValue => ({});
+function createBaseBytesValue(): BytesValue {
+  return { value: new Uint8Array() };
+}
 
 export const BytesValue = {
   encode(message: BytesValue, writer: Writer = Writer.create()): Writer {
@@ -484,7 +502,6 @@ export const BytesValue = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseBytesValue();
-    message.value = new Uint8Array();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {

--- a/integration/simple-snake/google/protobuf/wrappers.ts
+++ b/integration/simple-snake/google/protobuf/wrappers.ts
@@ -94,7 +94,7 @@ export interface BytesValue {
   value: Uint8Array;
 }
 
-const baseDoubleValue: object = { value: 0 };
+const createBaseDoubleValue = (): DoubleValue => ({ value: 0 });
 
 export const DoubleValue = {
   encode(message: DoubleValue, writer: Writer = Writer.create()): Writer {
@@ -107,7 +107,7 @@ export const DoubleValue = {
   decode(input: Reader | Uint8Array, length?: number): DoubleValue {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseDoubleValue } as DoubleValue;
+    const message = createBaseDoubleValue();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -123,7 +123,7 @@ export const DoubleValue = {
   },
 
   fromJSON(object: any): DoubleValue {
-    const message = { ...baseDoubleValue } as DoubleValue;
+    const message = createBaseDoubleValue();
     message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
@@ -135,13 +135,13 @@ export const DoubleValue = {
   },
 
   fromPartial<I extends Exact<DeepPartial<DoubleValue>, I>>(object: I): DoubleValue {
-    const message = { ...baseDoubleValue } as DoubleValue;
+    const message = createBaseDoubleValue();
     message.value = object.value ?? 0;
     return message;
   },
 };
 
-const baseFloatValue: object = { value: 0 };
+const createBaseFloatValue = (): FloatValue => ({ value: 0 });
 
 export const FloatValue = {
   encode(message: FloatValue, writer: Writer = Writer.create()): Writer {
@@ -154,7 +154,7 @@ export const FloatValue = {
   decode(input: Reader | Uint8Array, length?: number): FloatValue {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseFloatValue } as FloatValue;
+    const message = createBaseFloatValue();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -170,7 +170,7 @@ export const FloatValue = {
   },
 
   fromJSON(object: any): FloatValue {
-    const message = { ...baseFloatValue } as FloatValue;
+    const message = createBaseFloatValue();
     message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
@@ -182,13 +182,13 @@ export const FloatValue = {
   },
 
   fromPartial<I extends Exact<DeepPartial<FloatValue>, I>>(object: I): FloatValue {
-    const message = { ...baseFloatValue } as FloatValue;
+    const message = createBaseFloatValue();
     message.value = object.value ?? 0;
     return message;
   },
 };
 
-const baseInt64Value: object = { value: 0 };
+const createBaseInt64Value = (): Int64Value => ({ value: 0 });
 
 export const Int64Value = {
   encode(message: Int64Value, writer: Writer = Writer.create()): Writer {
@@ -201,7 +201,7 @@ export const Int64Value = {
   decode(input: Reader | Uint8Array, length?: number): Int64Value {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseInt64Value } as Int64Value;
+    const message = createBaseInt64Value();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -217,7 +217,7 @@ export const Int64Value = {
   },
 
   fromJSON(object: any): Int64Value {
-    const message = { ...baseInt64Value } as Int64Value;
+    const message = createBaseInt64Value();
     message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
@@ -229,13 +229,13 @@ export const Int64Value = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Int64Value>, I>>(object: I): Int64Value {
-    const message = { ...baseInt64Value } as Int64Value;
+    const message = createBaseInt64Value();
     message.value = object.value ?? 0;
     return message;
   },
 };
 
-const baseUInt64Value: object = { value: 0 };
+const createBaseUInt64Value = (): UInt64Value => ({ value: 0 });
 
 export const UInt64Value = {
   encode(message: UInt64Value, writer: Writer = Writer.create()): Writer {
@@ -248,7 +248,7 @@ export const UInt64Value = {
   decode(input: Reader | Uint8Array, length?: number): UInt64Value {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseUInt64Value } as UInt64Value;
+    const message = createBaseUInt64Value();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -264,7 +264,7 @@ export const UInt64Value = {
   },
 
   fromJSON(object: any): UInt64Value {
-    const message = { ...baseUInt64Value } as UInt64Value;
+    const message = createBaseUInt64Value();
     message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
@@ -276,13 +276,13 @@ export const UInt64Value = {
   },
 
   fromPartial<I extends Exact<DeepPartial<UInt64Value>, I>>(object: I): UInt64Value {
-    const message = { ...baseUInt64Value } as UInt64Value;
+    const message = createBaseUInt64Value();
     message.value = object.value ?? 0;
     return message;
   },
 };
 
-const baseInt32Value: object = { value: 0 };
+const createBaseInt32Value = (): Int32Value => ({ value: 0 });
 
 export const Int32Value = {
   encode(message: Int32Value, writer: Writer = Writer.create()): Writer {
@@ -295,7 +295,7 @@ export const Int32Value = {
   decode(input: Reader | Uint8Array, length?: number): Int32Value {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseInt32Value } as Int32Value;
+    const message = createBaseInt32Value();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -311,7 +311,7 @@ export const Int32Value = {
   },
 
   fromJSON(object: any): Int32Value {
-    const message = { ...baseInt32Value } as Int32Value;
+    const message = createBaseInt32Value();
     message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
@@ -323,13 +323,13 @@ export const Int32Value = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Int32Value>, I>>(object: I): Int32Value {
-    const message = { ...baseInt32Value } as Int32Value;
+    const message = createBaseInt32Value();
     message.value = object.value ?? 0;
     return message;
   },
 };
 
-const baseUInt32Value: object = { value: 0 };
+const createBaseUInt32Value = (): UInt32Value => ({ value: 0 });
 
 export const UInt32Value = {
   encode(message: UInt32Value, writer: Writer = Writer.create()): Writer {
@@ -342,7 +342,7 @@ export const UInt32Value = {
   decode(input: Reader | Uint8Array, length?: number): UInt32Value {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseUInt32Value } as UInt32Value;
+    const message = createBaseUInt32Value();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -358,7 +358,7 @@ export const UInt32Value = {
   },
 
   fromJSON(object: any): UInt32Value {
-    const message = { ...baseUInt32Value } as UInt32Value;
+    const message = createBaseUInt32Value();
     message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
@@ -370,13 +370,13 @@ export const UInt32Value = {
   },
 
   fromPartial<I extends Exact<DeepPartial<UInt32Value>, I>>(object: I): UInt32Value {
-    const message = { ...baseUInt32Value } as UInt32Value;
+    const message = createBaseUInt32Value();
     message.value = object.value ?? 0;
     return message;
   },
 };
 
-const baseBoolValue: object = { value: false };
+const createBaseBoolValue = (): BoolValue => ({ value: false });
 
 export const BoolValue = {
   encode(message: BoolValue, writer: Writer = Writer.create()): Writer {
@@ -389,7 +389,7 @@ export const BoolValue = {
   decode(input: Reader | Uint8Array, length?: number): BoolValue {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseBoolValue } as BoolValue;
+    const message = createBaseBoolValue();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -405,7 +405,7 @@ export const BoolValue = {
   },
 
   fromJSON(object: any): BoolValue {
-    const message = { ...baseBoolValue } as BoolValue;
+    const message = createBaseBoolValue();
     message.value = object.value !== undefined && object.value !== null ? Boolean(object.value) : false;
     return message;
   },
@@ -417,13 +417,13 @@ export const BoolValue = {
   },
 
   fromPartial<I extends Exact<DeepPartial<BoolValue>, I>>(object: I): BoolValue {
-    const message = { ...baseBoolValue } as BoolValue;
+    const message = createBaseBoolValue();
     message.value = object.value ?? false;
     return message;
   },
 };
 
-const baseStringValue: object = { value: '' };
+const createBaseStringValue = (): StringValue => ({ value: '' });
 
 export const StringValue = {
   encode(message: StringValue, writer: Writer = Writer.create()): Writer {
@@ -436,7 +436,7 @@ export const StringValue = {
   decode(input: Reader | Uint8Array, length?: number): StringValue {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseStringValue } as StringValue;
+    const message = createBaseStringValue();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -452,7 +452,7 @@ export const StringValue = {
   },
 
   fromJSON(object: any): StringValue {
-    const message = { ...baseStringValue } as StringValue;
+    const message = createBaseStringValue();
     message.value = object.value !== undefined && object.value !== null ? String(object.value) : '';
     return message;
   },
@@ -464,13 +464,13 @@ export const StringValue = {
   },
 
   fromPartial<I extends Exact<DeepPartial<StringValue>, I>>(object: I): StringValue {
-    const message = { ...baseStringValue } as StringValue;
+    const message = createBaseStringValue();
     message.value = object.value ?? '';
     return message;
   },
 };
 
-const baseBytesValue: object = {};
+const createBaseBytesValue = (): BytesValue => ({});
 
 export const BytesValue = {
   encode(message: BytesValue, writer: Writer = Writer.create()): Writer {
@@ -483,7 +483,7 @@ export const BytesValue = {
   decode(input: Reader | Uint8Array, length?: number): BytesValue {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseBytesValue } as BytesValue;
+    const message = createBaseBytesValue();
     message.value = new Uint8Array();
     while (reader.pos < end) {
       const tag = reader.uint32();
@@ -500,7 +500,7 @@ export const BytesValue = {
   },
 
   fromJSON(object: any): BytesValue {
-    const message = { ...baseBytesValue } as BytesValue;
+    const message = createBaseBytesValue();
     message.value =
       object.value !== undefined && object.value !== null ? bytesFromBase64(object.value) : new Uint8Array();
     return message;
@@ -514,7 +514,7 @@ export const BytesValue = {
   },
 
   fromPartial<I extends Exact<DeepPartial<BytesValue>, I>>(object: I): BytesValue {
-    const message = { ...baseBytesValue } as BytesValue;
+    const message = createBaseBytesValue();
     message.value = object.value ?? new Uint8Array();
     return message;
   },

--- a/integration/simple-snake/import_dir/thing.ts
+++ b/integration/simple-snake/import_dir/thing.ts
@@ -9,7 +9,9 @@ export interface ImportedThing {
   created_at: Date | undefined;
 }
 
-const createBaseImportedThing = (): ImportedThing => ({});
+function createBaseImportedThing(): ImportedThing {
+  return { created_at: undefined };
+}
 
 export const ImportedThing = {
   encode(message: ImportedThing, writer: Writer = Writer.create()): Writer {

--- a/integration/simple-snake/import_dir/thing.ts
+++ b/integration/simple-snake/import_dir/thing.ts
@@ -9,7 +9,7 @@ export interface ImportedThing {
   created_at: Date | undefined;
 }
 
-const baseImportedThing: object = {};
+const createBaseImportedThing = (): ImportedThing => ({});
 
 export const ImportedThing = {
   encode(message: ImportedThing, writer: Writer = Writer.create()): Writer {
@@ -22,7 +22,7 @@ export const ImportedThing = {
   decode(input: Reader | Uint8Array, length?: number): ImportedThing {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseImportedThing } as ImportedThing;
+    const message = createBaseImportedThing();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -38,7 +38,7 @@ export const ImportedThing = {
   },
 
   fromJSON(object: any): ImportedThing {
-    const message = { ...baseImportedThing } as ImportedThing;
+    const message = createBaseImportedThing();
     message.created_at =
       object.created_at !== undefined && object.created_at !== null ? fromJsonTimestamp(object.created_at) : undefined;
     return message;
@@ -51,7 +51,7 @@ export const ImportedThing = {
   },
 
   fromPartial<I extends Exact<DeepPartial<ImportedThing>, I>>(object: I): ImportedThing {
-    const message = { ...baseImportedThing } as ImportedThing;
+    const message = createBaseImportedThing();
     message.created_at = object.created_at ?? undefined;
     return message;
   },

--- a/integration/simple-snake/simple.ts
+++ b/integration/simple-snake/simple.ts
@@ -235,7 +235,20 @@ export interface Numbers {
   sfixed64: number;
 }
 
-const createBaseSimple = (): Simple => ({ name: '', age: 0, state: 0, coins: 0, snacks: '', old_states: 0 });
+function createBaseSimple(): Simple {
+  return {
+    name: '',
+    age: 0,
+    created_at: undefined,
+    child: undefined,
+    state: 0,
+    grand_children: [],
+    coins: [],
+    snacks: [],
+    old_states: [],
+    thing: undefined,
+  };
+}
 
 export const Simple = {
   encode(message: Simple, writer: Writer = Writer.create()): Writer {
@@ -280,10 +293,6 @@ export const Simple = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseSimple();
-    message.grand_children = [];
-    message.coins = [];
-    message.snacks = [];
-    message.old_states = [];
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -404,7 +413,9 @@ export const Simple = {
   },
 };
 
-const createBaseChild = (): Child => ({ name: '', type: 0 });
+function createBaseChild(): Child {
+  return { name: '', type: 0 };
+}
 
 export const Child = {
   encode(message: Child, writer: Writer = Writer.create()): Writer {
@@ -460,7 +471,9 @@ export const Child = {
   },
 };
 
-const createBaseNested = (): Nested => ({ name: '', state: 0 });
+function createBaseNested(): Nested {
+  return { name: '', message: undefined, state: 0 };
+}
 
 export const Nested = {
   encode(message: Nested, writer: Writer = Writer.create()): Writer {
@@ -532,7 +545,9 @@ export const Nested = {
   },
 };
 
-const createBaseNested_InnerMessage = (): Nested_InnerMessage => ({ name: '' });
+function createBaseNested_InnerMessage(): Nested_InnerMessage {
+  return { name: '', deep: undefined };
+}
 
 export const Nested_InnerMessage = {
   encode(message: Nested_InnerMessage, writer: Writer = Writer.create()): Writer {
@@ -595,7 +610,9 @@ export const Nested_InnerMessage = {
   },
 };
 
-const createBaseNested_InnerMessage_DeepMessage = (): Nested_InnerMessage_DeepMessage => ({ name: '' });
+function createBaseNested_InnerMessage_DeepMessage(): Nested_InnerMessage_DeepMessage {
+  return { name: '' };
+}
 
 export const Nested_InnerMessage_DeepMessage = {
   encode(message: Nested_InnerMessage_DeepMessage, writer: Writer = Writer.create()): Writer {
@@ -644,7 +661,9 @@ export const Nested_InnerMessage_DeepMessage = {
   },
 };
 
-const createBaseOneOfMessage = (): OneOfMessage => ({});
+function createBaseOneOfMessage(): OneOfMessage {
+  return { first: undefined, last: undefined };
+}
 
 export const OneOfMessage = {
   encode(message: OneOfMessage, writer: Writer = Writer.create()): Writer {
@@ -700,7 +719,9 @@ export const OneOfMessage = {
   },
 };
 
-const createBaseSimpleWithWrappers = (): SimpleWithWrappers => ({});
+function createBaseSimpleWithWrappers(): SimpleWithWrappers {
+  return { name: undefined, age: undefined, enabled: undefined, coins: [], snacks: [] };
+}
 
 export const SimpleWithWrappers = {
   encode(message: SimpleWithWrappers, writer: Writer = Writer.create()): Writer {
@@ -726,8 +747,6 @@ export const SimpleWithWrappers = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseSimpleWithWrappers();
-    message.coins = [];
-    message.snacks = [];
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -793,7 +812,9 @@ export const SimpleWithWrappers = {
   },
 };
 
-const createBaseEntity = (): Entity => ({ id: 0 });
+function createBaseEntity(): Entity {
+  return { id: 0 };
+}
 
 export const Entity = {
   encode(message: Entity, writer: Writer = Writer.create()): Writer {
@@ -840,7 +861,9 @@ export const Entity = {
   },
 };
 
-const createBaseSimpleWithMap = (): SimpleWithMap => ({});
+function createBaseSimpleWithMap(): SimpleWithMap {
+  return { entitiesById: {}, nameLookup: {}, intLookup: {} };
+}
 
 export const SimpleWithMap = {
   encode(message: SimpleWithMap, writer: Writer = Writer.create()): Writer {
@@ -860,9 +883,6 @@ export const SimpleWithMap = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseSimpleWithMap();
-    message.entitiesById = {};
-    message.nameLookup = {};
-    message.intLookup = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -974,7 +994,9 @@ export const SimpleWithMap = {
   },
 };
 
-const createBaseSimpleWithMap_EntitiesByIdEntry = (): SimpleWithMap_EntitiesByIdEntry => ({ key: 0 });
+function createBaseSimpleWithMap_EntitiesByIdEntry(): SimpleWithMap_EntitiesByIdEntry {
+  return { key: 0, value: undefined };
+}
 
 export const SimpleWithMap_EntitiesByIdEntry = {
   encode(message: SimpleWithMap_EntitiesByIdEntry, writer: Writer = Writer.create()): Writer {
@@ -1032,7 +1054,9 @@ export const SimpleWithMap_EntitiesByIdEntry = {
   },
 };
 
-const createBaseSimpleWithMap_NameLookupEntry = (): SimpleWithMap_NameLookupEntry => ({ key: '', value: '' });
+function createBaseSimpleWithMap_NameLookupEntry(): SimpleWithMap_NameLookupEntry {
+  return { key: '', value: '' };
+}
 
 export const SimpleWithMap_NameLookupEntry = {
   encode(message: SimpleWithMap_NameLookupEntry, writer: Writer = Writer.create()): Writer {
@@ -1090,7 +1114,9 @@ export const SimpleWithMap_NameLookupEntry = {
   },
 };
 
-const createBaseSimpleWithMap_IntLookupEntry = (): SimpleWithMap_IntLookupEntry => ({ key: 0, value: 0 });
+function createBaseSimpleWithMap_IntLookupEntry(): SimpleWithMap_IntLookupEntry {
+  return { key: 0, value: 0 };
+}
 
 export const SimpleWithMap_IntLookupEntry = {
   encode(message: SimpleWithMap_IntLookupEntry, writer: Writer = Writer.create()): Writer {
@@ -1146,7 +1172,9 @@ export const SimpleWithMap_IntLookupEntry = {
   },
 };
 
-const createBaseSimpleWithSnakeCaseMap = (): SimpleWithSnakeCaseMap => ({});
+function createBaseSimpleWithSnakeCaseMap(): SimpleWithSnakeCaseMap {
+  return { entities_by_id: {} };
+}
 
 export const SimpleWithSnakeCaseMap = {
   encode(message: SimpleWithSnakeCaseMap, writer: Writer = Writer.create()): Writer {
@@ -1160,7 +1188,6 @@ export const SimpleWithSnakeCaseMap = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseSimpleWithSnakeCaseMap();
-    message.entities_by_id = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -1216,7 +1243,9 @@ export const SimpleWithSnakeCaseMap = {
   },
 };
 
-const createBaseSimpleWithSnakeCaseMap_EntitiesByIdEntry = (): SimpleWithSnakeCaseMap_EntitiesByIdEntry => ({ key: 0 });
+function createBaseSimpleWithSnakeCaseMap_EntitiesByIdEntry(): SimpleWithSnakeCaseMap_EntitiesByIdEntry {
+  return { key: 0, value: undefined };
+}
 
 export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
   encode(message: SimpleWithSnakeCaseMap_EntitiesByIdEntry, writer: Writer = Writer.create()): Writer {
@@ -1274,7 +1303,9 @@ export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
   },
 };
 
-const createBasePingRequest = (): PingRequest => ({ input: '' });
+function createBasePingRequest(): PingRequest {
+  return { input: '' };
+}
 
 export const PingRequest = {
   encode(message: PingRequest, writer: Writer = Writer.create()): Writer {
@@ -1321,7 +1352,9 @@ export const PingRequest = {
   },
 };
 
-const createBasePingResponse = (): PingResponse => ({ output: '' });
+function createBasePingResponse(): PingResponse {
+  return { output: '' };
+}
 
 export const PingResponse = {
   encode(message: PingResponse, writer: Writer = Writer.create()): Writer {
@@ -1368,20 +1401,22 @@ export const PingResponse = {
   },
 };
 
-const createBaseNumbers = (): Numbers => ({
-  double: 0,
-  float: 0,
-  int32: 0,
-  int64: 0,
-  uint32: 0,
-  uint64: 0,
-  sint32: 0,
-  sint64: 0,
-  fixed32: 0,
-  fixed64: 0,
-  sfixed32: 0,
-  sfixed64: 0,
-});
+function createBaseNumbers(): Numbers {
+  return {
+    double: 0,
+    float: 0,
+    int32: 0,
+    int64: 0,
+    uint32: 0,
+    uint64: 0,
+    sint32: 0,
+    sint64: 0,
+    fixed32: 0,
+    fixed64: 0,
+    sfixed32: 0,
+    sfixed64: 0,
+  };
+}
 
 export const Numbers = {
   encode(message: Numbers, writer: Writer = Writer.create()): Writer {

--- a/integration/simple-snake/simple.ts
+++ b/integration/simple-snake/simple.ts
@@ -235,7 +235,7 @@ export interface Numbers {
   sfixed64: number;
 }
 
-const baseSimple: object = { name: '', age: 0, state: 0, coins: 0, snacks: '', old_states: 0 };
+const createBaseSimple = (): Simple => ({ name: '', age: 0, state: 0, coins: 0, snacks: '', old_states: 0 });
 
 export const Simple = {
   encode(message: Simple, writer: Writer = Writer.create()): Writer {
@@ -279,7 +279,7 @@ export const Simple = {
   decode(input: Reader | Uint8Array, length?: number): Simple {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimple } as Simple;
+    const message = createBaseSimple();
     message.grand_children = [];
     message.coins = [];
     message.snacks = [];
@@ -340,7 +340,7 @@ export const Simple = {
   },
 
   fromJSON(object: any): Simple {
-    const message = { ...baseSimple } as Simple;
+    const message = createBaseSimple();
     message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
     message.age = object.age !== undefined && object.age !== null ? Number(object.age) : 0;
     message.created_at =
@@ -388,7 +388,7 @@ export const Simple = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Simple>, I>>(object: I): Simple {
-    const message = { ...baseSimple } as Simple;
+    const message = createBaseSimple();
     message.name = object.name ?? '';
     message.age = object.age ?? 0;
     message.created_at = object.created_at ?? undefined;
@@ -404,7 +404,7 @@ export const Simple = {
   },
 };
 
-const baseChild: object = { name: '', type: 0 };
+const createBaseChild = (): Child => ({ name: '', type: 0 });
 
 export const Child = {
   encode(message: Child, writer: Writer = Writer.create()): Writer {
@@ -420,7 +420,7 @@ export const Child = {
   decode(input: Reader | Uint8Array, length?: number): Child {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseChild } as Child;
+    const message = createBaseChild();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -439,7 +439,7 @@ export const Child = {
   },
 
   fromJSON(object: any): Child {
-    const message = { ...baseChild } as Child;
+    const message = createBaseChild();
     message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
     message.type = object.type !== undefined && object.type !== null ? child_TypeFromJSON(object.type) : 0;
     return message;
@@ -453,14 +453,14 @@ export const Child = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Child>, I>>(object: I): Child {
-    const message = { ...baseChild } as Child;
+    const message = createBaseChild();
     message.name = object.name ?? '';
     message.type = object.type ?? 0;
     return message;
   },
 };
 
-const baseNested: object = { name: '', state: 0 };
+const createBaseNested = (): Nested => ({ name: '', state: 0 });
 
 export const Nested = {
   encode(message: Nested, writer: Writer = Writer.create()): Writer {
@@ -479,7 +479,7 @@ export const Nested = {
   decode(input: Reader | Uint8Array, length?: number): Nested {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseNested } as Nested;
+    const message = createBaseNested();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -501,7 +501,7 @@ export const Nested = {
   },
 
   fromJSON(object: any): Nested {
-    const message = { ...baseNested } as Nested;
+    const message = createBaseNested();
     message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
     message.message =
       object.message !== undefined && object.message !== null
@@ -521,7 +521,7 @@ export const Nested = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Nested>, I>>(object: I): Nested {
-    const message = { ...baseNested } as Nested;
+    const message = createBaseNested();
     message.name = object.name ?? '';
     message.message =
       object.message !== undefined && object.message !== null
@@ -532,7 +532,7 @@ export const Nested = {
   },
 };
 
-const baseNested_InnerMessage: object = { name: '' };
+const createBaseNested_InnerMessage = (): Nested_InnerMessage => ({ name: '' });
 
 export const Nested_InnerMessage = {
   encode(message: Nested_InnerMessage, writer: Writer = Writer.create()): Writer {
@@ -548,7 +548,7 @@ export const Nested_InnerMessage = {
   decode(input: Reader | Uint8Array, length?: number): Nested_InnerMessage {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseNested_InnerMessage } as Nested_InnerMessage;
+    const message = createBaseNested_InnerMessage();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -567,7 +567,7 @@ export const Nested_InnerMessage = {
   },
 
   fromJSON(object: any): Nested_InnerMessage {
-    const message = { ...baseNested_InnerMessage } as Nested_InnerMessage;
+    const message = createBaseNested_InnerMessage();
     message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
     message.deep =
       object.deep !== undefined && object.deep !== null
@@ -585,7 +585,7 @@ export const Nested_InnerMessage = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Nested_InnerMessage>, I>>(object: I): Nested_InnerMessage {
-    const message = { ...baseNested_InnerMessage } as Nested_InnerMessage;
+    const message = createBaseNested_InnerMessage();
     message.name = object.name ?? '';
     message.deep =
       object.deep !== undefined && object.deep !== null
@@ -595,7 +595,7 @@ export const Nested_InnerMessage = {
   },
 };
 
-const baseNested_InnerMessage_DeepMessage: object = { name: '' };
+const createBaseNested_InnerMessage_DeepMessage = (): Nested_InnerMessage_DeepMessage => ({ name: '' });
 
 export const Nested_InnerMessage_DeepMessage = {
   encode(message: Nested_InnerMessage_DeepMessage, writer: Writer = Writer.create()): Writer {
@@ -608,7 +608,7 @@ export const Nested_InnerMessage_DeepMessage = {
   decode(input: Reader | Uint8Array, length?: number): Nested_InnerMessage_DeepMessage {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseNested_InnerMessage_DeepMessage } as Nested_InnerMessage_DeepMessage;
+    const message = createBaseNested_InnerMessage_DeepMessage();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -624,7 +624,7 @@ export const Nested_InnerMessage_DeepMessage = {
   },
 
   fromJSON(object: any): Nested_InnerMessage_DeepMessage {
-    const message = { ...baseNested_InnerMessage_DeepMessage } as Nested_InnerMessage_DeepMessage;
+    const message = createBaseNested_InnerMessage_DeepMessage();
     message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
     return message;
   },
@@ -638,13 +638,13 @@ export const Nested_InnerMessage_DeepMessage = {
   fromPartial<I extends Exact<DeepPartial<Nested_InnerMessage_DeepMessage>, I>>(
     object: I
   ): Nested_InnerMessage_DeepMessage {
-    const message = { ...baseNested_InnerMessage_DeepMessage } as Nested_InnerMessage_DeepMessage;
+    const message = createBaseNested_InnerMessage_DeepMessage();
     message.name = object.name ?? '';
     return message;
   },
 };
 
-const baseOneOfMessage: object = {};
+const createBaseOneOfMessage = (): OneOfMessage => ({});
 
 export const OneOfMessage = {
   encode(message: OneOfMessage, writer: Writer = Writer.create()): Writer {
@@ -660,7 +660,7 @@ export const OneOfMessage = {
   decode(input: Reader | Uint8Array, length?: number): OneOfMessage {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseOneOfMessage } as OneOfMessage;
+    const message = createBaseOneOfMessage();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -679,7 +679,7 @@ export const OneOfMessage = {
   },
 
   fromJSON(object: any): OneOfMessage {
-    const message = { ...baseOneOfMessage } as OneOfMessage;
+    const message = createBaseOneOfMessage();
     message.first = object.first !== undefined && object.first !== null ? String(object.first) : undefined;
     message.last = object.last !== undefined && object.last !== null ? String(object.last) : undefined;
     return message;
@@ -693,14 +693,14 @@ export const OneOfMessage = {
   },
 
   fromPartial<I extends Exact<DeepPartial<OneOfMessage>, I>>(object: I): OneOfMessage {
-    const message = { ...baseOneOfMessage } as OneOfMessage;
+    const message = createBaseOneOfMessage();
     message.first = object.first ?? undefined;
     message.last = object.last ?? undefined;
     return message;
   },
 };
 
-const baseSimpleWithWrappers: object = {};
+const createBaseSimpleWithWrappers = (): SimpleWithWrappers => ({});
 
 export const SimpleWithWrappers = {
   encode(message: SimpleWithWrappers, writer: Writer = Writer.create()): Writer {
@@ -725,7 +725,7 @@ export const SimpleWithWrappers = {
   decode(input: Reader | Uint8Array, length?: number): SimpleWithWrappers {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimpleWithWrappers } as SimpleWithWrappers;
+    const message = createBaseSimpleWithWrappers();
     message.coins = [];
     message.snacks = [];
     while (reader.pos < end) {
@@ -755,7 +755,7 @@ export const SimpleWithWrappers = {
   },
 
   fromJSON(object: any): SimpleWithWrappers {
-    const message = { ...baseSimpleWithWrappers } as SimpleWithWrappers;
+    const message = createBaseSimpleWithWrappers();
     message.name = object.name !== undefined && object.name !== null ? String(object.name) : undefined;
     message.age = object.age !== undefined && object.age !== null ? Number(object.age) : undefined;
     message.enabled = object.enabled !== undefined && object.enabled !== null ? Boolean(object.enabled) : undefined;
@@ -783,7 +783,7 @@ export const SimpleWithWrappers = {
   },
 
   fromPartial<I extends Exact<DeepPartial<SimpleWithWrappers>, I>>(object: I): SimpleWithWrappers {
-    const message = { ...baseSimpleWithWrappers } as SimpleWithWrappers;
+    const message = createBaseSimpleWithWrappers();
     message.name = object.name ?? undefined;
     message.age = object.age ?? undefined;
     message.enabled = object.enabled ?? undefined;
@@ -793,7 +793,7 @@ export const SimpleWithWrappers = {
   },
 };
 
-const baseEntity: object = { id: 0 };
+const createBaseEntity = (): Entity => ({ id: 0 });
 
 export const Entity = {
   encode(message: Entity, writer: Writer = Writer.create()): Writer {
@@ -806,7 +806,7 @@ export const Entity = {
   decode(input: Reader | Uint8Array, length?: number): Entity {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseEntity } as Entity;
+    const message = createBaseEntity();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -822,7 +822,7 @@ export const Entity = {
   },
 
   fromJSON(object: any): Entity {
-    const message = { ...baseEntity } as Entity;
+    const message = createBaseEntity();
     message.id = object.id !== undefined && object.id !== null ? Number(object.id) : 0;
     return message;
   },
@@ -834,13 +834,13 @@ export const Entity = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Entity>, I>>(object: I): Entity {
-    const message = { ...baseEntity } as Entity;
+    const message = createBaseEntity();
     message.id = object.id ?? 0;
     return message;
   },
 };
 
-const baseSimpleWithMap: object = {};
+const createBaseSimpleWithMap = (): SimpleWithMap => ({});
 
 export const SimpleWithMap = {
   encode(message: SimpleWithMap, writer: Writer = Writer.create()): Writer {
@@ -859,7 +859,7 @@ export const SimpleWithMap = {
   decode(input: Reader | Uint8Array, length?: number): SimpleWithMap {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimpleWithMap } as SimpleWithMap;
+    const message = createBaseSimpleWithMap();
     message.entitiesById = {};
     message.nameLookup = {};
     message.intLookup = {};
@@ -893,7 +893,7 @@ export const SimpleWithMap = {
   },
 
   fromJSON(object: any): SimpleWithMap {
-    const message = { ...baseSimpleWithMap } as SimpleWithMap;
+    const message = createBaseSimpleWithMap();
     message.entitiesById = Object.entries(object.entitiesById ?? {}).reduce<{ [key: number]: Entity }>(
       (acc, [key, value]) => {
         acc[Number(key)] = Entity.fromJSON(value);
@@ -942,7 +942,7 @@ export const SimpleWithMap = {
   },
 
   fromPartial<I extends Exact<DeepPartial<SimpleWithMap>, I>>(object: I): SimpleWithMap {
-    const message = { ...baseSimpleWithMap } as SimpleWithMap;
+    const message = createBaseSimpleWithMap();
     message.entitiesById = Object.entries(object.entitiesById ?? {}).reduce<{ [key: number]: Entity }>(
       (acc, [key, value]) => {
         if (value !== undefined) {
@@ -974,7 +974,7 @@ export const SimpleWithMap = {
   },
 };
 
-const baseSimpleWithMap_EntitiesByIdEntry: object = { key: 0 };
+const createBaseSimpleWithMap_EntitiesByIdEntry = (): SimpleWithMap_EntitiesByIdEntry => ({ key: 0 });
 
 export const SimpleWithMap_EntitiesByIdEntry = {
   encode(message: SimpleWithMap_EntitiesByIdEntry, writer: Writer = Writer.create()): Writer {
@@ -990,7 +990,7 @@ export const SimpleWithMap_EntitiesByIdEntry = {
   decode(input: Reader | Uint8Array, length?: number): SimpleWithMap_EntitiesByIdEntry {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimpleWithMap_EntitiesByIdEntry } as SimpleWithMap_EntitiesByIdEntry;
+    const message = createBaseSimpleWithMap_EntitiesByIdEntry();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -1009,7 +1009,7 @@ export const SimpleWithMap_EntitiesByIdEntry = {
   },
 
   fromJSON(object: any): SimpleWithMap_EntitiesByIdEntry {
-    const message = { ...baseSimpleWithMap_EntitiesByIdEntry } as SimpleWithMap_EntitiesByIdEntry;
+    const message = createBaseSimpleWithMap_EntitiesByIdEntry();
     message.key = object.key !== undefined && object.key !== null ? Number(object.key) : 0;
     message.value = object.value !== undefined && object.value !== null ? Entity.fromJSON(object.value) : undefined;
     return message;
@@ -1025,14 +1025,14 @@ export const SimpleWithMap_EntitiesByIdEntry = {
   fromPartial<I extends Exact<DeepPartial<SimpleWithMap_EntitiesByIdEntry>, I>>(
     object: I
   ): SimpleWithMap_EntitiesByIdEntry {
-    const message = { ...baseSimpleWithMap_EntitiesByIdEntry } as SimpleWithMap_EntitiesByIdEntry;
+    const message = createBaseSimpleWithMap_EntitiesByIdEntry();
     message.key = object.key ?? 0;
     message.value = object.value !== undefined && object.value !== null ? Entity.fromPartial(object.value) : undefined;
     return message;
   },
 };
 
-const baseSimpleWithMap_NameLookupEntry: object = { key: '', value: '' };
+const createBaseSimpleWithMap_NameLookupEntry = (): SimpleWithMap_NameLookupEntry => ({ key: '', value: '' });
 
 export const SimpleWithMap_NameLookupEntry = {
   encode(message: SimpleWithMap_NameLookupEntry, writer: Writer = Writer.create()): Writer {
@@ -1048,7 +1048,7 @@ export const SimpleWithMap_NameLookupEntry = {
   decode(input: Reader | Uint8Array, length?: number): SimpleWithMap_NameLookupEntry {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimpleWithMap_NameLookupEntry } as SimpleWithMap_NameLookupEntry;
+    const message = createBaseSimpleWithMap_NameLookupEntry();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -1067,7 +1067,7 @@ export const SimpleWithMap_NameLookupEntry = {
   },
 
   fromJSON(object: any): SimpleWithMap_NameLookupEntry {
-    const message = { ...baseSimpleWithMap_NameLookupEntry } as SimpleWithMap_NameLookupEntry;
+    const message = createBaseSimpleWithMap_NameLookupEntry();
     message.key = object.key !== undefined && object.key !== null ? String(object.key) : '';
     message.value = object.value !== undefined && object.value !== null ? String(object.value) : '';
     return message;
@@ -1083,14 +1083,14 @@ export const SimpleWithMap_NameLookupEntry = {
   fromPartial<I extends Exact<DeepPartial<SimpleWithMap_NameLookupEntry>, I>>(
     object: I
   ): SimpleWithMap_NameLookupEntry {
-    const message = { ...baseSimpleWithMap_NameLookupEntry } as SimpleWithMap_NameLookupEntry;
+    const message = createBaseSimpleWithMap_NameLookupEntry();
     message.key = object.key ?? '';
     message.value = object.value ?? '';
     return message;
   },
 };
 
-const baseSimpleWithMap_IntLookupEntry: object = { key: 0, value: 0 };
+const createBaseSimpleWithMap_IntLookupEntry = (): SimpleWithMap_IntLookupEntry => ({ key: 0, value: 0 });
 
 export const SimpleWithMap_IntLookupEntry = {
   encode(message: SimpleWithMap_IntLookupEntry, writer: Writer = Writer.create()): Writer {
@@ -1106,7 +1106,7 @@ export const SimpleWithMap_IntLookupEntry = {
   decode(input: Reader | Uint8Array, length?: number): SimpleWithMap_IntLookupEntry {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimpleWithMap_IntLookupEntry } as SimpleWithMap_IntLookupEntry;
+    const message = createBaseSimpleWithMap_IntLookupEntry();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -1125,7 +1125,7 @@ export const SimpleWithMap_IntLookupEntry = {
   },
 
   fromJSON(object: any): SimpleWithMap_IntLookupEntry {
-    const message = { ...baseSimpleWithMap_IntLookupEntry } as SimpleWithMap_IntLookupEntry;
+    const message = createBaseSimpleWithMap_IntLookupEntry();
     message.key = object.key !== undefined && object.key !== null ? Number(object.key) : 0;
     message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
@@ -1139,14 +1139,14 @@ export const SimpleWithMap_IntLookupEntry = {
   },
 
   fromPartial<I extends Exact<DeepPartial<SimpleWithMap_IntLookupEntry>, I>>(object: I): SimpleWithMap_IntLookupEntry {
-    const message = { ...baseSimpleWithMap_IntLookupEntry } as SimpleWithMap_IntLookupEntry;
+    const message = createBaseSimpleWithMap_IntLookupEntry();
     message.key = object.key ?? 0;
     message.value = object.value ?? 0;
     return message;
   },
 };
 
-const baseSimpleWithSnakeCaseMap: object = {};
+const createBaseSimpleWithSnakeCaseMap = (): SimpleWithSnakeCaseMap => ({});
 
 export const SimpleWithSnakeCaseMap = {
   encode(message: SimpleWithSnakeCaseMap, writer: Writer = Writer.create()): Writer {
@@ -1159,7 +1159,7 @@ export const SimpleWithSnakeCaseMap = {
   decode(input: Reader | Uint8Array, length?: number): SimpleWithSnakeCaseMap {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimpleWithSnakeCaseMap } as SimpleWithSnakeCaseMap;
+    const message = createBaseSimpleWithSnakeCaseMap();
     message.entities_by_id = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
@@ -1179,7 +1179,7 @@ export const SimpleWithSnakeCaseMap = {
   },
 
   fromJSON(object: any): SimpleWithSnakeCaseMap {
-    const message = { ...baseSimpleWithSnakeCaseMap } as SimpleWithSnakeCaseMap;
+    const message = createBaseSimpleWithSnakeCaseMap();
     message.entities_by_id = Object.entries(object.entities_by_id ?? {}).reduce<{ [key: number]: Entity }>(
       (acc, [key, value]) => {
         acc[Number(key)] = Entity.fromJSON(value);
@@ -1202,7 +1202,7 @@ export const SimpleWithSnakeCaseMap = {
   },
 
   fromPartial<I extends Exact<DeepPartial<SimpleWithSnakeCaseMap>, I>>(object: I): SimpleWithSnakeCaseMap {
-    const message = { ...baseSimpleWithSnakeCaseMap } as SimpleWithSnakeCaseMap;
+    const message = createBaseSimpleWithSnakeCaseMap();
     message.entities_by_id = Object.entries(object.entities_by_id ?? {}).reduce<{ [key: number]: Entity }>(
       (acc, [key, value]) => {
         if (value !== undefined) {
@@ -1216,7 +1216,7 @@ export const SimpleWithSnakeCaseMap = {
   },
 };
 
-const baseSimpleWithSnakeCaseMap_EntitiesByIdEntry: object = { key: 0 };
+const createBaseSimpleWithSnakeCaseMap_EntitiesByIdEntry = (): SimpleWithSnakeCaseMap_EntitiesByIdEntry => ({ key: 0 });
 
 export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
   encode(message: SimpleWithSnakeCaseMap_EntitiesByIdEntry, writer: Writer = Writer.create()): Writer {
@@ -1232,7 +1232,7 @@ export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
   decode(input: Reader | Uint8Array, length?: number): SimpleWithSnakeCaseMap_EntitiesByIdEntry {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimpleWithSnakeCaseMap_EntitiesByIdEntry } as SimpleWithSnakeCaseMap_EntitiesByIdEntry;
+    const message = createBaseSimpleWithSnakeCaseMap_EntitiesByIdEntry();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -1251,7 +1251,7 @@ export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
   },
 
   fromJSON(object: any): SimpleWithSnakeCaseMap_EntitiesByIdEntry {
-    const message = { ...baseSimpleWithSnakeCaseMap_EntitiesByIdEntry } as SimpleWithSnakeCaseMap_EntitiesByIdEntry;
+    const message = createBaseSimpleWithSnakeCaseMap_EntitiesByIdEntry();
     message.key = object.key !== undefined && object.key !== null ? Number(object.key) : 0;
     message.value = object.value !== undefined && object.value !== null ? Entity.fromJSON(object.value) : undefined;
     return message;
@@ -1267,14 +1267,14 @@ export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
   fromPartial<I extends Exact<DeepPartial<SimpleWithSnakeCaseMap_EntitiesByIdEntry>, I>>(
     object: I
   ): SimpleWithSnakeCaseMap_EntitiesByIdEntry {
-    const message = { ...baseSimpleWithSnakeCaseMap_EntitiesByIdEntry } as SimpleWithSnakeCaseMap_EntitiesByIdEntry;
+    const message = createBaseSimpleWithSnakeCaseMap_EntitiesByIdEntry();
     message.key = object.key ?? 0;
     message.value = object.value !== undefined && object.value !== null ? Entity.fromPartial(object.value) : undefined;
     return message;
   },
 };
 
-const basePingRequest: object = { input: '' };
+const createBasePingRequest = (): PingRequest => ({ input: '' });
 
 export const PingRequest = {
   encode(message: PingRequest, writer: Writer = Writer.create()): Writer {
@@ -1287,7 +1287,7 @@ export const PingRequest = {
   decode(input: Reader | Uint8Array, length?: number): PingRequest {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...basePingRequest } as PingRequest;
+    const message = createBasePingRequest();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -1303,7 +1303,7 @@ export const PingRequest = {
   },
 
   fromJSON(object: any): PingRequest {
-    const message = { ...basePingRequest } as PingRequest;
+    const message = createBasePingRequest();
     message.input = object.input !== undefined && object.input !== null ? String(object.input) : '';
     return message;
   },
@@ -1315,13 +1315,13 @@ export const PingRequest = {
   },
 
   fromPartial<I extends Exact<DeepPartial<PingRequest>, I>>(object: I): PingRequest {
-    const message = { ...basePingRequest } as PingRequest;
+    const message = createBasePingRequest();
     message.input = object.input ?? '';
     return message;
   },
 };
 
-const basePingResponse: object = { output: '' };
+const createBasePingResponse = (): PingResponse => ({ output: '' });
 
 export const PingResponse = {
   encode(message: PingResponse, writer: Writer = Writer.create()): Writer {
@@ -1334,7 +1334,7 @@ export const PingResponse = {
   decode(input: Reader | Uint8Array, length?: number): PingResponse {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...basePingResponse } as PingResponse;
+    const message = createBasePingResponse();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -1350,7 +1350,7 @@ export const PingResponse = {
   },
 
   fromJSON(object: any): PingResponse {
-    const message = { ...basePingResponse } as PingResponse;
+    const message = createBasePingResponse();
     message.output = object.output !== undefined && object.output !== null ? String(object.output) : '';
     return message;
   },
@@ -1362,13 +1362,13 @@ export const PingResponse = {
   },
 
   fromPartial<I extends Exact<DeepPartial<PingResponse>, I>>(object: I): PingResponse {
-    const message = { ...basePingResponse } as PingResponse;
+    const message = createBasePingResponse();
     message.output = object.output ?? '';
     return message;
   },
 };
 
-const baseNumbers: object = {
+const createBaseNumbers = (): Numbers => ({
   double: 0,
   float: 0,
   int32: 0,
@@ -1381,7 +1381,7 @@ const baseNumbers: object = {
   fixed64: 0,
   sfixed32: 0,
   sfixed64: 0,
-};
+});
 
 export const Numbers = {
   encode(message: Numbers, writer: Writer = Writer.create()): Writer {
@@ -1427,7 +1427,7 @@ export const Numbers = {
   decode(input: Reader | Uint8Array, length?: number): Numbers {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseNumbers } as Numbers;
+    const message = createBaseNumbers();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -1476,7 +1476,7 @@ export const Numbers = {
   },
 
   fromJSON(object: any): Numbers {
-    const message = { ...baseNumbers } as Numbers;
+    const message = createBaseNumbers();
     message.double = object.double !== undefined && object.double !== null ? Number(object.double) : 0;
     message.float = object.float !== undefined && object.float !== null ? Number(object.float) : 0;
     message.int32 = object.int32 !== undefined && object.int32 !== null ? Number(object.int32) : 0;
@@ -1510,7 +1510,7 @@ export const Numbers = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Numbers>, I>>(object: I): Numbers {
-    const message = { ...baseNumbers } as Numbers;
+    const message = createBaseNumbers();
     message.double = object.double ?? 0;
     message.float = object.float ?? 0;
     message.int32 = object.int32 ?? 0;

--- a/integration/simple-string-enums/google/protobuf/struct.ts
+++ b/integration/simple-string-enums/google/protobuf/struct.ts
@@ -99,7 +99,7 @@ export interface ListValue {
   values: any[];
 }
 
-const baseStruct: object = {};
+const createBaseStruct = (): Struct => ({});
 
 export const Struct = {
   encode(message: Struct, writer: Writer = Writer.create()): Writer {
@@ -114,7 +114,7 @@ export const Struct = {
   decode(input: Reader | Uint8Array, length?: number): Struct {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseStruct } as Struct;
+    const message = createBaseStruct();
     message.fields = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
@@ -134,7 +134,7 @@ export const Struct = {
   },
 
   fromJSON(object: any): Struct {
-    const message = { ...baseStruct } as Struct;
+    const message = createBaseStruct();
     message.fields = Object.entries(object.fields ?? {}).reduce<{ [key: string]: any | undefined }>(
       (acc, [key, value]) => {
         acc[key] = value as any | undefined;
@@ -157,7 +157,7 @@ export const Struct = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Struct>, I>>(object: I): Struct {
-    const message = { ...baseStruct } as Struct;
+    const message = createBaseStruct();
     message.fields = Object.entries(object.fields ?? {}).reduce<{ [key: string]: any | undefined }>(
       (acc, [key, value]) => {
         if (value !== undefined) {
@@ -189,7 +189,7 @@ export const Struct = {
   },
 };
 
-const baseStruct_FieldsEntry: object = { key: '' };
+const createBaseStruct_FieldsEntry = (): Struct_FieldsEntry => ({ key: '' });
 
 export const Struct_FieldsEntry = {
   encode(message: Struct_FieldsEntry, writer: Writer = Writer.create()): Writer {
@@ -205,7 +205,7 @@ export const Struct_FieldsEntry = {
   decode(input: Reader | Uint8Array, length?: number): Struct_FieldsEntry {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseStruct_FieldsEntry } as Struct_FieldsEntry;
+    const message = createBaseStruct_FieldsEntry();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -224,7 +224,7 @@ export const Struct_FieldsEntry = {
   },
 
   fromJSON(object: any): Struct_FieldsEntry {
-    const message = { ...baseStruct_FieldsEntry } as Struct_FieldsEntry;
+    const message = createBaseStruct_FieldsEntry();
     message.key = object.key !== undefined && object.key !== null ? String(object.key) : '';
     message.value = object.value;
     return message;
@@ -238,14 +238,14 @@ export const Struct_FieldsEntry = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Struct_FieldsEntry>, I>>(object: I): Struct_FieldsEntry {
-    const message = { ...baseStruct_FieldsEntry } as Struct_FieldsEntry;
+    const message = createBaseStruct_FieldsEntry();
     message.key = object.key ?? '';
     message.value = object.value ?? undefined;
     return message;
   },
 };
 
-const baseValue: object = {};
+const createBaseValue = (): Value => ({});
 
 export const Value = {
   encode(message: Value, writer: Writer = Writer.create()): Writer {
@@ -273,7 +273,7 @@ export const Value = {
   decode(input: Reader | Uint8Array, length?: number): Value {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseValue } as Value;
+    const message = createBaseValue();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -304,7 +304,7 @@ export const Value = {
   },
 
   fromJSON(object: any): Value {
-    const message = { ...baseValue } as Value;
+    const message = createBaseValue();
     message.nullValue =
       object.nullValue !== undefined && object.nullValue !== null ? nullValueFromJSON(object.nullValue) : undefined;
     message.numberValue =
@@ -331,7 +331,7 @@ export const Value = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Value>, I>>(object: I): Value {
-    const message = { ...baseValue } as Value;
+    const message = createBaseValue();
     message.nullValue = object.nullValue ?? undefined;
     message.numberValue = object.numberValue ?? undefined;
     message.stringValue = object.stringValue ?? undefined;
@@ -379,7 +379,7 @@ export const Value = {
   },
 };
 
-const baseListValue: object = {};
+const createBaseListValue = (): ListValue => ({});
 
 export const ListValue = {
   encode(message: ListValue, writer: Writer = Writer.create()): Writer {
@@ -392,7 +392,7 @@ export const ListValue = {
   decode(input: Reader | Uint8Array, length?: number): ListValue {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseListValue } as ListValue;
+    const message = createBaseListValue();
     message.values = [];
     while (reader.pos < end) {
       const tag = reader.uint32();
@@ -409,7 +409,7 @@ export const ListValue = {
   },
 
   fromJSON(object: any): ListValue {
-    const message = { ...baseListValue } as ListValue;
+    const message = createBaseListValue();
     message.values = Array.isArray(object?.values) ? [...object.values] : [];
     return message;
   },
@@ -425,7 +425,7 @@ export const ListValue = {
   },
 
   fromPartial<I extends Exact<DeepPartial<ListValue>, I>>(object: I): ListValue {
-    const message = { ...baseListValue } as ListValue;
+    const message = createBaseListValue();
     message.values = object.values?.map((e) => e) || [];
     return message;
   },

--- a/integration/simple-string-enums/google/protobuf/struct.ts
+++ b/integration/simple-string-enums/google/protobuf/struct.ts
@@ -99,7 +99,9 @@ export interface ListValue {
   values: any[];
 }
 
-const createBaseStruct = (): Struct => ({});
+function createBaseStruct(): Struct {
+  return { fields: {} };
+}
 
 export const Struct = {
   encode(message: Struct, writer: Writer = Writer.create()): Writer {
@@ -115,7 +117,6 @@ export const Struct = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseStruct();
-    message.fields = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -189,7 +190,9 @@ export const Struct = {
   },
 };
 
-const createBaseStruct_FieldsEntry = (): Struct_FieldsEntry => ({ key: '' });
+function createBaseStruct_FieldsEntry(): Struct_FieldsEntry {
+  return { key: '', value: undefined };
+}
 
 export const Struct_FieldsEntry = {
   encode(message: Struct_FieldsEntry, writer: Writer = Writer.create()): Writer {
@@ -245,7 +248,16 @@ export const Struct_FieldsEntry = {
   },
 };
 
-const createBaseValue = (): Value => ({});
+function createBaseValue(): Value {
+  return {
+    nullValue: undefined,
+    numberValue: undefined,
+    stringValue: undefined,
+    boolValue: undefined,
+    structValue: undefined,
+    listValue: undefined,
+  };
+}
 
 export const Value = {
   encode(message: Value, writer: Writer = Writer.create()): Writer {
@@ -379,7 +391,9 @@ export const Value = {
   },
 };
 
-const createBaseListValue = (): ListValue => ({});
+function createBaseListValue(): ListValue {
+  return { values: [] };
+}
 
 export const ListValue = {
   encode(message: ListValue, writer: Writer = Writer.create()): Writer {
@@ -393,7 +407,6 @@ export const ListValue = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseListValue();
-    message.values = [];
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {

--- a/integration/simple-string-enums/simple.ts
+++ b/integration/simple-string-enums/simple.ts
@@ -63,12 +63,12 @@ export interface Simple {
   nullValue: NullValue;
 }
 
-const baseSimple: object = {
+const createBaseSimple = (): Simple => ({
   name: '',
   state: StateEnum.UNKNOWN,
   states: StateEnum.UNKNOWN,
   nullValue: NullValue.NULL_VALUE,
-};
+});
 
 export const Simple = {
   encode(message: Simple, writer: Writer = Writer.create()): Writer {
@@ -92,7 +92,7 @@ export const Simple = {
   decode(input: Reader | Uint8Array, length?: number): Simple {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimple } as Simple;
+    const message = createBaseSimple();
     message.states = [];
     while (reader.pos < end) {
       const tag = reader.uint32();
@@ -125,7 +125,7 @@ export const Simple = {
   },
 
   fromJSON(object: any): Simple {
-    const message = { ...baseSimple } as Simple;
+    const message = createBaseSimple();
     message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
     message.state =
       object.state !== undefined && object.state !== null ? stateEnumFromJSON(object.state) : StateEnum.UNKNOWN;
@@ -151,7 +151,7 @@ export const Simple = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Simple>, I>>(object: I): Simple {
-    const message = { ...baseSimple } as Simple;
+    const message = createBaseSimple();
     message.name = object.name ?? '';
     message.state = object.state ?? StateEnum.UNKNOWN;
     message.states = object.states?.map((e) => e) || [];

--- a/integration/simple-string-enums/simple.ts
+++ b/integration/simple-string-enums/simple.ts
@@ -63,12 +63,9 @@ export interface Simple {
   nullValue: NullValue;
 }
 
-const createBaseSimple = (): Simple => ({
-  name: '',
-  state: StateEnum.UNKNOWN,
-  states: StateEnum.UNKNOWN,
-  nullValue: NullValue.NULL_VALUE,
-});
+function createBaseSimple(): Simple {
+  return { name: '', state: StateEnum.UNKNOWN, states: [], nullValue: NullValue.NULL_VALUE };
+}
 
 export const Simple = {
   encode(message: Simple, writer: Writer = Writer.create()): Writer {
@@ -93,7 +90,6 @@ export const Simple = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseSimple();
-    message.states = [];
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {

--- a/integration/simple-unrecognized-enum/google/protobuf/timestamp.ts
+++ b/integration/simple-unrecognized-enum/google/protobuf/timestamp.ts
@@ -113,7 +113,9 @@ export interface Timestamp {
   nanos: number;
 }
 
-const createBaseTimestamp = (): Timestamp => ({ seconds: 0, nanos: 0 });
+function createBaseTimestamp(): Timestamp {
+  return { seconds: 0, nanos: 0 };
+}
 
 export const Timestamp = {
   encode(message: Timestamp, writer: Writer = Writer.create()): Writer {

--- a/integration/simple-unrecognized-enum/google/protobuf/timestamp.ts
+++ b/integration/simple-unrecognized-enum/google/protobuf/timestamp.ts
@@ -113,7 +113,7 @@ export interface Timestamp {
   nanos: number;
 }
 
-const baseTimestamp: object = { seconds: 0, nanos: 0 };
+const createBaseTimestamp = (): Timestamp => ({ seconds: 0, nanos: 0 });
 
 export const Timestamp = {
   encode(message: Timestamp, writer: Writer = Writer.create()): Writer {
@@ -129,7 +129,7 @@ export const Timestamp = {
   decode(input: Reader | Uint8Array, length?: number): Timestamp {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseTimestamp } as Timestamp;
+    const message = createBaseTimestamp();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -148,7 +148,7 @@ export const Timestamp = {
   },
 
   fromJSON(object: any): Timestamp {
-    const message = { ...baseTimestamp } as Timestamp;
+    const message = createBaseTimestamp();
     message.seconds = object.seconds !== undefined && object.seconds !== null ? Number(object.seconds) : 0;
     message.nanos = object.nanos !== undefined && object.nanos !== null ? Number(object.nanos) : 0;
     return message;
@@ -162,7 +162,7 @@ export const Timestamp = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Timestamp>, I>>(object: I): Timestamp {
-    const message = { ...baseTimestamp } as Timestamp;
+    const message = createBaseTimestamp();
     message.seconds = object.seconds ?? 0;
     message.nanos = object.nanos ?? 0;
     return message;

--- a/integration/simple-unrecognized-enum/google/protobuf/wrappers.ts
+++ b/integration/simple-unrecognized-enum/google/protobuf/wrappers.ts
@@ -94,7 +94,9 @@ export interface BytesValue {
   value: Uint8Array;
 }
 
-const createBaseDoubleValue = (): DoubleValue => ({ value: 0 });
+function createBaseDoubleValue(): DoubleValue {
+  return { value: 0 };
+}
 
 export const DoubleValue = {
   encode(message: DoubleValue, writer: Writer = Writer.create()): Writer {
@@ -141,7 +143,9 @@ export const DoubleValue = {
   },
 };
 
-const createBaseFloatValue = (): FloatValue => ({ value: 0 });
+function createBaseFloatValue(): FloatValue {
+  return { value: 0 };
+}
 
 export const FloatValue = {
   encode(message: FloatValue, writer: Writer = Writer.create()): Writer {
@@ -188,7 +192,9 @@ export const FloatValue = {
   },
 };
 
-const createBaseInt64Value = (): Int64Value => ({ value: 0 });
+function createBaseInt64Value(): Int64Value {
+  return { value: 0 };
+}
 
 export const Int64Value = {
   encode(message: Int64Value, writer: Writer = Writer.create()): Writer {
@@ -235,7 +241,9 @@ export const Int64Value = {
   },
 };
 
-const createBaseUInt64Value = (): UInt64Value => ({ value: 0 });
+function createBaseUInt64Value(): UInt64Value {
+  return { value: 0 };
+}
 
 export const UInt64Value = {
   encode(message: UInt64Value, writer: Writer = Writer.create()): Writer {
@@ -282,7 +290,9 @@ export const UInt64Value = {
   },
 };
 
-const createBaseInt32Value = (): Int32Value => ({ value: 0 });
+function createBaseInt32Value(): Int32Value {
+  return { value: 0 };
+}
 
 export const Int32Value = {
   encode(message: Int32Value, writer: Writer = Writer.create()): Writer {
@@ -329,7 +339,9 @@ export const Int32Value = {
   },
 };
 
-const createBaseUInt32Value = (): UInt32Value => ({ value: 0 });
+function createBaseUInt32Value(): UInt32Value {
+  return { value: 0 };
+}
 
 export const UInt32Value = {
   encode(message: UInt32Value, writer: Writer = Writer.create()): Writer {
@@ -376,7 +388,9 @@ export const UInt32Value = {
   },
 };
 
-const createBaseBoolValue = (): BoolValue => ({ value: false });
+function createBaseBoolValue(): BoolValue {
+  return { value: false };
+}
 
 export const BoolValue = {
   encode(message: BoolValue, writer: Writer = Writer.create()): Writer {
@@ -423,7 +437,9 @@ export const BoolValue = {
   },
 };
 
-const createBaseStringValue = (): StringValue => ({ value: '' });
+function createBaseStringValue(): StringValue {
+  return { value: '' };
+}
 
 export const StringValue = {
   encode(message: StringValue, writer: Writer = Writer.create()): Writer {
@@ -470,7 +486,9 @@ export const StringValue = {
   },
 };
 
-const createBaseBytesValue = (): BytesValue => ({});
+function createBaseBytesValue(): BytesValue {
+  return { value: new Uint8Array() };
+}
 
 export const BytesValue = {
   encode(message: BytesValue, writer: Writer = Writer.create()): Writer {
@@ -484,7 +502,6 @@ export const BytesValue = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseBytesValue();
-    message.value = new Uint8Array();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {

--- a/integration/simple-unrecognized-enum/google/protobuf/wrappers.ts
+++ b/integration/simple-unrecognized-enum/google/protobuf/wrappers.ts
@@ -94,7 +94,7 @@ export interface BytesValue {
   value: Uint8Array;
 }
 
-const baseDoubleValue: object = { value: 0 };
+const createBaseDoubleValue = (): DoubleValue => ({ value: 0 });
 
 export const DoubleValue = {
   encode(message: DoubleValue, writer: Writer = Writer.create()): Writer {
@@ -107,7 +107,7 @@ export const DoubleValue = {
   decode(input: Reader | Uint8Array, length?: number): DoubleValue {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseDoubleValue } as DoubleValue;
+    const message = createBaseDoubleValue();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -123,7 +123,7 @@ export const DoubleValue = {
   },
 
   fromJSON(object: any): DoubleValue {
-    const message = { ...baseDoubleValue } as DoubleValue;
+    const message = createBaseDoubleValue();
     message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
@@ -135,13 +135,13 @@ export const DoubleValue = {
   },
 
   fromPartial<I extends Exact<DeepPartial<DoubleValue>, I>>(object: I): DoubleValue {
-    const message = { ...baseDoubleValue } as DoubleValue;
+    const message = createBaseDoubleValue();
     message.value = object.value ?? 0;
     return message;
   },
 };
 
-const baseFloatValue: object = { value: 0 };
+const createBaseFloatValue = (): FloatValue => ({ value: 0 });
 
 export const FloatValue = {
   encode(message: FloatValue, writer: Writer = Writer.create()): Writer {
@@ -154,7 +154,7 @@ export const FloatValue = {
   decode(input: Reader | Uint8Array, length?: number): FloatValue {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseFloatValue } as FloatValue;
+    const message = createBaseFloatValue();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -170,7 +170,7 @@ export const FloatValue = {
   },
 
   fromJSON(object: any): FloatValue {
-    const message = { ...baseFloatValue } as FloatValue;
+    const message = createBaseFloatValue();
     message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
@@ -182,13 +182,13 @@ export const FloatValue = {
   },
 
   fromPartial<I extends Exact<DeepPartial<FloatValue>, I>>(object: I): FloatValue {
-    const message = { ...baseFloatValue } as FloatValue;
+    const message = createBaseFloatValue();
     message.value = object.value ?? 0;
     return message;
   },
 };
 
-const baseInt64Value: object = { value: 0 };
+const createBaseInt64Value = (): Int64Value => ({ value: 0 });
 
 export const Int64Value = {
   encode(message: Int64Value, writer: Writer = Writer.create()): Writer {
@@ -201,7 +201,7 @@ export const Int64Value = {
   decode(input: Reader | Uint8Array, length?: number): Int64Value {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseInt64Value } as Int64Value;
+    const message = createBaseInt64Value();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -217,7 +217,7 @@ export const Int64Value = {
   },
 
   fromJSON(object: any): Int64Value {
-    const message = { ...baseInt64Value } as Int64Value;
+    const message = createBaseInt64Value();
     message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
@@ -229,13 +229,13 @@ export const Int64Value = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Int64Value>, I>>(object: I): Int64Value {
-    const message = { ...baseInt64Value } as Int64Value;
+    const message = createBaseInt64Value();
     message.value = object.value ?? 0;
     return message;
   },
 };
 
-const baseUInt64Value: object = { value: 0 };
+const createBaseUInt64Value = (): UInt64Value => ({ value: 0 });
 
 export const UInt64Value = {
   encode(message: UInt64Value, writer: Writer = Writer.create()): Writer {
@@ -248,7 +248,7 @@ export const UInt64Value = {
   decode(input: Reader | Uint8Array, length?: number): UInt64Value {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseUInt64Value } as UInt64Value;
+    const message = createBaseUInt64Value();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -264,7 +264,7 @@ export const UInt64Value = {
   },
 
   fromJSON(object: any): UInt64Value {
-    const message = { ...baseUInt64Value } as UInt64Value;
+    const message = createBaseUInt64Value();
     message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
@@ -276,13 +276,13 @@ export const UInt64Value = {
   },
 
   fromPartial<I extends Exact<DeepPartial<UInt64Value>, I>>(object: I): UInt64Value {
-    const message = { ...baseUInt64Value } as UInt64Value;
+    const message = createBaseUInt64Value();
     message.value = object.value ?? 0;
     return message;
   },
 };
 
-const baseInt32Value: object = { value: 0 };
+const createBaseInt32Value = (): Int32Value => ({ value: 0 });
 
 export const Int32Value = {
   encode(message: Int32Value, writer: Writer = Writer.create()): Writer {
@@ -295,7 +295,7 @@ export const Int32Value = {
   decode(input: Reader | Uint8Array, length?: number): Int32Value {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseInt32Value } as Int32Value;
+    const message = createBaseInt32Value();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -311,7 +311,7 @@ export const Int32Value = {
   },
 
   fromJSON(object: any): Int32Value {
-    const message = { ...baseInt32Value } as Int32Value;
+    const message = createBaseInt32Value();
     message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
@@ -323,13 +323,13 @@ export const Int32Value = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Int32Value>, I>>(object: I): Int32Value {
-    const message = { ...baseInt32Value } as Int32Value;
+    const message = createBaseInt32Value();
     message.value = object.value ?? 0;
     return message;
   },
 };
 
-const baseUInt32Value: object = { value: 0 };
+const createBaseUInt32Value = (): UInt32Value => ({ value: 0 });
 
 export const UInt32Value = {
   encode(message: UInt32Value, writer: Writer = Writer.create()): Writer {
@@ -342,7 +342,7 @@ export const UInt32Value = {
   decode(input: Reader | Uint8Array, length?: number): UInt32Value {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseUInt32Value } as UInt32Value;
+    const message = createBaseUInt32Value();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -358,7 +358,7 @@ export const UInt32Value = {
   },
 
   fromJSON(object: any): UInt32Value {
-    const message = { ...baseUInt32Value } as UInt32Value;
+    const message = createBaseUInt32Value();
     message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
@@ -370,13 +370,13 @@ export const UInt32Value = {
   },
 
   fromPartial<I extends Exact<DeepPartial<UInt32Value>, I>>(object: I): UInt32Value {
-    const message = { ...baseUInt32Value } as UInt32Value;
+    const message = createBaseUInt32Value();
     message.value = object.value ?? 0;
     return message;
   },
 };
 
-const baseBoolValue: object = { value: false };
+const createBaseBoolValue = (): BoolValue => ({ value: false });
 
 export const BoolValue = {
   encode(message: BoolValue, writer: Writer = Writer.create()): Writer {
@@ -389,7 +389,7 @@ export const BoolValue = {
   decode(input: Reader | Uint8Array, length?: number): BoolValue {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseBoolValue } as BoolValue;
+    const message = createBaseBoolValue();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -405,7 +405,7 @@ export const BoolValue = {
   },
 
   fromJSON(object: any): BoolValue {
-    const message = { ...baseBoolValue } as BoolValue;
+    const message = createBaseBoolValue();
     message.value = object.value !== undefined && object.value !== null ? Boolean(object.value) : false;
     return message;
   },
@@ -417,13 +417,13 @@ export const BoolValue = {
   },
 
   fromPartial<I extends Exact<DeepPartial<BoolValue>, I>>(object: I): BoolValue {
-    const message = { ...baseBoolValue } as BoolValue;
+    const message = createBaseBoolValue();
     message.value = object.value ?? false;
     return message;
   },
 };
 
-const baseStringValue: object = { value: '' };
+const createBaseStringValue = (): StringValue => ({ value: '' });
 
 export const StringValue = {
   encode(message: StringValue, writer: Writer = Writer.create()): Writer {
@@ -436,7 +436,7 @@ export const StringValue = {
   decode(input: Reader | Uint8Array, length?: number): StringValue {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseStringValue } as StringValue;
+    const message = createBaseStringValue();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -452,7 +452,7 @@ export const StringValue = {
   },
 
   fromJSON(object: any): StringValue {
-    const message = { ...baseStringValue } as StringValue;
+    const message = createBaseStringValue();
     message.value = object.value !== undefined && object.value !== null ? String(object.value) : '';
     return message;
   },
@@ -464,13 +464,13 @@ export const StringValue = {
   },
 
   fromPartial<I extends Exact<DeepPartial<StringValue>, I>>(object: I): StringValue {
-    const message = { ...baseStringValue } as StringValue;
+    const message = createBaseStringValue();
     message.value = object.value ?? '';
     return message;
   },
 };
 
-const baseBytesValue: object = {};
+const createBaseBytesValue = (): BytesValue => ({});
 
 export const BytesValue = {
   encode(message: BytesValue, writer: Writer = Writer.create()): Writer {
@@ -483,7 +483,7 @@ export const BytesValue = {
   decode(input: Reader | Uint8Array, length?: number): BytesValue {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseBytesValue } as BytesValue;
+    const message = createBaseBytesValue();
     message.value = new Uint8Array();
     while (reader.pos < end) {
       const tag = reader.uint32();
@@ -500,7 +500,7 @@ export const BytesValue = {
   },
 
   fromJSON(object: any): BytesValue {
-    const message = { ...baseBytesValue } as BytesValue;
+    const message = createBaseBytesValue();
     message.value =
       object.value !== undefined && object.value !== null ? bytesFromBase64(object.value) : new Uint8Array();
     return message;
@@ -514,7 +514,7 @@ export const BytesValue = {
   },
 
   fromPartial<I extends Exact<DeepPartial<BytesValue>, I>>(object: I): BytesValue {
-    const message = { ...baseBytesValue } as BytesValue;
+    const message = createBaseBytesValue();
     message.value = object.value ?? new Uint8Array();
     return message;
   },

--- a/integration/simple-unrecognized-enum/import_dir/thing.ts
+++ b/integration/simple-unrecognized-enum/import_dir/thing.ts
@@ -9,7 +9,7 @@ export interface ImportedThing {
   createdAt: Date | undefined;
 }
 
-const baseImportedThing: object = {};
+const createBaseImportedThing = (): ImportedThing => ({});
 
 export const ImportedThing = {
   encode(message: ImportedThing, writer: Writer = Writer.create()): Writer {
@@ -22,7 +22,7 @@ export const ImportedThing = {
   decode(input: Reader | Uint8Array, length?: number): ImportedThing {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseImportedThing } as ImportedThing;
+    const message = createBaseImportedThing();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -38,7 +38,7 @@ export const ImportedThing = {
   },
 
   fromJSON(object: any): ImportedThing {
-    const message = { ...baseImportedThing } as ImportedThing;
+    const message = createBaseImportedThing();
     message.createdAt =
       object.createdAt !== undefined && object.createdAt !== null ? fromJsonTimestamp(object.createdAt) : undefined;
     return message;
@@ -51,7 +51,7 @@ export const ImportedThing = {
   },
 
   fromPartial<I extends Exact<DeepPartial<ImportedThing>, I>>(object: I): ImportedThing {
-    const message = { ...baseImportedThing } as ImportedThing;
+    const message = createBaseImportedThing();
     message.createdAt = object.createdAt ?? undefined;
     return message;
   },

--- a/integration/simple-unrecognized-enum/import_dir/thing.ts
+++ b/integration/simple-unrecognized-enum/import_dir/thing.ts
@@ -9,7 +9,9 @@ export interface ImportedThing {
   createdAt: Date | undefined;
 }
 
-const createBaseImportedThing = (): ImportedThing => ({});
+function createBaseImportedThing(): ImportedThing {
+  return { createdAt: undefined };
+}
 
 export const ImportedThing = {
   encode(message: ImportedThing, writer: Writer = Writer.create()): Writer {

--- a/integration/simple-unrecognized-enum/simple.ts
+++ b/integration/simple-unrecognized-enum/simple.ts
@@ -226,7 +226,7 @@ export interface Numbers {
   sfixed64: number;
 }
 
-const baseSimple: object = { name: '', age: 0, state: 0, coins: 0, snacks: '', oldStates: 0 };
+const createBaseSimple = (): Simple => ({ name: '', age: 0, state: 0, coins: 0, snacks: '', oldStates: 0 });
 
 export const Simple = {
   encode(message: Simple, writer: Writer = Writer.create()): Writer {
@@ -270,7 +270,7 @@ export const Simple = {
   decode(input: Reader | Uint8Array, length?: number): Simple {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimple } as Simple;
+    const message = createBaseSimple();
     message.grandChildren = [];
     message.coins = [];
     message.snacks = [];
@@ -331,7 +331,7 @@ export const Simple = {
   },
 
   fromJSON(object: any): Simple {
-    const message = { ...baseSimple } as Simple;
+    const message = createBaseSimple();
     message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
     message.age = object.age !== undefined && object.age !== null ? Number(object.age) : 0;
     message.createdAt =
@@ -379,7 +379,7 @@ export const Simple = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Simple>, I>>(object: I): Simple {
-    const message = { ...baseSimple } as Simple;
+    const message = createBaseSimple();
     message.name = object.name ?? '';
     message.age = object.age ?? 0;
     message.createdAt = object.createdAt ?? undefined;
@@ -395,7 +395,7 @@ export const Simple = {
   },
 };
 
-const baseChild: object = { name: '', type: 0 };
+const createBaseChild = (): Child => ({ name: '', type: 0 });
 
 export const Child = {
   encode(message: Child, writer: Writer = Writer.create()): Writer {
@@ -411,7 +411,7 @@ export const Child = {
   decode(input: Reader | Uint8Array, length?: number): Child {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseChild } as Child;
+    const message = createBaseChild();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -430,7 +430,7 @@ export const Child = {
   },
 
   fromJSON(object: any): Child {
-    const message = { ...baseChild } as Child;
+    const message = createBaseChild();
     message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
     message.type = object.type !== undefined && object.type !== null ? child_TypeFromJSON(object.type) : 0;
     return message;
@@ -444,14 +444,14 @@ export const Child = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Child>, I>>(object: I): Child {
-    const message = { ...baseChild } as Child;
+    const message = createBaseChild();
     message.name = object.name ?? '';
     message.type = object.type ?? 0;
     return message;
   },
 };
 
-const baseNested: object = { name: '', state: 0 };
+const createBaseNested = (): Nested => ({ name: '', state: 0 });
 
 export const Nested = {
   encode(message: Nested, writer: Writer = Writer.create()): Writer {
@@ -470,7 +470,7 @@ export const Nested = {
   decode(input: Reader | Uint8Array, length?: number): Nested {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseNested } as Nested;
+    const message = createBaseNested();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -492,7 +492,7 @@ export const Nested = {
   },
 
   fromJSON(object: any): Nested {
-    const message = { ...baseNested } as Nested;
+    const message = createBaseNested();
     message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
     message.message =
       object.message !== undefined && object.message !== null
@@ -512,7 +512,7 @@ export const Nested = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Nested>, I>>(object: I): Nested {
-    const message = { ...baseNested } as Nested;
+    const message = createBaseNested();
     message.name = object.name ?? '';
     message.message =
       object.message !== undefined && object.message !== null
@@ -523,7 +523,7 @@ export const Nested = {
   },
 };
 
-const baseNested_InnerMessage: object = { name: '' };
+const createBaseNested_InnerMessage = (): Nested_InnerMessage => ({ name: '' });
 
 export const Nested_InnerMessage = {
   encode(message: Nested_InnerMessage, writer: Writer = Writer.create()): Writer {
@@ -539,7 +539,7 @@ export const Nested_InnerMessage = {
   decode(input: Reader | Uint8Array, length?: number): Nested_InnerMessage {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseNested_InnerMessage } as Nested_InnerMessage;
+    const message = createBaseNested_InnerMessage();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -558,7 +558,7 @@ export const Nested_InnerMessage = {
   },
 
   fromJSON(object: any): Nested_InnerMessage {
-    const message = { ...baseNested_InnerMessage } as Nested_InnerMessage;
+    const message = createBaseNested_InnerMessage();
     message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
     message.deep =
       object.deep !== undefined && object.deep !== null
@@ -576,7 +576,7 @@ export const Nested_InnerMessage = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Nested_InnerMessage>, I>>(object: I): Nested_InnerMessage {
-    const message = { ...baseNested_InnerMessage } as Nested_InnerMessage;
+    const message = createBaseNested_InnerMessage();
     message.name = object.name ?? '';
     message.deep =
       object.deep !== undefined && object.deep !== null
@@ -586,7 +586,7 @@ export const Nested_InnerMessage = {
   },
 };
 
-const baseNested_InnerMessage_DeepMessage: object = { name: '' };
+const createBaseNested_InnerMessage_DeepMessage = (): Nested_InnerMessage_DeepMessage => ({ name: '' });
 
 export const Nested_InnerMessage_DeepMessage = {
   encode(message: Nested_InnerMessage_DeepMessage, writer: Writer = Writer.create()): Writer {
@@ -599,7 +599,7 @@ export const Nested_InnerMessage_DeepMessage = {
   decode(input: Reader | Uint8Array, length?: number): Nested_InnerMessage_DeepMessage {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseNested_InnerMessage_DeepMessage } as Nested_InnerMessage_DeepMessage;
+    const message = createBaseNested_InnerMessage_DeepMessage();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -615,7 +615,7 @@ export const Nested_InnerMessage_DeepMessage = {
   },
 
   fromJSON(object: any): Nested_InnerMessage_DeepMessage {
-    const message = { ...baseNested_InnerMessage_DeepMessage } as Nested_InnerMessage_DeepMessage;
+    const message = createBaseNested_InnerMessage_DeepMessage();
     message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
     return message;
   },
@@ -629,13 +629,13 @@ export const Nested_InnerMessage_DeepMessage = {
   fromPartial<I extends Exact<DeepPartial<Nested_InnerMessage_DeepMessage>, I>>(
     object: I
   ): Nested_InnerMessage_DeepMessage {
-    const message = { ...baseNested_InnerMessage_DeepMessage } as Nested_InnerMessage_DeepMessage;
+    const message = createBaseNested_InnerMessage_DeepMessage();
     message.name = object.name ?? '';
     return message;
   },
 };
 
-const baseOneOfMessage: object = {};
+const createBaseOneOfMessage = (): OneOfMessage => ({});
 
 export const OneOfMessage = {
   encode(message: OneOfMessage, writer: Writer = Writer.create()): Writer {
@@ -651,7 +651,7 @@ export const OneOfMessage = {
   decode(input: Reader | Uint8Array, length?: number): OneOfMessage {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseOneOfMessage } as OneOfMessage;
+    const message = createBaseOneOfMessage();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -670,7 +670,7 @@ export const OneOfMessage = {
   },
 
   fromJSON(object: any): OneOfMessage {
-    const message = { ...baseOneOfMessage } as OneOfMessage;
+    const message = createBaseOneOfMessage();
     message.first = object.first !== undefined && object.first !== null ? String(object.first) : undefined;
     message.last = object.last !== undefined && object.last !== null ? String(object.last) : undefined;
     return message;
@@ -684,14 +684,14 @@ export const OneOfMessage = {
   },
 
   fromPartial<I extends Exact<DeepPartial<OneOfMessage>, I>>(object: I): OneOfMessage {
-    const message = { ...baseOneOfMessage } as OneOfMessage;
+    const message = createBaseOneOfMessage();
     message.first = object.first ?? undefined;
     message.last = object.last ?? undefined;
     return message;
   },
 };
 
-const baseSimpleWithWrappers: object = {};
+const createBaseSimpleWithWrappers = (): SimpleWithWrappers => ({});
 
 export const SimpleWithWrappers = {
   encode(message: SimpleWithWrappers, writer: Writer = Writer.create()): Writer {
@@ -716,7 +716,7 @@ export const SimpleWithWrappers = {
   decode(input: Reader | Uint8Array, length?: number): SimpleWithWrappers {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimpleWithWrappers } as SimpleWithWrappers;
+    const message = createBaseSimpleWithWrappers();
     message.coins = [];
     message.snacks = [];
     while (reader.pos < end) {
@@ -746,7 +746,7 @@ export const SimpleWithWrappers = {
   },
 
   fromJSON(object: any): SimpleWithWrappers {
-    const message = { ...baseSimpleWithWrappers } as SimpleWithWrappers;
+    const message = createBaseSimpleWithWrappers();
     message.name = object.name !== undefined && object.name !== null ? String(object.name) : undefined;
     message.age = object.age !== undefined && object.age !== null ? Number(object.age) : undefined;
     message.enabled = object.enabled !== undefined && object.enabled !== null ? Boolean(object.enabled) : undefined;
@@ -774,7 +774,7 @@ export const SimpleWithWrappers = {
   },
 
   fromPartial<I extends Exact<DeepPartial<SimpleWithWrappers>, I>>(object: I): SimpleWithWrappers {
-    const message = { ...baseSimpleWithWrappers } as SimpleWithWrappers;
+    const message = createBaseSimpleWithWrappers();
     message.name = object.name ?? undefined;
     message.age = object.age ?? undefined;
     message.enabled = object.enabled ?? undefined;
@@ -784,7 +784,7 @@ export const SimpleWithWrappers = {
   },
 };
 
-const baseEntity: object = { id: 0 };
+const createBaseEntity = (): Entity => ({ id: 0 });
 
 export const Entity = {
   encode(message: Entity, writer: Writer = Writer.create()): Writer {
@@ -797,7 +797,7 @@ export const Entity = {
   decode(input: Reader | Uint8Array, length?: number): Entity {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseEntity } as Entity;
+    const message = createBaseEntity();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -813,7 +813,7 @@ export const Entity = {
   },
 
   fromJSON(object: any): Entity {
-    const message = { ...baseEntity } as Entity;
+    const message = createBaseEntity();
     message.id = object.id !== undefined && object.id !== null ? Number(object.id) : 0;
     return message;
   },
@@ -825,13 +825,13 @@ export const Entity = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Entity>, I>>(object: I): Entity {
-    const message = { ...baseEntity } as Entity;
+    const message = createBaseEntity();
     message.id = object.id ?? 0;
     return message;
   },
 };
 
-const baseSimpleWithMap: object = {};
+const createBaseSimpleWithMap = (): SimpleWithMap => ({});
 
 export const SimpleWithMap = {
   encode(message: SimpleWithMap, writer: Writer = Writer.create()): Writer {
@@ -850,7 +850,7 @@ export const SimpleWithMap = {
   decode(input: Reader | Uint8Array, length?: number): SimpleWithMap {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimpleWithMap } as SimpleWithMap;
+    const message = createBaseSimpleWithMap();
     message.entitiesById = {};
     message.nameLookup = {};
     message.intLookup = {};
@@ -884,7 +884,7 @@ export const SimpleWithMap = {
   },
 
   fromJSON(object: any): SimpleWithMap {
-    const message = { ...baseSimpleWithMap } as SimpleWithMap;
+    const message = createBaseSimpleWithMap();
     message.entitiesById = Object.entries(object.entitiesById ?? {}).reduce<{ [key: number]: Entity }>(
       (acc, [key, value]) => {
         acc[Number(key)] = Entity.fromJSON(value);
@@ -933,7 +933,7 @@ export const SimpleWithMap = {
   },
 
   fromPartial<I extends Exact<DeepPartial<SimpleWithMap>, I>>(object: I): SimpleWithMap {
-    const message = { ...baseSimpleWithMap } as SimpleWithMap;
+    const message = createBaseSimpleWithMap();
     message.entitiesById = Object.entries(object.entitiesById ?? {}).reduce<{ [key: number]: Entity }>(
       (acc, [key, value]) => {
         if (value !== undefined) {
@@ -965,7 +965,7 @@ export const SimpleWithMap = {
   },
 };
 
-const baseSimpleWithMap_EntitiesByIdEntry: object = { key: 0 };
+const createBaseSimpleWithMap_EntitiesByIdEntry = (): SimpleWithMap_EntitiesByIdEntry => ({ key: 0 });
 
 export const SimpleWithMap_EntitiesByIdEntry = {
   encode(message: SimpleWithMap_EntitiesByIdEntry, writer: Writer = Writer.create()): Writer {
@@ -981,7 +981,7 @@ export const SimpleWithMap_EntitiesByIdEntry = {
   decode(input: Reader | Uint8Array, length?: number): SimpleWithMap_EntitiesByIdEntry {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimpleWithMap_EntitiesByIdEntry } as SimpleWithMap_EntitiesByIdEntry;
+    const message = createBaseSimpleWithMap_EntitiesByIdEntry();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -1000,7 +1000,7 @@ export const SimpleWithMap_EntitiesByIdEntry = {
   },
 
   fromJSON(object: any): SimpleWithMap_EntitiesByIdEntry {
-    const message = { ...baseSimpleWithMap_EntitiesByIdEntry } as SimpleWithMap_EntitiesByIdEntry;
+    const message = createBaseSimpleWithMap_EntitiesByIdEntry();
     message.key = object.key !== undefined && object.key !== null ? Number(object.key) : 0;
     message.value = object.value !== undefined && object.value !== null ? Entity.fromJSON(object.value) : undefined;
     return message;
@@ -1016,14 +1016,14 @@ export const SimpleWithMap_EntitiesByIdEntry = {
   fromPartial<I extends Exact<DeepPartial<SimpleWithMap_EntitiesByIdEntry>, I>>(
     object: I
   ): SimpleWithMap_EntitiesByIdEntry {
-    const message = { ...baseSimpleWithMap_EntitiesByIdEntry } as SimpleWithMap_EntitiesByIdEntry;
+    const message = createBaseSimpleWithMap_EntitiesByIdEntry();
     message.key = object.key ?? 0;
     message.value = object.value !== undefined && object.value !== null ? Entity.fromPartial(object.value) : undefined;
     return message;
   },
 };
 
-const baseSimpleWithMap_NameLookupEntry: object = { key: '', value: '' };
+const createBaseSimpleWithMap_NameLookupEntry = (): SimpleWithMap_NameLookupEntry => ({ key: '', value: '' });
 
 export const SimpleWithMap_NameLookupEntry = {
   encode(message: SimpleWithMap_NameLookupEntry, writer: Writer = Writer.create()): Writer {
@@ -1039,7 +1039,7 @@ export const SimpleWithMap_NameLookupEntry = {
   decode(input: Reader | Uint8Array, length?: number): SimpleWithMap_NameLookupEntry {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimpleWithMap_NameLookupEntry } as SimpleWithMap_NameLookupEntry;
+    const message = createBaseSimpleWithMap_NameLookupEntry();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -1058,7 +1058,7 @@ export const SimpleWithMap_NameLookupEntry = {
   },
 
   fromJSON(object: any): SimpleWithMap_NameLookupEntry {
-    const message = { ...baseSimpleWithMap_NameLookupEntry } as SimpleWithMap_NameLookupEntry;
+    const message = createBaseSimpleWithMap_NameLookupEntry();
     message.key = object.key !== undefined && object.key !== null ? String(object.key) : '';
     message.value = object.value !== undefined && object.value !== null ? String(object.value) : '';
     return message;
@@ -1074,14 +1074,14 @@ export const SimpleWithMap_NameLookupEntry = {
   fromPartial<I extends Exact<DeepPartial<SimpleWithMap_NameLookupEntry>, I>>(
     object: I
   ): SimpleWithMap_NameLookupEntry {
-    const message = { ...baseSimpleWithMap_NameLookupEntry } as SimpleWithMap_NameLookupEntry;
+    const message = createBaseSimpleWithMap_NameLookupEntry();
     message.key = object.key ?? '';
     message.value = object.value ?? '';
     return message;
   },
 };
 
-const baseSimpleWithMap_IntLookupEntry: object = { key: 0, value: 0 };
+const createBaseSimpleWithMap_IntLookupEntry = (): SimpleWithMap_IntLookupEntry => ({ key: 0, value: 0 });
 
 export const SimpleWithMap_IntLookupEntry = {
   encode(message: SimpleWithMap_IntLookupEntry, writer: Writer = Writer.create()): Writer {
@@ -1097,7 +1097,7 @@ export const SimpleWithMap_IntLookupEntry = {
   decode(input: Reader | Uint8Array, length?: number): SimpleWithMap_IntLookupEntry {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimpleWithMap_IntLookupEntry } as SimpleWithMap_IntLookupEntry;
+    const message = createBaseSimpleWithMap_IntLookupEntry();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -1116,7 +1116,7 @@ export const SimpleWithMap_IntLookupEntry = {
   },
 
   fromJSON(object: any): SimpleWithMap_IntLookupEntry {
-    const message = { ...baseSimpleWithMap_IntLookupEntry } as SimpleWithMap_IntLookupEntry;
+    const message = createBaseSimpleWithMap_IntLookupEntry();
     message.key = object.key !== undefined && object.key !== null ? Number(object.key) : 0;
     message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
@@ -1130,14 +1130,14 @@ export const SimpleWithMap_IntLookupEntry = {
   },
 
   fromPartial<I extends Exact<DeepPartial<SimpleWithMap_IntLookupEntry>, I>>(object: I): SimpleWithMap_IntLookupEntry {
-    const message = { ...baseSimpleWithMap_IntLookupEntry } as SimpleWithMap_IntLookupEntry;
+    const message = createBaseSimpleWithMap_IntLookupEntry();
     message.key = object.key ?? 0;
     message.value = object.value ?? 0;
     return message;
   },
 };
 
-const baseSimpleWithSnakeCaseMap: object = {};
+const createBaseSimpleWithSnakeCaseMap = (): SimpleWithSnakeCaseMap => ({});
 
 export const SimpleWithSnakeCaseMap = {
   encode(message: SimpleWithSnakeCaseMap, writer: Writer = Writer.create()): Writer {
@@ -1150,7 +1150,7 @@ export const SimpleWithSnakeCaseMap = {
   decode(input: Reader | Uint8Array, length?: number): SimpleWithSnakeCaseMap {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimpleWithSnakeCaseMap } as SimpleWithSnakeCaseMap;
+    const message = createBaseSimpleWithSnakeCaseMap();
     message.entitiesById = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
@@ -1170,7 +1170,7 @@ export const SimpleWithSnakeCaseMap = {
   },
 
   fromJSON(object: any): SimpleWithSnakeCaseMap {
-    const message = { ...baseSimpleWithSnakeCaseMap } as SimpleWithSnakeCaseMap;
+    const message = createBaseSimpleWithSnakeCaseMap();
     message.entitiesById = Object.entries(object.entitiesById ?? {}).reduce<{ [key: number]: Entity }>(
       (acc, [key, value]) => {
         acc[Number(key)] = Entity.fromJSON(value);
@@ -1193,7 +1193,7 @@ export const SimpleWithSnakeCaseMap = {
   },
 
   fromPartial<I extends Exact<DeepPartial<SimpleWithSnakeCaseMap>, I>>(object: I): SimpleWithSnakeCaseMap {
-    const message = { ...baseSimpleWithSnakeCaseMap } as SimpleWithSnakeCaseMap;
+    const message = createBaseSimpleWithSnakeCaseMap();
     message.entitiesById = Object.entries(object.entitiesById ?? {}).reduce<{ [key: number]: Entity }>(
       (acc, [key, value]) => {
         if (value !== undefined) {
@@ -1207,7 +1207,7 @@ export const SimpleWithSnakeCaseMap = {
   },
 };
 
-const baseSimpleWithSnakeCaseMap_EntitiesByIdEntry: object = { key: 0 };
+const createBaseSimpleWithSnakeCaseMap_EntitiesByIdEntry = (): SimpleWithSnakeCaseMap_EntitiesByIdEntry => ({ key: 0 });
 
 export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
   encode(message: SimpleWithSnakeCaseMap_EntitiesByIdEntry, writer: Writer = Writer.create()): Writer {
@@ -1223,7 +1223,7 @@ export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
   decode(input: Reader | Uint8Array, length?: number): SimpleWithSnakeCaseMap_EntitiesByIdEntry {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimpleWithSnakeCaseMap_EntitiesByIdEntry } as SimpleWithSnakeCaseMap_EntitiesByIdEntry;
+    const message = createBaseSimpleWithSnakeCaseMap_EntitiesByIdEntry();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -1242,7 +1242,7 @@ export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
   },
 
   fromJSON(object: any): SimpleWithSnakeCaseMap_EntitiesByIdEntry {
-    const message = { ...baseSimpleWithSnakeCaseMap_EntitiesByIdEntry } as SimpleWithSnakeCaseMap_EntitiesByIdEntry;
+    const message = createBaseSimpleWithSnakeCaseMap_EntitiesByIdEntry();
     message.key = object.key !== undefined && object.key !== null ? Number(object.key) : 0;
     message.value = object.value !== undefined && object.value !== null ? Entity.fromJSON(object.value) : undefined;
     return message;
@@ -1258,14 +1258,14 @@ export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
   fromPartial<I extends Exact<DeepPartial<SimpleWithSnakeCaseMap_EntitiesByIdEntry>, I>>(
     object: I
   ): SimpleWithSnakeCaseMap_EntitiesByIdEntry {
-    const message = { ...baseSimpleWithSnakeCaseMap_EntitiesByIdEntry } as SimpleWithSnakeCaseMap_EntitiesByIdEntry;
+    const message = createBaseSimpleWithSnakeCaseMap_EntitiesByIdEntry();
     message.key = object.key ?? 0;
     message.value = object.value !== undefined && object.value !== null ? Entity.fromPartial(object.value) : undefined;
     return message;
   },
 };
 
-const basePingRequest: object = { input: '' };
+const createBasePingRequest = (): PingRequest => ({ input: '' });
 
 export const PingRequest = {
   encode(message: PingRequest, writer: Writer = Writer.create()): Writer {
@@ -1278,7 +1278,7 @@ export const PingRequest = {
   decode(input: Reader | Uint8Array, length?: number): PingRequest {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...basePingRequest } as PingRequest;
+    const message = createBasePingRequest();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -1294,7 +1294,7 @@ export const PingRequest = {
   },
 
   fromJSON(object: any): PingRequest {
-    const message = { ...basePingRequest } as PingRequest;
+    const message = createBasePingRequest();
     message.input = object.input !== undefined && object.input !== null ? String(object.input) : '';
     return message;
   },
@@ -1306,13 +1306,13 @@ export const PingRequest = {
   },
 
   fromPartial<I extends Exact<DeepPartial<PingRequest>, I>>(object: I): PingRequest {
-    const message = { ...basePingRequest } as PingRequest;
+    const message = createBasePingRequest();
     message.input = object.input ?? '';
     return message;
   },
 };
 
-const basePingResponse: object = { output: '' };
+const createBasePingResponse = (): PingResponse => ({ output: '' });
 
 export const PingResponse = {
   encode(message: PingResponse, writer: Writer = Writer.create()): Writer {
@@ -1325,7 +1325,7 @@ export const PingResponse = {
   decode(input: Reader | Uint8Array, length?: number): PingResponse {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...basePingResponse } as PingResponse;
+    const message = createBasePingResponse();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -1341,7 +1341,7 @@ export const PingResponse = {
   },
 
   fromJSON(object: any): PingResponse {
-    const message = { ...basePingResponse } as PingResponse;
+    const message = createBasePingResponse();
     message.output = object.output !== undefined && object.output !== null ? String(object.output) : '';
     return message;
   },
@@ -1353,13 +1353,13 @@ export const PingResponse = {
   },
 
   fromPartial<I extends Exact<DeepPartial<PingResponse>, I>>(object: I): PingResponse {
-    const message = { ...basePingResponse } as PingResponse;
+    const message = createBasePingResponse();
     message.output = object.output ?? '';
     return message;
   },
 };
 
-const baseNumbers: object = {
+const createBaseNumbers = (): Numbers => ({
   double: 0,
   float: 0,
   int32: 0,
@@ -1372,7 +1372,7 @@ const baseNumbers: object = {
   fixed64: 0,
   sfixed32: 0,
   sfixed64: 0,
-};
+});
 
 export const Numbers = {
   encode(message: Numbers, writer: Writer = Writer.create()): Writer {
@@ -1418,7 +1418,7 @@ export const Numbers = {
   decode(input: Reader | Uint8Array, length?: number): Numbers {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseNumbers } as Numbers;
+    const message = createBaseNumbers();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -1467,7 +1467,7 @@ export const Numbers = {
   },
 
   fromJSON(object: any): Numbers {
-    const message = { ...baseNumbers } as Numbers;
+    const message = createBaseNumbers();
     message.double = object.double !== undefined && object.double !== null ? Number(object.double) : 0;
     message.float = object.float !== undefined && object.float !== null ? Number(object.float) : 0;
     message.int32 = object.int32 !== undefined && object.int32 !== null ? Number(object.int32) : 0;
@@ -1501,7 +1501,7 @@ export const Numbers = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Numbers>, I>>(object: I): Numbers {
-    const message = { ...baseNumbers } as Numbers;
+    const message = createBaseNumbers();
     message.double = object.double ?? 0;
     message.float = object.float ?? 0;
     message.int32 = object.int32 ?? 0;

--- a/integration/simple-unrecognized-enum/simple.ts
+++ b/integration/simple-unrecognized-enum/simple.ts
@@ -226,7 +226,20 @@ export interface Numbers {
   sfixed64: number;
 }
 
-const createBaseSimple = (): Simple => ({ name: '', age: 0, state: 0, coins: 0, snacks: '', oldStates: 0 });
+function createBaseSimple(): Simple {
+  return {
+    name: '',
+    age: 0,
+    createdAt: undefined,
+    child: undefined,
+    state: 0,
+    grandChildren: [],
+    coins: [],
+    snacks: [],
+    oldStates: [],
+    thing: undefined,
+  };
+}
 
 export const Simple = {
   encode(message: Simple, writer: Writer = Writer.create()): Writer {
@@ -271,10 +284,6 @@ export const Simple = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseSimple();
-    message.grandChildren = [];
-    message.coins = [];
-    message.snacks = [];
-    message.oldStates = [];
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -395,7 +404,9 @@ export const Simple = {
   },
 };
 
-const createBaseChild = (): Child => ({ name: '', type: 0 });
+function createBaseChild(): Child {
+  return { name: '', type: 0 };
+}
 
 export const Child = {
   encode(message: Child, writer: Writer = Writer.create()): Writer {
@@ -451,7 +462,9 @@ export const Child = {
   },
 };
 
-const createBaseNested = (): Nested => ({ name: '', state: 0 });
+function createBaseNested(): Nested {
+  return { name: '', message: undefined, state: 0 };
+}
 
 export const Nested = {
   encode(message: Nested, writer: Writer = Writer.create()): Writer {
@@ -523,7 +536,9 @@ export const Nested = {
   },
 };
 
-const createBaseNested_InnerMessage = (): Nested_InnerMessage => ({ name: '' });
+function createBaseNested_InnerMessage(): Nested_InnerMessage {
+  return { name: '', deep: undefined };
+}
 
 export const Nested_InnerMessage = {
   encode(message: Nested_InnerMessage, writer: Writer = Writer.create()): Writer {
@@ -586,7 +601,9 @@ export const Nested_InnerMessage = {
   },
 };
 
-const createBaseNested_InnerMessage_DeepMessage = (): Nested_InnerMessage_DeepMessage => ({ name: '' });
+function createBaseNested_InnerMessage_DeepMessage(): Nested_InnerMessage_DeepMessage {
+  return { name: '' };
+}
 
 export const Nested_InnerMessage_DeepMessage = {
   encode(message: Nested_InnerMessage_DeepMessage, writer: Writer = Writer.create()): Writer {
@@ -635,7 +652,9 @@ export const Nested_InnerMessage_DeepMessage = {
   },
 };
 
-const createBaseOneOfMessage = (): OneOfMessage => ({});
+function createBaseOneOfMessage(): OneOfMessage {
+  return { first: undefined, last: undefined };
+}
 
 export const OneOfMessage = {
   encode(message: OneOfMessage, writer: Writer = Writer.create()): Writer {
@@ -691,7 +710,9 @@ export const OneOfMessage = {
   },
 };
 
-const createBaseSimpleWithWrappers = (): SimpleWithWrappers => ({});
+function createBaseSimpleWithWrappers(): SimpleWithWrappers {
+  return { name: undefined, age: undefined, enabled: undefined, coins: [], snacks: [] };
+}
 
 export const SimpleWithWrappers = {
   encode(message: SimpleWithWrappers, writer: Writer = Writer.create()): Writer {
@@ -717,8 +738,6 @@ export const SimpleWithWrappers = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseSimpleWithWrappers();
-    message.coins = [];
-    message.snacks = [];
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -784,7 +803,9 @@ export const SimpleWithWrappers = {
   },
 };
 
-const createBaseEntity = (): Entity => ({ id: 0 });
+function createBaseEntity(): Entity {
+  return { id: 0 };
+}
 
 export const Entity = {
   encode(message: Entity, writer: Writer = Writer.create()): Writer {
@@ -831,7 +852,9 @@ export const Entity = {
   },
 };
 
-const createBaseSimpleWithMap = (): SimpleWithMap => ({});
+function createBaseSimpleWithMap(): SimpleWithMap {
+  return { entitiesById: {}, nameLookup: {}, intLookup: {} };
+}
 
 export const SimpleWithMap = {
   encode(message: SimpleWithMap, writer: Writer = Writer.create()): Writer {
@@ -851,9 +874,6 @@ export const SimpleWithMap = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseSimpleWithMap();
-    message.entitiesById = {};
-    message.nameLookup = {};
-    message.intLookup = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -965,7 +985,9 @@ export const SimpleWithMap = {
   },
 };
 
-const createBaseSimpleWithMap_EntitiesByIdEntry = (): SimpleWithMap_EntitiesByIdEntry => ({ key: 0 });
+function createBaseSimpleWithMap_EntitiesByIdEntry(): SimpleWithMap_EntitiesByIdEntry {
+  return { key: 0, value: undefined };
+}
 
 export const SimpleWithMap_EntitiesByIdEntry = {
   encode(message: SimpleWithMap_EntitiesByIdEntry, writer: Writer = Writer.create()): Writer {
@@ -1023,7 +1045,9 @@ export const SimpleWithMap_EntitiesByIdEntry = {
   },
 };
 
-const createBaseSimpleWithMap_NameLookupEntry = (): SimpleWithMap_NameLookupEntry => ({ key: '', value: '' });
+function createBaseSimpleWithMap_NameLookupEntry(): SimpleWithMap_NameLookupEntry {
+  return { key: '', value: '' };
+}
 
 export const SimpleWithMap_NameLookupEntry = {
   encode(message: SimpleWithMap_NameLookupEntry, writer: Writer = Writer.create()): Writer {
@@ -1081,7 +1105,9 @@ export const SimpleWithMap_NameLookupEntry = {
   },
 };
 
-const createBaseSimpleWithMap_IntLookupEntry = (): SimpleWithMap_IntLookupEntry => ({ key: 0, value: 0 });
+function createBaseSimpleWithMap_IntLookupEntry(): SimpleWithMap_IntLookupEntry {
+  return { key: 0, value: 0 };
+}
 
 export const SimpleWithMap_IntLookupEntry = {
   encode(message: SimpleWithMap_IntLookupEntry, writer: Writer = Writer.create()): Writer {
@@ -1137,7 +1163,9 @@ export const SimpleWithMap_IntLookupEntry = {
   },
 };
 
-const createBaseSimpleWithSnakeCaseMap = (): SimpleWithSnakeCaseMap => ({});
+function createBaseSimpleWithSnakeCaseMap(): SimpleWithSnakeCaseMap {
+  return { entitiesById: {} };
+}
 
 export const SimpleWithSnakeCaseMap = {
   encode(message: SimpleWithSnakeCaseMap, writer: Writer = Writer.create()): Writer {
@@ -1151,7 +1179,6 @@ export const SimpleWithSnakeCaseMap = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseSimpleWithSnakeCaseMap();
-    message.entitiesById = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -1207,7 +1234,9 @@ export const SimpleWithSnakeCaseMap = {
   },
 };
 
-const createBaseSimpleWithSnakeCaseMap_EntitiesByIdEntry = (): SimpleWithSnakeCaseMap_EntitiesByIdEntry => ({ key: 0 });
+function createBaseSimpleWithSnakeCaseMap_EntitiesByIdEntry(): SimpleWithSnakeCaseMap_EntitiesByIdEntry {
+  return { key: 0, value: undefined };
+}
 
 export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
   encode(message: SimpleWithSnakeCaseMap_EntitiesByIdEntry, writer: Writer = Writer.create()): Writer {
@@ -1265,7 +1294,9 @@ export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
   },
 };
 
-const createBasePingRequest = (): PingRequest => ({ input: '' });
+function createBasePingRequest(): PingRequest {
+  return { input: '' };
+}
 
 export const PingRequest = {
   encode(message: PingRequest, writer: Writer = Writer.create()): Writer {
@@ -1312,7 +1343,9 @@ export const PingRequest = {
   },
 };
 
-const createBasePingResponse = (): PingResponse => ({ output: '' });
+function createBasePingResponse(): PingResponse {
+  return { output: '' };
+}
 
 export const PingResponse = {
   encode(message: PingResponse, writer: Writer = Writer.create()): Writer {
@@ -1359,20 +1392,22 @@ export const PingResponse = {
   },
 };
 
-const createBaseNumbers = (): Numbers => ({
-  double: 0,
-  float: 0,
-  int32: 0,
-  int64: 0,
-  uint32: 0,
-  uint64: 0,
-  sint32: 0,
-  sint64: 0,
-  fixed32: 0,
-  fixed64: 0,
-  sfixed32: 0,
-  sfixed64: 0,
-});
+function createBaseNumbers(): Numbers {
+  return {
+    double: 0,
+    float: 0,
+    int32: 0,
+    int64: 0,
+    uint32: 0,
+    uint64: 0,
+    sint32: 0,
+    sint64: 0,
+    fixed32: 0,
+    fixed64: 0,
+    sfixed32: 0,
+    sfixed64: 0,
+  };
+}
 
 export const Numbers = {
   encode(message: Numbers, writer: Writer = Writer.create()): Writer {

--- a/integration/simple/google/protobuf/timestamp.ts
+++ b/integration/simple/google/protobuf/timestamp.ts
@@ -113,7 +113,9 @@ export interface Timestamp {
   nanos: number;
 }
 
-const createBaseTimestamp = (): Timestamp => ({ seconds: 0, nanos: 0 });
+function createBaseTimestamp(): Timestamp {
+  return { seconds: 0, nanos: 0 };
+}
 
 export const Timestamp = {
   encode(message: Timestamp, writer: Writer = Writer.create()): Writer {

--- a/integration/simple/google/protobuf/timestamp.ts
+++ b/integration/simple/google/protobuf/timestamp.ts
@@ -113,7 +113,7 @@ export interface Timestamp {
   nanos: number;
 }
 
-const baseTimestamp: object = { seconds: 0, nanos: 0 };
+const createBaseTimestamp = (): Timestamp => ({ seconds: 0, nanos: 0 });
 
 export const Timestamp = {
   encode(message: Timestamp, writer: Writer = Writer.create()): Writer {
@@ -129,7 +129,7 @@ export const Timestamp = {
   decode(input: Reader | Uint8Array, length?: number): Timestamp {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseTimestamp } as Timestamp;
+    const message = createBaseTimestamp();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -148,7 +148,7 @@ export const Timestamp = {
   },
 
   fromJSON(object: any): Timestamp {
-    const message = { ...baseTimestamp } as Timestamp;
+    const message = createBaseTimestamp();
     message.seconds = object.seconds !== undefined && object.seconds !== null ? Number(object.seconds) : 0;
     message.nanos = object.nanos !== undefined && object.nanos !== null ? Number(object.nanos) : 0;
     return message;
@@ -162,7 +162,7 @@ export const Timestamp = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Timestamp>, I>>(object: I): Timestamp {
-    const message = { ...baseTimestamp } as Timestamp;
+    const message = createBaseTimestamp();
     message.seconds = object.seconds ?? 0;
     message.nanos = object.nanos ?? 0;
     return message;

--- a/integration/simple/google/protobuf/wrappers.ts
+++ b/integration/simple/google/protobuf/wrappers.ts
@@ -94,7 +94,9 @@ export interface BytesValue {
   value: Uint8Array;
 }
 
-const createBaseDoubleValue = (): DoubleValue => ({ value: 0 });
+function createBaseDoubleValue(): DoubleValue {
+  return { value: 0 };
+}
 
 export const DoubleValue = {
   encode(message: DoubleValue, writer: Writer = Writer.create()): Writer {
@@ -141,7 +143,9 @@ export const DoubleValue = {
   },
 };
 
-const createBaseFloatValue = (): FloatValue => ({ value: 0 });
+function createBaseFloatValue(): FloatValue {
+  return { value: 0 };
+}
 
 export const FloatValue = {
   encode(message: FloatValue, writer: Writer = Writer.create()): Writer {
@@ -188,7 +192,9 @@ export const FloatValue = {
   },
 };
 
-const createBaseInt64Value = (): Int64Value => ({ value: 0 });
+function createBaseInt64Value(): Int64Value {
+  return { value: 0 };
+}
 
 export const Int64Value = {
   encode(message: Int64Value, writer: Writer = Writer.create()): Writer {
@@ -235,7 +241,9 @@ export const Int64Value = {
   },
 };
 
-const createBaseUInt64Value = (): UInt64Value => ({ value: 0 });
+function createBaseUInt64Value(): UInt64Value {
+  return { value: 0 };
+}
 
 export const UInt64Value = {
   encode(message: UInt64Value, writer: Writer = Writer.create()): Writer {
@@ -282,7 +290,9 @@ export const UInt64Value = {
   },
 };
 
-const createBaseInt32Value = (): Int32Value => ({ value: 0 });
+function createBaseInt32Value(): Int32Value {
+  return { value: 0 };
+}
 
 export const Int32Value = {
   encode(message: Int32Value, writer: Writer = Writer.create()): Writer {
@@ -329,7 +339,9 @@ export const Int32Value = {
   },
 };
 
-const createBaseUInt32Value = (): UInt32Value => ({ value: 0 });
+function createBaseUInt32Value(): UInt32Value {
+  return { value: 0 };
+}
 
 export const UInt32Value = {
   encode(message: UInt32Value, writer: Writer = Writer.create()): Writer {
@@ -376,7 +388,9 @@ export const UInt32Value = {
   },
 };
 
-const createBaseBoolValue = (): BoolValue => ({ value: false });
+function createBaseBoolValue(): BoolValue {
+  return { value: false };
+}
 
 export const BoolValue = {
   encode(message: BoolValue, writer: Writer = Writer.create()): Writer {
@@ -423,7 +437,9 @@ export const BoolValue = {
   },
 };
 
-const createBaseStringValue = (): StringValue => ({ value: '' });
+function createBaseStringValue(): StringValue {
+  return { value: '' };
+}
 
 export const StringValue = {
   encode(message: StringValue, writer: Writer = Writer.create()): Writer {
@@ -470,7 +486,9 @@ export const StringValue = {
   },
 };
 
-const createBaseBytesValue = (): BytesValue => ({});
+function createBaseBytesValue(): BytesValue {
+  return { value: new Uint8Array() };
+}
 
 export const BytesValue = {
   encode(message: BytesValue, writer: Writer = Writer.create()): Writer {
@@ -484,7 +502,6 @@ export const BytesValue = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseBytesValue();
-    message.value = new Uint8Array();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {

--- a/integration/simple/google/protobuf/wrappers.ts
+++ b/integration/simple/google/protobuf/wrappers.ts
@@ -94,7 +94,7 @@ export interface BytesValue {
   value: Uint8Array;
 }
 
-const baseDoubleValue: object = { value: 0 };
+const createBaseDoubleValue = (): DoubleValue => ({ value: 0 });
 
 export const DoubleValue = {
   encode(message: DoubleValue, writer: Writer = Writer.create()): Writer {
@@ -107,7 +107,7 @@ export const DoubleValue = {
   decode(input: Reader | Uint8Array, length?: number): DoubleValue {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseDoubleValue } as DoubleValue;
+    const message = createBaseDoubleValue();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -123,7 +123,7 @@ export const DoubleValue = {
   },
 
   fromJSON(object: any): DoubleValue {
-    const message = { ...baseDoubleValue } as DoubleValue;
+    const message = createBaseDoubleValue();
     message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
@@ -135,13 +135,13 @@ export const DoubleValue = {
   },
 
   fromPartial<I extends Exact<DeepPartial<DoubleValue>, I>>(object: I): DoubleValue {
-    const message = { ...baseDoubleValue } as DoubleValue;
+    const message = createBaseDoubleValue();
     message.value = object.value ?? 0;
     return message;
   },
 };
 
-const baseFloatValue: object = { value: 0 };
+const createBaseFloatValue = (): FloatValue => ({ value: 0 });
 
 export const FloatValue = {
   encode(message: FloatValue, writer: Writer = Writer.create()): Writer {
@@ -154,7 +154,7 @@ export const FloatValue = {
   decode(input: Reader | Uint8Array, length?: number): FloatValue {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseFloatValue } as FloatValue;
+    const message = createBaseFloatValue();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -170,7 +170,7 @@ export const FloatValue = {
   },
 
   fromJSON(object: any): FloatValue {
-    const message = { ...baseFloatValue } as FloatValue;
+    const message = createBaseFloatValue();
     message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
@@ -182,13 +182,13 @@ export const FloatValue = {
   },
 
   fromPartial<I extends Exact<DeepPartial<FloatValue>, I>>(object: I): FloatValue {
-    const message = { ...baseFloatValue } as FloatValue;
+    const message = createBaseFloatValue();
     message.value = object.value ?? 0;
     return message;
   },
 };
 
-const baseInt64Value: object = { value: 0 };
+const createBaseInt64Value = (): Int64Value => ({ value: 0 });
 
 export const Int64Value = {
   encode(message: Int64Value, writer: Writer = Writer.create()): Writer {
@@ -201,7 +201,7 @@ export const Int64Value = {
   decode(input: Reader | Uint8Array, length?: number): Int64Value {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseInt64Value } as Int64Value;
+    const message = createBaseInt64Value();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -217,7 +217,7 @@ export const Int64Value = {
   },
 
   fromJSON(object: any): Int64Value {
-    const message = { ...baseInt64Value } as Int64Value;
+    const message = createBaseInt64Value();
     message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
@@ -229,13 +229,13 @@ export const Int64Value = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Int64Value>, I>>(object: I): Int64Value {
-    const message = { ...baseInt64Value } as Int64Value;
+    const message = createBaseInt64Value();
     message.value = object.value ?? 0;
     return message;
   },
 };
 
-const baseUInt64Value: object = { value: 0 };
+const createBaseUInt64Value = (): UInt64Value => ({ value: 0 });
 
 export const UInt64Value = {
   encode(message: UInt64Value, writer: Writer = Writer.create()): Writer {
@@ -248,7 +248,7 @@ export const UInt64Value = {
   decode(input: Reader | Uint8Array, length?: number): UInt64Value {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseUInt64Value } as UInt64Value;
+    const message = createBaseUInt64Value();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -264,7 +264,7 @@ export const UInt64Value = {
   },
 
   fromJSON(object: any): UInt64Value {
-    const message = { ...baseUInt64Value } as UInt64Value;
+    const message = createBaseUInt64Value();
     message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
@@ -276,13 +276,13 @@ export const UInt64Value = {
   },
 
   fromPartial<I extends Exact<DeepPartial<UInt64Value>, I>>(object: I): UInt64Value {
-    const message = { ...baseUInt64Value } as UInt64Value;
+    const message = createBaseUInt64Value();
     message.value = object.value ?? 0;
     return message;
   },
 };
 
-const baseInt32Value: object = { value: 0 };
+const createBaseInt32Value = (): Int32Value => ({ value: 0 });
 
 export const Int32Value = {
   encode(message: Int32Value, writer: Writer = Writer.create()): Writer {
@@ -295,7 +295,7 @@ export const Int32Value = {
   decode(input: Reader | Uint8Array, length?: number): Int32Value {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseInt32Value } as Int32Value;
+    const message = createBaseInt32Value();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -311,7 +311,7 @@ export const Int32Value = {
   },
 
   fromJSON(object: any): Int32Value {
-    const message = { ...baseInt32Value } as Int32Value;
+    const message = createBaseInt32Value();
     message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
@@ -323,13 +323,13 @@ export const Int32Value = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Int32Value>, I>>(object: I): Int32Value {
-    const message = { ...baseInt32Value } as Int32Value;
+    const message = createBaseInt32Value();
     message.value = object.value ?? 0;
     return message;
   },
 };
 
-const baseUInt32Value: object = { value: 0 };
+const createBaseUInt32Value = (): UInt32Value => ({ value: 0 });
 
 export const UInt32Value = {
   encode(message: UInt32Value, writer: Writer = Writer.create()): Writer {
@@ -342,7 +342,7 @@ export const UInt32Value = {
   decode(input: Reader | Uint8Array, length?: number): UInt32Value {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseUInt32Value } as UInt32Value;
+    const message = createBaseUInt32Value();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -358,7 +358,7 @@ export const UInt32Value = {
   },
 
   fromJSON(object: any): UInt32Value {
-    const message = { ...baseUInt32Value } as UInt32Value;
+    const message = createBaseUInt32Value();
     message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
   },
@@ -370,13 +370,13 @@ export const UInt32Value = {
   },
 
   fromPartial<I extends Exact<DeepPartial<UInt32Value>, I>>(object: I): UInt32Value {
-    const message = { ...baseUInt32Value } as UInt32Value;
+    const message = createBaseUInt32Value();
     message.value = object.value ?? 0;
     return message;
   },
 };
 
-const baseBoolValue: object = { value: false };
+const createBaseBoolValue = (): BoolValue => ({ value: false });
 
 export const BoolValue = {
   encode(message: BoolValue, writer: Writer = Writer.create()): Writer {
@@ -389,7 +389,7 @@ export const BoolValue = {
   decode(input: Reader | Uint8Array, length?: number): BoolValue {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseBoolValue } as BoolValue;
+    const message = createBaseBoolValue();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -405,7 +405,7 @@ export const BoolValue = {
   },
 
   fromJSON(object: any): BoolValue {
-    const message = { ...baseBoolValue } as BoolValue;
+    const message = createBaseBoolValue();
     message.value = object.value !== undefined && object.value !== null ? Boolean(object.value) : false;
     return message;
   },
@@ -417,13 +417,13 @@ export const BoolValue = {
   },
 
   fromPartial<I extends Exact<DeepPartial<BoolValue>, I>>(object: I): BoolValue {
-    const message = { ...baseBoolValue } as BoolValue;
+    const message = createBaseBoolValue();
     message.value = object.value ?? false;
     return message;
   },
 };
 
-const baseStringValue: object = { value: '' };
+const createBaseStringValue = (): StringValue => ({ value: '' });
 
 export const StringValue = {
   encode(message: StringValue, writer: Writer = Writer.create()): Writer {
@@ -436,7 +436,7 @@ export const StringValue = {
   decode(input: Reader | Uint8Array, length?: number): StringValue {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseStringValue } as StringValue;
+    const message = createBaseStringValue();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -452,7 +452,7 @@ export const StringValue = {
   },
 
   fromJSON(object: any): StringValue {
-    const message = { ...baseStringValue } as StringValue;
+    const message = createBaseStringValue();
     message.value = object.value !== undefined && object.value !== null ? String(object.value) : '';
     return message;
   },
@@ -464,13 +464,13 @@ export const StringValue = {
   },
 
   fromPartial<I extends Exact<DeepPartial<StringValue>, I>>(object: I): StringValue {
-    const message = { ...baseStringValue } as StringValue;
+    const message = createBaseStringValue();
     message.value = object.value ?? '';
     return message;
   },
 };
 
-const baseBytesValue: object = {};
+const createBaseBytesValue = (): BytesValue => ({});
 
 export const BytesValue = {
   encode(message: BytesValue, writer: Writer = Writer.create()): Writer {
@@ -483,7 +483,7 @@ export const BytesValue = {
   decode(input: Reader | Uint8Array, length?: number): BytesValue {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseBytesValue } as BytesValue;
+    const message = createBaseBytesValue();
     message.value = new Uint8Array();
     while (reader.pos < end) {
       const tag = reader.uint32();
@@ -500,7 +500,7 @@ export const BytesValue = {
   },
 
   fromJSON(object: any): BytesValue {
-    const message = { ...baseBytesValue } as BytesValue;
+    const message = createBaseBytesValue();
     message.value =
       object.value !== undefined && object.value !== null ? bytesFromBase64(object.value) : new Uint8Array();
     return message;
@@ -514,7 +514,7 @@ export const BytesValue = {
   },
 
   fromPartial<I extends Exact<DeepPartial<BytesValue>, I>>(object: I): BytesValue {
-    const message = { ...baseBytesValue } as BytesValue;
+    const message = createBaseBytesValue();
     message.value = object.value ?? new Uint8Array();
     return message;
   },

--- a/integration/simple/google/type/date.ts
+++ b/integration/simple/google/type/date.ts
@@ -35,7 +35,9 @@ export interface DateMessage {
   day: number;
 }
 
-const createBaseDateMessage = (): DateMessage => ({ year: 0, month: 0, day: 0 });
+function createBaseDateMessage(): DateMessage {
+  return { year: 0, month: 0, day: 0 };
+}
 
 export const DateMessage = {
   encode(message: DateMessage, writer: Writer = Writer.create()): Writer {

--- a/integration/simple/google/type/date.ts
+++ b/integration/simple/google/type/date.ts
@@ -35,7 +35,7 @@ export interface DateMessage {
   day: number;
 }
 
-const baseDateMessage: object = { year: 0, month: 0, day: 0 };
+const createBaseDateMessage = (): DateMessage => ({ year: 0, month: 0, day: 0 });
 
 export const DateMessage = {
   encode(message: DateMessage, writer: Writer = Writer.create()): Writer {
@@ -54,7 +54,7 @@ export const DateMessage = {
   decode(input: Reader | Uint8Array, length?: number): DateMessage {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseDateMessage } as DateMessage;
+    const message = createBaseDateMessage();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -76,7 +76,7 @@ export const DateMessage = {
   },
 
   fromJSON(object: any): DateMessage {
-    const message = { ...baseDateMessage } as DateMessage;
+    const message = createBaseDateMessage();
     message.year = object.year !== undefined && object.year !== null ? Number(object.year) : 0;
     message.month = object.month !== undefined && object.month !== null ? Number(object.month) : 0;
     message.day = object.day !== undefined && object.day !== null ? Number(object.day) : 0;
@@ -92,7 +92,7 @@ export const DateMessage = {
   },
 
   fromPartial<I extends Exact<DeepPartial<DateMessage>, I>>(object: I): DateMessage {
-    const message = { ...baseDateMessage } as DateMessage;
+    const message = createBaseDateMessage();
     message.year = object.year ?? 0;
     message.month = object.month ?? 0;
     message.day = object.day ?? 0;

--- a/integration/simple/import_dir/thing.ts
+++ b/integration/simple/import_dir/thing.ts
@@ -9,7 +9,7 @@ export interface ImportedThing {
   createdAt: Date | undefined;
 }
 
-const baseImportedThing: object = {};
+const createBaseImportedThing = (): ImportedThing => ({});
 
 export const ImportedThing = {
   encode(message: ImportedThing, writer: Writer = Writer.create()): Writer {
@@ -22,7 +22,7 @@ export const ImportedThing = {
   decode(input: Reader | Uint8Array, length?: number): ImportedThing {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseImportedThing } as ImportedThing;
+    const message = createBaseImportedThing();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -38,7 +38,7 @@ export const ImportedThing = {
   },
 
   fromJSON(object: any): ImportedThing {
-    const message = { ...baseImportedThing } as ImportedThing;
+    const message = createBaseImportedThing();
     message.createdAt =
       object.createdAt !== undefined && object.createdAt !== null ? fromJsonTimestamp(object.createdAt) : undefined;
     return message;
@@ -51,7 +51,7 @@ export const ImportedThing = {
   },
 
   fromPartial<I extends Exact<DeepPartial<ImportedThing>, I>>(object: I): ImportedThing {
-    const message = { ...baseImportedThing } as ImportedThing;
+    const message = createBaseImportedThing();
     message.createdAt = object.createdAt ?? undefined;
     return message;
   },

--- a/integration/simple/import_dir/thing.ts
+++ b/integration/simple/import_dir/thing.ts
@@ -9,7 +9,9 @@ export interface ImportedThing {
   createdAt: Date | undefined;
 }
 
-const createBaseImportedThing = (): ImportedThing => ({});
+function createBaseImportedThing(): ImportedThing {
+  return { createdAt: undefined };
+}
 
 export const ImportedThing = {
   encode(message: ImportedThing, writer: Writer = Writer.create()): Writer {

--- a/integration/simple/simple-oneofs-test.ts
+++ b/integration/simple/simple-oneofs-test.ts
@@ -7,32 +7,33 @@ describe('simple', () => {
   it('can encode oneofs', () => {
     const s1: OneOfMessage = {
       first: 'bob',
-      last: undefined
+      last: undefined,
     };
     const s2 = PbOneOfMessage.toObject(PbOneOfMessage.decode(OneOfMessage.encode(s1).finish()));
     expect(s2).toMatchInlineSnapshot(`
-Object {
-  "first": "bob",
-}
-`);
+      Object {
+        "first": "bob",
+      }
+    `);
   });
 
   it('can decode oneofs', () => {
     const s1 = PbOneOfMessage.fromObject({
-      last: 'smith'
+      last: 'smith',
     });
     const s2 = OneOfMessage.decode(Reader.create(PbOneOfMessage.encode(s1).finish()));
     expect(s2).toMatchInlineSnapshot(`
-Object {
-  "last": "smith",
-}
-`);
+      Object {
+        "first": undefined,
+        "last": "smith",
+      }
+    `);
   });
 
   it('can encode oneofs to json', () => {
     const s1: OneOfMessage = {
       first: 'bob',
-      last: undefined
+      last: undefined,
     };
     const ourJson = s1;
     const pbJson = PbOneOfMessage.decode(OneOfMessage.encode(s1).finish()).toJSON();
@@ -41,7 +42,7 @@ Object {
 
   it('can decode oneofs from json', () => {
     const s1 = PbOneOfMessage.fromObject({
-      last: 'smith'
+      last: 'smith',
     });
     const fromJson = s1.toJSON() as OneOfMessage;
     const fromPb = OneOfMessage.decode(Reader.create(PbOneOfMessage.encode(s1).finish()));

--- a/integration/simple/simple-test.ts
+++ b/integration/simple/simple-test.ts
@@ -127,12 +127,16 @@ describe('simple', () => {
       Array [
         "name",
         "age",
+        "createdAt",
+        "child",
         "state",
+        "grandChildren",
         "coins",
         "snacks",
         "oldStates",
-        "grandChildren",
+        "thing",
         "blobs",
+        "birthday",
         "blob",
       ]
     `);

--- a/integration/simple/simple-value-wrappers-test.ts
+++ b/integration/simple/simple-value-wrappers-test.ts
@@ -75,6 +75,8 @@ describe('simple value types', () => {
       Object {
         "age": 1,
         "coins": Array [],
+        "enabled": undefined,
+        "id": undefined,
         "name": "asdf",
         "snacks": Array [],
       }
@@ -86,7 +88,11 @@ describe('simple value types', () => {
     const s2 = SimpleWithWrappers.decode(Reader.create(PbSimpleWithWrappers.encode(s1).finish()));
     expect(s2).toMatchInlineSnapshot(`
       Object {
+        "age": undefined,
         "coins": Array [],
+        "enabled": undefined,
+        "id": undefined,
+        "name": undefined,
         "snacks": Array [],
       }
     `);

--- a/integration/simple/simple.ts
+++ b/integration/simple/simple.ts
@@ -290,7 +290,7 @@ export interface SimpleButOptional {
 
 export interface Empty {}
 
-const baseSimple: object = { name: '', age: 0, state: 0, coins: 0, snacks: '', oldStates: 0 };
+const createBaseSimple = (): Simple => ({ name: '', age: 0, state: 0, coins: 0, snacks: '', oldStates: 0 });
 
 export const Simple = {
   encode(message: Simple, writer: Writer = Writer.create()): Writer {
@@ -343,7 +343,7 @@ export const Simple = {
   decode(input: Reader | Uint8Array, length?: number): Simple {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimple } as Simple;
+    const message = createBaseSimple();
     message.grandChildren = [];
     message.coins = [];
     message.snacks = [];
@@ -415,7 +415,7 @@ export const Simple = {
   },
 
   fromJSON(object: any): Simple {
-    const message = { ...baseSimple } as Simple;
+    const message = createBaseSimple();
     message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
     message.age = object.age !== undefined && object.age !== null ? Number(object.age) : 0;
     message.createdAt =
@@ -476,7 +476,7 @@ export const Simple = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Simple>, I>>(object: I): Simple {
-    const message = { ...baseSimple } as Simple;
+    const message = createBaseSimple();
     message.name = object.name ?? '';
     message.age = object.age ?? 0;
     message.createdAt = object.createdAt ?? undefined;
@@ -496,7 +496,7 @@ export const Simple = {
   },
 };
 
-const baseChild: object = { name: '', type: 0 };
+const createBaseChild = (): Child => ({ name: '', type: 0 });
 
 export const Child = {
   encode(message: Child, writer: Writer = Writer.create()): Writer {
@@ -512,7 +512,7 @@ export const Child = {
   decode(input: Reader | Uint8Array, length?: number): Child {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseChild } as Child;
+    const message = createBaseChild();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -531,7 +531,7 @@ export const Child = {
   },
 
   fromJSON(object: any): Child {
-    const message = { ...baseChild } as Child;
+    const message = createBaseChild();
     message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
     message.type = object.type !== undefined && object.type !== null ? child_TypeFromJSON(object.type) : 0;
     return message;
@@ -545,14 +545,14 @@ export const Child = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Child>, I>>(object: I): Child {
-    const message = { ...baseChild } as Child;
+    const message = createBaseChild();
     message.name = object.name ?? '';
     message.type = object.type ?? 0;
     return message;
   },
 };
 
-const baseNested: object = { name: '', state: 0 };
+const createBaseNested = (): Nested => ({ name: '', state: 0 });
 
 export const Nested = {
   encode(message: Nested, writer: Writer = Writer.create()): Writer {
@@ -571,7 +571,7 @@ export const Nested = {
   decode(input: Reader | Uint8Array, length?: number): Nested {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseNested } as Nested;
+    const message = createBaseNested();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -593,7 +593,7 @@ export const Nested = {
   },
 
   fromJSON(object: any): Nested {
-    const message = { ...baseNested } as Nested;
+    const message = createBaseNested();
     message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
     message.message =
       object.message !== undefined && object.message !== null
@@ -613,7 +613,7 @@ export const Nested = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Nested>, I>>(object: I): Nested {
-    const message = { ...baseNested } as Nested;
+    const message = createBaseNested();
     message.name = object.name ?? '';
     message.message =
       object.message !== undefined && object.message !== null
@@ -624,7 +624,7 @@ export const Nested = {
   },
 };
 
-const baseNested_InnerMessage: object = { name: '' };
+const createBaseNested_InnerMessage = (): Nested_InnerMessage => ({ name: '' });
 
 export const Nested_InnerMessage = {
   encode(message: Nested_InnerMessage, writer: Writer = Writer.create()): Writer {
@@ -640,7 +640,7 @@ export const Nested_InnerMessage = {
   decode(input: Reader | Uint8Array, length?: number): Nested_InnerMessage {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseNested_InnerMessage } as Nested_InnerMessage;
+    const message = createBaseNested_InnerMessage();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -659,7 +659,7 @@ export const Nested_InnerMessage = {
   },
 
   fromJSON(object: any): Nested_InnerMessage {
-    const message = { ...baseNested_InnerMessage } as Nested_InnerMessage;
+    const message = createBaseNested_InnerMessage();
     message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
     message.deep =
       object.deep !== undefined && object.deep !== null
@@ -677,7 +677,7 @@ export const Nested_InnerMessage = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Nested_InnerMessage>, I>>(object: I): Nested_InnerMessage {
-    const message = { ...baseNested_InnerMessage } as Nested_InnerMessage;
+    const message = createBaseNested_InnerMessage();
     message.name = object.name ?? '';
     message.deep =
       object.deep !== undefined && object.deep !== null
@@ -687,7 +687,7 @@ export const Nested_InnerMessage = {
   },
 };
 
-const baseNested_InnerMessage_DeepMessage: object = { name: '' };
+const createBaseNested_InnerMessage_DeepMessage = (): Nested_InnerMessage_DeepMessage => ({ name: '' });
 
 export const Nested_InnerMessage_DeepMessage = {
   encode(message: Nested_InnerMessage_DeepMessage, writer: Writer = Writer.create()): Writer {
@@ -700,7 +700,7 @@ export const Nested_InnerMessage_DeepMessage = {
   decode(input: Reader | Uint8Array, length?: number): Nested_InnerMessage_DeepMessage {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseNested_InnerMessage_DeepMessage } as Nested_InnerMessage_DeepMessage;
+    const message = createBaseNested_InnerMessage_DeepMessage();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -716,7 +716,7 @@ export const Nested_InnerMessage_DeepMessage = {
   },
 
   fromJSON(object: any): Nested_InnerMessage_DeepMessage {
-    const message = { ...baseNested_InnerMessage_DeepMessage } as Nested_InnerMessage_DeepMessage;
+    const message = createBaseNested_InnerMessage_DeepMessage();
     message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
     return message;
   },
@@ -730,13 +730,13 @@ export const Nested_InnerMessage_DeepMessage = {
   fromPartial<I extends Exact<DeepPartial<Nested_InnerMessage_DeepMessage>, I>>(
     object: I
   ): Nested_InnerMessage_DeepMessage {
-    const message = { ...baseNested_InnerMessage_DeepMessage } as Nested_InnerMessage_DeepMessage;
+    const message = createBaseNested_InnerMessage_DeepMessage();
     message.name = object.name ?? '';
     return message;
   },
 };
 
-const baseOneOfMessage: object = {};
+const createBaseOneOfMessage = (): OneOfMessage => ({});
 
 export const OneOfMessage = {
   encode(message: OneOfMessage, writer: Writer = Writer.create()): Writer {
@@ -752,7 +752,7 @@ export const OneOfMessage = {
   decode(input: Reader | Uint8Array, length?: number): OneOfMessage {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseOneOfMessage } as OneOfMessage;
+    const message = createBaseOneOfMessage();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -771,7 +771,7 @@ export const OneOfMessage = {
   },
 
   fromJSON(object: any): OneOfMessage {
-    const message = { ...baseOneOfMessage } as OneOfMessage;
+    const message = createBaseOneOfMessage();
     message.first = object.first !== undefined && object.first !== null ? String(object.first) : undefined;
     message.last = object.last !== undefined && object.last !== null ? String(object.last) : undefined;
     return message;
@@ -785,14 +785,14 @@ export const OneOfMessage = {
   },
 
   fromPartial<I extends Exact<DeepPartial<OneOfMessage>, I>>(object: I): OneOfMessage {
-    const message = { ...baseOneOfMessage } as OneOfMessage;
+    const message = createBaseOneOfMessage();
     message.first = object.first ?? undefined;
     message.last = object.last ?? undefined;
     return message;
   },
 };
 
-const baseSimpleWithWrappers: object = {};
+const createBaseSimpleWithWrappers = (): SimpleWithWrappers => ({});
 
 export const SimpleWithWrappers = {
   encode(message: SimpleWithWrappers, writer: Writer = Writer.create()): Writer {
@@ -820,7 +820,7 @@ export const SimpleWithWrappers = {
   decode(input: Reader | Uint8Array, length?: number): SimpleWithWrappers {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimpleWithWrappers } as SimpleWithWrappers;
+    const message = createBaseSimpleWithWrappers();
     message.coins = [];
     message.snacks = [];
     while (reader.pos < end) {
@@ -853,7 +853,7 @@ export const SimpleWithWrappers = {
   },
 
   fromJSON(object: any): SimpleWithWrappers {
-    const message = { ...baseSimpleWithWrappers } as SimpleWithWrappers;
+    const message = createBaseSimpleWithWrappers();
     message.name = object.name !== undefined && object.name !== null ? String(object.name) : undefined;
     message.age = object.age !== undefined && object.age !== null ? Number(object.age) : undefined;
     message.enabled = object.enabled !== undefined && object.enabled !== null ? Boolean(object.enabled) : undefined;
@@ -883,7 +883,7 @@ export const SimpleWithWrappers = {
   },
 
   fromPartial<I extends Exact<DeepPartial<SimpleWithWrappers>, I>>(object: I): SimpleWithWrappers {
-    const message = { ...baseSimpleWithWrappers } as SimpleWithWrappers;
+    const message = createBaseSimpleWithWrappers();
     message.name = object.name ?? undefined;
     message.age = object.age ?? undefined;
     message.enabled = object.enabled ?? undefined;
@@ -894,7 +894,7 @@ export const SimpleWithWrappers = {
   },
 };
 
-const baseEntity: object = { id: 0 };
+const createBaseEntity = (): Entity => ({ id: 0 });
 
 export const Entity = {
   encode(message: Entity, writer: Writer = Writer.create()): Writer {
@@ -907,7 +907,7 @@ export const Entity = {
   decode(input: Reader | Uint8Array, length?: number): Entity {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseEntity } as Entity;
+    const message = createBaseEntity();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -923,7 +923,7 @@ export const Entity = {
   },
 
   fromJSON(object: any): Entity {
-    const message = { ...baseEntity } as Entity;
+    const message = createBaseEntity();
     message.id = object.id !== undefined && object.id !== null ? Number(object.id) : 0;
     return message;
   },
@@ -935,13 +935,13 @@ export const Entity = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Entity>, I>>(object: I): Entity {
-    const message = { ...baseEntity } as Entity;
+    const message = createBaseEntity();
     message.id = object.id ?? 0;
     return message;
   },
 };
 
-const baseSimpleWithMap: object = {};
+const createBaseSimpleWithMap = (): SimpleWithMap => ({});
 
 export const SimpleWithMap = {
   encode(message: SimpleWithMap, writer: Writer = Writer.create()): Writer {
@@ -974,7 +974,7 @@ export const SimpleWithMap = {
   decode(input: Reader | Uint8Array, length?: number): SimpleWithMap {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimpleWithMap } as SimpleWithMap;
+    const message = createBaseSimpleWithMap();
     message.entitiesById = {};
     message.nameLookup = {};
     message.intLookup = {};
@@ -1036,7 +1036,7 @@ export const SimpleWithMap = {
   },
 
   fromJSON(object: any): SimpleWithMap {
-    const message = { ...baseSimpleWithMap } as SimpleWithMap;
+    const message = createBaseSimpleWithMap();
     message.entitiesById = Object.entries(object.entitiesById ?? {}).reduce<{ [key: number]: Entity }>(
       (acc, [key, value]) => {
         acc[Number(key)] = Entity.fromJSON(value);
@@ -1136,7 +1136,7 @@ export const SimpleWithMap = {
   },
 
   fromPartial<I extends Exact<DeepPartial<SimpleWithMap>, I>>(object: I): SimpleWithMap {
-    const message = { ...baseSimpleWithMap } as SimpleWithMap;
+    const message = createBaseSimpleWithMap();
     message.entitiesById = Object.entries(object.entitiesById ?? {}).reduce<{ [key: number]: Entity }>(
       (acc, [key, value]) => {
         if (value !== undefined) {
@@ -1203,7 +1203,7 @@ export const SimpleWithMap = {
   },
 };
 
-const baseSimpleWithMap_EntitiesByIdEntry: object = { key: 0 };
+const createBaseSimpleWithMap_EntitiesByIdEntry = (): SimpleWithMap_EntitiesByIdEntry => ({ key: 0 });
 
 export const SimpleWithMap_EntitiesByIdEntry = {
   encode(message: SimpleWithMap_EntitiesByIdEntry, writer: Writer = Writer.create()): Writer {
@@ -1219,7 +1219,7 @@ export const SimpleWithMap_EntitiesByIdEntry = {
   decode(input: Reader | Uint8Array, length?: number): SimpleWithMap_EntitiesByIdEntry {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimpleWithMap_EntitiesByIdEntry } as SimpleWithMap_EntitiesByIdEntry;
+    const message = createBaseSimpleWithMap_EntitiesByIdEntry();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -1238,7 +1238,7 @@ export const SimpleWithMap_EntitiesByIdEntry = {
   },
 
   fromJSON(object: any): SimpleWithMap_EntitiesByIdEntry {
-    const message = { ...baseSimpleWithMap_EntitiesByIdEntry } as SimpleWithMap_EntitiesByIdEntry;
+    const message = createBaseSimpleWithMap_EntitiesByIdEntry();
     message.key = object.key !== undefined && object.key !== null ? Number(object.key) : 0;
     message.value = object.value !== undefined && object.value !== null ? Entity.fromJSON(object.value) : undefined;
     return message;
@@ -1254,14 +1254,14 @@ export const SimpleWithMap_EntitiesByIdEntry = {
   fromPartial<I extends Exact<DeepPartial<SimpleWithMap_EntitiesByIdEntry>, I>>(
     object: I
   ): SimpleWithMap_EntitiesByIdEntry {
-    const message = { ...baseSimpleWithMap_EntitiesByIdEntry } as SimpleWithMap_EntitiesByIdEntry;
+    const message = createBaseSimpleWithMap_EntitiesByIdEntry();
     message.key = object.key ?? 0;
     message.value = object.value !== undefined && object.value !== null ? Entity.fromPartial(object.value) : undefined;
     return message;
   },
 };
 
-const baseSimpleWithMap_NameLookupEntry: object = { key: '', value: '' };
+const createBaseSimpleWithMap_NameLookupEntry = (): SimpleWithMap_NameLookupEntry => ({ key: '', value: '' });
 
 export const SimpleWithMap_NameLookupEntry = {
   encode(message: SimpleWithMap_NameLookupEntry, writer: Writer = Writer.create()): Writer {
@@ -1277,7 +1277,7 @@ export const SimpleWithMap_NameLookupEntry = {
   decode(input: Reader | Uint8Array, length?: number): SimpleWithMap_NameLookupEntry {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimpleWithMap_NameLookupEntry } as SimpleWithMap_NameLookupEntry;
+    const message = createBaseSimpleWithMap_NameLookupEntry();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -1296,7 +1296,7 @@ export const SimpleWithMap_NameLookupEntry = {
   },
 
   fromJSON(object: any): SimpleWithMap_NameLookupEntry {
-    const message = { ...baseSimpleWithMap_NameLookupEntry } as SimpleWithMap_NameLookupEntry;
+    const message = createBaseSimpleWithMap_NameLookupEntry();
     message.key = object.key !== undefined && object.key !== null ? String(object.key) : '';
     message.value = object.value !== undefined && object.value !== null ? String(object.value) : '';
     return message;
@@ -1312,14 +1312,14 @@ export const SimpleWithMap_NameLookupEntry = {
   fromPartial<I extends Exact<DeepPartial<SimpleWithMap_NameLookupEntry>, I>>(
     object: I
   ): SimpleWithMap_NameLookupEntry {
-    const message = { ...baseSimpleWithMap_NameLookupEntry } as SimpleWithMap_NameLookupEntry;
+    const message = createBaseSimpleWithMap_NameLookupEntry();
     message.key = object.key ?? '';
     message.value = object.value ?? '';
     return message;
   },
 };
 
-const baseSimpleWithMap_IntLookupEntry: object = { key: 0, value: 0 };
+const createBaseSimpleWithMap_IntLookupEntry = (): SimpleWithMap_IntLookupEntry => ({ key: 0, value: 0 });
 
 export const SimpleWithMap_IntLookupEntry = {
   encode(message: SimpleWithMap_IntLookupEntry, writer: Writer = Writer.create()): Writer {
@@ -1335,7 +1335,7 @@ export const SimpleWithMap_IntLookupEntry = {
   decode(input: Reader | Uint8Array, length?: number): SimpleWithMap_IntLookupEntry {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimpleWithMap_IntLookupEntry } as SimpleWithMap_IntLookupEntry;
+    const message = createBaseSimpleWithMap_IntLookupEntry();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -1354,7 +1354,7 @@ export const SimpleWithMap_IntLookupEntry = {
   },
 
   fromJSON(object: any): SimpleWithMap_IntLookupEntry {
-    const message = { ...baseSimpleWithMap_IntLookupEntry } as SimpleWithMap_IntLookupEntry;
+    const message = createBaseSimpleWithMap_IntLookupEntry();
     message.key = object.key !== undefined && object.key !== null ? Number(object.key) : 0;
     message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
@@ -1368,14 +1368,14 @@ export const SimpleWithMap_IntLookupEntry = {
   },
 
   fromPartial<I extends Exact<DeepPartial<SimpleWithMap_IntLookupEntry>, I>>(object: I): SimpleWithMap_IntLookupEntry {
-    const message = { ...baseSimpleWithMap_IntLookupEntry } as SimpleWithMap_IntLookupEntry;
+    const message = createBaseSimpleWithMap_IntLookupEntry();
     message.key = object.key ?? 0;
     message.value = object.value ?? 0;
     return message;
   },
 };
 
-const baseSimpleWithMap_MapOfTimestampsEntry: object = { key: '' };
+const createBaseSimpleWithMap_MapOfTimestampsEntry = (): SimpleWithMap_MapOfTimestampsEntry => ({ key: '' });
 
 export const SimpleWithMap_MapOfTimestampsEntry = {
   encode(message: SimpleWithMap_MapOfTimestampsEntry, writer: Writer = Writer.create()): Writer {
@@ -1391,7 +1391,7 @@ export const SimpleWithMap_MapOfTimestampsEntry = {
   decode(input: Reader | Uint8Array, length?: number): SimpleWithMap_MapOfTimestampsEntry {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimpleWithMap_MapOfTimestampsEntry } as SimpleWithMap_MapOfTimestampsEntry;
+    const message = createBaseSimpleWithMap_MapOfTimestampsEntry();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -1410,7 +1410,7 @@ export const SimpleWithMap_MapOfTimestampsEntry = {
   },
 
   fromJSON(object: any): SimpleWithMap_MapOfTimestampsEntry {
-    const message = { ...baseSimpleWithMap_MapOfTimestampsEntry } as SimpleWithMap_MapOfTimestampsEntry;
+    const message = createBaseSimpleWithMap_MapOfTimestampsEntry();
     message.key = object.key !== undefined && object.key !== null ? String(object.key) : '';
     message.value = object.value !== undefined && object.value !== null ? fromJsonTimestamp(object.value) : undefined;
     return message;
@@ -1426,14 +1426,14 @@ export const SimpleWithMap_MapOfTimestampsEntry = {
   fromPartial<I extends Exact<DeepPartial<SimpleWithMap_MapOfTimestampsEntry>, I>>(
     object: I
   ): SimpleWithMap_MapOfTimestampsEntry {
-    const message = { ...baseSimpleWithMap_MapOfTimestampsEntry } as SimpleWithMap_MapOfTimestampsEntry;
+    const message = createBaseSimpleWithMap_MapOfTimestampsEntry();
     message.key = object.key ?? '';
     message.value = object.value ?? undefined;
     return message;
   },
 };
 
-const baseSimpleWithMap_MapOfBytesEntry: object = { key: '' };
+const createBaseSimpleWithMap_MapOfBytesEntry = (): SimpleWithMap_MapOfBytesEntry => ({ key: '' });
 
 export const SimpleWithMap_MapOfBytesEntry = {
   encode(message: SimpleWithMap_MapOfBytesEntry, writer: Writer = Writer.create()): Writer {
@@ -1449,7 +1449,7 @@ export const SimpleWithMap_MapOfBytesEntry = {
   decode(input: Reader | Uint8Array, length?: number): SimpleWithMap_MapOfBytesEntry {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimpleWithMap_MapOfBytesEntry } as SimpleWithMap_MapOfBytesEntry;
+    const message = createBaseSimpleWithMap_MapOfBytesEntry();
     message.value = new Uint8Array();
     while (reader.pos < end) {
       const tag = reader.uint32();
@@ -1469,7 +1469,7 @@ export const SimpleWithMap_MapOfBytesEntry = {
   },
 
   fromJSON(object: any): SimpleWithMap_MapOfBytesEntry {
-    const message = { ...baseSimpleWithMap_MapOfBytesEntry } as SimpleWithMap_MapOfBytesEntry;
+    const message = createBaseSimpleWithMap_MapOfBytesEntry();
     message.key = object.key !== undefined && object.key !== null ? String(object.key) : '';
     message.value =
       object.value !== undefined && object.value !== null ? bytesFromBase64(object.value) : new Uint8Array();
@@ -1487,14 +1487,14 @@ export const SimpleWithMap_MapOfBytesEntry = {
   fromPartial<I extends Exact<DeepPartial<SimpleWithMap_MapOfBytesEntry>, I>>(
     object: I
   ): SimpleWithMap_MapOfBytesEntry {
-    const message = { ...baseSimpleWithMap_MapOfBytesEntry } as SimpleWithMap_MapOfBytesEntry;
+    const message = createBaseSimpleWithMap_MapOfBytesEntry();
     message.key = object.key ?? '';
     message.value = object.value ?? new Uint8Array();
     return message;
   },
 };
 
-const baseSimpleWithMap_MapOfStringValuesEntry: object = { key: '' };
+const createBaseSimpleWithMap_MapOfStringValuesEntry = (): SimpleWithMap_MapOfStringValuesEntry => ({ key: '' });
 
 export const SimpleWithMap_MapOfStringValuesEntry = {
   encode(message: SimpleWithMap_MapOfStringValuesEntry, writer: Writer = Writer.create()): Writer {
@@ -1510,7 +1510,7 @@ export const SimpleWithMap_MapOfStringValuesEntry = {
   decode(input: Reader | Uint8Array, length?: number): SimpleWithMap_MapOfStringValuesEntry {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimpleWithMap_MapOfStringValuesEntry } as SimpleWithMap_MapOfStringValuesEntry;
+    const message = createBaseSimpleWithMap_MapOfStringValuesEntry();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -1529,7 +1529,7 @@ export const SimpleWithMap_MapOfStringValuesEntry = {
   },
 
   fromJSON(object: any): SimpleWithMap_MapOfStringValuesEntry {
-    const message = { ...baseSimpleWithMap_MapOfStringValuesEntry } as SimpleWithMap_MapOfStringValuesEntry;
+    const message = createBaseSimpleWithMap_MapOfStringValuesEntry();
     message.key = object.key !== undefined && object.key !== null ? String(object.key) : '';
     message.value = object.value !== undefined && object.value !== null ? String(object.value) : undefined;
     return message;
@@ -1545,14 +1545,14 @@ export const SimpleWithMap_MapOfStringValuesEntry = {
   fromPartial<I extends Exact<DeepPartial<SimpleWithMap_MapOfStringValuesEntry>, I>>(
     object: I
   ): SimpleWithMap_MapOfStringValuesEntry {
-    const message = { ...baseSimpleWithMap_MapOfStringValuesEntry } as SimpleWithMap_MapOfStringValuesEntry;
+    const message = createBaseSimpleWithMap_MapOfStringValuesEntry();
     message.key = object.key ?? '';
     message.value = object.value ?? undefined;
     return message;
   },
 };
 
-const baseSimpleWithMap_LongLookupEntry: object = { key: 0, value: 0 };
+const createBaseSimpleWithMap_LongLookupEntry = (): SimpleWithMap_LongLookupEntry => ({ key: 0, value: 0 });
 
 export const SimpleWithMap_LongLookupEntry = {
   encode(message: SimpleWithMap_LongLookupEntry, writer: Writer = Writer.create()): Writer {
@@ -1568,7 +1568,7 @@ export const SimpleWithMap_LongLookupEntry = {
   decode(input: Reader | Uint8Array, length?: number): SimpleWithMap_LongLookupEntry {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimpleWithMap_LongLookupEntry } as SimpleWithMap_LongLookupEntry;
+    const message = createBaseSimpleWithMap_LongLookupEntry();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -1587,7 +1587,7 @@ export const SimpleWithMap_LongLookupEntry = {
   },
 
   fromJSON(object: any): SimpleWithMap_LongLookupEntry {
-    const message = { ...baseSimpleWithMap_LongLookupEntry } as SimpleWithMap_LongLookupEntry;
+    const message = createBaseSimpleWithMap_LongLookupEntry();
     message.key = object.key !== undefined && object.key !== null ? Number(object.key) : 0;
     message.value = object.value !== undefined && object.value !== null ? Number(object.value) : 0;
     return message;
@@ -1603,14 +1603,14 @@ export const SimpleWithMap_LongLookupEntry = {
   fromPartial<I extends Exact<DeepPartial<SimpleWithMap_LongLookupEntry>, I>>(
     object: I
   ): SimpleWithMap_LongLookupEntry {
-    const message = { ...baseSimpleWithMap_LongLookupEntry } as SimpleWithMap_LongLookupEntry;
+    const message = createBaseSimpleWithMap_LongLookupEntry();
     message.key = object.key ?? 0;
     message.value = object.value ?? 0;
     return message;
   },
 };
 
-const baseSimpleWithSnakeCaseMap: object = {};
+const createBaseSimpleWithSnakeCaseMap = (): SimpleWithSnakeCaseMap => ({});
 
 export const SimpleWithSnakeCaseMap = {
   encode(message: SimpleWithSnakeCaseMap, writer: Writer = Writer.create()): Writer {
@@ -1623,7 +1623,7 @@ export const SimpleWithSnakeCaseMap = {
   decode(input: Reader | Uint8Array, length?: number): SimpleWithSnakeCaseMap {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimpleWithSnakeCaseMap } as SimpleWithSnakeCaseMap;
+    const message = createBaseSimpleWithSnakeCaseMap();
     message.entitiesById = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
@@ -1643,7 +1643,7 @@ export const SimpleWithSnakeCaseMap = {
   },
 
   fromJSON(object: any): SimpleWithSnakeCaseMap {
-    const message = { ...baseSimpleWithSnakeCaseMap } as SimpleWithSnakeCaseMap;
+    const message = createBaseSimpleWithSnakeCaseMap();
     message.entitiesById = Object.entries(object.entitiesById ?? {}).reduce<{ [key: number]: Entity }>(
       (acc, [key, value]) => {
         acc[Number(key)] = Entity.fromJSON(value);
@@ -1666,7 +1666,7 @@ export const SimpleWithSnakeCaseMap = {
   },
 
   fromPartial<I extends Exact<DeepPartial<SimpleWithSnakeCaseMap>, I>>(object: I): SimpleWithSnakeCaseMap {
-    const message = { ...baseSimpleWithSnakeCaseMap } as SimpleWithSnakeCaseMap;
+    const message = createBaseSimpleWithSnakeCaseMap();
     message.entitiesById = Object.entries(object.entitiesById ?? {}).reduce<{ [key: number]: Entity }>(
       (acc, [key, value]) => {
         if (value !== undefined) {
@@ -1680,7 +1680,7 @@ export const SimpleWithSnakeCaseMap = {
   },
 };
 
-const baseSimpleWithSnakeCaseMap_EntitiesByIdEntry: object = { key: 0 };
+const createBaseSimpleWithSnakeCaseMap_EntitiesByIdEntry = (): SimpleWithSnakeCaseMap_EntitiesByIdEntry => ({ key: 0 });
 
 export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
   encode(message: SimpleWithSnakeCaseMap_EntitiesByIdEntry, writer: Writer = Writer.create()): Writer {
@@ -1696,7 +1696,7 @@ export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
   decode(input: Reader | Uint8Array, length?: number): SimpleWithSnakeCaseMap_EntitiesByIdEntry {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimpleWithSnakeCaseMap_EntitiesByIdEntry } as SimpleWithSnakeCaseMap_EntitiesByIdEntry;
+    const message = createBaseSimpleWithSnakeCaseMap_EntitiesByIdEntry();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -1715,7 +1715,7 @@ export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
   },
 
   fromJSON(object: any): SimpleWithSnakeCaseMap_EntitiesByIdEntry {
-    const message = { ...baseSimpleWithSnakeCaseMap_EntitiesByIdEntry } as SimpleWithSnakeCaseMap_EntitiesByIdEntry;
+    const message = createBaseSimpleWithSnakeCaseMap_EntitiesByIdEntry();
     message.key = object.key !== undefined && object.key !== null ? Number(object.key) : 0;
     message.value = object.value !== undefined && object.value !== null ? Entity.fromJSON(object.value) : undefined;
     return message;
@@ -1731,14 +1731,14 @@ export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
   fromPartial<I extends Exact<DeepPartial<SimpleWithSnakeCaseMap_EntitiesByIdEntry>, I>>(
     object: I
   ): SimpleWithSnakeCaseMap_EntitiesByIdEntry {
-    const message = { ...baseSimpleWithSnakeCaseMap_EntitiesByIdEntry } as SimpleWithSnakeCaseMap_EntitiesByIdEntry;
+    const message = createBaseSimpleWithSnakeCaseMap_EntitiesByIdEntry();
     message.key = object.key ?? 0;
     message.value = object.value !== undefined && object.value !== null ? Entity.fromPartial(object.value) : undefined;
     return message;
   },
 };
 
-const baseSimpleWithMapOfEnums: object = {};
+const createBaseSimpleWithMapOfEnums = (): SimpleWithMapOfEnums => ({});
 
 export const SimpleWithMapOfEnums = {
   encode(message: SimpleWithMapOfEnums, writer: Writer = Writer.create()): Writer {
@@ -1751,7 +1751,7 @@ export const SimpleWithMapOfEnums = {
   decode(input: Reader | Uint8Array, length?: number): SimpleWithMapOfEnums {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimpleWithMapOfEnums } as SimpleWithMapOfEnums;
+    const message = createBaseSimpleWithMapOfEnums();
     message.enumsById = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
@@ -1771,7 +1771,7 @@ export const SimpleWithMapOfEnums = {
   },
 
   fromJSON(object: any): SimpleWithMapOfEnums {
-    const message = { ...baseSimpleWithMapOfEnums } as SimpleWithMapOfEnums;
+    const message = createBaseSimpleWithMapOfEnums();
     message.enumsById = Object.entries(object.enumsById ?? {}).reduce<{ [key: number]: StateEnum }>(
       (acc, [key, value]) => {
         acc[Number(key)] = value as number;
@@ -1794,7 +1794,7 @@ export const SimpleWithMapOfEnums = {
   },
 
   fromPartial<I extends Exact<DeepPartial<SimpleWithMapOfEnums>, I>>(object: I): SimpleWithMapOfEnums {
-    const message = { ...baseSimpleWithMapOfEnums } as SimpleWithMapOfEnums;
+    const message = createBaseSimpleWithMapOfEnums();
     message.enumsById = Object.entries(object.enumsById ?? {}).reduce<{ [key: number]: StateEnum }>(
       (acc, [key, value]) => {
         if (value !== undefined) {
@@ -1808,7 +1808,7 @@ export const SimpleWithMapOfEnums = {
   },
 };
 
-const baseSimpleWithMapOfEnums_EnumsByIdEntry: object = { key: 0, value: 0 };
+const createBaseSimpleWithMapOfEnums_EnumsByIdEntry = (): SimpleWithMapOfEnums_EnumsByIdEntry => ({ key: 0, value: 0 });
 
 export const SimpleWithMapOfEnums_EnumsByIdEntry = {
   encode(message: SimpleWithMapOfEnums_EnumsByIdEntry, writer: Writer = Writer.create()): Writer {
@@ -1824,7 +1824,7 @@ export const SimpleWithMapOfEnums_EnumsByIdEntry = {
   decode(input: Reader | Uint8Array, length?: number): SimpleWithMapOfEnums_EnumsByIdEntry {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimpleWithMapOfEnums_EnumsByIdEntry } as SimpleWithMapOfEnums_EnumsByIdEntry;
+    const message = createBaseSimpleWithMapOfEnums_EnumsByIdEntry();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -1843,7 +1843,7 @@ export const SimpleWithMapOfEnums_EnumsByIdEntry = {
   },
 
   fromJSON(object: any): SimpleWithMapOfEnums_EnumsByIdEntry {
-    const message = { ...baseSimpleWithMapOfEnums_EnumsByIdEntry } as SimpleWithMapOfEnums_EnumsByIdEntry;
+    const message = createBaseSimpleWithMapOfEnums_EnumsByIdEntry();
     message.key = object.key !== undefined && object.key !== null ? Number(object.key) : 0;
     message.value = object.value !== undefined && object.value !== null ? stateEnumFromJSON(object.value) : 0;
     return message;
@@ -1859,14 +1859,14 @@ export const SimpleWithMapOfEnums_EnumsByIdEntry = {
   fromPartial<I extends Exact<DeepPartial<SimpleWithMapOfEnums_EnumsByIdEntry>, I>>(
     object: I
   ): SimpleWithMapOfEnums_EnumsByIdEntry {
-    const message = { ...baseSimpleWithMapOfEnums_EnumsByIdEntry } as SimpleWithMapOfEnums_EnumsByIdEntry;
+    const message = createBaseSimpleWithMapOfEnums_EnumsByIdEntry();
     message.key = object.key ?? 0;
     message.value = object.value ?? 0;
     return message;
   },
 };
 
-const basePingRequest: object = { input: '' };
+const createBasePingRequest = (): PingRequest => ({ input: '' });
 
 export const PingRequest = {
   encode(message: PingRequest, writer: Writer = Writer.create()): Writer {
@@ -1879,7 +1879,7 @@ export const PingRequest = {
   decode(input: Reader | Uint8Array, length?: number): PingRequest {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...basePingRequest } as PingRequest;
+    const message = createBasePingRequest();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -1895,7 +1895,7 @@ export const PingRequest = {
   },
 
   fromJSON(object: any): PingRequest {
-    const message = { ...basePingRequest } as PingRequest;
+    const message = createBasePingRequest();
     message.input = object.input !== undefined && object.input !== null ? String(object.input) : '';
     return message;
   },
@@ -1907,13 +1907,13 @@ export const PingRequest = {
   },
 
   fromPartial<I extends Exact<DeepPartial<PingRequest>, I>>(object: I): PingRequest {
-    const message = { ...basePingRequest } as PingRequest;
+    const message = createBasePingRequest();
     message.input = object.input ?? '';
     return message;
   },
 };
 
-const basePingResponse: object = { output: '' };
+const createBasePingResponse = (): PingResponse => ({ output: '' });
 
 export const PingResponse = {
   encode(message: PingResponse, writer: Writer = Writer.create()): Writer {
@@ -1926,7 +1926,7 @@ export const PingResponse = {
   decode(input: Reader | Uint8Array, length?: number): PingResponse {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...basePingResponse } as PingResponse;
+    const message = createBasePingResponse();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -1942,7 +1942,7 @@ export const PingResponse = {
   },
 
   fromJSON(object: any): PingResponse {
-    const message = { ...basePingResponse } as PingResponse;
+    const message = createBasePingResponse();
     message.output = object.output !== undefined && object.output !== null ? String(object.output) : '';
     return message;
   },
@@ -1954,13 +1954,13 @@ export const PingResponse = {
   },
 
   fromPartial<I extends Exact<DeepPartial<PingResponse>, I>>(object: I): PingResponse {
-    const message = { ...basePingResponse } as PingResponse;
+    const message = createBasePingResponse();
     message.output = object.output ?? '';
     return message;
   },
 };
 
-const baseNumbers: object = {
+const createBaseNumbers = (): Numbers => ({
   double: 0,
   float: 0,
   int32: 0,
@@ -1973,7 +1973,7 @@ const baseNumbers: object = {
   fixed64: 0,
   sfixed32: 0,
   sfixed64: 0,
-};
+});
 
 export const Numbers = {
   encode(message: Numbers, writer: Writer = Writer.create()): Writer {
@@ -2019,7 +2019,7 @@ export const Numbers = {
   decode(input: Reader | Uint8Array, length?: number): Numbers {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseNumbers } as Numbers;
+    const message = createBaseNumbers();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -2068,7 +2068,7 @@ export const Numbers = {
   },
 
   fromJSON(object: any): Numbers {
-    const message = { ...baseNumbers } as Numbers;
+    const message = createBaseNumbers();
     message.double = object.double !== undefined && object.double !== null ? Number(object.double) : 0;
     message.float = object.float !== undefined && object.float !== null ? Number(object.float) : 0;
     message.int32 = object.int32 !== undefined && object.int32 !== null ? Number(object.int32) : 0;
@@ -2102,7 +2102,7 @@ export const Numbers = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Numbers>, I>>(object: I): Numbers {
-    const message = { ...baseNumbers } as Numbers;
+    const message = createBaseNumbers();
     message.double = object.double ?? 0;
     message.float = object.float ?? 0;
     message.int32 = object.int32 ?? 0;
@@ -2119,7 +2119,7 @@ export const Numbers = {
   },
 };
 
-const baseSimpleButOptional: object = {};
+const createBaseSimpleButOptional = (): SimpleButOptional => ({});
 
 export const SimpleButOptional = {
   encode(message: SimpleButOptional, writer: Writer = Writer.create()): Writer {
@@ -2150,7 +2150,7 @@ export const SimpleButOptional = {
   decode(input: Reader | Uint8Array, length?: number): SimpleButOptional {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseSimpleButOptional } as SimpleButOptional;
+    const message = createBaseSimpleButOptional();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -2184,7 +2184,7 @@ export const SimpleButOptional = {
   },
 
   fromJSON(object: any): SimpleButOptional {
-    const message = { ...baseSimpleButOptional } as SimpleButOptional;
+    const message = createBaseSimpleButOptional();
     message.name = object.name !== undefined && object.name !== null ? String(object.name) : undefined;
     message.age = object.age !== undefined && object.age !== null ? Number(object.age) : undefined;
     message.createdAt =
@@ -2213,7 +2213,7 @@ export const SimpleButOptional = {
   },
 
   fromPartial<I extends Exact<DeepPartial<SimpleButOptional>, I>>(object: I): SimpleButOptional {
-    const message = { ...baseSimpleButOptional } as SimpleButOptional;
+    const message = createBaseSimpleButOptional();
     message.name = object.name ?? undefined;
     message.age = object.age ?? undefined;
     message.createdAt = object.createdAt ?? undefined;
@@ -2227,7 +2227,7 @@ export const SimpleButOptional = {
   },
 };
 
-const baseEmpty: object = {};
+const createBaseEmpty = (): Empty => ({});
 
 export const Empty = {
   encode(_: Empty, writer: Writer = Writer.create()): Writer {
@@ -2237,7 +2237,7 @@ export const Empty = {
   decode(input: Reader | Uint8Array, length?: number): Empty {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseEmpty } as Empty;
+    const message = createBaseEmpty();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -2250,7 +2250,7 @@ export const Empty = {
   },
 
   fromJSON(_: any): Empty {
-    const message = { ...baseEmpty } as Empty;
+    const message = createBaseEmpty();
     return message;
   },
 
@@ -2260,7 +2260,7 @@ export const Empty = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Empty>, I>>(_: I): Empty {
-    const message = { ...baseEmpty } as Empty;
+    const message = createBaseEmpty();
     return message;
   },
 };

--- a/integration/simple/simple.ts
+++ b/integration/simple/simple.ts
@@ -290,7 +290,23 @@ export interface SimpleButOptional {
 
 export interface Empty {}
 
-const createBaseSimple = (): Simple => ({ name: '', age: 0, state: 0, coins: 0, snacks: '', oldStates: 0 });
+function createBaseSimple(): Simple {
+  return {
+    name: '',
+    age: 0,
+    createdAt: undefined,
+    child: undefined,
+    state: 0,
+    grandChildren: [],
+    coins: [],
+    snacks: [],
+    oldStates: [],
+    thing: undefined,
+    blobs: [],
+    birthday: undefined,
+    blob: new Uint8Array(),
+  };
+}
 
 export const Simple = {
   encode(message: Simple, writer: Writer = Writer.create()): Writer {
@@ -344,12 +360,6 @@ export const Simple = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseSimple();
-    message.grandChildren = [];
-    message.coins = [];
-    message.snacks = [];
-    message.oldStates = [];
-    message.blobs = [];
-    message.blob = new Uint8Array();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -496,7 +506,9 @@ export const Simple = {
   },
 };
 
-const createBaseChild = (): Child => ({ name: '', type: 0 });
+function createBaseChild(): Child {
+  return { name: '', type: 0 };
+}
 
 export const Child = {
   encode(message: Child, writer: Writer = Writer.create()): Writer {
@@ -552,7 +564,9 @@ export const Child = {
   },
 };
 
-const createBaseNested = (): Nested => ({ name: '', state: 0 });
+function createBaseNested(): Nested {
+  return { name: '', message: undefined, state: 0 };
+}
 
 export const Nested = {
   encode(message: Nested, writer: Writer = Writer.create()): Writer {
@@ -624,7 +638,9 @@ export const Nested = {
   },
 };
 
-const createBaseNested_InnerMessage = (): Nested_InnerMessage => ({ name: '' });
+function createBaseNested_InnerMessage(): Nested_InnerMessage {
+  return { name: '', deep: undefined };
+}
 
 export const Nested_InnerMessage = {
   encode(message: Nested_InnerMessage, writer: Writer = Writer.create()): Writer {
@@ -687,7 +703,9 @@ export const Nested_InnerMessage = {
   },
 };
 
-const createBaseNested_InnerMessage_DeepMessage = (): Nested_InnerMessage_DeepMessage => ({ name: '' });
+function createBaseNested_InnerMessage_DeepMessage(): Nested_InnerMessage_DeepMessage {
+  return { name: '' };
+}
 
 export const Nested_InnerMessage_DeepMessage = {
   encode(message: Nested_InnerMessage_DeepMessage, writer: Writer = Writer.create()): Writer {
@@ -736,7 +754,9 @@ export const Nested_InnerMessage_DeepMessage = {
   },
 };
 
-const createBaseOneOfMessage = (): OneOfMessage => ({});
+function createBaseOneOfMessage(): OneOfMessage {
+  return { first: undefined, last: undefined };
+}
 
 export const OneOfMessage = {
   encode(message: OneOfMessage, writer: Writer = Writer.create()): Writer {
@@ -792,7 +812,9 @@ export const OneOfMessage = {
   },
 };
 
-const createBaseSimpleWithWrappers = (): SimpleWithWrappers => ({});
+function createBaseSimpleWithWrappers(): SimpleWithWrappers {
+  return { name: undefined, age: undefined, enabled: undefined, coins: [], snacks: [], id: undefined };
+}
 
 export const SimpleWithWrappers = {
   encode(message: SimpleWithWrappers, writer: Writer = Writer.create()): Writer {
@@ -821,8 +843,6 @@ export const SimpleWithWrappers = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseSimpleWithWrappers();
-    message.coins = [];
-    message.snacks = [];
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -894,7 +914,9 @@ export const SimpleWithWrappers = {
   },
 };
 
-const createBaseEntity = (): Entity => ({ id: 0 });
+function createBaseEntity(): Entity {
+  return { id: 0 };
+}
 
 export const Entity = {
   encode(message: Entity, writer: Writer = Writer.create()): Writer {
@@ -941,7 +963,17 @@ export const Entity = {
   },
 };
 
-const createBaseSimpleWithMap = (): SimpleWithMap => ({});
+function createBaseSimpleWithMap(): SimpleWithMap {
+  return {
+    entitiesById: {},
+    nameLookup: {},
+    intLookup: {},
+    mapOfTimestamps: {},
+    mapOfBytes: {},
+    mapOfStringValues: {},
+    longLookup: {},
+  };
+}
 
 export const SimpleWithMap = {
   encode(message: SimpleWithMap, writer: Writer = Writer.create()): Writer {
@@ -975,13 +1007,6 @@ export const SimpleWithMap = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseSimpleWithMap();
-    message.entitiesById = {};
-    message.nameLookup = {};
-    message.intLookup = {};
-    message.mapOfTimestamps = {};
-    message.mapOfBytes = {};
-    message.mapOfStringValues = {};
-    message.longLookup = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -1203,7 +1228,9 @@ export const SimpleWithMap = {
   },
 };
 
-const createBaseSimpleWithMap_EntitiesByIdEntry = (): SimpleWithMap_EntitiesByIdEntry => ({ key: 0 });
+function createBaseSimpleWithMap_EntitiesByIdEntry(): SimpleWithMap_EntitiesByIdEntry {
+  return { key: 0, value: undefined };
+}
 
 export const SimpleWithMap_EntitiesByIdEntry = {
   encode(message: SimpleWithMap_EntitiesByIdEntry, writer: Writer = Writer.create()): Writer {
@@ -1261,7 +1288,9 @@ export const SimpleWithMap_EntitiesByIdEntry = {
   },
 };
 
-const createBaseSimpleWithMap_NameLookupEntry = (): SimpleWithMap_NameLookupEntry => ({ key: '', value: '' });
+function createBaseSimpleWithMap_NameLookupEntry(): SimpleWithMap_NameLookupEntry {
+  return { key: '', value: '' };
+}
 
 export const SimpleWithMap_NameLookupEntry = {
   encode(message: SimpleWithMap_NameLookupEntry, writer: Writer = Writer.create()): Writer {
@@ -1319,7 +1348,9 @@ export const SimpleWithMap_NameLookupEntry = {
   },
 };
 
-const createBaseSimpleWithMap_IntLookupEntry = (): SimpleWithMap_IntLookupEntry => ({ key: 0, value: 0 });
+function createBaseSimpleWithMap_IntLookupEntry(): SimpleWithMap_IntLookupEntry {
+  return { key: 0, value: 0 };
+}
 
 export const SimpleWithMap_IntLookupEntry = {
   encode(message: SimpleWithMap_IntLookupEntry, writer: Writer = Writer.create()): Writer {
@@ -1375,7 +1406,9 @@ export const SimpleWithMap_IntLookupEntry = {
   },
 };
 
-const createBaseSimpleWithMap_MapOfTimestampsEntry = (): SimpleWithMap_MapOfTimestampsEntry => ({ key: '' });
+function createBaseSimpleWithMap_MapOfTimestampsEntry(): SimpleWithMap_MapOfTimestampsEntry {
+  return { key: '', value: undefined };
+}
 
 export const SimpleWithMap_MapOfTimestampsEntry = {
   encode(message: SimpleWithMap_MapOfTimestampsEntry, writer: Writer = Writer.create()): Writer {
@@ -1433,7 +1466,9 @@ export const SimpleWithMap_MapOfTimestampsEntry = {
   },
 };
 
-const createBaseSimpleWithMap_MapOfBytesEntry = (): SimpleWithMap_MapOfBytesEntry => ({ key: '' });
+function createBaseSimpleWithMap_MapOfBytesEntry(): SimpleWithMap_MapOfBytesEntry {
+  return { key: '', value: new Uint8Array() };
+}
 
 export const SimpleWithMap_MapOfBytesEntry = {
   encode(message: SimpleWithMap_MapOfBytesEntry, writer: Writer = Writer.create()): Writer {
@@ -1450,7 +1485,6 @@ export const SimpleWithMap_MapOfBytesEntry = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseSimpleWithMap_MapOfBytesEntry();
-    message.value = new Uint8Array();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -1494,7 +1528,9 @@ export const SimpleWithMap_MapOfBytesEntry = {
   },
 };
 
-const createBaseSimpleWithMap_MapOfStringValuesEntry = (): SimpleWithMap_MapOfStringValuesEntry => ({ key: '' });
+function createBaseSimpleWithMap_MapOfStringValuesEntry(): SimpleWithMap_MapOfStringValuesEntry {
+  return { key: '', value: undefined };
+}
 
 export const SimpleWithMap_MapOfStringValuesEntry = {
   encode(message: SimpleWithMap_MapOfStringValuesEntry, writer: Writer = Writer.create()): Writer {
@@ -1552,7 +1588,9 @@ export const SimpleWithMap_MapOfStringValuesEntry = {
   },
 };
 
-const createBaseSimpleWithMap_LongLookupEntry = (): SimpleWithMap_LongLookupEntry => ({ key: 0, value: 0 });
+function createBaseSimpleWithMap_LongLookupEntry(): SimpleWithMap_LongLookupEntry {
+  return { key: 0, value: 0 };
+}
 
 export const SimpleWithMap_LongLookupEntry = {
   encode(message: SimpleWithMap_LongLookupEntry, writer: Writer = Writer.create()): Writer {
@@ -1610,7 +1648,9 @@ export const SimpleWithMap_LongLookupEntry = {
   },
 };
 
-const createBaseSimpleWithSnakeCaseMap = (): SimpleWithSnakeCaseMap => ({});
+function createBaseSimpleWithSnakeCaseMap(): SimpleWithSnakeCaseMap {
+  return { entitiesById: {} };
+}
 
 export const SimpleWithSnakeCaseMap = {
   encode(message: SimpleWithSnakeCaseMap, writer: Writer = Writer.create()): Writer {
@@ -1624,7 +1664,6 @@ export const SimpleWithSnakeCaseMap = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseSimpleWithSnakeCaseMap();
-    message.entitiesById = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -1680,7 +1719,9 @@ export const SimpleWithSnakeCaseMap = {
   },
 };
 
-const createBaseSimpleWithSnakeCaseMap_EntitiesByIdEntry = (): SimpleWithSnakeCaseMap_EntitiesByIdEntry => ({ key: 0 });
+function createBaseSimpleWithSnakeCaseMap_EntitiesByIdEntry(): SimpleWithSnakeCaseMap_EntitiesByIdEntry {
+  return { key: 0, value: undefined };
+}
 
 export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
   encode(message: SimpleWithSnakeCaseMap_EntitiesByIdEntry, writer: Writer = Writer.create()): Writer {
@@ -1738,7 +1779,9 @@ export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
   },
 };
 
-const createBaseSimpleWithMapOfEnums = (): SimpleWithMapOfEnums => ({});
+function createBaseSimpleWithMapOfEnums(): SimpleWithMapOfEnums {
+  return { enumsById: {} };
+}
 
 export const SimpleWithMapOfEnums = {
   encode(message: SimpleWithMapOfEnums, writer: Writer = Writer.create()): Writer {
@@ -1752,7 +1795,6 @@ export const SimpleWithMapOfEnums = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseSimpleWithMapOfEnums();
-    message.enumsById = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -1808,7 +1850,9 @@ export const SimpleWithMapOfEnums = {
   },
 };
 
-const createBaseSimpleWithMapOfEnums_EnumsByIdEntry = (): SimpleWithMapOfEnums_EnumsByIdEntry => ({ key: 0, value: 0 });
+function createBaseSimpleWithMapOfEnums_EnumsByIdEntry(): SimpleWithMapOfEnums_EnumsByIdEntry {
+  return { key: 0, value: 0 };
+}
 
 export const SimpleWithMapOfEnums_EnumsByIdEntry = {
   encode(message: SimpleWithMapOfEnums_EnumsByIdEntry, writer: Writer = Writer.create()): Writer {
@@ -1866,7 +1910,9 @@ export const SimpleWithMapOfEnums_EnumsByIdEntry = {
   },
 };
 
-const createBasePingRequest = (): PingRequest => ({ input: '' });
+function createBasePingRequest(): PingRequest {
+  return { input: '' };
+}
 
 export const PingRequest = {
   encode(message: PingRequest, writer: Writer = Writer.create()): Writer {
@@ -1913,7 +1959,9 @@ export const PingRequest = {
   },
 };
 
-const createBasePingResponse = (): PingResponse => ({ output: '' });
+function createBasePingResponse(): PingResponse {
+  return { output: '' };
+}
 
 export const PingResponse = {
   encode(message: PingResponse, writer: Writer = Writer.create()): Writer {
@@ -1960,20 +2008,22 @@ export const PingResponse = {
   },
 };
 
-const createBaseNumbers = (): Numbers => ({
-  double: 0,
-  float: 0,
-  int32: 0,
-  int64: 0,
-  uint32: 0,
-  uint64: 0,
-  sint32: 0,
-  sint64: 0,
-  fixed32: 0,
-  fixed64: 0,
-  sfixed32: 0,
-  sfixed64: 0,
-});
+function createBaseNumbers(): Numbers {
+  return {
+    double: 0,
+    float: 0,
+    int32: 0,
+    int64: 0,
+    uint32: 0,
+    uint64: 0,
+    sint32: 0,
+    sint64: 0,
+    fixed32: 0,
+    fixed64: 0,
+    sfixed32: 0,
+    sfixed64: 0,
+  };
+}
 
 export const Numbers = {
   encode(message: Numbers, writer: Writer = Writer.create()): Writer {
@@ -2119,7 +2169,17 @@ export const Numbers = {
   },
 };
 
-const createBaseSimpleButOptional = (): SimpleButOptional => ({});
+function createBaseSimpleButOptional(): SimpleButOptional {
+  return {
+    name: undefined,
+    age: undefined,
+    createdAt: undefined,
+    child: undefined,
+    state: undefined,
+    thing: undefined,
+    birthday: undefined,
+  };
+}
 
 export const SimpleButOptional = {
   encode(message: SimpleButOptional, writer: Writer = Writer.create()): Writer {
@@ -2227,7 +2287,9 @@ export const SimpleButOptional = {
   },
 };
 
-const createBaseEmpty = (): Empty => ({});
+function createBaseEmpty(): Empty {
+  return {};
+}
 
 export const Empty = {
   encode(_: Empty, writer: Writer = Writer.create()): Writer {

--- a/integration/struct/google/protobuf/struct.ts
+++ b/integration/struct/google/protobuf/struct.ts
@@ -90,7 +90,7 @@ export interface ListValue {
   values: any[];
 }
 
-const baseStruct: object = {};
+const createBaseStruct = (): Struct => ({});
 
 export const Struct = {
   encode(message: Struct, writer: Writer = Writer.create()): Writer {
@@ -105,7 +105,7 @@ export const Struct = {
   decode(input: Reader | Uint8Array, length?: number): Struct {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseStruct } as Struct;
+    const message = createBaseStruct();
     message.fields = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
@@ -125,7 +125,7 @@ export const Struct = {
   },
 
   fromJSON(object: any): Struct {
-    const message = { ...baseStruct } as Struct;
+    const message = createBaseStruct();
     message.fields = Object.entries(object.fields ?? {}).reduce<{ [key: string]: any | undefined }>(
       (acc, [key, value]) => {
         acc[key] = value as any | undefined;
@@ -148,7 +148,7 @@ export const Struct = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Struct>, I>>(object: I): Struct {
-    const message = { ...baseStruct } as Struct;
+    const message = createBaseStruct();
     message.fields = Object.entries(object.fields ?? {}).reduce<{ [key: string]: any | undefined }>(
       (acc, [key, value]) => {
         if (value !== undefined) {
@@ -180,7 +180,7 @@ export const Struct = {
   },
 };
 
-const baseStruct_FieldsEntry: object = { key: '' };
+const createBaseStruct_FieldsEntry = (): Struct_FieldsEntry => ({ key: '' });
 
 export const Struct_FieldsEntry = {
   encode(message: Struct_FieldsEntry, writer: Writer = Writer.create()): Writer {
@@ -196,7 +196,7 @@ export const Struct_FieldsEntry = {
   decode(input: Reader | Uint8Array, length?: number): Struct_FieldsEntry {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseStruct_FieldsEntry } as Struct_FieldsEntry;
+    const message = createBaseStruct_FieldsEntry();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -215,7 +215,7 @@ export const Struct_FieldsEntry = {
   },
 
   fromJSON(object: any): Struct_FieldsEntry {
-    const message = { ...baseStruct_FieldsEntry } as Struct_FieldsEntry;
+    const message = createBaseStruct_FieldsEntry();
     message.key = object.key !== undefined && object.key !== null ? String(object.key) : '';
     message.value = object.value;
     return message;
@@ -229,14 +229,14 @@ export const Struct_FieldsEntry = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Struct_FieldsEntry>, I>>(object: I): Struct_FieldsEntry {
-    const message = { ...baseStruct_FieldsEntry } as Struct_FieldsEntry;
+    const message = createBaseStruct_FieldsEntry();
     message.key = object.key ?? '';
     message.value = object.value ?? undefined;
     return message;
   },
 };
 
-const baseValue: object = {};
+const createBaseValue = (): Value => ({});
 
 export const Value = {
   encode(message: Value, writer: Writer = Writer.create()): Writer {
@@ -264,7 +264,7 @@ export const Value = {
   decode(input: Reader | Uint8Array, length?: number): Value {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseValue } as Value;
+    const message = createBaseValue();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -295,7 +295,7 @@ export const Value = {
   },
 
   fromJSON(object: any): Value {
-    const message = { ...baseValue } as Value;
+    const message = createBaseValue();
     message.nullValue =
       object.nullValue !== undefined && object.nullValue !== null ? nullValueFromJSON(object.nullValue) : undefined;
     message.numberValue =
@@ -322,7 +322,7 @@ export const Value = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Value>, I>>(object: I): Value {
-    const message = { ...baseValue } as Value;
+    const message = createBaseValue();
     message.nullValue = object.nullValue ?? undefined;
     message.numberValue = object.numberValue ?? undefined;
     message.stringValue = object.stringValue ?? undefined;
@@ -370,7 +370,7 @@ export const Value = {
   },
 };
 
-const baseListValue: object = {};
+const createBaseListValue = (): ListValue => ({});
 
 export const ListValue = {
   encode(message: ListValue, writer: Writer = Writer.create()): Writer {
@@ -383,7 +383,7 @@ export const ListValue = {
   decode(input: Reader | Uint8Array, length?: number): ListValue {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseListValue } as ListValue;
+    const message = createBaseListValue();
     message.values = [];
     while (reader.pos < end) {
       const tag = reader.uint32();
@@ -400,7 +400,7 @@ export const ListValue = {
   },
 
   fromJSON(object: any): ListValue {
-    const message = { ...baseListValue } as ListValue;
+    const message = createBaseListValue();
     message.values = Array.isArray(object?.values) ? [...object.values] : [];
     return message;
   },
@@ -416,7 +416,7 @@ export const ListValue = {
   },
 
   fromPartial<I extends Exact<DeepPartial<ListValue>, I>>(object: I): ListValue {
-    const message = { ...baseListValue } as ListValue;
+    const message = createBaseListValue();
     message.values = object.values?.map((e) => e) || [];
     return message;
   },

--- a/integration/struct/google/protobuf/struct.ts
+++ b/integration/struct/google/protobuf/struct.ts
@@ -90,7 +90,9 @@ export interface ListValue {
   values: any[];
 }
 
-const createBaseStruct = (): Struct => ({});
+function createBaseStruct(): Struct {
+  return { fields: {} };
+}
 
 export const Struct = {
   encode(message: Struct, writer: Writer = Writer.create()): Writer {
@@ -106,7 +108,6 @@ export const Struct = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseStruct();
-    message.fields = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -180,7 +181,9 @@ export const Struct = {
   },
 };
 
-const createBaseStruct_FieldsEntry = (): Struct_FieldsEntry => ({ key: '' });
+function createBaseStruct_FieldsEntry(): Struct_FieldsEntry {
+  return { key: '', value: undefined };
+}
 
 export const Struct_FieldsEntry = {
   encode(message: Struct_FieldsEntry, writer: Writer = Writer.create()): Writer {
@@ -236,7 +239,16 @@ export const Struct_FieldsEntry = {
   },
 };
 
-const createBaseValue = (): Value => ({});
+function createBaseValue(): Value {
+  return {
+    nullValue: undefined,
+    numberValue: undefined,
+    stringValue: undefined,
+    boolValue: undefined,
+    structValue: undefined,
+    listValue: undefined,
+  };
+}
 
 export const Value = {
   encode(message: Value, writer: Writer = Writer.create()): Writer {
@@ -370,7 +382,9 @@ export const Value = {
   },
 };
 
-const createBaseListValue = (): ListValue => ({});
+function createBaseListValue(): ListValue {
+  return { values: [] };
+}
 
 export const ListValue = {
   encode(message: ListValue, writer: Writer = Writer.create()): Writer {
@@ -384,7 +398,6 @@ export const ListValue = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseListValue();
-    message.values = [];
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {

--- a/integration/struct/struct.ts
+++ b/integration/struct/struct.ts
@@ -9,7 +9,9 @@ export interface StructMessage {
   value: { [key: string]: any } | undefined;
 }
 
-const createBaseStructMessage = (): StructMessage => ({});
+function createBaseStructMessage(): StructMessage {
+  return { value: undefined };
+}
 
 export const StructMessage = {
   encode(message: StructMessage, writer: Writer = Writer.create()): Writer {

--- a/integration/struct/struct.ts
+++ b/integration/struct/struct.ts
@@ -9,7 +9,7 @@ export interface StructMessage {
   value: { [key: string]: any } | undefined;
 }
 
-const baseStructMessage: object = {};
+const createBaseStructMessage = (): StructMessage => ({});
 
 export const StructMessage = {
   encode(message: StructMessage, writer: Writer = Writer.create()): Writer {
@@ -22,7 +22,7 @@ export const StructMessage = {
   decode(input: Reader | Uint8Array, length?: number): StructMessage {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseStructMessage } as StructMessage;
+    const message = createBaseStructMessage();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -38,7 +38,7 @@ export const StructMessage = {
   },
 
   fromJSON(object: any): StructMessage {
-    const message = { ...baseStructMessage } as StructMessage;
+    const message = createBaseStructMessage();
     message.value = typeof object.value === 'object' ? object.value : undefined;
     return message;
   },
@@ -50,7 +50,7 @@ export const StructMessage = {
   },
 
   fromPartial<I extends Exact<DeepPartial<StructMessage>, I>>(object: I): StructMessage {
-    const message = { ...baseStructMessage } as StructMessage;
+    const message = createBaseStructMessage();
     message.value = object.value ?? undefined;
     return message;
   },

--- a/integration/type-registry/bar/bar.ts
+++ b/integration/type-registry/bar/bar.ts
@@ -11,7 +11,9 @@ export interface Bar {
   foo: Foo | undefined;
 }
 
-const createBaseBar = (): Bar => ({ $type: 'foo.bar.Bar' });
+function createBaseBar(): Bar {
+  return { $type: 'foo.bar.Bar', foo: undefined };
+}
 
 export const Bar = {
   $type: 'foo.bar.Bar' as const,

--- a/integration/type-registry/bar/bar.ts
+++ b/integration/type-registry/bar/bar.ts
@@ -11,7 +11,7 @@ export interface Bar {
   foo: Foo | undefined;
 }
 
-const baseBar: object = { $type: 'foo.bar.Bar' };
+const createBaseBar = (): Bar => ({ $type: 'foo.bar.Bar' });
 
 export const Bar = {
   $type: 'foo.bar.Bar' as const,
@@ -26,7 +26,7 @@ export const Bar = {
   decode(input: Reader | Uint8Array, length?: number): Bar {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseBar } as Bar;
+    const message = createBaseBar();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -42,7 +42,7 @@ export const Bar = {
   },
 
   fromJSON(object: any): Bar {
-    const message = { ...baseBar } as Bar;
+    const message = createBaseBar();
     message.foo = object.foo !== undefined && object.foo !== null ? Foo.fromJSON(object.foo) : undefined;
     return message;
   },
@@ -54,7 +54,7 @@ export const Bar = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Bar>, I>>(object: I): Bar {
-    const message = { ...baseBar } as Bar;
+    const message = createBaseBar();
     message.foo = object.foo !== undefined && object.foo !== null ? Foo.fromPartial(object.foo) : undefined;
     return message;
   },

--- a/integration/type-registry/foo.ts
+++ b/integration/type-registry/foo.ts
@@ -16,7 +16,7 @@ export interface Foo2 {
   timestamp: Date | undefined;
 }
 
-const baseFoo: object = { $type: 'foo.Foo' };
+const createBaseFoo = (): Foo => ({ $type: 'foo.Foo' });
 
 export const Foo = {
   $type: 'foo.Foo' as const,
@@ -31,7 +31,7 @@ export const Foo = {
   decode(input: Reader | Uint8Array, length?: number): Foo {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseFoo } as Foo;
+    const message = createBaseFoo();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -47,7 +47,7 @@ export const Foo = {
   },
 
   fromJSON(object: any): Foo {
-    const message = { ...baseFoo } as Foo;
+    const message = createBaseFoo();
     message.timestamp =
       object.timestamp !== undefined && object.timestamp !== null ? fromJsonTimestamp(object.timestamp) : undefined;
     return message;
@@ -60,7 +60,7 @@ export const Foo = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Foo>, I>>(object: I): Foo {
-    const message = { ...baseFoo } as Foo;
+    const message = createBaseFoo();
     message.timestamp = object.timestamp ?? undefined;
     return message;
   },
@@ -68,7 +68,7 @@ export const Foo = {
 
 messageTypeRegistry.set(Foo.$type, Foo);
 
-const baseFoo2: object = { $type: 'foo.Foo2' };
+const createBaseFoo2 = (): Foo2 => ({ $type: 'foo.Foo2' });
 
 export const Foo2 = {
   $type: 'foo.Foo2' as const,
@@ -83,7 +83,7 @@ export const Foo2 = {
   decode(input: Reader | Uint8Array, length?: number): Foo2 {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseFoo2 } as Foo2;
+    const message = createBaseFoo2();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -99,7 +99,7 @@ export const Foo2 = {
   },
 
   fromJSON(object: any): Foo2 {
-    const message = { ...baseFoo2 } as Foo2;
+    const message = createBaseFoo2();
     message.timestamp =
       object.timestamp !== undefined && object.timestamp !== null ? fromJsonTimestamp(object.timestamp) : undefined;
     return message;
@@ -112,7 +112,7 @@ export const Foo2 = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Foo2>, I>>(object: I): Foo2 {
-    const message = { ...baseFoo2 } as Foo2;
+    const message = createBaseFoo2();
     message.timestamp = object.timestamp ?? undefined;
     return message;
   },

--- a/integration/type-registry/foo.ts
+++ b/integration/type-registry/foo.ts
@@ -16,7 +16,9 @@ export interface Foo2 {
   timestamp: Date | undefined;
 }
 
-const createBaseFoo = (): Foo => ({ $type: 'foo.Foo' });
+function createBaseFoo(): Foo {
+  return { $type: 'foo.Foo', timestamp: undefined };
+}
 
 export const Foo = {
   $type: 'foo.Foo' as const,
@@ -68,7 +70,9 @@ export const Foo = {
 
 messageTypeRegistry.set(Foo.$type, Foo);
 
-const createBaseFoo2 = (): Foo2 => ({ $type: 'foo.Foo2' });
+function createBaseFoo2(): Foo2 {
+  return { $type: 'foo.Foo2', timestamp: undefined };
+}
 
 export const Foo2 = {
   $type: 'foo.Foo2' as const,

--- a/integration/type-registry/google/protobuf/timestamp.ts
+++ b/integration/type-registry/google/protobuf/timestamp.ts
@@ -115,7 +115,9 @@ export interface Timestamp {
   nanos: number;
 }
 
-const createBaseTimestamp = (): Timestamp => ({ $type: 'google.protobuf.Timestamp', seconds: 0, nanos: 0 });
+function createBaseTimestamp(): Timestamp {
+  return { $type: 'google.protobuf.Timestamp', seconds: 0, nanos: 0 };
+}
 
 export const Timestamp = {
   $type: 'google.protobuf.Timestamp' as const,

--- a/integration/type-registry/google/protobuf/timestamp.ts
+++ b/integration/type-registry/google/protobuf/timestamp.ts
@@ -115,7 +115,7 @@ export interface Timestamp {
   nanos: number;
 }
 
-const baseTimestamp: object = { $type: 'google.protobuf.Timestamp', seconds: 0, nanos: 0 };
+const createBaseTimestamp = (): Timestamp => ({ $type: 'google.protobuf.Timestamp', seconds: 0, nanos: 0 });
 
 export const Timestamp = {
   $type: 'google.protobuf.Timestamp' as const,
@@ -133,7 +133,7 @@ export const Timestamp = {
   decode(input: Reader | Uint8Array, length?: number): Timestamp {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseTimestamp } as Timestamp;
+    const message = createBaseTimestamp();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -152,7 +152,7 @@ export const Timestamp = {
   },
 
   fromJSON(object: any): Timestamp {
-    const message = { ...baseTimestamp } as Timestamp;
+    const message = createBaseTimestamp();
     message.seconds = object.seconds !== undefined && object.seconds !== null ? Number(object.seconds) : 0;
     message.nanos = object.nanos !== undefined && object.nanos !== null ? Number(object.nanos) : 0;
     return message;
@@ -166,7 +166,7 @@ export const Timestamp = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Timestamp>, I>>(object: I): Timestamp {
-    const message = { ...baseTimestamp } as Timestamp;
+    const message = createBaseTimestamp();
     message.seconds = object.seconds ?? 0;
     message.nanos = object.nanos ?? 0;
     return message;

--- a/integration/types-with-underscores/file.ts
+++ b/integration/types-with-underscores/file.ts
@@ -10,7 +10,9 @@ export interface Baz {
 
 export interface FooBar {}
 
-const createBaseBaz = (): Baz => ({});
+function createBaseBaz(): Baz {
+  return { foo: undefined };
+}
 
 export const Baz = {
   encode(message: Baz, writer: Writer = Writer.create()): Writer {
@@ -57,7 +59,9 @@ export const Baz = {
   },
 };
 
-const createBaseFooBar = (): FooBar => ({});
+function createBaseFooBar(): FooBar {
+  return {};
+}
 
 export const FooBar = {
   encode(_: FooBar, writer: Writer = Writer.create()): Writer {

--- a/integration/types-with-underscores/file.ts
+++ b/integration/types-with-underscores/file.ts
@@ -10,7 +10,7 @@ export interface Baz {
 
 export interface FooBar {}
 
-const baseBaz: object = {};
+const createBaseBaz = (): Baz => ({});
 
 export const Baz = {
   encode(message: Baz, writer: Writer = Writer.create()): Writer {
@@ -23,7 +23,7 @@ export const Baz = {
   decode(input: Reader | Uint8Array, length?: number): Baz {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseBaz } as Baz;
+    const message = createBaseBaz();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -39,7 +39,7 @@ export const Baz = {
   },
 
   fromJSON(object: any): Baz {
-    const message = { ...baseBaz } as Baz;
+    const message = createBaseBaz();
     message.foo = object.foo !== undefined && object.foo !== null ? FooBar.fromJSON(object.foo) : undefined;
     return message;
   },
@@ -51,13 +51,13 @@ export const Baz = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Baz>, I>>(object: I): Baz {
-    const message = { ...baseBaz } as Baz;
+    const message = createBaseBaz();
     message.foo = object.foo !== undefined && object.foo !== null ? FooBar.fromPartial(object.foo) : undefined;
     return message;
   },
 };
 
-const baseFooBar: object = {};
+const createBaseFooBar = (): FooBar => ({});
 
 export const FooBar = {
   encode(_: FooBar, writer: Writer = Writer.create()): Writer {
@@ -67,7 +67,7 @@ export const FooBar = {
   decode(input: Reader | Uint8Array, length?: number): FooBar {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseFooBar } as FooBar;
+    const message = createBaseFooBar();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -80,7 +80,7 @@ export const FooBar = {
   },
 
   fromJSON(_: any): FooBar {
-    const message = { ...baseFooBar } as FooBar;
+    const message = createBaseFooBar();
     return message;
   },
 
@@ -90,7 +90,7 @@ export const FooBar = {
   },
 
   fromPartial<I extends Exact<DeepPartial<FooBar>, I>>(_: I): FooBar {
-    const message = { ...baseFooBar } as FooBar;
+    const message = createBaseFooBar();
     return message;
   },
 };

--- a/integration/use-date-false/google/protobuf/timestamp.ts
+++ b/integration/use-date-false/google/protobuf/timestamp.ts
@@ -113,7 +113,9 @@ export interface Timestamp {
   nanos: number;
 }
 
-const createBaseTimestamp = (): Timestamp => ({ seconds: 0, nanos: 0 });
+function createBaseTimestamp(): Timestamp {
+  return { seconds: 0, nanos: 0 };
+}
 
 export const Timestamp = {
   encode(message: Timestamp, writer: Writer = Writer.create()): Writer {

--- a/integration/use-date-false/google/protobuf/timestamp.ts
+++ b/integration/use-date-false/google/protobuf/timestamp.ts
@@ -113,7 +113,7 @@ export interface Timestamp {
   nanos: number;
 }
 
-const baseTimestamp: object = { seconds: 0, nanos: 0 };
+const createBaseTimestamp = (): Timestamp => ({ seconds: 0, nanos: 0 });
 
 export const Timestamp = {
   encode(message: Timestamp, writer: Writer = Writer.create()): Writer {
@@ -129,7 +129,7 @@ export const Timestamp = {
   decode(input: Reader | Uint8Array, length?: number): Timestamp {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseTimestamp } as Timestamp;
+    const message = createBaseTimestamp();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -148,7 +148,7 @@ export const Timestamp = {
   },
 
   fromJSON(object: any): Timestamp {
-    const message = { ...baseTimestamp } as Timestamp;
+    const message = createBaseTimestamp();
     message.seconds = object.seconds !== undefined && object.seconds !== null ? Number(object.seconds) : 0;
     message.nanos = object.nanos !== undefined && object.nanos !== null ? Number(object.nanos) : 0;
     return message;
@@ -162,7 +162,7 @@ export const Timestamp = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Timestamp>, I>>(object: I): Timestamp {
-    const message = { ...baseTimestamp } as Timestamp;
+    const message = createBaseTimestamp();
     message.seconds = object.seconds ?? 0;
     message.nanos = object.nanos ?? 0;
     return message;

--- a/integration/use-date-false/metadata.ts
+++ b/integration/use-date-false/metadata.ts
@@ -9,7 +9,9 @@ export interface Metadata {
   lastEdited: Timestamp | undefined;
 }
 
-const createBaseMetadata = (): Metadata => ({});
+function createBaseMetadata(): Metadata {
+  return { lastEdited: undefined };
+}
 
 export const Metadata = {
   encode(message: Metadata, writer: Writer = Writer.create()): Writer {

--- a/integration/use-date-false/metadata.ts
+++ b/integration/use-date-false/metadata.ts
@@ -9,7 +9,7 @@ export interface Metadata {
   lastEdited: Timestamp | undefined;
 }
 
-const baseMetadata: object = {};
+const createBaseMetadata = (): Metadata => ({});
 
 export const Metadata = {
   encode(message: Metadata, writer: Writer = Writer.create()): Writer {
@@ -22,7 +22,7 @@ export const Metadata = {
   decode(input: Reader | Uint8Array, length?: number): Metadata {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseMetadata } as Metadata;
+    const message = createBaseMetadata();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -38,7 +38,7 @@ export const Metadata = {
   },
 
   fromJSON(object: any): Metadata {
-    const message = { ...baseMetadata } as Metadata;
+    const message = createBaseMetadata();
     message.lastEdited =
       object.lastEdited !== undefined && object.lastEdited !== null ? fromJsonTimestamp(object.lastEdited) : undefined;
     return message;
@@ -51,7 +51,7 @@ export const Metadata = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Metadata>, I>>(object: I): Metadata {
-    const message = { ...baseMetadata } as Metadata;
+    const message = createBaseMetadata();
     message.lastEdited =
       object.lastEdited !== undefined && object.lastEdited !== null
         ? Timestamp.fromPartial(object.lastEdited)

--- a/integration/use-date-string/google/protobuf/timestamp.ts
+++ b/integration/use-date-string/google/protobuf/timestamp.ts
@@ -113,7 +113,9 @@ export interface Timestamp {
   nanos: number;
 }
 
-const createBaseTimestamp = (): Timestamp => ({ seconds: 0, nanos: 0 });
+function createBaseTimestamp(): Timestamp {
+  return { seconds: 0, nanos: 0 };
+}
 
 export const Timestamp = {
   encode(message: Timestamp, writer: Writer = Writer.create()): Writer {

--- a/integration/use-date-string/google/protobuf/timestamp.ts
+++ b/integration/use-date-string/google/protobuf/timestamp.ts
@@ -113,7 +113,7 @@ export interface Timestamp {
   nanos: number;
 }
 
-const baseTimestamp: object = { seconds: 0, nanos: 0 };
+const createBaseTimestamp = (): Timestamp => ({ seconds: 0, nanos: 0 });
 
 export const Timestamp = {
   encode(message: Timestamp, writer: Writer = Writer.create()): Writer {
@@ -129,7 +129,7 @@ export const Timestamp = {
   decode(input: Reader | Uint8Array, length?: number): Timestamp {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseTimestamp } as Timestamp;
+    const message = createBaseTimestamp();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -148,7 +148,7 @@ export const Timestamp = {
   },
 
   fromJSON(object: any): Timestamp {
-    const message = { ...baseTimestamp } as Timestamp;
+    const message = createBaseTimestamp();
     message.seconds = object.seconds !== undefined && object.seconds !== null ? Number(object.seconds) : 0;
     message.nanos = object.nanos !== undefined && object.nanos !== null ? Number(object.nanos) : 0;
     return message;
@@ -162,7 +162,7 @@ export const Timestamp = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Timestamp>, I>>(object: I): Timestamp {
-    const message = { ...baseTimestamp } as Timestamp;
+    const message = createBaseTimestamp();
     message.seconds = object.seconds ?? 0;
     message.nanos = object.nanos ?? 0;
     return message;

--- a/integration/use-date-string/use-date-string-test.ts
+++ b/integration/use-date-string/use-date-string-test.ts
@@ -22,6 +22,7 @@ describe('useDate=string', () => {
           "feb1": "1970-02-01T00:00:00.000Z",
           "jan1": "1970-01-01T00:00:00.000Z",
         },
+        "optionalTimestamp": undefined,
         "repeatedTimestamp": Array [
           "1970-01-01T00:00:00.000Z",
           "1970-02-01T00:00:00.000Z",

--- a/integration/use-date-string/use-date-string.ts
+++ b/integration/use-date-string/use-date-string.ts
@@ -18,7 +18,9 @@ export interface Todo_MapOfTimestampsEntry {
   value: string | undefined;
 }
 
-const createBaseTodo = (): Todo => ({ id: '' });
+function createBaseTodo(): Todo {
+  return { id: '', timestamp: undefined, repeatedTimestamp: [], optionalTimestamp: undefined, mapOfTimestamps: {} };
+}
 
 export const Todo = {
   encode(message: Todo, writer: Writer = Writer.create()): Writer {
@@ -44,8 +46,6 @@ export const Todo = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseTodo();
-    message.repeatedTimestamp = [];
-    message.mapOfTimestamps = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -133,7 +133,9 @@ export const Todo = {
   },
 };
 
-const createBaseTodo_MapOfTimestampsEntry = (): Todo_MapOfTimestampsEntry => ({ key: '' });
+function createBaseTodo_MapOfTimestampsEntry(): Todo_MapOfTimestampsEntry {
+  return { key: '', value: undefined };
+}
 
 export const Todo_MapOfTimestampsEntry = {
   encode(message: Todo_MapOfTimestampsEntry, writer: Writer = Writer.create()): Writer {

--- a/integration/use-date-string/use-date-string.ts
+++ b/integration/use-date-string/use-date-string.ts
@@ -18,7 +18,7 @@ export interface Todo_MapOfTimestampsEntry {
   value: string | undefined;
 }
 
-const baseTodo: object = { id: '' };
+const createBaseTodo = (): Todo => ({ id: '' });
 
 export const Todo = {
   encode(message: Todo, writer: Writer = Writer.create()): Writer {
@@ -43,7 +43,7 @@ export const Todo = {
   decode(input: Reader | Uint8Array, length?: number): Todo {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseTodo } as Todo;
+    const message = createBaseTodo();
     message.repeatedTimestamp = [];
     message.mapOfTimestamps = {};
     while (reader.pos < end) {
@@ -76,7 +76,7 @@ export const Todo = {
   },
 
   fromJSON(object: any): Todo {
-    const message = { ...baseTodo } as Todo;
+    const message = createBaseTodo();
     message.id = object.id !== undefined && object.id !== null ? String(object.id) : '';
     message.timestamp =
       object.timestamp !== undefined && object.timestamp !== null ? String(object.timestamp) : undefined;
@@ -115,7 +115,7 @@ export const Todo = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Todo>, I>>(object: I): Todo {
-    const message = { ...baseTodo } as Todo;
+    const message = createBaseTodo();
     message.id = object.id ?? '';
     message.timestamp = object.timestamp ?? undefined;
     message.repeatedTimestamp = object.repeatedTimestamp?.map((e) => e) || [];
@@ -133,7 +133,7 @@ export const Todo = {
   },
 };
 
-const baseTodo_MapOfTimestampsEntry: object = { key: '' };
+const createBaseTodo_MapOfTimestampsEntry = (): Todo_MapOfTimestampsEntry => ({ key: '' });
 
 export const Todo_MapOfTimestampsEntry = {
   encode(message: Todo_MapOfTimestampsEntry, writer: Writer = Writer.create()): Writer {
@@ -149,7 +149,7 @@ export const Todo_MapOfTimestampsEntry = {
   decode(input: Reader | Uint8Array, length?: number): Todo_MapOfTimestampsEntry {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseTodo_MapOfTimestampsEntry } as Todo_MapOfTimestampsEntry;
+    const message = createBaseTodo_MapOfTimestampsEntry();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -168,7 +168,7 @@ export const Todo_MapOfTimestampsEntry = {
   },
 
   fromJSON(object: any): Todo_MapOfTimestampsEntry {
-    const message = { ...baseTodo_MapOfTimestampsEntry } as Todo_MapOfTimestampsEntry;
+    const message = createBaseTodo_MapOfTimestampsEntry();
     message.key = object.key !== undefined && object.key !== null ? String(object.key) : '';
     message.value = object.value !== undefined && object.value !== null ? String(object.value) : undefined;
     return message;
@@ -182,7 +182,7 @@ export const Todo_MapOfTimestampsEntry = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Todo_MapOfTimestampsEntry>, I>>(object: I): Todo_MapOfTimestampsEntry {
-    const message = { ...baseTodo_MapOfTimestampsEntry } as Todo_MapOfTimestampsEntry;
+    const message = createBaseTodo_MapOfTimestampsEntry();
     message.key = object.key ?? '';
     message.value = object.value ?? undefined;
     return message;

--- a/integration/use-date-true/google/protobuf/timestamp.ts
+++ b/integration/use-date-true/google/protobuf/timestamp.ts
@@ -113,7 +113,9 @@ export interface Timestamp {
   nanos: number;
 }
 
-const createBaseTimestamp = (): Timestamp => ({ seconds: 0, nanos: 0 });
+function createBaseTimestamp(): Timestamp {
+  return { seconds: 0, nanos: 0 };
+}
 
 export const Timestamp = {
   encode(message: Timestamp, writer: Writer = Writer.create()): Writer {

--- a/integration/use-date-true/google/protobuf/timestamp.ts
+++ b/integration/use-date-true/google/protobuf/timestamp.ts
@@ -113,7 +113,7 @@ export interface Timestamp {
   nanos: number;
 }
 
-const baseTimestamp: object = { seconds: 0, nanos: 0 };
+const createBaseTimestamp = (): Timestamp => ({ seconds: 0, nanos: 0 });
 
 export const Timestamp = {
   encode(message: Timestamp, writer: Writer = Writer.create()): Writer {
@@ -129,7 +129,7 @@ export const Timestamp = {
   decode(input: Reader | Uint8Array, length?: number): Timestamp {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseTimestamp } as Timestamp;
+    const message = createBaseTimestamp();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -148,7 +148,7 @@ export const Timestamp = {
   },
 
   fromJSON(object: any): Timestamp {
-    const message = { ...baseTimestamp } as Timestamp;
+    const message = createBaseTimestamp();
     message.seconds = object.seconds !== undefined && object.seconds !== null ? Number(object.seconds) : 0;
     message.nanos = object.nanos !== undefined && object.nanos !== null ? Number(object.nanos) : 0;
     return message;
@@ -162,7 +162,7 @@ export const Timestamp = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Timestamp>, I>>(object: I): Timestamp {
-    const message = { ...baseTimestamp } as Timestamp;
+    const message = createBaseTimestamp();
     message.seconds = object.seconds ?? 0;
     message.nanos = object.nanos ?? 0;
     return message;

--- a/integration/use-date-true/use-date-true-test.ts
+++ b/integration/use-date-true/use-date-true-test.ts
@@ -22,6 +22,7 @@ describe('useDate=true', () => {
           "feb1": 1970-02-01T00:00:00.000Z,
           "jan1": 1970-01-01T00:00:00.000Z,
         },
+        "optionalTimestamp": undefined,
         "repeatedTimestamp": Array [
           1970-01-01T00:00:00.000Z,
           1970-02-01T00:00:00.000Z,

--- a/integration/use-date-true/use-date-true.ts
+++ b/integration/use-date-true/use-date-true.ts
@@ -18,7 +18,7 @@ export interface Todo_MapOfTimestampsEntry {
   value: Date | undefined;
 }
 
-const baseTodo: object = { id: '' };
+const createBaseTodo = (): Todo => ({ id: '' });
 
 export const Todo = {
   encode(message: Todo, writer: Writer = Writer.create()): Writer {
@@ -43,7 +43,7 @@ export const Todo = {
   decode(input: Reader | Uint8Array, length?: number): Todo {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseTodo } as Todo;
+    const message = createBaseTodo();
     message.repeatedTimestamp = [];
     message.mapOfTimestamps = {};
     while (reader.pos < end) {
@@ -76,7 +76,7 @@ export const Todo = {
   },
 
   fromJSON(object: any): Todo {
-    const message = { ...baseTodo } as Todo;
+    const message = createBaseTodo();
     message.id = object.id !== undefined && object.id !== null ? String(object.id) : '';
     message.timestamp =
       object.timestamp !== undefined && object.timestamp !== null ? fromJsonTimestamp(object.timestamp) : undefined;
@@ -115,7 +115,7 @@ export const Todo = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Todo>, I>>(object: I): Todo {
-    const message = { ...baseTodo } as Todo;
+    const message = createBaseTodo();
     message.id = object.id ?? '';
     message.timestamp = object.timestamp ?? undefined;
     message.repeatedTimestamp = object.repeatedTimestamp?.map((e) => e) || [];
@@ -133,7 +133,7 @@ export const Todo = {
   },
 };
 
-const baseTodo_MapOfTimestampsEntry: object = { key: '' };
+const createBaseTodo_MapOfTimestampsEntry = (): Todo_MapOfTimestampsEntry => ({ key: '' });
 
 export const Todo_MapOfTimestampsEntry = {
   encode(message: Todo_MapOfTimestampsEntry, writer: Writer = Writer.create()): Writer {
@@ -149,7 +149,7 @@ export const Todo_MapOfTimestampsEntry = {
   decode(input: Reader | Uint8Array, length?: number): Todo_MapOfTimestampsEntry {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseTodo_MapOfTimestampsEntry } as Todo_MapOfTimestampsEntry;
+    const message = createBaseTodo_MapOfTimestampsEntry();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -168,7 +168,7 @@ export const Todo_MapOfTimestampsEntry = {
   },
 
   fromJSON(object: any): Todo_MapOfTimestampsEntry {
-    const message = { ...baseTodo_MapOfTimestampsEntry } as Todo_MapOfTimestampsEntry;
+    const message = createBaseTodo_MapOfTimestampsEntry();
     message.key = object.key !== undefined && object.key !== null ? String(object.key) : '';
     message.value = object.value !== undefined && object.value !== null ? fromJsonTimestamp(object.value) : undefined;
     return message;
@@ -182,7 +182,7 @@ export const Todo_MapOfTimestampsEntry = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Todo_MapOfTimestampsEntry>, I>>(object: I): Todo_MapOfTimestampsEntry {
-    const message = { ...baseTodo_MapOfTimestampsEntry } as Todo_MapOfTimestampsEntry;
+    const message = createBaseTodo_MapOfTimestampsEntry();
     message.key = object.key ?? '';
     message.value = object.value ?? undefined;
     return message;

--- a/integration/use-date-true/use-date-true.ts
+++ b/integration/use-date-true/use-date-true.ts
@@ -18,7 +18,9 @@ export interface Todo_MapOfTimestampsEntry {
   value: Date | undefined;
 }
 
-const createBaseTodo = (): Todo => ({ id: '' });
+function createBaseTodo(): Todo {
+  return { id: '', timestamp: undefined, repeatedTimestamp: [], optionalTimestamp: undefined, mapOfTimestamps: {} };
+}
 
 export const Todo = {
   encode(message: Todo, writer: Writer = Writer.create()): Writer {
@@ -44,8 +46,6 @@ export const Todo = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseTodo();
-    message.repeatedTimestamp = [];
-    message.mapOfTimestamps = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -133,7 +133,9 @@ export const Todo = {
   },
 };
 
-const createBaseTodo_MapOfTimestampsEntry = (): Todo_MapOfTimestampsEntry => ({ key: '' });
+function createBaseTodo_MapOfTimestampsEntry(): Todo_MapOfTimestampsEntry {
+  return { key: '', value: undefined };
+}
 
 export const Todo_MapOfTimestampsEntry = {
   encode(message: Todo_MapOfTimestampsEntry, writer: Writer = Writer.create()): Writer {

--- a/integration/use-optionals-all/test.ts
+++ b/integration/use-optionals-all/test.ts
@@ -74,18 +74,32 @@ export interface OptionalsTest_TranslationsEntry {
 
 export interface Child {}
 
-const createBaseOptionalsTest = (): OptionalsTest => ({
-  id: 0,
-  state: 0,
-  long: 0,
-  truth: false,
-  description: '',
-  repId: 0,
-  repState: 0,
-  repLong: 0,
-  repTruth: false,
-  repDescription: '',
-});
+function createBaseOptionalsTest(): OptionalsTest {
+  return {
+    id: 0,
+    child: undefined,
+    state: 0,
+    long: 0,
+    truth: false,
+    description: '',
+    data: new Uint8Array(),
+    repId: [],
+    repChild: [],
+    repState: [],
+    repLong: [],
+    repTruth: [],
+    repDescription: [],
+    repData: [],
+    optId: undefined,
+    optChild: undefined,
+    optState: undefined,
+    optLong: undefined,
+    optTruth: undefined,
+    optDescription: undefined,
+    optData: undefined,
+    translations: {},
+  };
+}
 
 export const OptionalsTest = {
   encode(message: OptionalsTest, writer: Writer = Writer.create()): Writer {
@@ -184,15 +198,6 @@ export const OptionalsTest = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseOptionalsTest();
-    message.repId = [];
-    message.repChild = [];
-    message.repState = [];
-    message.repLong = [];
-    message.repTruth = [];
-    message.repDescription = [];
-    message.repData = [];
-    message.translations = {};
-    message.data = new Uint8Array();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -221,50 +226,50 @@ export const OptionalsTest = {
           if ((tag & 7) === 2) {
             const end2 = reader.uint32() + reader.pos;
             while (reader.pos < end2) {
-              message.repId.push(reader.int32());
+              message.repId!.push(reader.int32());
             }
           } else {
-            message.repId.push(reader.int32());
+            message.repId!.push(reader.int32());
           }
           break;
         case 12:
-          message.repChild.push(Child.decode(reader, reader.uint32()));
+          message.repChild!.push(Child.decode(reader, reader.uint32()));
           break;
         case 13:
           if ((tag & 7) === 2) {
             const end2 = reader.uint32() + reader.pos;
             while (reader.pos < end2) {
-              message.repState.push(reader.int32() as any);
+              message.repState!.push(reader.int32() as any);
             }
           } else {
-            message.repState.push(reader.int32() as any);
+            message.repState!.push(reader.int32() as any);
           }
           break;
         case 14:
           if ((tag & 7) === 2) {
             const end2 = reader.uint32() + reader.pos;
             while (reader.pos < end2) {
-              message.repLong.push(longToNumber(reader.int64() as Long));
+              message.repLong!.push(longToNumber(reader.int64() as Long));
             }
           } else {
-            message.repLong.push(longToNumber(reader.int64() as Long));
+            message.repLong!.push(longToNumber(reader.int64() as Long));
           }
           break;
         case 15:
           if ((tag & 7) === 2) {
             const end2 = reader.uint32() + reader.pos;
             while (reader.pos < end2) {
-              message.repTruth.push(reader.bool());
+              message.repTruth!.push(reader.bool());
             }
           } else {
-            message.repTruth.push(reader.bool());
+            message.repTruth!.push(reader.bool());
           }
           break;
         case 16:
-          message.repDescription.push(reader.string());
+          message.repDescription!.push(reader.string());
           break;
         case 17:
-          message.repData.push(reader.bytes());
+          message.repData!.push(reader.bytes());
           break;
         case 21:
           message.optId = reader.int32();
@@ -290,7 +295,7 @@ export const OptionalsTest = {
         case 30:
           const entry30 = OptionalsTest_TranslationsEntry.decode(reader, reader.uint32());
           if (entry30.value !== undefined) {
-            message.translations[entry30.key] = entry30.value;
+            message.translations![entry30.key] = entry30.value;
           }
           break;
         default:
@@ -439,7 +444,9 @@ export const OptionalsTest = {
   },
 };
 
-const createBaseOptionalsTest_TranslationsEntry = (): OptionalsTest_TranslationsEntry => ({ key: '', value: '' });
+function createBaseOptionalsTest_TranslationsEntry(): OptionalsTest_TranslationsEntry {
+  return { key: '', value: '' };
+}
 
 export const OptionalsTest_TranslationsEntry = {
   encode(message: OptionalsTest_TranslationsEntry, writer: Writer = Writer.create()): Writer {
@@ -497,7 +504,9 @@ export const OptionalsTest_TranslationsEntry = {
   },
 };
 
-const createBaseChild = (): Child => ({});
+function createBaseChild(): Child {
+  return {};
+}
 
 export const Child = {
   encode(_: Child, writer: Writer = Writer.create()): Writer {

--- a/integration/use-optionals-all/test.ts
+++ b/integration/use-optionals-all/test.ts
@@ -74,7 +74,7 @@ export interface OptionalsTest_TranslationsEntry {
 
 export interface Child {}
 
-const baseOptionalsTest: object = {
+const createBaseOptionalsTest = (): OptionalsTest => ({
   id: 0,
   state: 0,
   long: 0,
@@ -85,7 +85,7 @@ const baseOptionalsTest: object = {
   repLong: 0,
   repTruth: false,
   repDescription: '',
-};
+});
 
 export const OptionalsTest = {
   encode(message: OptionalsTest, writer: Writer = Writer.create()): Writer {
@@ -183,7 +183,7 @@ export const OptionalsTest = {
   decode(input: Reader | Uint8Array, length?: number): OptionalsTest {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseOptionalsTest } as OptionalsTest;
+    const message = createBaseOptionalsTest();
     message.repId = [];
     message.repChild = [];
     message.repState = [];
@@ -302,7 +302,7 @@ export const OptionalsTest = {
   },
 
   fromJSON(object: any): OptionalsTest {
-    const message = { ...baseOptionalsTest } as OptionalsTest;
+    const message = createBaseOptionalsTest();
     message.id = object.id !== undefined && object.id !== null ? Number(object.id) : 0;
     message.child = object.child !== undefined && object.child !== null ? Child.fromJSON(object.child) : undefined;
     message.state = object.state !== undefined && object.state !== null ? stateEnumFromJSON(object.state) : 0;
@@ -403,7 +403,7 @@ export const OptionalsTest = {
   },
 
   fromPartial<I extends Exact<DeepPartial<OptionalsTest>, I>>(object: I): OptionalsTest {
-    const message = { ...baseOptionalsTest } as OptionalsTest;
+    const message = createBaseOptionalsTest();
     message.id = object.id ?? 0;
     message.child = object.child !== undefined && object.child !== null ? Child.fromPartial(object.child) : undefined;
     message.state = object.state ?? 0;
@@ -439,7 +439,7 @@ export const OptionalsTest = {
   },
 };
 
-const baseOptionalsTest_TranslationsEntry: object = { key: '', value: '' };
+const createBaseOptionalsTest_TranslationsEntry = (): OptionalsTest_TranslationsEntry => ({ key: '', value: '' });
 
 export const OptionalsTest_TranslationsEntry = {
   encode(message: OptionalsTest_TranslationsEntry, writer: Writer = Writer.create()): Writer {
@@ -455,7 +455,7 @@ export const OptionalsTest_TranslationsEntry = {
   decode(input: Reader | Uint8Array, length?: number): OptionalsTest_TranslationsEntry {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseOptionalsTest_TranslationsEntry } as OptionalsTest_TranslationsEntry;
+    const message = createBaseOptionalsTest_TranslationsEntry();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -474,7 +474,7 @@ export const OptionalsTest_TranslationsEntry = {
   },
 
   fromJSON(object: any): OptionalsTest_TranslationsEntry {
-    const message = { ...baseOptionalsTest_TranslationsEntry } as OptionalsTest_TranslationsEntry;
+    const message = createBaseOptionalsTest_TranslationsEntry();
     message.key = object.key !== undefined && object.key !== null ? String(object.key) : '';
     message.value = object.value !== undefined && object.value !== null ? String(object.value) : '';
     return message;
@@ -490,14 +490,14 @@ export const OptionalsTest_TranslationsEntry = {
   fromPartial<I extends Exact<DeepPartial<OptionalsTest_TranslationsEntry>, I>>(
     object: I
   ): OptionalsTest_TranslationsEntry {
-    const message = { ...baseOptionalsTest_TranslationsEntry } as OptionalsTest_TranslationsEntry;
+    const message = createBaseOptionalsTest_TranslationsEntry();
     message.key = object.key ?? '';
     message.value = object.value ?? '';
     return message;
   },
 };
 
-const baseChild: object = {};
+const createBaseChild = (): Child => ({});
 
 export const Child = {
   encode(_: Child, writer: Writer = Writer.create()): Writer {
@@ -507,7 +507,7 @@ export const Child = {
   decode(input: Reader | Uint8Array, length?: number): Child {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseChild } as Child;
+    const message = createBaseChild();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -520,7 +520,7 @@ export const Child = {
   },
 
   fromJSON(_: any): Child {
-    const message = { ...baseChild } as Child;
+    const message = createBaseChild();
     return message;
   },
 
@@ -530,7 +530,7 @@ export const Child = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Child>, I>>(_: I): Child {
-    const message = { ...baseChild } as Child;
+    const message = createBaseChild();
     return message;
   },
 };

--- a/integration/value/google/protobuf/struct.ts
+++ b/integration/value/google/protobuf/struct.ts
@@ -90,7 +90,7 @@ export interface ListValue {
   values: any[];
 }
 
-const baseStruct: object = {};
+const createBaseStruct = (): Struct => ({});
 
 export const Struct = {
   encode(message: Struct, writer: Writer = Writer.create()): Writer {
@@ -105,7 +105,7 @@ export const Struct = {
   decode(input: Reader | Uint8Array, length?: number): Struct {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseStruct } as Struct;
+    const message = createBaseStruct();
     message.fields = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
@@ -125,7 +125,7 @@ export const Struct = {
   },
 
   fromJSON(object: any): Struct {
-    const message = { ...baseStruct } as Struct;
+    const message = createBaseStruct();
     message.fields = Object.entries(object.fields ?? {}).reduce<{ [key: string]: any | undefined }>(
       (acc, [key, value]) => {
         acc[key] = value as any | undefined;
@@ -148,7 +148,7 @@ export const Struct = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Struct>, I>>(object: I): Struct {
-    const message = { ...baseStruct } as Struct;
+    const message = createBaseStruct();
     message.fields = Object.entries(object.fields ?? {}).reduce<{ [key: string]: any | undefined }>(
       (acc, [key, value]) => {
         if (value !== undefined) {
@@ -180,7 +180,7 @@ export const Struct = {
   },
 };
 
-const baseStruct_FieldsEntry: object = { key: '' };
+const createBaseStruct_FieldsEntry = (): Struct_FieldsEntry => ({ key: '' });
 
 export const Struct_FieldsEntry = {
   encode(message: Struct_FieldsEntry, writer: Writer = Writer.create()): Writer {
@@ -196,7 +196,7 @@ export const Struct_FieldsEntry = {
   decode(input: Reader | Uint8Array, length?: number): Struct_FieldsEntry {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseStruct_FieldsEntry } as Struct_FieldsEntry;
+    const message = createBaseStruct_FieldsEntry();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -215,7 +215,7 @@ export const Struct_FieldsEntry = {
   },
 
   fromJSON(object: any): Struct_FieldsEntry {
-    const message = { ...baseStruct_FieldsEntry } as Struct_FieldsEntry;
+    const message = createBaseStruct_FieldsEntry();
     message.key = object.key !== undefined && object.key !== null ? String(object.key) : '';
     message.value = object.value;
     return message;
@@ -229,14 +229,14 @@ export const Struct_FieldsEntry = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Struct_FieldsEntry>, I>>(object: I): Struct_FieldsEntry {
-    const message = { ...baseStruct_FieldsEntry } as Struct_FieldsEntry;
+    const message = createBaseStruct_FieldsEntry();
     message.key = object.key ?? '';
     message.value = object.value ?? undefined;
     return message;
   },
 };
 
-const baseValue: object = {};
+const createBaseValue = (): Value => ({});
 
 export const Value = {
   encode(message: Value, writer: Writer = Writer.create()): Writer {
@@ -264,7 +264,7 @@ export const Value = {
   decode(input: Reader | Uint8Array, length?: number): Value {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseValue } as Value;
+    const message = createBaseValue();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -295,7 +295,7 @@ export const Value = {
   },
 
   fromJSON(object: any): Value {
-    const message = { ...baseValue } as Value;
+    const message = createBaseValue();
     message.nullValue =
       object.nullValue !== undefined && object.nullValue !== null ? nullValueFromJSON(object.nullValue) : undefined;
     message.numberValue =
@@ -322,7 +322,7 @@ export const Value = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Value>, I>>(object: I): Value {
-    const message = { ...baseValue } as Value;
+    const message = createBaseValue();
     message.nullValue = object.nullValue ?? undefined;
     message.numberValue = object.numberValue ?? undefined;
     message.stringValue = object.stringValue ?? undefined;
@@ -370,7 +370,7 @@ export const Value = {
   },
 };
 
-const baseListValue: object = {};
+const createBaseListValue = (): ListValue => ({});
 
 export const ListValue = {
   encode(message: ListValue, writer: Writer = Writer.create()): Writer {
@@ -383,7 +383,7 @@ export const ListValue = {
   decode(input: Reader | Uint8Array, length?: number): ListValue {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseListValue } as ListValue;
+    const message = createBaseListValue();
     message.values = [];
     while (reader.pos < end) {
       const tag = reader.uint32();
@@ -400,7 +400,7 @@ export const ListValue = {
   },
 
   fromJSON(object: any): ListValue {
-    const message = { ...baseListValue } as ListValue;
+    const message = createBaseListValue();
     message.values = Array.isArray(object?.values) ? [...object.values] : [];
     return message;
   },
@@ -416,7 +416,7 @@ export const ListValue = {
   },
 
   fromPartial<I extends Exact<DeepPartial<ListValue>, I>>(object: I): ListValue {
-    const message = { ...baseListValue } as ListValue;
+    const message = createBaseListValue();
     message.values = object.values?.map((e) => e) || [];
     return message;
   },

--- a/integration/value/google/protobuf/struct.ts
+++ b/integration/value/google/protobuf/struct.ts
@@ -90,7 +90,9 @@ export interface ListValue {
   values: any[];
 }
 
-const createBaseStruct = (): Struct => ({});
+function createBaseStruct(): Struct {
+  return { fields: {} };
+}
 
 export const Struct = {
   encode(message: Struct, writer: Writer = Writer.create()): Writer {
@@ -106,7 +108,6 @@ export const Struct = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseStruct();
-    message.fields = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -180,7 +181,9 @@ export const Struct = {
   },
 };
 
-const createBaseStruct_FieldsEntry = (): Struct_FieldsEntry => ({ key: '' });
+function createBaseStruct_FieldsEntry(): Struct_FieldsEntry {
+  return { key: '', value: undefined };
+}
 
 export const Struct_FieldsEntry = {
   encode(message: Struct_FieldsEntry, writer: Writer = Writer.create()): Writer {
@@ -236,7 +239,16 @@ export const Struct_FieldsEntry = {
   },
 };
 
-const createBaseValue = (): Value => ({});
+function createBaseValue(): Value {
+  return {
+    nullValue: undefined,
+    numberValue: undefined,
+    stringValue: undefined,
+    boolValue: undefined,
+    structValue: undefined,
+    listValue: undefined,
+  };
+}
 
 export const Value = {
   encode(message: Value, writer: Writer = Writer.create()): Writer {
@@ -370,7 +382,9 @@ export const Value = {
   },
 };
 
-const createBaseListValue = (): ListValue => ({});
+function createBaseListValue(): ListValue {
+  return { values: [] };
+}
 
 export const ListValue = {
   encode(message: ListValue, writer: Writer = Writer.create()): Writer {
@@ -384,7 +398,6 @@ export const ListValue = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseListValue();
-    message.values = [];
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {

--- a/integration/value/value.ts
+++ b/integration/value/value.ts
@@ -11,7 +11,7 @@ export interface ValueMessage {
   repeatedAny: any[];
 }
 
-const baseValueMessage: object = {};
+const createBaseValueMessage = (): ValueMessage => ({});
 
 export const ValueMessage = {
   encode(message: ValueMessage, writer: Writer = Writer.create()): Writer {
@@ -30,7 +30,7 @@ export const ValueMessage = {
   decode(input: Reader | Uint8Array, length?: number): ValueMessage {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseValueMessage } as ValueMessage;
+    const message = createBaseValueMessage();
     message.repeatedAny = [];
     while (reader.pos < end) {
       const tag = reader.uint32();
@@ -53,7 +53,7 @@ export const ValueMessage = {
   },
 
   fromJSON(object: any): ValueMessage {
-    const message = { ...baseValueMessage } as ValueMessage;
+    const message = createBaseValueMessage();
     message.value = object.value;
     message.anyList = Array.isArray(object?.anyList) ? [...object.anyList] : undefined;
     message.repeatedAny = Array.isArray(object?.repeatedAny) ? [...object.repeatedAny] : [];
@@ -73,7 +73,7 @@ export const ValueMessage = {
   },
 
   fromPartial<I extends Exact<DeepPartial<ValueMessage>, I>>(object: I): ValueMessage {
-    const message = { ...baseValueMessage } as ValueMessage;
+    const message = createBaseValueMessage();
     message.value = object.value ?? undefined;
     message.anyList = object.anyList ?? undefined;
     message.repeatedAny = object.repeatedAny?.map((e) => e) || [];

--- a/integration/value/value.ts
+++ b/integration/value/value.ts
@@ -11,7 +11,9 @@ export interface ValueMessage {
   repeatedAny: any[];
 }
 
-const createBaseValueMessage = (): ValueMessage => ({});
+function createBaseValueMessage(): ValueMessage {
+  return { value: undefined, anyList: undefined, repeatedAny: [] };
+}
 
 export const ValueMessage = {
   encode(message: ValueMessage, writer: Writer = Writer.create()): Writer {
@@ -31,7 +33,6 @@ export const ValueMessage = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseValueMessage();
-    message.repeatedAny = [];
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {

--- a/integration/vector-tile/vector_tile.ts
+++ b/integration/vector-tile/vector_tile.ts
@@ -78,7 +78,7 @@ export interface Tile_Layer {
   extent: number;
 }
 
-const baseTile: object = {};
+const createBaseTile = (): Tile => ({});
 
 export const Tile = {
   encode(message: Tile, writer: Writer = Writer.create()): Writer {
@@ -91,7 +91,7 @@ export const Tile = {
   decode(input: Reader | Uint8Array, length?: number): Tile {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseTile } as Tile;
+    const message = createBaseTile();
     message.layers = [];
     while (reader.pos < end) {
       const tag = reader.uint32();
@@ -108,7 +108,7 @@ export const Tile = {
   },
 
   fromJSON(object: any): Tile {
-    const message = { ...baseTile } as Tile;
+    const message = createBaseTile();
     message.layers = (object.layers ?? []).map((e: any) => Tile_Layer.fromJSON(e));
     return message;
   },
@@ -124,13 +124,13 @@ export const Tile = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Tile>, I>>(object: I): Tile {
-    const message = { ...baseTile } as Tile;
+    const message = createBaseTile();
     message.layers = object.layers?.map((e) => Tile_Layer.fromPartial(e)) || [];
     return message;
   },
 };
 
-const baseTile_Value: object = {
+const createBaseTile_Value = (): Tile_Value => ({
   stringValue: '',
   floatValue: 0,
   doubleValue: 0,
@@ -138,7 +138,7 @@ const baseTile_Value: object = {
   uintValue: 0,
   sintValue: 0,
   boolValue: false,
-};
+});
 
 export const Tile_Value = {
   encode(message: Tile_Value, writer: Writer = Writer.create()): Writer {
@@ -169,7 +169,7 @@ export const Tile_Value = {
   decode(input: Reader | Uint8Array, length?: number): Tile_Value {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseTile_Value } as Tile_Value;
+    const message = createBaseTile_Value();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -203,7 +203,7 @@ export const Tile_Value = {
   },
 
   fromJSON(object: any): Tile_Value {
-    const message = { ...baseTile_Value } as Tile_Value;
+    const message = createBaseTile_Value();
     message.stringValue =
       object.stringValue !== undefined && object.stringValue !== null ? String(object.stringValue) : '';
     message.floatValue = object.floatValue !== undefined && object.floatValue !== null ? Number(object.floatValue) : 0;
@@ -229,7 +229,7 @@ export const Tile_Value = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Tile_Value>, I>>(object: I): Tile_Value {
-    const message = { ...baseTile_Value } as Tile_Value;
+    const message = createBaseTile_Value();
     message.stringValue = object.stringValue ?? '';
     message.floatValue = object.floatValue ?? 0;
     message.doubleValue = object.doubleValue ?? 0;
@@ -241,7 +241,7 @@ export const Tile_Value = {
   },
 };
 
-const baseTile_Feature: object = { id: 0, tags: 0, type: 0, geometry: 0 };
+const createBaseTile_Feature = (): Tile_Feature => ({ id: 0, tags: 0, type: 0, geometry: 0 });
 
 export const Tile_Feature = {
   encode(message: Tile_Feature, writer: Writer = Writer.create()): Writer {
@@ -267,7 +267,7 @@ export const Tile_Feature = {
   decode(input: Reader | Uint8Array, length?: number): Tile_Feature {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseTile_Feature } as Tile_Feature;
+    const message = createBaseTile_Feature();
     message.tags = [];
     message.geometry = [];
     while (reader.pos < end) {
@@ -308,7 +308,7 @@ export const Tile_Feature = {
   },
 
   fromJSON(object: any): Tile_Feature {
-    const message = { ...baseTile_Feature } as Tile_Feature;
+    const message = createBaseTile_Feature();
     message.id = object.id !== undefined && object.id !== null ? Number(object.id) : 0;
     message.tags = (object.tags ?? []).map((e: any) => Number(e));
     message.type = object.type !== undefined && object.type !== null ? tile_GeomTypeFromJSON(object.type) : 0;
@@ -334,7 +334,7 @@ export const Tile_Feature = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Tile_Feature>, I>>(object: I): Tile_Feature {
-    const message = { ...baseTile_Feature } as Tile_Feature;
+    const message = createBaseTile_Feature();
     message.id = object.id ?? 0;
     message.tags = object.tags?.map((e) => e) || [];
     message.type = object.type ?? 0;
@@ -343,7 +343,7 @@ export const Tile_Feature = {
   },
 };
 
-const baseTile_Layer: object = { version: 0, name: '', keys: '', extent: 0 };
+const createBaseTile_Layer = (): Tile_Layer => ({ version: 0, name: '', keys: '', extent: 0 });
 
 export const Tile_Layer = {
   encode(message: Tile_Layer, writer: Writer = Writer.create()): Writer {
@@ -371,7 +371,7 @@ export const Tile_Layer = {
   decode(input: Reader | Uint8Array, length?: number): Tile_Layer {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = { ...baseTile_Layer } as Tile_Layer;
+    const message = createBaseTile_Layer();
     message.features = [];
     message.keys = [];
     message.values = [];
@@ -405,7 +405,7 @@ export const Tile_Layer = {
   },
 
   fromJSON(object: any): Tile_Layer {
-    const message = { ...baseTile_Layer } as Tile_Layer;
+    const message = createBaseTile_Layer();
     message.version = object.version !== undefined && object.version !== null ? Number(object.version) : 0;
     message.name = object.name !== undefined && object.name !== null ? String(object.name) : '';
     message.features = (object.features ?? []).map((e: any) => Tile_Feature.fromJSON(e));
@@ -439,7 +439,7 @@ export const Tile_Layer = {
   },
 
   fromPartial<I extends Exact<DeepPartial<Tile_Layer>, I>>(object: I): Tile_Layer {
-    const message = { ...baseTile_Layer } as Tile_Layer;
+    const message = createBaseTile_Layer();
     message.version = object.version ?? 0;
     message.name = object.name ?? '';
     message.features = object.features?.map((e) => Tile_Feature.fromPartial(e)) || [];

--- a/integration/vector-tile/vector_tile.ts
+++ b/integration/vector-tile/vector_tile.ts
@@ -78,7 +78,9 @@ export interface Tile_Layer {
   extent: number;
 }
 
-const createBaseTile = (): Tile => ({});
+function createBaseTile(): Tile {
+  return { layers: [] };
+}
 
 export const Tile = {
   encode(message: Tile, writer: Writer = Writer.create()): Writer {
@@ -92,7 +94,6 @@ export const Tile = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseTile();
-    message.layers = [];
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -130,15 +131,9 @@ export const Tile = {
   },
 };
 
-const createBaseTile_Value = (): Tile_Value => ({
-  stringValue: '',
-  floatValue: 0,
-  doubleValue: 0,
-  intValue: 0,
-  uintValue: 0,
-  sintValue: 0,
-  boolValue: false,
-});
+function createBaseTile_Value(): Tile_Value {
+  return { stringValue: '', floatValue: 0, doubleValue: 0, intValue: 0, uintValue: 0, sintValue: 0, boolValue: false };
+}
 
 export const Tile_Value = {
   encode(message: Tile_Value, writer: Writer = Writer.create()): Writer {
@@ -241,7 +236,9 @@ export const Tile_Value = {
   },
 };
 
-const createBaseTile_Feature = (): Tile_Feature => ({ id: 0, tags: 0, type: 0, geometry: 0 });
+function createBaseTile_Feature(): Tile_Feature {
+  return { id: 0, tags: [], type: 0, geometry: [] };
+}
 
 export const Tile_Feature = {
   encode(message: Tile_Feature, writer: Writer = Writer.create()): Writer {
@@ -268,8 +265,6 @@ export const Tile_Feature = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseTile_Feature();
-    message.tags = [];
-    message.geometry = [];
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -343,7 +338,9 @@ export const Tile_Feature = {
   },
 };
 
-const createBaseTile_Layer = (): Tile_Layer => ({ version: 0, name: '', keys: '', extent: 0 });
+function createBaseTile_Layer(): Tile_Layer {
+  return { version: 0, name: '', features: [], keys: [], values: [], extent: 0 };
+}
 
 export const Tile_Layer = {
   encode(message: Tile_Layer, writer: Writer = Writer.create()): Writer {
@@ -372,9 +369,6 @@ export const Tile_Layer = {
     const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseTile_Layer();
-    message.features = [];
-    message.keys = [];
-    message.values = [];
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {


### PR DESCRIPTION
Creating an object via object spread can be 100 times slower than creating via object literal: https://jsbench.me/0nkxobf9gt/1