### PR TITLE
perf: fromJSON returns object literal to allow v8 optimizations

### DIFF
--- a/integration/angular/simple-message.ts
+++ b/integration/angular/simple-message.ts
@@ -39,9 +39,9 @@ export const SimpleMessage = {
   },
 
   fromJSON(object: any): SimpleMessage {
-    const message = createBaseSimpleMessage();
-    message.numberField = isSet(object.numberField) ? Number(object.numberField) : 0;
-    return message;
+    return {
+      numberField: isSet(object.numberField) ? Number(object.numberField) : 0,
+    };
   },
 
   toJSON(message: SimpleMessage): unknown {

--- a/integration/avoid-import-conflicts/simple.ts
+++ b/integration/avoid-import-conflicts/simple.ts
@@ -95,10 +95,10 @@ export const Simple = {
   },
 
   fromJSON(object: any): Simple {
-    const message = createBaseSimple();
-    message.name = isSet(object.name) ? String(object.name) : '';
-    message.otherSimple = isSet(object.otherSimple) ? Simple2.fromJSON(object.otherSimple) : undefined;
-    return message;
+    return {
+      name: isSet(object.name) ? String(object.name) : '',
+      otherSimple: isSet(object.otherSimple) ? Simple2.fromJSON(object.otherSimple) : undefined,
+    };
   },
 
   toJSON(message: Simple): unknown {
@@ -157,10 +157,10 @@ export const SimpleEnums = {
   },
 
   fromJSON(object: any): SimpleEnums {
-    const message = createBaseSimpleEnums();
-    message.localEnum = isSet(object.localEnum) ? simpleEnumFromJSON(object.localEnum) : 0;
-    message.importEnum = isSet(object.importEnum) ? simpleEnumFromJSON3(object.importEnum) : 0;
-    return message;
+    return {
+      localEnum: isSet(object.localEnum) ? simpleEnumFromJSON(object.localEnum) : 0,
+      importEnum: isSet(object.importEnum) ? simpleEnumFromJSON3(object.importEnum) : 0,
+    };
   },
 
   toJSON(message: SimpleEnums): unknown {

--- a/integration/avoid-import-conflicts/simple2.ts
+++ b/integration/avoid-import-conflicts/simple2.ts
@@ -84,10 +84,10 @@ export const Simple = {
   },
 
   fromJSON(object: any): Simple {
-    const message = createBaseSimple();
-    message.name = isSet(object.name) ? String(object.name) : '';
-    message.age = isSet(object.age) ? Number(object.age) : 0;
-    return message;
+    return {
+      name: isSet(object.name) ? String(object.name) : '',
+      age: isSet(object.age) ? Number(object.age) : 0,
+    };
   },
 
   toJSON(message: Simple): unknown {

--- a/integration/barrel-imports/bar.ts
+++ b/integration/barrel-imports/bar.ts
@@ -44,10 +44,10 @@ export const Bar = {
   },
 
   fromJSON(object: any): Bar {
-    const message = createBaseBar();
-    message.name = isSet(object.name) ? String(object.name) : '';
-    message.age = isSet(object.age) ? Number(object.age) : 0;
-    return message;
+    return {
+      name: isSet(object.name) ? String(object.name) : '',
+      age: isSet(object.age) ? Number(object.age) : 0,
+    };
   },
 
   toJSON(message: Bar): unknown {

--- a/integration/barrel-imports/foo.ts
+++ b/integration/barrel-imports/foo.ts
@@ -45,10 +45,10 @@ export const Foo = {
   },
 
   fromJSON(object: any): Foo {
-    const message = createBaseFoo();
-    message.name = isSet(object.name) ? String(object.name) : '';
-    message.bar = isSet(object.bar) ? Bar.fromJSON(object.bar) : undefined;
-    return message;
+    return {
+      name: isSet(object.name) ? String(object.name) : '',
+      bar: isSet(object.bar) ? Bar.fromJSON(object.bar) : undefined,
+    };
   },
 
   toJSON(message: Foo): unknown {

--- a/integration/batching-with-context/batching.ts
+++ b/integration/batching-with-context/batching.ts
@@ -77,9 +77,9 @@ export const BatchQueryRequest = {
   },
 
   fromJSON(object: any): BatchQueryRequest {
-    const message = createBaseBatchQueryRequest();
-    message.ids = Array.isArray(object?.ids) ? object.ids.map((e: any) => String(e)) : [];
-    return message;
+    return {
+      ids: Array.isArray(object?.ids) ? object.ids.map((e: any) => String(e)) : [],
+    };
   },
 
   toJSON(message: BatchQueryRequest): unknown {
@@ -130,9 +130,9 @@ export const BatchQueryResponse = {
   },
 
   fromJSON(object: any): BatchQueryResponse {
-    const message = createBaseBatchQueryResponse();
-    message.entities = Array.isArray(object?.entities) ? object.entities.map((e: any) => Entity.fromJSON(e)) : [];
-    return message;
+    return {
+      entities: Array.isArray(object?.entities) ? object.entities.map((e: any) => Entity.fromJSON(e)) : [],
+    };
   },
 
   toJSON(message: BatchQueryResponse): unknown {
@@ -183,9 +183,9 @@ export const BatchMapQueryRequest = {
   },
 
   fromJSON(object: any): BatchMapQueryRequest {
-    const message = createBaseBatchMapQueryRequest();
-    message.ids = Array.isArray(object?.ids) ? object.ids.map((e: any) => String(e)) : [];
-    return message;
+    return {
+      ids: Array.isArray(object?.ids) ? object.ids.map((e: any) => String(e)) : [],
+    };
   },
 
   toJSON(message: BatchMapQueryRequest): unknown {
@@ -239,12 +239,14 @@ export const BatchMapQueryResponse = {
   },
 
   fromJSON(object: any): BatchMapQueryResponse {
-    const message = createBaseBatchMapQueryResponse();
-    message.entities = Object.entries(object.entities ?? {}).reduce<{ [key: string]: Entity }>((acc, [key, value]) => {
-      acc[key] = Entity.fromJSON(value);
-      return acc;
-    }, {});
-    return message;
+    return {
+      entities: isObject(object.entities)
+        ? Object.entries(object.entities).reduce<{ [key: string]: Entity }>((acc, [key, value]) => {
+            acc[key] = Entity.fromJSON(value);
+            return acc;
+          }, {})
+        : {},
+    };
   },
 
   toJSON(message: BatchMapQueryResponse): unknown {
@@ -307,10 +309,10 @@ export const BatchMapQueryResponse_EntitiesEntry = {
   },
 
   fromJSON(object: any): BatchMapQueryResponse_EntitiesEntry {
-    const message = createBaseBatchMapQueryResponse_EntitiesEntry();
-    message.key = isSet(object.key) ? String(object.key) : '';
-    message.value = isSet(object.value) ? Entity.fromJSON(object.value) : undefined;
-    return message;
+    return {
+      key: isSet(object.key) ? String(object.key) : '',
+      value: isSet(object.value) ? Entity.fromJSON(object.value) : undefined,
+    };
   },
 
   toJSON(message: BatchMapQueryResponse_EntitiesEntry): unknown {
@@ -361,9 +363,9 @@ export const GetOnlyMethodRequest = {
   },
 
   fromJSON(object: any): GetOnlyMethodRequest {
-    const message = createBaseGetOnlyMethodRequest();
-    message.id = isSet(object.id) ? String(object.id) : '';
-    return message;
+    return {
+      id: isSet(object.id) ? String(object.id) : '',
+    };
   },
 
   toJSON(message: GetOnlyMethodRequest): unknown {
@@ -410,9 +412,9 @@ export const GetOnlyMethodResponse = {
   },
 
   fromJSON(object: any): GetOnlyMethodResponse {
-    const message = createBaseGetOnlyMethodResponse();
-    message.entity = isSet(object.entity) ? Entity.fromJSON(object.entity) : undefined;
-    return message;
+    return {
+      entity: isSet(object.entity) ? Entity.fromJSON(object.entity) : undefined,
+    };
   },
 
   toJSON(message: GetOnlyMethodResponse): unknown {
@@ -460,9 +462,9 @@ export const WriteMethodRequest = {
   },
 
   fromJSON(object: any): WriteMethodRequest {
-    const message = createBaseWriteMethodRequest();
-    message.id = isSet(object.id) ? String(object.id) : '';
-    return message;
+    return {
+      id: isSet(object.id) ? String(object.id) : '',
+    };
   },
 
   toJSON(message: WriteMethodRequest): unknown {
@@ -503,8 +505,7 @@ export const WriteMethodResponse = {
   },
 
   fromJSON(_: any): WriteMethodResponse {
-    const message = createBaseWriteMethodResponse();
-    return message;
+    return {};
   },
 
   toJSON(_: WriteMethodResponse): unknown {
@@ -555,10 +556,10 @@ export const Entity = {
   },
 
   fromJSON(object: any): Entity {
-    const message = createBaseEntity();
-    message.id = isSet(object.id) ? String(object.id) : '';
-    message.name = isSet(object.name) ? String(object.name) : '';
-    return message;
+    return {
+      id: isSet(object.id) ? String(object.id) : '',
+      name: isSet(object.name) ? String(object.name) : '',
+    };
   },
 
   toJSON(message: Entity): unknown {
@@ -695,6 +696,10 @@ export type Exact<P, I extends P> = P extends Builtin
 if (util.Long !== Long) {
   util.Long = Long as any;
   configure();
+}
+
+function isObject(value: any): boolean {
+  return typeof value === 'object' && value !== null;
 }
 
 function isSet(value: any): boolean {

--- a/integration/batching/batching.ts
+++ b/integration/batching/batching.ts
@@ -75,9 +75,9 @@ export const BatchQueryRequest = {
   },
 
   fromJSON(object: any): BatchQueryRequest {
-    const message = createBaseBatchQueryRequest();
-    message.ids = Array.isArray(object?.ids) ? object.ids.map((e: any) => String(e)) : [];
-    return message;
+    return {
+      ids: Array.isArray(object?.ids) ? object.ids.map((e: any) => String(e)) : [],
+    };
   },
 
   toJSON(message: BatchQueryRequest): unknown {
@@ -128,9 +128,9 @@ export const BatchQueryResponse = {
   },
 
   fromJSON(object: any): BatchQueryResponse {
-    const message = createBaseBatchQueryResponse();
-    message.entities = Array.isArray(object?.entities) ? object.entities.map((e: any) => Entity.fromJSON(e)) : [];
-    return message;
+    return {
+      entities: Array.isArray(object?.entities) ? object.entities.map((e: any) => Entity.fromJSON(e)) : [],
+    };
   },
 
   toJSON(message: BatchQueryResponse): unknown {
@@ -181,9 +181,9 @@ export const BatchMapQueryRequest = {
   },
 
   fromJSON(object: any): BatchMapQueryRequest {
-    const message = createBaseBatchMapQueryRequest();
-    message.ids = Array.isArray(object?.ids) ? object.ids.map((e: any) => String(e)) : [];
-    return message;
+    return {
+      ids: Array.isArray(object?.ids) ? object.ids.map((e: any) => String(e)) : [],
+    };
   },
 
   toJSON(message: BatchMapQueryRequest): unknown {
@@ -237,12 +237,14 @@ export const BatchMapQueryResponse = {
   },
 
   fromJSON(object: any): BatchMapQueryResponse {
-    const message = createBaseBatchMapQueryResponse();
-    message.entities = Object.entries(object.entities ?? {}).reduce<{ [key: string]: Entity }>((acc, [key, value]) => {
-      acc[key] = Entity.fromJSON(value);
-      return acc;
-    }, {});
-    return message;
+    return {
+      entities: isObject(object.entities)
+        ? Object.entries(object.entities).reduce<{ [key: string]: Entity }>((acc, [key, value]) => {
+            acc[key] = Entity.fromJSON(value);
+            return acc;
+          }, {})
+        : {},
+    };
   },
 
   toJSON(message: BatchMapQueryResponse): unknown {
@@ -305,10 +307,10 @@ export const BatchMapQueryResponse_EntitiesEntry = {
   },
 
   fromJSON(object: any): BatchMapQueryResponse_EntitiesEntry {
-    const message = createBaseBatchMapQueryResponse_EntitiesEntry();
-    message.key = isSet(object.key) ? String(object.key) : '';
-    message.value = isSet(object.value) ? Entity.fromJSON(object.value) : undefined;
-    return message;
+    return {
+      key: isSet(object.key) ? String(object.key) : '',
+      value: isSet(object.value) ? Entity.fromJSON(object.value) : undefined,
+    };
   },
 
   toJSON(message: BatchMapQueryResponse_EntitiesEntry): unknown {
@@ -359,9 +361,9 @@ export const GetOnlyMethodRequest = {
   },
 
   fromJSON(object: any): GetOnlyMethodRequest {
-    const message = createBaseGetOnlyMethodRequest();
-    message.id = isSet(object.id) ? String(object.id) : '';
-    return message;
+    return {
+      id: isSet(object.id) ? String(object.id) : '',
+    };
   },
 
   toJSON(message: GetOnlyMethodRequest): unknown {
@@ -408,9 +410,9 @@ export const GetOnlyMethodResponse = {
   },
 
   fromJSON(object: any): GetOnlyMethodResponse {
-    const message = createBaseGetOnlyMethodResponse();
-    message.entity = isSet(object.entity) ? Entity.fromJSON(object.entity) : undefined;
-    return message;
+    return {
+      entity: isSet(object.entity) ? Entity.fromJSON(object.entity) : undefined,
+    };
   },
 
   toJSON(message: GetOnlyMethodResponse): unknown {
@@ -458,9 +460,9 @@ export const WriteMethodRequest = {
   },
 
   fromJSON(object: any): WriteMethodRequest {
-    const message = createBaseWriteMethodRequest();
-    message.id = isSet(object.id) ? String(object.id) : '';
-    return message;
+    return {
+      id: isSet(object.id) ? String(object.id) : '',
+    };
   },
 
   toJSON(message: WriteMethodRequest): unknown {
@@ -501,8 +503,7 @@ export const WriteMethodResponse = {
   },
 
   fromJSON(_: any): WriteMethodResponse {
-    const message = createBaseWriteMethodResponse();
-    return message;
+    return {};
   },
 
   toJSON(_: WriteMethodResponse): unknown {
@@ -553,10 +554,10 @@ export const Entity = {
   },
 
   fromJSON(object: any): Entity {
-    const message = createBaseEntity();
-    message.id = isSet(object.id) ? String(object.id) : '';
-    message.name = isSet(object.name) ? String(object.name) : '';
-    return message;
+    return {
+      id: isSet(object.id) ? String(object.id) : '',
+      name: isSet(object.name) ? String(object.name) : '',
+    };
   },
 
   toJSON(message: Entity): unknown {
@@ -643,6 +644,10 @@ export type Exact<P, I extends P> = P extends Builtin
 if (util.Long !== Long) {
   util.Long = Long as any;
   configure();
+}
+
+function isObject(value: any): boolean {
+  return typeof value === 'object' && value !== null;
 }
 
 function isSet(value: any): boolean {

--- a/integration/bytes-as-base64/message.ts
+++ b/integration/bytes-as-base64/message.ts
@@ -14,9 +14,9 @@ function createBaseMessage(): Message {
 
 export const Message = {
   fromJSON(object: any): Message {
-    const message = createBaseMessage();
-    message.data = isSet(object.data) ? bytesFromBase64(object.data) : new Uint8Array();
-    return message;
+    return {
+      data: isSet(object.data) ? bytesFromBase64(object.data) : new Uint8Array(),
+    };
   },
 
   toJSON(message: Message): unknown {

--- a/integration/bytes-node/google/protobuf/wrappers.ts
+++ b/integration/bytes-node/google/protobuf/wrappers.ts
@@ -125,9 +125,9 @@ export const DoubleValue = {
   },
 
   fromJSON(object: any): DoubleValue {
-    const message = createBaseDoubleValue();
-    message.value = isSet(object.value) ? Number(object.value) : 0;
-    return message;
+    return {
+      value: isSet(object.value) ? Number(object.value) : 0,
+    };
   },
 
   toJSON(message: DoubleValue): unknown {
@@ -174,9 +174,9 @@ export const FloatValue = {
   },
 
   fromJSON(object: any): FloatValue {
-    const message = createBaseFloatValue();
-    message.value = isSet(object.value) ? Number(object.value) : 0;
-    return message;
+    return {
+      value: isSet(object.value) ? Number(object.value) : 0,
+    };
   },
 
   toJSON(message: FloatValue): unknown {
@@ -223,9 +223,9 @@ export const Int64Value = {
   },
 
   fromJSON(object: any): Int64Value {
-    const message = createBaseInt64Value();
-    message.value = isSet(object.value) ? Number(object.value) : 0;
-    return message;
+    return {
+      value: isSet(object.value) ? Number(object.value) : 0,
+    };
   },
 
   toJSON(message: Int64Value): unknown {
@@ -272,9 +272,9 @@ export const UInt64Value = {
   },
 
   fromJSON(object: any): UInt64Value {
-    const message = createBaseUInt64Value();
-    message.value = isSet(object.value) ? Number(object.value) : 0;
-    return message;
+    return {
+      value: isSet(object.value) ? Number(object.value) : 0,
+    };
   },
 
   toJSON(message: UInt64Value): unknown {
@@ -321,9 +321,9 @@ export const Int32Value = {
   },
 
   fromJSON(object: any): Int32Value {
-    const message = createBaseInt32Value();
-    message.value = isSet(object.value) ? Number(object.value) : 0;
-    return message;
+    return {
+      value: isSet(object.value) ? Number(object.value) : 0,
+    };
   },
 
   toJSON(message: Int32Value): unknown {
@@ -370,9 +370,9 @@ export const UInt32Value = {
   },
 
   fromJSON(object: any): UInt32Value {
-    const message = createBaseUInt32Value();
-    message.value = isSet(object.value) ? Number(object.value) : 0;
-    return message;
+    return {
+      value: isSet(object.value) ? Number(object.value) : 0,
+    };
   },
 
   toJSON(message: UInt32Value): unknown {
@@ -419,9 +419,9 @@ export const BoolValue = {
   },
 
   fromJSON(object: any): BoolValue {
-    const message = createBaseBoolValue();
-    message.value = isSet(object.value) ? Boolean(object.value) : false;
-    return message;
+    return {
+      value: isSet(object.value) ? Boolean(object.value) : false,
+    };
   },
 
   toJSON(message: BoolValue): unknown {
@@ -468,9 +468,9 @@ export const StringValue = {
   },
 
   fromJSON(object: any): StringValue {
-    const message = createBaseStringValue();
-    message.value = isSet(object.value) ? String(object.value) : '';
-    return message;
+    return {
+      value: isSet(object.value) ? String(object.value) : '',
+    };
   },
 
   toJSON(message: StringValue): unknown {
@@ -517,9 +517,9 @@ export const BytesValue = {
   },
 
   fromJSON(object: any): BytesValue {
-    const message = createBaseBytesValue();
-    message.value = isSet(object.value) ? Buffer.from(bytesFromBase64(object.value)) : Buffer.alloc(0);
-    return message;
+    return {
+      value: isSet(object.value) ? Buffer.from(bytesFromBase64(object.value)) : Buffer.alloc(0),
+    };
   },
 
   toJSON(message: BytesValue): unknown {

--- a/integration/bytes-node/point.ts
+++ b/integration/bytes-node/point.ts
@@ -47,10 +47,10 @@ export const Point = {
   },
 
   fromJSON(object: any): Point {
-    const message = createBasePoint();
-    message.data = isSet(object.data) ? Buffer.from(bytesFromBase64(object.data)) : Buffer.alloc(0);
-    message.dataWrapped = isSet(object.dataWrapped) ? new Buffer(object.dataWrapped) : undefined;
-    return message;
+    return {
+      data: isSet(object.data) ? Buffer.from(bytesFromBase64(object.data)) : Buffer.alloc(0),
+      dataWrapped: isSet(object.dataWrapped) ? new Buffer(object.dataWrapped) : undefined,
+    };
   },
 
   toJSON(message: Point): unknown {

--- a/integration/const-enum/const-enum.ts
+++ b/integration/const-enum/const-enum.ts
@@ -98,9 +98,9 @@ export const DividerData = {
   },
 
   fromJSON(object: any): DividerData {
-    const message = createBaseDividerData();
-    message.type = isSet(object.type) ? dividerData_DividerTypeFromJSON(object.type) : DividerData_DividerType.DOUBLE;
-    return message;
+    return {
+      type: isSet(object.type) ? dividerData_DividerTypeFromJSON(object.type) : DividerData_DividerType.DOUBLE,
+    };
   },
 
   toJSON(message: DividerData): unknown {

--- a/integration/enums-as-literals-with-string-enums/enums-as-literals-with-string-enums.ts
+++ b/integration/enums-as-literals-with-string-enums/enums-as-literals-with-string-enums.ts
@@ -100,9 +100,9 @@ export const DividerData = {
   },
 
   fromJSON(object: any): DividerData {
-    const message = createBaseDividerData();
-    message.type = isSet(object.type) ? dividerData_DividerTypeFromJSON(object.type) : DividerData_DividerType.DOUBLE;
-    return message;
+    return {
+      type: isSet(object.type) ? dividerData_DividerTypeFromJSON(object.type) : DividerData_DividerType.DOUBLE,
+    };
   },
 
   toJSON(message: DividerData): unknown {

--- a/integration/enums-as-literals/enums-as-literals.ts
+++ b/integration/enums-as-literals/enums-as-literals.ts
@@ -85,9 +85,9 @@ export const DividerData = {
   },
 
   fromJSON(object: any): DividerData {
-    const message = createBaseDividerData();
-    message.type = isSet(object.type) ? dividerData_DividerTypeFromJSON(object.type) : 0;
-    return message;
+    return {
+      type: isSet(object.type) ? dividerData_DividerTypeFromJSON(object.type) : 0,
+    };
   },
 
   toJSON(message: DividerData): unknown {

--- a/integration/file-suffix/child.pb.ts
+++ b/integration/file-suffix/child.pb.ts
@@ -71,9 +71,9 @@ export const Child = {
   },
 
   fromJSON(object: any): Child {
-    const message = createBaseChild();
-    message.name = isSet(object.name) ? String(object.name) : '';
-    return message;
+    return {
+      name: isSet(object.name) ? String(object.name) : '',
+    };
   },
 
   toJSON(message: Child): unknown {

--- a/integration/file-suffix/google/protobuf/timestamp.pb.ts
+++ b/integration/file-suffix/google/protobuf/timestamp.pb.ts
@@ -150,10 +150,10 @@ export const Timestamp = {
   },
 
   fromJSON(object: any): Timestamp {
-    const message = createBaseTimestamp();
-    message.seconds = isSet(object.seconds) ? Number(object.seconds) : 0;
-    message.nanos = isSet(object.nanos) ? Number(object.nanos) : 0;
-    return message;
+    return {
+      seconds: isSet(object.seconds) ? Number(object.seconds) : 0,
+      nanos: isSet(object.nanos) ? Number(object.nanos) : 0,
+    };
   },
 
   toJSON(message: Timestamp): unknown {

--- a/integration/file-suffix/parent.pb.ts
+++ b/integration/file-suffix/parent.pb.ts
@@ -55,11 +55,11 @@ export const Parent = {
   },
 
   fromJSON(object: any): Parent {
-    const message = createBaseParent();
-    message.child = isSet(object.child) ? Child.fromJSON(object.child) : undefined;
-    message.childEnum = isSet(object.childEnum) ? childEnumFromJSON(object.childEnum) : 0;
-    message.createdAt = isSet(object.createdAt) ? fromJsonTimestamp(object.createdAt) : undefined;
-    return message;
+    return {
+      child: isSet(object.child) ? Child.fromJSON(object.child) : undefined,
+      childEnum: isSet(object.childEnum) ? childEnumFromJSON(object.childEnum) : 0,
+      createdAt: isSet(object.createdAt) ? fromJsonTimestamp(object.createdAt) : undefined,
+    };
   },
 
   toJSON(message: Parent): unknown {

--- a/integration/generic-service-definitions/simple.ts
+++ b/integration/generic-service-definitions/simple.ts
@@ -39,9 +39,9 @@ export const TestMessage = {
   },
 
   fromJSON(object: any): TestMessage {
-    const message = createBaseTestMessage();
-    message.value = isSet(object.value) ? String(object.value) : '';
-    return message;
+    return {
+      value: isSet(object.value) ? String(object.value) : '',
+    };
   },
 
   toJSON(message: TestMessage): unknown {

--- a/integration/global-this/global-this.ts
+++ b/integration/global-this/global-this.ts
@@ -43,9 +43,9 @@ export const Object = {
   },
 
   fromJSON(object: any): Object {
-    const message = createBaseObject();
-    message.name = isSet(object.name) ? String(object.name) : '';
-    return message;
+    return {
+      name: isSet(object.name) ? String(object.name) : '',
+    };
   },
 
   toJSON(message: Object): unknown {
@@ -92,9 +92,9 @@ export const Error = {
   },
 
   fromJSON(object: any): Error {
-    const message = createBaseError();
-    message.name = isSet(object.name) ? String(object.name) : '';
-    return message;
+    return {
+      name: isSet(object.name) ? String(object.name) : '',
+    };
   },
 
   toJSON(message: Error): unknown {

--- a/integration/grpc-js/google/protobuf/empty.ts
+++ b/integration/grpc-js/google/protobuf/empty.ts
@@ -42,8 +42,7 @@ export const Empty = {
   },
 
   fromJSON(_: any): Empty {
-    const message = createBaseEmpty();
-    return message;
+    return {};
   },
 
   toJSON(_: Empty): unknown {

--- a/integration/grpc-js/google/protobuf/struct.ts
+++ b/integration/grpc-js/google/protobuf/struct.ts
@@ -126,15 +126,14 @@ export const Struct = {
   },
 
   fromJSON(object: any): Struct {
-    const message = createBaseStruct();
-    message.fields = Object.entries(object.fields ?? {}).reduce<{ [key: string]: any | undefined }>(
-      (acc, [key, value]) => {
-        acc[key] = value as any | undefined;
-        return acc;
-      },
-      {}
-    );
-    return message;
+    return {
+      fields: isObject(object.fields)
+        ? Object.entries(object.fields).reduce<{ [key: string]: any | undefined }>((acc, [key, value]) => {
+            acc[key] = value as any | undefined;
+            return acc;
+          }, {})
+        : {},
+    };
   },
 
   toJSON(message: Struct): unknown {
@@ -218,10 +217,10 @@ export const Struct_FieldsEntry = {
   },
 
   fromJSON(object: any): Struct_FieldsEntry {
-    const message = createBaseStruct_FieldsEntry();
-    message.key = isSet(object.key) ? String(object.key) : '';
-    message.value = isSet(object?.value) ? object.value : undefined;
-    return message;
+    return {
+      key: isSet(object.key) ? String(object.key) : '',
+      value: isSet(object?.value) ? object.value : undefined,
+    };
   },
 
   toJSON(message: Struct_FieldsEntry): unknown {
@@ -307,14 +306,14 @@ export const Value = {
   },
 
   fromJSON(object: any): Value {
-    const message = createBaseValue();
-    message.nullValue = isSet(object.nullValue) ? nullValueFromJSON(object.nullValue) : undefined;
-    message.numberValue = isSet(object.numberValue) ? Number(object.numberValue) : undefined;
-    message.stringValue = isSet(object.stringValue) ? String(object.stringValue) : undefined;
-    message.boolValue = isSet(object.boolValue) ? Boolean(object.boolValue) : undefined;
-    message.structValue = isObject(object.structValue) ? object.structValue : undefined;
-    message.listValue = Array.isArray(object.listValue) ? [...object.listValue] : undefined;
-    return message;
+    return {
+      nullValue: isSet(object.nullValue) ? nullValueFromJSON(object.nullValue) : undefined,
+      numberValue: isSet(object.numberValue) ? Number(object.numberValue) : undefined,
+      stringValue: isSet(object.stringValue) ? String(object.stringValue) : undefined,
+      boolValue: isSet(object.boolValue) ? Boolean(object.boolValue) : undefined,
+      structValue: isObject(object.structValue) ? object.structValue : undefined,
+      listValue: Array.isArray(object.listValue) ? [...object.listValue] : undefined,
+    };
   },
 
   toJSON(message: Value): unknown {
@@ -409,9 +408,9 @@ export const ListValue = {
   },
 
   fromJSON(object: any): ListValue {
-    const message = createBaseListValue();
-    message.values = Array.isArray(object?.values) ? [...object.values] : [];
-    return message;
+    return {
+      values: Array.isArray(object?.values) ? [...object.values] : [],
+    };
   },
 
   toJSON(message: ListValue): unknown {

--- a/integration/grpc-js/google/protobuf/timestamp.ts
+++ b/integration/grpc-js/google/protobuf/timestamp.ts
@@ -150,10 +150,10 @@ export const Timestamp = {
   },
 
   fromJSON(object: any): Timestamp {
-    const message = createBaseTimestamp();
-    message.seconds = isSet(object.seconds) ? Number(object.seconds) : 0;
-    message.nanos = isSet(object.nanos) ? Number(object.nanos) : 0;
-    return message;
+    return {
+      seconds: isSet(object.seconds) ? Number(object.seconds) : 0,
+      nanos: isSet(object.nanos) ? Number(object.nanos) : 0,
+    };
   },
 
   toJSON(message: Timestamp): unknown {

--- a/integration/grpc-js/google/protobuf/wrappers.ts
+++ b/integration/grpc-js/google/protobuf/wrappers.ts
@@ -125,9 +125,9 @@ export const DoubleValue = {
   },
 
   fromJSON(object: any): DoubleValue {
-    const message = createBaseDoubleValue();
-    message.value = isSet(object.value) ? Number(object.value) : 0;
-    return message;
+    return {
+      value: isSet(object.value) ? Number(object.value) : 0,
+    };
   },
 
   toJSON(message: DoubleValue): unknown {
@@ -174,9 +174,9 @@ export const FloatValue = {
   },
 
   fromJSON(object: any): FloatValue {
-    const message = createBaseFloatValue();
-    message.value = isSet(object.value) ? Number(object.value) : 0;
-    return message;
+    return {
+      value: isSet(object.value) ? Number(object.value) : 0,
+    };
   },
 
   toJSON(message: FloatValue): unknown {
@@ -223,9 +223,9 @@ export const Int64Value = {
   },
 
   fromJSON(object: any): Int64Value {
-    const message = createBaseInt64Value();
-    message.value = isSet(object.value) ? Number(object.value) : 0;
-    return message;
+    return {
+      value: isSet(object.value) ? Number(object.value) : 0,
+    };
   },
 
   toJSON(message: Int64Value): unknown {
@@ -272,9 +272,9 @@ export const UInt64Value = {
   },
 
   fromJSON(object: any): UInt64Value {
-    const message = createBaseUInt64Value();
-    message.value = isSet(object.value) ? Number(object.value) : 0;
-    return message;
+    return {
+      value: isSet(object.value) ? Number(object.value) : 0,
+    };
   },
 
   toJSON(message: UInt64Value): unknown {
@@ -321,9 +321,9 @@ export const Int32Value = {
   },
 
   fromJSON(object: any): Int32Value {
-    const message = createBaseInt32Value();
-    message.value = isSet(object.value) ? Number(object.value) : 0;
-    return message;
+    return {
+      value: isSet(object.value) ? Number(object.value) : 0,
+    };
   },
 
   toJSON(message: Int32Value): unknown {
@@ -370,9 +370,9 @@ export const UInt32Value = {
   },
 
   fromJSON(object: any): UInt32Value {
-    const message = createBaseUInt32Value();
-    message.value = isSet(object.value) ? Number(object.value) : 0;
-    return message;
+    return {
+      value: isSet(object.value) ? Number(object.value) : 0,
+    };
   },
 
   toJSON(message: UInt32Value): unknown {
@@ -419,9 +419,9 @@ export const BoolValue = {
   },
 
   fromJSON(object: any): BoolValue {
-    const message = createBaseBoolValue();
-    message.value = isSet(object.value) ? Boolean(object.value) : false;
-    return message;
+    return {
+      value: isSet(object.value) ? Boolean(object.value) : false,
+    };
   },
 
   toJSON(message: BoolValue): unknown {
@@ -468,9 +468,9 @@ export const StringValue = {
   },
 
   fromJSON(object: any): StringValue {
-    const message = createBaseStringValue();
-    message.value = isSet(object.value) ? String(object.value) : '';
-    return message;
+    return {
+      value: isSet(object.value) ? String(object.value) : '',
+    };
   },
 
   toJSON(message: StringValue): unknown {
@@ -517,9 +517,9 @@ export const BytesValue = {
   },
 
   fromJSON(object: any): BytesValue {
-    const message = createBaseBytesValue();
-    message.value = isSet(object.value) ? bytesFromBase64(object.value) : new Uint8Array();
-    return message;
+    return {
+      value: isSet(object.value) ? bytesFromBase64(object.value) : new Uint8Array(),
+    };
   },
 
   toJSON(message: BytesValue): unknown {

--- a/integration/grpc-js/simple.ts
+++ b/integration/grpc-js/simple.ts
@@ -71,9 +71,9 @@ export const TestMessage = {
   },
 
   fromJSON(object: any): TestMessage {
-    const message = createBaseTestMessage();
-    message.timestamp = isSet(object.timestamp) ? fromJsonTimestamp(object.timestamp) : undefined;
-    return message;
+    return {
+      timestamp: isSet(object.timestamp) ? fromJsonTimestamp(object.timestamp) : undefined,
+    };
   },
 
   toJSON(message: TestMessage): unknown {

--- a/integration/grpc-web-go-server/example.ts
+++ b/integration/grpc-web-go-server/example.ts
@@ -129,10 +129,10 @@ export const DashFlash = {
   },
 
   fromJSON(object: any): DashFlash {
-    const message = createBaseDashFlash();
-    message.msg = isSet(object.msg) ? String(object.msg) : '';
-    message.type = isSet(object.type) ? dashFlash_TypeFromJSON(object.type) : 0;
-    return message;
+    return {
+      msg: isSet(object.msg) ? String(object.msg) : '',
+      type: isSet(object.type) ? dashFlash_TypeFromJSON(object.type) : 0,
+    };
   },
 
   toJSON(message: DashFlash): unknown {
@@ -193,11 +193,11 @@ export const DashUserSettingsState = {
   },
 
   fromJSON(object: any): DashUserSettingsState {
-    const message = createBaseDashUserSettingsState();
-    message.email = isSet(object.email) ? String(object.email) : '';
-    message.urls = isSet(object.urls) ? DashUserSettingsState_URLs.fromJSON(object.urls) : undefined;
-    message.flashes = Array.isArray(object?.flashes) ? object.flashes.map((e: any) => DashFlash.fromJSON(e)) : [];
-    return message;
+    return {
+      email: isSet(object.email) ? String(object.email) : '',
+      urls: isSet(object.urls) ? DashUserSettingsState_URLs.fromJSON(object.urls) : undefined,
+      flashes: Array.isArray(object?.flashes) ? object.flashes.map((e: any) => DashFlash.fromJSON(e)) : [],
+    };
   },
 
   toJSON(message: DashUserSettingsState): unknown {
@@ -262,10 +262,10 @@ export const DashUserSettingsState_URLs = {
   },
 
   fromJSON(object: any): DashUserSettingsState_URLs {
-    const message = createBaseDashUserSettingsState_URLs();
-    message.connectGoogle = isSet(object.connectGoogle) ? String(object.connectGoogle) : '';
-    message.connectGithub = isSet(object.connectGithub) ? String(object.connectGithub) : '';
-    return message;
+    return {
+      connectGoogle: isSet(object.connectGoogle) ? String(object.connectGoogle) : '',
+      connectGithub: isSet(object.connectGithub) ? String(object.connectGithub) : '',
+    };
   },
 
   toJSON(message: DashUserSettingsState_URLs): unknown {
@@ -332,12 +332,12 @@ export const DashCred = {
   },
 
   fromJSON(object: any): DashCred {
-    const message = createBaseDashCred();
-    message.description = isSet(object.description) ? String(object.description) : '';
-    message.metadata = isSet(object.metadata) ? String(object.metadata) : '';
-    message.token = isSet(object.token) ? String(object.token) : '';
-    message.id = isSet(object.id) ? String(object.id) : '';
-    return message;
+    return {
+      description: isSet(object.description) ? String(object.description) : '',
+      metadata: isSet(object.metadata) ? String(object.metadata) : '',
+      token: isSet(object.token) ? String(object.token) : '',
+      id: isSet(object.id) ? String(object.id) : '',
+    };
   },
 
   toJSON(message: DashCred): unknown {
@@ -396,10 +396,10 @@ export const DashAPICredsCreateReq = {
   },
 
   fromJSON(object: any): DashAPICredsCreateReq {
-    const message = createBaseDashAPICredsCreateReq();
-    message.description = isSet(object.description) ? String(object.description) : '';
-    message.metadata = isSet(object.metadata) ? String(object.metadata) : '';
-    return message;
+    return {
+      description: isSet(object.description) ? String(object.description) : '',
+      metadata: isSet(object.metadata) ? String(object.metadata) : '',
+    };
   },
 
   toJSON(message: DashAPICredsCreateReq): unknown {
@@ -466,12 +466,12 @@ export const DashAPICredsUpdateReq = {
   },
 
   fromJSON(object: any): DashAPICredsUpdateReq {
-    const message = createBaseDashAPICredsUpdateReq();
-    message.credSid = isSet(object.credSid) ? String(object.credSid) : '';
-    message.description = isSet(object.description) ? String(object.description) : '';
-    message.metadata = isSet(object.metadata) ? String(object.metadata) : '';
-    message.id = isSet(object.id) ? String(object.id) : '';
-    return message;
+    return {
+      credSid: isSet(object.credSid) ? String(object.credSid) : '',
+      description: isSet(object.description) ? String(object.description) : '',
+      metadata: isSet(object.metadata) ? String(object.metadata) : '',
+      id: isSet(object.id) ? String(object.id) : '',
+    };
   },
 
   toJSON(message: DashAPICredsUpdateReq): unknown {
@@ -530,10 +530,10 @@ export const DashAPICredsDeleteReq = {
   },
 
   fromJSON(object: any): DashAPICredsDeleteReq {
-    const message = createBaseDashAPICredsDeleteReq();
-    message.credSid = isSet(object.credSid) ? String(object.credSid) : '';
-    message.id = isSet(object.id) ? String(object.id) : '';
-    return message;
+    return {
+      credSid: isSet(object.credSid) ? String(object.credSid) : '',
+      id: isSet(object.id) ? String(object.id) : '',
+    };
   },
 
   toJSON(message: DashAPICredsDeleteReq): unknown {
@@ -576,8 +576,7 @@ export const Empty = {
   },
 
   fromJSON(_: any): Empty {
-    const message = createBaseEmpty();
-    return message;
+    return {};
   },
 
   toJSON(_: Empty): unknown {

--- a/integration/grpc-web-no-streaming-observable/example.ts
+++ b/integration/grpc-web-no-streaming-observable/example.ts
@@ -107,10 +107,10 @@ export const DashFlash = {
   },
 
   fromJSON(object: any): DashFlash {
-    const message = createBaseDashFlash();
-    message.msg = isSet(object.msg) ? String(object.msg) : '';
-    message.type = isSet(object.type) ? dashFlash_TypeFromJSON(object.type) : 0;
-    return message;
+    return {
+      msg: isSet(object.msg) ? String(object.msg) : '',
+      type: isSet(object.type) ? dashFlash_TypeFromJSON(object.type) : 0,
+    };
   },
 
   toJSON(message: DashFlash): unknown {
@@ -171,11 +171,11 @@ export const DashUserSettingsState = {
   },
 
   fromJSON(object: any): DashUserSettingsState {
-    const message = createBaseDashUserSettingsState();
-    message.email = isSet(object.email) ? String(object.email) : '';
-    message.urls = isSet(object.urls) ? DashUserSettingsState_URLs.fromJSON(object.urls) : undefined;
-    message.flashes = Array.isArray(object?.flashes) ? object.flashes.map((e: any) => DashFlash.fromJSON(e)) : [];
-    return message;
+    return {
+      email: isSet(object.email) ? String(object.email) : '',
+      urls: isSet(object.urls) ? DashUserSettingsState_URLs.fromJSON(object.urls) : undefined,
+      flashes: Array.isArray(object?.flashes) ? object.flashes.map((e: any) => DashFlash.fromJSON(e)) : [],
+    };
   },
 
   toJSON(message: DashUserSettingsState): unknown {
@@ -240,10 +240,10 @@ export const DashUserSettingsState_URLs = {
   },
 
   fromJSON(object: any): DashUserSettingsState_URLs {
-    const message = createBaseDashUserSettingsState_URLs();
-    message.connectGoogle = isSet(object.connectGoogle) ? String(object.connectGoogle) : '';
-    message.connectGithub = isSet(object.connectGithub) ? String(object.connectGithub) : '';
-    return message;
+    return {
+      connectGoogle: isSet(object.connectGoogle) ? String(object.connectGoogle) : '',
+      connectGithub: isSet(object.connectGithub) ? String(object.connectGithub) : '',
+    };
   },
 
   toJSON(message: DashUserSettingsState_URLs): unknown {
@@ -286,8 +286,7 @@ export const Empty = {
   },
 
   fromJSON(_: any): Empty {
-    const message = createBaseEmpty();
-    return message;
+    return {};
   },
 
   toJSON(_: Empty): unknown {

--- a/integration/grpc-web-no-streaming/example.ts
+++ b/integration/grpc-web-no-streaming/example.ts
@@ -105,10 +105,10 @@ export const DashFlash = {
   },
 
   fromJSON(object: any): DashFlash {
-    const message = createBaseDashFlash();
-    message.msg = isSet(object.msg) ? String(object.msg) : '';
-    message.type = isSet(object.type) ? dashFlash_TypeFromJSON(object.type) : 0;
-    return message;
+    return {
+      msg: isSet(object.msg) ? String(object.msg) : '',
+      type: isSet(object.type) ? dashFlash_TypeFromJSON(object.type) : 0,
+    };
   },
 
   toJSON(message: DashFlash): unknown {
@@ -169,11 +169,11 @@ export const DashUserSettingsState = {
   },
 
   fromJSON(object: any): DashUserSettingsState {
-    const message = createBaseDashUserSettingsState();
-    message.email = isSet(object.email) ? String(object.email) : '';
-    message.urls = isSet(object.urls) ? DashUserSettingsState_URLs.fromJSON(object.urls) : undefined;
-    message.flashes = Array.isArray(object?.flashes) ? object.flashes.map((e: any) => DashFlash.fromJSON(e)) : [];
-    return message;
+    return {
+      email: isSet(object.email) ? String(object.email) : '',
+      urls: isSet(object.urls) ? DashUserSettingsState_URLs.fromJSON(object.urls) : undefined,
+      flashes: Array.isArray(object?.flashes) ? object.flashes.map((e: any) => DashFlash.fromJSON(e)) : [],
+    };
   },
 
   toJSON(message: DashUserSettingsState): unknown {
@@ -238,10 +238,10 @@ export const DashUserSettingsState_URLs = {
   },
 
   fromJSON(object: any): DashUserSettingsState_URLs {
-    const message = createBaseDashUserSettingsState_URLs();
-    message.connectGoogle = isSet(object.connectGoogle) ? String(object.connectGoogle) : '';
-    message.connectGithub = isSet(object.connectGithub) ? String(object.connectGithub) : '';
-    return message;
+    return {
+      connectGoogle: isSet(object.connectGoogle) ? String(object.connectGoogle) : '',
+      connectGithub: isSet(object.connectGithub) ? String(object.connectGithub) : '',
+    };
   },
 
   toJSON(message: DashUserSettingsState_URLs): unknown {
@@ -284,8 +284,7 @@ export const Empty = {
   },
 
   fromJSON(_: any): Empty {
-    const message = createBaseEmpty();
-    return message;
+    return {};
   },
 
   toJSON(_: Empty): unknown {

--- a/integration/grpc-web/example.ts
+++ b/integration/grpc-web/example.ts
@@ -131,10 +131,10 @@ export const DashFlash = {
   },
 
   fromJSON(object: any): DashFlash {
-    const message = createBaseDashFlash();
-    message.msg = isSet(object.msg) ? String(object.msg) : '';
-    message.type = isSet(object.type) ? dashFlash_TypeFromJSON(object.type) : 0;
-    return message;
+    return {
+      msg: isSet(object.msg) ? String(object.msg) : '',
+      type: isSet(object.type) ? dashFlash_TypeFromJSON(object.type) : 0,
+    };
   },
 
   toJSON(message: DashFlash): unknown {
@@ -195,11 +195,11 @@ export const DashUserSettingsState = {
   },
 
   fromJSON(object: any): DashUserSettingsState {
-    const message = createBaseDashUserSettingsState();
-    message.email = isSet(object.email) ? String(object.email) : '';
-    message.urls = isSet(object.urls) ? DashUserSettingsState_URLs.fromJSON(object.urls) : undefined;
-    message.flashes = Array.isArray(object?.flashes) ? object.flashes.map((e: any) => DashFlash.fromJSON(e)) : [];
-    return message;
+    return {
+      email: isSet(object.email) ? String(object.email) : '',
+      urls: isSet(object.urls) ? DashUserSettingsState_URLs.fromJSON(object.urls) : undefined,
+      flashes: Array.isArray(object?.flashes) ? object.flashes.map((e: any) => DashFlash.fromJSON(e)) : [],
+    };
   },
 
   toJSON(message: DashUserSettingsState): unknown {
@@ -264,10 +264,10 @@ export const DashUserSettingsState_URLs = {
   },
 
   fromJSON(object: any): DashUserSettingsState_URLs {
-    const message = createBaseDashUserSettingsState_URLs();
-    message.connectGoogle = isSet(object.connectGoogle) ? String(object.connectGoogle) : '';
-    message.connectGithub = isSet(object.connectGithub) ? String(object.connectGithub) : '';
-    return message;
+    return {
+      connectGoogle: isSet(object.connectGoogle) ? String(object.connectGoogle) : '',
+      connectGithub: isSet(object.connectGithub) ? String(object.connectGithub) : '',
+    };
   },
 
   toJSON(message: DashUserSettingsState_URLs): unknown {
@@ -334,12 +334,12 @@ export const DashCred = {
   },
 
   fromJSON(object: any): DashCred {
-    const message = createBaseDashCred();
-    message.description = isSet(object.description) ? String(object.description) : '';
-    message.metadata = isSet(object.metadata) ? String(object.metadata) : '';
-    message.token = isSet(object.token) ? String(object.token) : '';
-    message.id = isSet(object.id) ? String(object.id) : '';
-    return message;
+    return {
+      description: isSet(object.description) ? String(object.description) : '',
+      metadata: isSet(object.metadata) ? String(object.metadata) : '',
+      token: isSet(object.token) ? String(object.token) : '',
+      id: isSet(object.id) ? String(object.id) : '',
+    };
   },
 
   toJSON(message: DashCred): unknown {
@@ -398,10 +398,10 @@ export const DashAPICredsCreateReq = {
   },
 
   fromJSON(object: any): DashAPICredsCreateReq {
-    const message = createBaseDashAPICredsCreateReq();
-    message.description = isSet(object.description) ? String(object.description) : '';
-    message.metadata = isSet(object.metadata) ? String(object.metadata) : '';
-    return message;
+    return {
+      description: isSet(object.description) ? String(object.description) : '',
+      metadata: isSet(object.metadata) ? String(object.metadata) : '',
+    };
   },
 
   toJSON(message: DashAPICredsCreateReq): unknown {
@@ -468,12 +468,12 @@ export const DashAPICredsUpdateReq = {
   },
 
   fromJSON(object: any): DashAPICredsUpdateReq {
-    const message = createBaseDashAPICredsUpdateReq();
-    message.credSid = isSet(object.credSid) ? String(object.credSid) : '';
-    message.description = isSet(object.description) ? String(object.description) : '';
-    message.metadata = isSet(object.metadata) ? String(object.metadata) : '';
-    message.id = isSet(object.id) ? String(object.id) : '';
-    return message;
+    return {
+      credSid: isSet(object.credSid) ? String(object.credSid) : '',
+      description: isSet(object.description) ? String(object.description) : '',
+      metadata: isSet(object.metadata) ? String(object.metadata) : '',
+      id: isSet(object.id) ? String(object.id) : '',
+    };
   },
 
   toJSON(message: DashAPICredsUpdateReq): unknown {
@@ -532,10 +532,10 @@ export const DashAPICredsDeleteReq = {
   },
 
   fromJSON(object: any): DashAPICredsDeleteReq {
-    const message = createBaseDashAPICredsDeleteReq();
-    message.credSid = isSet(object.credSid) ? String(object.credSid) : '';
-    message.id = isSet(object.id) ? String(object.id) : '';
-    return message;
+    return {
+      credSid: isSet(object.credSid) ? String(object.credSid) : '',
+      id: isSet(object.id) ? String(object.id) : '',
+    };
   },
 
   toJSON(message: DashAPICredsDeleteReq): unknown {
@@ -578,8 +578,7 @@ export const Empty = {
   },
 
   fromJSON(_: any): Empty {
-    const message = createBaseEmpty();
-    return message;
+    return {};
   },
 
   toJSON(_: Empty): unknown {

--- a/integration/lower-case-svc-methods/math.ts
+++ b/integration/lower-case-svc-methods/math.ts
@@ -56,10 +56,10 @@ export const NumPair = {
   },
 
   fromJSON(object: any): NumPair {
-    const message = createBaseNumPair();
-    message.num1 = isSet(object.num1) ? Number(object.num1) : 0;
-    message.num2 = isSet(object.num2) ? Number(object.num2) : 0;
-    return message;
+    return {
+      num1: isSet(object.num1) ? Number(object.num1) : 0,
+      num2: isSet(object.num2) ? Number(object.num2) : 0,
+    };
   },
 
   toJSON(message: NumPair): unknown {
@@ -108,9 +108,9 @@ export const NumSingle = {
   },
 
   fromJSON(object: any): NumSingle {
-    const message = createBaseNumSingle();
-    message.num = isSet(object.num) ? Number(object.num) : 0;
-    return message;
+    return {
+      num: isSet(object.num) ? Number(object.num) : 0,
+    };
   },
 
   toJSON(message: NumSingle): unknown {
@@ -166,9 +166,9 @@ export const Numbers = {
   },
 
   fromJSON(object: any): Numbers {
-    const message = createBaseNumbers();
-    message.num = Array.isArray(object?.num) ? object.num.map((e: any) => Number(e)) : [];
-    return message;
+    return {
+      num: Array.isArray(object?.num) ? object.num.map((e: any) => Number(e)) : [],
+    };
   },
 
   toJSON(message: Numbers): unknown {

--- a/integration/no-proto-package/no-proto-package.ts
+++ b/integration/no-proto-package/no-proto-package.ts
@@ -43,9 +43,9 @@ export const User = {
   },
 
   fromJSON(object: any): User {
-    const message = createBaseUser();
-    message.name = isSet(object.name) ? String(object.name) : '';
-    return message;
+    return {
+      name: isSet(object.name) ? String(object.name) : '',
+    };
   },
 
   toJSON(message: User): unknown {
@@ -86,8 +86,7 @@ export const Empty = {
   },
 
   fromJSON(_: any): Empty {
-    const message = createBaseEmpty();
-    return message;
+    return {};
   },
 
   toJSON(_: Empty): unknown {

--- a/integration/oneof-properties/oneof.ts
+++ b/integration/oneof-properties/oneof.ts
@@ -175,19 +175,19 @@ export const PleaseChoose = {
   },
 
   fromJSON(object: any): PleaseChoose {
-    const message = createBasePleaseChoose();
-    message.name = isSet(object.name) ? String(object.name) : '';
-    message.aNumber = isSet(object.aNumber) ? Number(object.aNumber) : undefined;
-    message.aString = isSet(object.aString) ? String(object.aString) : undefined;
-    message.aMessage = isSet(object.aMessage) ? PleaseChoose_Submessage.fromJSON(object.aMessage) : undefined;
-    message.aBool = isSet(object.aBool) ? Boolean(object.aBool) : undefined;
-    message.bunchaBytes = isSet(object.bunchaBytes) ? bytesFromBase64(object.bunchaBytes) : undefined;
-    message.anEnum = isSet(object.anEnum) ? pleaseChoose_StateEnumFromJSON(object.anEnum) : undefined;
-    message.age = isSet(object.age) ? Number(object.age) : 0;
-    message.either = isSet(object.either) ? String(object.either) : undefined;
-    message.or = isSet(object.or) ? String(object.or) : undefined;
-    message.thirdOption = isSet(object.thirdOption) ? String(object.thirdOption) : undefined;
-    return message;
+    return {
+      name: isSet(object.name) ? String(object.name) : '',
+      aNumber: isSet(object.aNumber) ? Number(object.aNumber) : undefined,
+      aString: isSet(object.aString) ? String(object.aString) : undefined,
+      aMessage: isSet(object.aMessage) ? PleaseChoose_Submessage.fromJSON(object.aMessage) : undefined,
+      aBool: isSet(object.aBool) ? Boolean(object.aBool) : undefined,
+      bunchaBytes: isSet(object.bunchaBytes) ? bytesFromBase64(object.bunchaBytes) : undefined,
+      anEnum: isSet(object.anEnum) ? pleaseChoose_StateEnumFromJSON(object.anEnum) : undefined,
+      age: isSet(object.age) ? Number(object.age) : 0,
+      either: isSet(object.either) ? String(object.either) : undefined,
+      or: isSet(object.or) ? String(object.or) : undefined,
+      thirdOption: isSet(object.thirdOption) ? String(object.thirdOption) : undefined,
+    };
   },
 
   toJSON(message: PleaseChoose): unknown {
@@ -260,9 +260,9 @@ export const PleaseChoose_Submessage = {
   },
 
   fromJSON(object: any): PleaseChoose_Submessage {
-    const message = createBasePleaseChoose_Submessage();
-    message.name = isSet(object.name) ? String(object.name) : '';
-    return message;
+    return {
+      name: isSet(object.name) ? String(object.name) : '',
+    };
   },
 
   toJSON(message: PleaseChoose_Submessage): unknown {

--- a/integration/oneof-unions/google/protobuf/struct.ts
+++ b/integration/oneof-unions/google/protobuf/struct.ts
@@ -121,15 +121,14 @@ export const Struct = {
   },
 
   fromJSON(object: any): Struct {
-    const message = createBaseStruct();
-    message.fields = Object.entries(object.fields ?? {}).reduce<{ [key: string]: any | undefined }>(
-      (acc, [key, value]) => {
-        acc[key] = value as any | undefined;
-        return acc;
-      },
-      {}
-    );
-    return message;
+    return {
+      fields: isObject(object.fields)
+        ? Object.entries(object.fields).reduce<{ [key: string]: any | undefined }>((acc, [key, value]) => {
+            acc[key] = value as any | undefined;
+            return acc;
+          }, {})
+        : {},
+    };
   },
 
   toJSON(message: Struct): unknown {
@@ -213,10 +212,10 @@ export const Struct_FieldsEntry = {
   },
 
   fromJSON(object: any): Struct_FieldsEntry {
-    const message = createBaseStruct_FieldsEntry();
-    message.key = isSet(object.key) ? String(object.key) : '';
-    message.value = isSet(object?.value) ? object.value : undefined;
-    return message;
+    return {
+      key: isSet(object.key) ? String(object.key) : '',
+      value: isSet(object?.value) ? object.value : undefined,
+    };
   },
 
   toJSON(message: Struct_FieldsEntry): unknown {
@@ -295,26 +294,21 @@ export const Value = {
   },
 
   fromJSON(object: any): Value {
-    const message = createBaseValue();
-    if (isSet(object.nullValue)) {
-      message.kind = { $case: 'nullValue', nullValue: nullValueFromJSON(object.nullValue) };
-    }
-    if (isSet(object.numberValue)) {
-      message.kind = { $case: 'numberValue', numberValue: Number(object.numberValue) };
-    }
-    if (isSet(object.stringValue)) {
-      message.kind = { $case: 'stringValue', stringValue: String(object.stringValue) };
-    }
-    if (isSet(object.boolValue)) {
-      message.kind = { $case: 'boolValue', boolValue: Boolean(object.boolValue) };
-    }
-    if (isSet(object.structValue)) {
-      message.kind = { $case: 'structValue', structValue: object.structValue };
-    }
-    if (isSet(object.listValue)) {
-      message.kind = { $case: 'listValue', listValue: [...object.listValue] };
-    }
-    return message;
+    return {
+      kind: isSet(object.nullValue)
+        ? { $case: 'nullValue', nullValue: nullValueFromJSON(object.nullValue) }
+        : isSet(object.numberValue)
+        ? { $case: 'numberValue', numberValue: Number(object.numberValue) }
+        : isSet(object.stringValue)
+        ? { $case: 'stringValue', stringValue: String(object.stringValue) }
+        : isSet(object.boolValue)
+        ? { $case: 'boolValue', boolValue: Boolean(object.boolValue) }
+        : isSet(object.structValue)
+        ? { $case: 'structValue', structValue: object.structValue }
+        : isSet(object.listValue)
+        ? { $case: 'listValue', listValue: [...object.listValue] }
+        : undefined,
+    };
   },
 
   toJSON(message: Value): unknown {
@@ -434,9 +428,9 @@ export const ListValue = {
   },
 
   fromJSON(object: any): ListValue {
-    const message = createBaseListValue();
-    message.values = Array.isArray(object?.values) ? [...object.values] : [];
-    return message;
+    return {
+      values: Array.isArray(object?.values) ? [...object.values] : [],
+    };
   },
 
   toJSON(message: ListValue): unknown {
@@ -488,6 +482,10 @@ export type Exact<P, I extends P> = P extends Builtin
 if (util.Long !== Long) {
   util.Long = Long as any;
   configure();
+}
+
+function isObject(value: any): boolean {
+  return typeof value === 'object' && value !== null;
 }
 
 function isSet(value: any): boolean {

--- a/integration/oneof-unions/oneof.ts
+++ b/integration/oneof-unions/oneof.ts
@@ -174,39 +174,32 @@ export const PleaseChoose = {
   },
 
   fromJSON(object: any): PleaseChoose {
-    const message = createBasePleaseChoose();
-    message.name = isSet(object.name) ? String(object.name) : '';
-    if (isSet(object.aNumber)) {
-      message.choice = { $case: 'aNumber', aNumber: Number(object.aNumber) };
-    }
-    if (isSet(object.aString)) {
-      message.choice = { $case: 'aString', aString: String(object.aString) };
-    }
-    if (isSet(object.aMessage)) {
-      message.choice = { $case: 'aMessage', aMessage: PleaseChoose_Submessage.fromJSON(object.aMessage) };
-    }
-    if (isSet(object.aBool)) {
-      message.choice = { $case: 'aBool', aBool: Boolean(object.aBool) };
-    }
-    if (isSet(object.bunchaBytes)) {
-      message.choice = { $case: 'bunchaBytes', bunchaBytes: bytesFromBase64(object.bunchaBytes) };
-    }
-    if (isSet(object.anEnum)) {
-      message.choice = { $case: 'anEnum', anEnum: pleaseChoose_StateEnumFromJSON(object.anEnum) };
-    }
-    message.age = isSet(object.age) ? Number(object.age) : 0;
-    if (isSet(object.either)) {
-      message.eitherOr = { $case: 'either', either: String(object.either) };
-    }
-    if (isSet(object.or)) {
-      message.eitherOr = { $case: 'or', or: String(object.or) };
-    }
-    if (isSet(object.thirdOption)) {
-      message.eitherOr = { $case: 'thirdOption', thirdOption: String(object.thirdOption) };
-    }
-    message.signature = isSet(object.signature) ? bytesFromBase64(object.signature) : new Uint8Array();
-    message.value = isSet(object?.value) ? object.value : undefined;
-    return message;
+    return {
+      name: isSet(object.name) ? String(object.name) : '',
+      choice: isSet(object.aNumber)
+        ? { $case: 'aNumber', aNumber: Number(object.aNumber) }
+        : isSet(object.aString)
+        ? { $case: 'aString', aString: String(object.aString) }
+        : isSet(object.aMessage)
+        ? { $case: 'aMessage', aMessage: PleaseChoose_Submessage.fromJSON(object.aMessage) }
+        : isSet(object.aBool)
+        ? { $case: 'aBool', aBool: Boolean(object.aBool) }
+        : isSet(object.bunchaBytes)
+        ? { $case: 'bunchaBytes', bunchaBytes: bytesFromBase64(object.bunchaBytes) }
+        : isSet(object.anEnum)
+        ? { $case: 'anEnum', anEnum: pleaseChoose_StateEnumFromJSON(object.anEnum) }
+        : undefined,
+      age: isSet(object.age) ? Number(object.age) : 0,
+      eitherOr: isSet(object.either)
+        ? { $case: 'either', either: String(object.either) }
+        : isSet(object.or)
+        ? { $case: 'or', or: String(object.or) }
+        : isSet(object.thirdOption)
+        ? { $case: 'thirdOption', thirdOption: String(object.thirdOption) }
+        : undefined,
+      signature: isSet(object.signature) ? bytesFromBase64(object.signature) : new Uint8Array(),
+      value: isSet(object?.value) ? object.value : undefined,
+    };
   },
 
   toJSON(message: PleaseChoose): unknown {
@@ -317,9 +310,9 @@ export const PleaseChoose_Submessage = {
   },
 
   fromJSON(object: any): PleaseChoose_Submessage {
-    const message = createBasePleaseChoose_Submessage();
-    message.name = isSet(object.name) ? String(object.name) : '';
-    return message;
+    return {
+      name: isSet(object.name) ? String(object.name) : '',
+    };
   },
 
   toJSON(message: PleaseChoose_Submessage): unknown {
@@ -372,10 +365,10 @@ export const SimpleButOptional = {
   },
 
   fromJSON(object: any): SimpleButOptional {
-    const message = createBaseSimpleButOptional();
-    message.name = isSet(object.name) ? String(object.name) : undefined;
-    message.age = isSet(object.age) ? Number(object.age) : undefined;
-    return message;
+    return {
+      name: isSet(object.name) ? String(object.name) : undefined,
+      age: isSet(object.age) ? Number(object.age) : undefined,
+    };
   },
 
   toJSON(message: SimpleButOptional): unknown {

--- a/integration/point/point.ts
+++ b/integration/point/point.ts
@@ -51,10 +51,10 @@ export const Point = {
   },
 
   fromJSON(object: any): Point {
-    const message = createBasePoint();
-    message.lat = isSet(object.lat) ? Number(object.lat) : 0;
-    message.lng = isSet(object.lng) ? Number(object.lng) : 0;
-    return message;
+    return {
+      lat: isSet(object.lat) ? Number(object.lat) : 0,
+      lng: isSet(object.lng) ? Number(object.lng) : 0,
+    };
   },
 
   toJSON(message: Point): unknown {
@@ -109,10 +109,10 @@ export const Area = {
   },
 
   fromJSON(object: any): Area {
-    const message = createBaseArea();
-    message.nw = isSet(object.nw) ? Point.fromJSON(object.nw) : undefined;
-    message.se = isSet(object.se) ? Point.fromJSON(object.se) : undefined;
-    return message;
+    return {
+      nw: isSet(object.nw) ? Point.fromJSON(object.nw) : undefined,
+      se: isSet(object.se) ? Point.fromJSON(object.se) : undefined,
+    };
   },
 
   toJSON(message: Area): unknown {

--- a/integration/return-observable/observable.ts
+++ b/integration/return-observable/observable.ts
@@ -44,9 +44,9 @@ export const ProduceRequest = {
   },
 
   fromJSON(object: any): ProduceRequest {
-    const message = createBaseProduceRequest();
-    message.ingredients = isSet(object.ingredients) ? String(object.ingredients) : '';
-    return message;
+    return {
+      ingredients: isSet(object.ingredients) ? String(object.ingredients) : '',
+    };
   },
 
   toJSON(message: ProduceRequest): unknown {
@@ -93,9 +93,9 @@ export const ProduceReply = {
   },
 
   fromJSON(object: any): ProduceReply {
-    const message = createBaseProduceReply();
-    message.result = isSet(object.result) ? String(object.result) : '';
-    return message;
+    return {
+      result: isSet(object.result) ? String(object.result) : '',
+    };
   },
 
   toJSON(message: ProduceReply): unknown {

--- a/integration/simple-deprecated-fields/simple.ts
+++ b/integration/simple-deprecated-fields/simple.ts
@@ -87,13 +87,13 @@ export const Simple = {
   },
 
   fromJSON(object: any): Simple {
-    const message = createBaseSimple();
-    message.name = isSet(object.name) ? String(object.name) : '';
-    message.age = isSet(object.age) ? Number(object.age) : 0;
-    message.child = isSet(object.child) ? Child.fromJSON(object.child) : undefined;
-    message.testField = isSet(object.testField) ? String(object.testField) : '';
-    message.testNotDeprecated = isSet(object.testNotDeprecated) ? String(object.testNotDeprecated) : '';
-    return message;
+    return {
+      name: isSet(object.name) ? String(object.name) : '',
+      age: isSet(object.age) ? Number(object.age) : 0,
+      child: isSet(object.child) ? Child.fromJSON(object.child) : undefined,
+      testField: isSet(object.testField) ? String(object.testField) : '',
+      testNotDeprecated: isSet(object.testNotDeprecated) ? String(object.testNotDeprecated) : '',
+    };
   },
 
   toJSON(message: Simple): unknown {
@@ -148,9 +148,9 @@ export const Child = {
   },
 
   fromJSON(object: any): Child {
-    const message = createBaseChild();
-    message.name = isSet(object.name) ? String(object.name) : '';
-    return message;
+    return {
+      name: isSet(object.name) ? String(object.name) : '',
+    };
   },
 
   toJSON(message: Child): unknown {

--- a/integration/simple-esmodule-interop/simple.ts
+++ b/integration/simple-esmodule-interop/simple.ts
@@ -61,10 +61,10 @@ export const Simple = {
   },
 
   fromJSON(object: any): Simple {
-    const message = createBaseSimple();
-    message.name = isSet(object.name) ? String(object.name) : '';
-    message.age = isSet(object.age) ? Number(object.age) : 0;
-    return message;
+    return {
+      name: isSet(object.name) ? String(object.name) : '',
+      age: isSet(object.age) ? Number(object.age) : 0,
+    };
   },
 
   toJSON(message: Simple): unknown {
@@ -192,20 +192,20 @@ export const Numbers = {
   },
 
   fromJSON(object: any): Numbers {
-    const message = createBaseNumbers();
-    message.double = isSet(object.double) ? Number(object.double) : 0;
-    message.float = isSet(object.float) ? Number(object.float) : 0;
-    message.int32 = isSet(object.int32) ? Number(object.int32) : 0;
-    message.int64 = isSet(object.int64) ? Number(object.int64) : 0;
-    message.uint32 = isSet(object.uint32) ? Number(object.uint32) : 0;
-    message.uint64 = isSet(object.uint64) ? Number(object.uint64) : 0;
-    message.sint32 = isSet(object.sint32) ? Number(object.sint32) : 0;
-    message.sint64 = isSet(object.sint64) ? Number(object.sint64) : 0;
-    message.fixed32 = isSet(object.fixed32) ? Number(object.fixed32) : 0;
-    message.fixed64 = isSet(object.fixed64) ? Number(object.fixed64) : 0;
-    message.sfixed32 = isSet(object.sfixed32) ? Number(object.sfixed32) : 0;
-    message.sfixed64 = isSet(object.sfixed64) ? Number(object.sfixed64) : 0;
-    return message;
+    return {
+      double: isSet(object.double) ? Number(object.double) : 0,
+      float: isSet(object.float) ? Number(object.float) : 0,
+      int32: isSet(object.int32) ? Number(object.int32) : 0,
+      int64: isSet(object.int64) ? Number(object.int64) : 0,
+      uint32: isSet(object.uint32) ? Number(object.uint32) : 0,
+      uint64: isSet(object.uint64) ? Number(object.uint64) : 0,
+      sint32: isSet(object.sint32) ? Number(object.sint32) : 0,
+      sint64: isSet(object.sint64) ? Number(object.sint64) : 0,
+      fixed32: isSet(object.fixed32) ? Number(object.fixed32) : 0,
+      fixed64: isSet(object.fixed64) ? Number(object.fixed64) : 0,
+      sfixed32: isSet(object.sfixed32) ? Number(object.sfixed32) : 0,
+      sfixed64: isSet(object.sfixed64) ? Number(object.sfixed64) : 0,
+    };
   },
 
   toJSON(message: Numbers): unknown {

--- a/integration/simple-json-name/google/protobuf/timestamp.ts
+++ b/integration/simple-json-name/google/protobuf/timestamp.ts
@@ -150,10 +150,10 @@ export const Timestamp = {
   },
 
   fromJSON(object: any): Timestamp {
-    const message = createBaseTimestamp();
-    message.seconds = isSet(object.seconds) ? Number(object.seconds) : 0;
-    message.nanos = isSet(object.nanos) ? Number(object.nanos) : 0;
-    return message;
+    return {
+      seconds: isSet(object.seconds) ? Number(object.seconds) : 0,
+      nanos: isSet(object.nanos) ? Number(object.nanos) : 0,
+    };
   },
 
   toJSON(message: Timestamp): unknown {

--- a/integration/simple-json-name/simple.ts
+++ b/integration/simple-json-name/simple.ts
@@ -54,11 +54,11 @@ export const Simple = {
   },
 
   fromJSON(object: any): Simple {
-    const message = createBaseSimple();
-    message.name = isSet(object.other_name) ? String(object.other_name) : '';
-    message.age = isSet(object.other_age) ? Number(object.other_age) : undefined;
-    message.createdAt = isSet(object.createdAt) ? fromJsonTimestamp(object.createdAt) : undefined;
-    return message;
+    return {
+      name: isSet(object.other_name) ? String(object.other_name) : '',
+      age: isSet(object.other_age) ? Number(object.other_age) : undefined,
+      createdAt: isSet(object.createdAt) ? fromJsonTimestamp(object.createdAt) : undefined,
+    };
   },
 
   toJSON(message: Simple): unknown {

--- a/integration/simple-long-string/google/protobuf/timestamp.ts
+++ b/integration/simple-long-string/google/protobuf/timestamp.ts
@@ -150,10 +150,10 @@ export const Timestamp = {
   },
 
   fromJSON(object: any): Timestamp {
-    const message = createBaseTimestamp();
-    message.seconds = isSet(object.seconds) ? String(object.seconds) : '0';
-    message.nanos = isSet(object.nanos) ? Number(object.nanos) : 0;
-    return message;
+    return {
+      seconds: isSet(object.seconds) ? String(object.seconds) : '0',
+      nanos: isSet(object.nanos) ? Number(object.nanos) : 0,
+    };
   },
 
   toJSON(message: Timestamp): unknown {

--- a/integration/simple-long-string/google/protobuf/wrappers.ts
+++ b/integration/simple-long-string/google/protobuf/wrappers.ts
@@ -125,9 +125,9 @@ export const DoubleValue = {
   },
 
   fromJSON(object: any): DoubleValue {
-    const message = createBaseDoubleValue();
-    message.value = isSet(object.value) ? Number(object.value) : 0;
-    return message;
+    return {
+      value: isSet(object.value) ? Number(object.value) : 0,
+    };
   },
 
   toJSON(message: DoubleValue): unknown {
@@ -174,9 +174,9 @@ export const FloatValue = {
   },
 
   fromJSON(object: any): FloatValue {
-    const message = createBaseFloatValue();
-    message.value = isSet(object.value) ? Number(object.value) : 0;
-    return message;
+    return {
+      value: isSet(object.value) ? Number(object.value) : 0,
+    };
   },
 
   toJSON(message: FloatValue): unknown {
@@ -223,9 +223,9 @@ export const Int64Value = {
   },
 
   fromJSON(object: any): Int64Value {
-    const message = createBaseInt64Value();
-    message.value = isSet(object.value) ? String(object.value) : '0';
-    return message;
+    return {
+      value: isSet(object.value) ? String(object.value) : '0',
+    };
   },
 
   toJSON(message: Int64Value): unknown {
@@ -272,9 +272,9 @@ export const UInt64Value = {
   },
 
   fromJSON(object: any): UInt64Value {
-    const message = createBaseUInt64Value();
-    message.value = isSet(object.value) ? String(object.value) : '0';
-    return message;
+    return {
+      value: isSet(object.value) ? String(object.value) : '0',
+    };
   },
 
   toJSON(message: UInt64Value): unknown {
@@ -321,9 +321,9 @@ export const Int32Value = {
   },
 
   fromJSON(object: any): Int32Value {
-    const message = createBaseInt32Value();
-    message.value = isSet(object.value) ? Number(object.value) : 0;
-    return message;
+    return {
+      value: isSet(object.value) ? Number(object.value) : 0,
+    };
   },
 
   toJSON(message: Int32Value): unknown {
@@ -370,9 +370,9 @@ export const UInt32Value = {
   },
 
   fromJSON(object: any): UInt32Value {
-    const message = createBaseUInt32Value();
-    message.value = isSet(object.value) ? Number(object.value) : 0;
-    return message;
+    return {
+      value: isSet(object.value) ? Number(object.value) : 0,
+    };
   },
 
   toJSON(message: UInt32Value): unknown {
@@ -419,9 +419,9 @@ export const BoolValue = {
   },
 
   fromJSON(object: any): BoolValue {
-    const message = createBaseBoolValue();
-    message.value = isSet(object.value) ? Boolean(object.value) : false;
-    return message;
+    return {
+      value: isSet(object.value) ? Boolean(object.value) : false,
+    };
   },
 
   toJSON(message: BoolValue): unknown {
@@ -468,9 +468,9 @@ export const StringValue = {
   },
 
   fromJSON(object: any): StringValue {
-    const message = createBaseStringValue();
-    message.value = isSet(object.value) ? String(object.value) : '';
-    return message;
+    return {
+      value: isSet(object.value) ? String(object.value) : '',
+    };
   },
 
   toJSON(message: StringValue): unknown {
@@ -517,9 +517,9 @@ export const BytesValue = {
   },
 
   fromJSON(object: any): BytesValue {
-    const message = createBaseBytesValue();
-    message.value = isSet(object.value) ? bytesFromBase64(object.value) : new Uint8Array();
-    return message;
+    return {
+      value: isSet(object.value) ? bytesFromBase64(object.value) : new Uint8Array(),
+    };
   },
 
   toJSON(message: BytesValue): unknown {

--- a/integration/simple-long-string/simple.ts
+++ b/integration/simple-long-string/simple.ts
@@ -147,22 +147,22 @@ export const Numbers = {
   },
 
   fromJSON(object: any): Numbers {
-    const message = createBaseNumbers();
-    message.double = isSet(object.double) ? Number(object.double) : 0;
-    message.float = isSet(object.float) ? Number(object.float) : 0;
-    message.int32 = isSet(object.int32) ? Number(object.int32) : 0;
-    message.int64 = isSet(object.int64) ? String(object.int64) : '0';
-    message.uint32 = isSet(object.uint32) ? Number(object.uint32) : 0;
-    message.uint64 = isSet(object.uint64) ? String(object.uint64) : '0';
-    message.sint32 = isSet(object.sint32) ? Number(object.sint32) : 0;
-    message.sint64 = isSet(object.sint64) ? String(object.sint64) : '0';
-    message.fixed32 = isSet(object.fixed32) ? Number(object.fixed32) : 0;
-    message.fixed64 = isSet(object.fixed64) ? String(object.fixed64) : '0';
-    message.sfixed32 = isSet(object.sfixed32) ? Number(object.sfixed32) : 0;
-    message.sfixed64 = isSet(object.sfixed64) ? String(object.sfixed64) : '0';
-    message.guint64 = isSet(object.guint64) ? String(object.guint64) : undefined;
-    message.timestamp = isSet(object.timestamp) ? fromJsonTimestamp(object.timestamp) : undefined;
-    return message;
+    return {
+      double: isSet(object.double) ? Number(object.double) : 0,
+      float: isSet(object.float) ? Number(object.float) : 0,
+      int32: isSet(object.int32) ? Number(object.int32) : 0,
+      int64: isSet(object.int64) ? String(object.int64) : '0',
+      uint32: isSet(object.uint32) ? Number(object.uint32) : 0,
+      uint64: isSet(object.uint64) ? String(object.uint64) : '0',
+      sint32: isSet(object.sint32) ? Number(object.sint32) : 0,
+      sint64: isSet(object.sint64) ? String(object.sint64) : '0',
+      fixed32: isSet(object.fixed32) ? Number(object.fixed32) : 0,
+      fixed64: isSet(object.fixed64) ? String(object.fixed64) : '0',
+      sfixed32: isSet(object.sfixed32) ? Number(object.sfixed32) : 0,
+      sfixed64: isSet(object.sfixed64) ? String(object.sfixed64) : '0',
+      guint64: isSet(object.guint64) ? String(object.guint64) : undefined,
+      timestamp: isSet(object.timestamp) ? fromJsonTimestamp(object.timestamp) : undefined,
+    };
   },
 
   toJSON(message: Numbers): unknown {

--- a/integration/simple-long/google/protobuf/wrappers.ts
+++ b/integration/simple-long/google/protobuf/wrappers.ts
@@ -125,9 +125,9 @@ export const DoubleValue = {
   },
 
   fromJSON(object: any): DoubleValue {
-    const message = createBaseDoubleValue();
-    message.value = isSet(object.value) ? Number(object.value) : 0;
-    return message;
+    return {
+      value: isSet(object.value) ? Number(object.value) : 0,
+    };
   },
 
   toJSON(message: DoubleValue): unknown {
@@ -174,9 +174,9 @@ export const FloatValue = {
   },
 
   fromJSON(object: any): FloatValue {
-    const message = createBaseFloatValue();
-    message.value = isSet(object.value) ? Number(object.value) : 0;
-    return message;
+    return {
+      value: isSet(object.value) ? Number(object.value) : 0,
+    };
   },
 
   toJSON(message: FloatValue): unknown {
@@ -223,9 +223,9 @@ export const Int64Value = {
   },
 
   fromJSON(object: any): Int64Value {
-    const message = createBaseInt64Value();
-    message.value = isSet(object.value) ? Long.fromString(object.value) : Long.ZERO;
-    return message;
+    return {
+      value: isSet(object.value) ? Long.fromString(object.value) : Long.ZERO,
+    };
   },
 
   toJSON(message: Int64Value): unknown {
@@ -272,9 +272,9 @@ export const UInt64Value = {
   },
 
   fromJSON(object: any): UInt64Value {
-    const message = createBaseUInt64Value();
-    message.value = isSet(object.value) ? Long.fromString(object.value) : Long.UZERO;
-    return message;
+    return {
+      value: isSet(object.value) ? Long.fromString(object.value) : Long.UZERO,
+    };
   },
 
   toJSON(message: UInt64Value): unknown {
@@ -321,9 +321,9 @@ export const Int32Value = {
   },
 
   fromJSON(object: any): Int32Value {
-    const message = createBaseInt32Value();
-    message.value = isSet(object.value) ? Number(object.value) : 0;
-    return message;
+    return {
+      value: isSet(object.value) ? Number(object.value) : 0,
+    };
   },
 
   toJSON(message: Int32Value): unknown {
@@ -370,9 +370,9 @@ export const UInt32Value = {
   },
 
   fromJSON(object: any): UInt32Value {
-    const message = createBaseUInt32Value();
-    message.value = isSet(object.value) ? Number(object.value) : 0;
-    return message;
+    return {
+      value: isSet(object.value) ? Number(object.value) : 0,
+    };
   },
 
   toJSON(message: UInt32Value): unknown {
@@ -419,9 +419,9 @@ export const BoolValue = {
   },
 
   fromJSON(object: any): BoolValue {
-    const message = createBaseBoolValue();
-    message.value = isSet(object.value) ? Boolean(object.value) : false;
-    return message;
+    return {
+      value: isSet(object.value) ? Boolean(object.value) : false,
+    };
   },
 
   toJSON(message: BoolValue): unknown {
@@ -468,9 +468,9 @@ export const StringValue = {
   },
 
   fromJSON(object: any): StringValue {
-    const message = createBaseStringValue();
-    message.value = isSet(object.value) ? String(object.value) : '';
-    return message;
+    return {
+      value: isSet(object.value) ? String(object.value) : '',
+    };
   },
 
   toJSON(message: StringValue): unknown {
@@ -517,9 +517,9 @@ export const BytesValue = {
   },
 
   fromJSON(object: any): BytesValue {
-    const message = createBaseBytesValue();
-    message.value = isSet(object.value) ? bytesFromBase64(object.value) : new Uint8Array();
-    return message;
+    return {
+      value: isSet(object.value) ? bytesFromBase64(object.value) : new Uint8Array(),
+    };
   },
 
   toJSON(message: BytesValue): unknown {

--- a/integration/simple-long/simple.ts
+++ b/integration/simple-long/simple.ts
@@ -114,14 +114,14 @@ export const SimpleWithWrappers = {
   },
 
   fromJSON(object: any): SimpleWithWrappers {
-    const message = createBaseSimpleWithWrappers();
-    message.name = isSet(object.name) ? String(object.name) : undefined;
-    message.age = isSet(object.age) ? Number(object.age) : undefined;
-    message.enabled = isSet(object.enabled) ? Boolean(object.enabled) : undefined;
-    message.bananas = isSet(object.bananas) ? Long.fromValue(object.bananas) : undefined;
-    message.coins = Array.isArray(object?.coins) ? object.coins.map((e: any) => Number(e)) : [];
-    message.snacks = Array.isArray(object?.snacks) ? object.snacks.map((e: any) => String(e)) : [];
-    return message;
+    return {
+      name: isSet(object.name) ? String(object.name) : undefined,
+      age: isSet(object.age) ? Number(object.age) : undefined,
+      enabled: isSet(object.enabled) ? Boolean(object.enabled) : undefined,
+      bananas: isSet(object.bananas) ? Long.fromValue(object.bananas) : undefined,
+      coins: Array.isArray(object?.coins) ? object.coins.map((e: any) => Number(e)) : [],
+      snacks: Array.isArray(object?.snacks) ? object.snacks.map((e: any) => String(e)) : [],
+    };
   },
 
   toJSON(message: SimpleWithWrappers): unknown {
@@ -208,29 +208,26 @@ export const SimpleWithMap = {
   },
 
   fromJSON(object: any): SimpleWithMap {
-    const message = createBaseSimpleWithMap();
-    message.nameLookup = Object.entries(object.nameLookup ?? {}).reduce<{ [key: string]: string }>(
-      (acc, [key, value]) => {
-        acc[key] = String(value);
-        return acc;
-      },
-      {}
-    );
-    message.intLookup = Object.entries(object.intLookup ?? {}).reduce<{ [key: number]: number }>(
-      (acc, [key, value]) => {
-        acc[Number(key)] = Number(value);
-        return acc;
-      },
-      {}
-    );
-    message.longLookup = Object.entries(object.longLookup ?? {}).reduce<{ [key: string]: Long }>(
-      (acc, [key, value]) => {
-        acc[key] = Long.fromValue(value as Long | string);
-        return acc;
-      },
-      {}
-    );
-    return message;
+    return {
+      nameLookup: isObject(object.nameLookup)
+        ? Object.entries(object.nameLookup).reduce<{ [key: string]: string }>((acc, [key, value]) => {
+            acc[key] = String(value);
+            return acc;
+          }, {})
+        : {},
+      intLookup: isObject(object.intLookup)
+        ? Object.entries(object.intLookup).reduce<{ [key: number]: number }>((acc, [key, value]) => {
+            acc[Number(key)] = Number(value);
+            return acc;
+          }, {})
+        : {},
+      longLookup: isObject(object.longLookup)
+        ? Object.entries(object.longLookup).reduce<{ [key: string]: Long }>((acc, [key, value]) => {
+            acc[key] = Long.fromValue(value as Long | string);
+            return acc;
+          }, {})
+        : {},
+    };
   },
 
   toJSON(message: SimpleWithMap): unknown {
@@ -326,10 +323,10 @@ export const SimpleWithMap_NameLookupEntry = {
   },
 
   fromJSON(object: any): SimpleWithMap_NameLookupEntry {
-    const message = createBaseSimpleWithMap_NameLookupEntry();
-    message.key = isSet(object.key) ? String(object.key) : '';
-    message.value = isSet(object.value) ? String(object.value) : '';
-    return message;
+    return {
+      key: isSet(object.key) ? String(object.key) : '',
+      value: isSet(object.value) ? String(object.value) : '',
+    };
   },
 
   toJSON(message: SimpleWithMap_NameLookupEntry): unknown {
@@ -386,10 +383,10 @@ export const SimpleWithMap_IntLookupEntry = {
   },
 
   fromJSON(object: any): SimpleWithMap_IntLookupEntry {
-    const message = createBaseSimpleWithMap_IntLookupEntry();
-    message.key = isSet(object.key) ? Number(object.key) : 0;
-    message.value = isSet(object.value) ? Number(object.value) : 0;
-    return message;
+    return {
+      key: isSet(object.key) ? Number(object.key) : 0,
+      value: isSet(object.value) ? Number(object.value) : 0,
+    };
   },
 
   toJSON(message: SimpleWithMap_IntLookupEntry): unknown {
@@ -444,10 +441,10 @@ export const SimpleWithMap_LongLookupEntry = {
   },
 
   fromJSON(object: any): SimpleWithMap_LongLookupEntry {
-    const message = createBaseSimpleWithMap_LongLookupEntry();
-    message.key = isSet(object.key) ? String(object.key) : '';
-    message.value = isSet(object.value) ? Long.fromString(object.value) : Long.ZERO;
-    return message;
+    return {
+      key: isSet(object.key) ? String(object.key) : '',
+      value: isSet(object.value) ? Long.fromString(object.value) : Long.ZERO,
+    };
   },
 
   toJSON(message: SimpleWithMap_LongLookupEntry): unknown {
@@ -593,21 +590,21 @@ export const Numbers = {
   },
 
   fromJSON(object: any): Numbers {
-    const message = createBaseNumbers();
-    message.double = isSet(object.double) ? Number(object.double) : 0;
-    message.float = isSet(object.float) ? Number(object.float) : 0;
-    message.int32 = isSet(object.int32) ? Number(object.int32) : 0;
-    message.int64 = isSet(object.int64) ? Long.fromString(object.int64) : Long.ZERO;
-    message.uint32 = isSet(object.uint32) ? Number(object.uint32) : 0;
-    message.uint64 = isSet(object.uint64) ? Long.fromString(object.uint64) : Long.UZERO;
-    message.sint32 = isSet(object.sint32) ? Number(object.sint32) : 0;
-    message.sint64 = isSet(object.sint64) ? Long.fromString(object.sint64) : Long.ZERO;
-    message.fixed32 = isSet(object.fixed32) ? Number(object.fixed32) : 0;
-    message.fixed64 = isSet(object.fixed64) ? Long.fromString(object.fixed64) : Long.UZERO;
-    message.sfixed32 = isSet(object.sfixed32) ? Number(object.sfixed32) : 0;
-    message.sfixed64 = isSet(object.sfixed64) ? Long.fromString(object.sfixed64) : Long.ZERO;
-    message.manyUint64 = Array.isArray(object?.manyUint64) ? object.manyUint64.map((e: any) => Long.fromString(e)) : [];
-    return message;
+    return {
+      double: isSet(object.double) ? Number(object.double) : 0,
+      float: isSet(object.float) ? Number(object.float) : 0,
+      int32: isSet(object.int32) ? Number(object.int32) : 0,
+      int64: isSet(object.int64) ? Long.fromString(object.int64) : Long.ZERO,
+      uint32: isSet(object.uint32) ? Number(object.uint32) : 0,
+      uint64: isSet(object.uint64) ? Long.fromString(object.uint64) : Long.UZERO,
+      sint32: isSet(object.sint32) ? Number(object.sint32) : 0,
+      sint64: isSet(object.sint64) ? Long.fromString(object.sint64) : Long.ZERO,
+      fixed32: isSet(object.fixed32) ? Number(object.fixed32) : 0,
+      fixed64: isSet(object.fixed64) ? Long.fromString(object.fixed64) : Long.UZERO,
+      sfixed32: isSet(object.sfixed32) ? Number(object.sfixed32) : 0,
+      sfixed64: isSet(object.sfixed64) ? Long.fromString(object.sfixed64) : Long.ZERO,
+      manyUint64: Array.isArray(object?.manyUint64) ? object.manyUint64.map((e: any) => Long.fromString(e)) : [],
+    };
   },
 
   toJSON(message: Numbers): unknown {
@@ -677,6 +674,10 @@ export type Exact<P, I extends P> = P extends Builtin
 if (util.Long !== Long) {
   util.Long = Long as any;
   configure();
+}
+
+function isObject(value: any): boolean {
+  return typeof value === 'object' && value !== null;
 }
 
 function isSet(value: any): boolean {

--- a/integration/simple-optionals/google/protobuf/timestamp.ts
+++ b/integration/simple-optionals/google/protobuf/timestamp.ts
@@ -150,10 +150,10 @@ export const Timestamp = {
   },
 
   fromJSON(object: any): Timestamp {
-    const message = createBaseTimestamp();
-    message.seconds = isSet(object.seconds) ? Number(object.seconds) : 0;
-    message.nanos = isSet(object.nanos) ? Number(object.nanos) : 0;
-    return message;
+    return {
+      seconds: isSet(object.seconds) ? Number(object.seconds) : 0,
+      nanos: isSet(object.nanos) ? Number(object.nanos) : 0,
+    };
   },
 
   toJSON(message: Timestamp): unknown {

--- a/integration/simple-optionals/google/protobuf/wrappers.ts
+++ b/integration/simple-optionals/google/protobuf/wrappers.ts
@@ -125,9 +125,9 @@ export const DoubleValue = {
   },
 
   fromJSON(object: any): DoubleValue {
-    const message = createBaseDoubleValue();
-    message.value = isSet(object.value) ? Number(object.value) : 0;
-    return message;
+    return {
+      value: isSet(object.value) ? Number(object.value) : 0,
+    };
   },
 
   toJSON(message: DoubleValue): unknown {
@@ -174,9 +174,9 @@ export const FloatValue = {
   },
 
   fromJSON(object: any): FloatValue {
-    const message = createBaseFloatValue();
-    message.value = isSet(object.value) ? Number(object.value) : 0;
-    return message;
+    return {
+      value: isSet(object.value) ? Number(object.value) : 0,
+    };
   },
 
   toJSON(message: FloatValue): unknown {
@@ -223,9 +223,9 @@ export const Int64Value = {
   },
 
   fromJSON(object: any): Int64Value {
-    const message = createBaseInt64Value();
-    message.value = isSet(object.value) ? Number(object.value) : 0;
-    return message;
+    return {
+      value: isSet(object.value) ? Number(object.value) : 0,
+    };
   },
 
   toJSON(message: Int64Value): unknown {
@@ -272,9 +272,9 @@ export const UInt64Value = {
   },
 
   fromJSON(object: any): UInt64Value {
-    const message = createBaseUInt64Value();
-    message.value = isSet(object.value) ? Number(object.value) : 0;
-    return message;
+    return {
+      value: isSet(object.value) ? Number(object.value) : 0,
+    };
   },
 
   toJSON(message: UInt64Value): unknown {
@@ -321,9 +321,9 @@ export const Int32Value = {
   },
 
   fromJSON(object: any): Int32Value {
-    const message = createBaseInt32Value();
-    message.value = isSet(object.value) ? Number(object.value) : 0;
-    return message;
+    return {
+      value: isSet(object.value) ? Number(object.value) : 0,
+    };
   },
 
   toJSON(message: Int32Value): unknown {
@@ -370,9 +370,9 @@ export const UInt32Value = {
   },
 
   fromJSON(object: any): UInt32Value {
-    const message = createBaseUInt32Value();
-    message.value = isSet(object.value) ? Number(object.value) : 0;
-    return message;
+    return {
+      value: isSet(object.value) ? Number(object.value) : 0,
+    };
   },
 
   toJSON(message: UInt32Value): unknown {
@@ -419,9 +419,9 @@ export const BoolValue = {
   },
 
   fromJSON(object: any): BoolValue {
-    const message = createBaseBoolValue();
-    message.value = isSet(object.value) ? Boolean(object.value) : false;
-    return message;
+    return {
+      value: isSet(object.value) ? Boolean(object.value) : false,
+    };
   },
 
   toJSON(message: BoolValue): unknown {
@@ -468,9 +468,9 @@ export const StringValue = {
   },
 
   fromJSON(object: any): StringValue {
-    const message = createBaseStringValue();
-    message.value = isSet(object.value) ? String(object.value) : '';
-    return message;
+    return {
+      value: isSet(object.value) ? String(object.value) : '',
+    };
   },
 
   toJSON(message: StringValue): unknown {
@@ -517,9 +517,9 @@ export const BytesValue = {
   },
 
   fromJSON(object: any): BytesValue {
-    const message = createBaseBytesValue();
-    message.value = isSet(object.value) ? bytesFromBase64(object.value) : new Uint8Array();
-    return message;
+    return {
+      value: isSet(object.value) ? bytesFromBase64(object.value) : new Uint8Array(),
+    };
   },
 
   toJSON(message: BytesValue): unknown {

--- a/integration/simple-optionals/import_dir/thing.ts
+++ b/integration/simple-optionals/import_dir/thing.ts
@@ -40,9 +40,9 @@ export const ImportedThing = {
   },
 
   fromJSON(object: any): ImportedThing {
-    const message = createBaseImportedThing();
-    message.createdAt = isSet(object.createdAt) ? fromJsonTimestamp(object.createdAt) : undefined;
-    return message;
+    return {
+      createdAt: isSet(object.createdAt) ? fromJsonTimestamp(object.createdAt) : undefined,
+    };
   },
 
   toJSON(message: ImportedThing): unknown {

--- a/integration/simple-optionals/simple.ts
+++ b/integration/simple-optionals/simple.ts
@@ -349,20 +349,20 @@ export const Simple = {
   },
 
   fromJSON(object: any): Simple {
-    const message = createBaseSimple();
-    message.name = isSet(object.name) ? String(object.name) : '';
-    message.age = isSet(object.age) ? Number(object.age) : 0;
-    message.createdAt = isSet(object.createdAt) ? fromJsonTimestamp(object.createdAt) : undefined;
-    message.child = isSet(object.child) ? Child.fromJSON(object.child) : undefined;
-    message.state = isSet(object.state) ? stateEnumFromJSON(object.state) : 0;
-    message.grandChildren = Array.isArray(object?.grandChildren)
-      ? object.grandChildren.map((e: any) => Child.fromJSON(e))
-      : [];
-    message.coins = Array.isArray(object?.coins) ? object.coins.map((e: any) => Number(e)) : [];
-    message.snacks = Array.isArray(object?.snacks) ? object.snacks.map((e: any) => String(e)) : [];
-    message.oldStates = Array.isArray(object?.oldStates) ? object.oldStates.map((e: any) => stateEnumFromJSON(e)) : [];
-    message.thing = isSet(object.thing) ? ImportedThing.fromJSON(object.thing) : undefined;
-    return message;
+    return {
+      name: isSet(object.name) ? String(object.name) : '',
+      age: isSet(object.age) ? Number(object.age) : 0,
+      createdAt: isSet(object.createdAt) ? fromJsonTimestamp(object.createdAt) : undefined,
+      child: isSet(object.child) ? Child.fromJSON(object.child) : undefined,
+      state: isSet(object.state) ? stateEnumFromJSON(object.state) : 0,
+      grandChildren: Array.isArray(object?.grandChildren)
+        ? object.grandChildren.map((e: any) => Child.fromJSON(e))
+        : [],
+      coins: Array.isArray(object?.coins) ? object.coins.map((e: any) => Number(e)) : [],
+      snacks: Array.isArray(object?.snacks) ? object.snacks.map((e: any) => String(e)) : [],
+      oldStates: Array.isArray(object?.oldStates) ? object.oldStates.map((e: any) => stateEnumFromJSON(e)) : [],
+      thing: isSet(object.thing) ? ImportedThing.fromJSON(object.thing) : undefined,
+    };
   },
 
   toJSON(message: Simple): unknown {
@@ -450,10 +450,10 @@ export const Child = {
   },
 
   fromJSON(object: any): Child {
-    const message = createBaseChild();
-    message.name = isSet(object.name) ? String(object.name) : '';
-    message.type = isSet(object.type) ? child_TypeFromJSON(object.type) : 0;
-    return message;
+    return {
+      name: isSet(object.name) ? String(object.name) : '',
+      type: isSet(object.type) ? child_TypeFromJSON(object.type) : 0,
+    };
   },
 
   toJSON(message: Child): unknown {
@@ -514,11 +514,11 @@ export const Nested = {
   },
 
   fromJSON(object: any): Nested {
-    const message = createBaseNested();
-    message.name = isSet(object.name) ? String(object.name) : '';
-    message.message = isSet(object.message) ? Nested_InnerMessage.fromJSON(object.message) : undefined;
-    message.state = isSet(object.state) ? nested_InnerEnumFromJSON(object.state) : 0;
-    return message;
+    return {
+      name: isSet(object.name) ? String(object.name) : '',
+      message: isSet(object.message) ? Nested_InnerMessage.fromJSON(object.message) : undefined,
+      state: isSet(object.state) ? nested_InnerEnumFromJSON(object.state) : 0,
+    };
   },
 
   toJSON(message: Nested): unknown {
@@ -579,10 +579,10 @@ export const Nested_InnerMessage = {
   },
 
   fromJSON(object: any): Nested_InnerMessage {
-    const message = createBaseNested_InnerMessage();
-    message.name = isSet(object.name) ? String(object.name) : '';
-    message.deep = isSet(object.deep) ? Nested_InnerMessage_DeepMessage.fromJSON(object.deep) : undefined;
-    return message;
+    return {
+      name: isSet(object.name) ? String(object.name) : '',
+      deep: isSet(object.deep) ? Nested_InnerMessage_DeepMessage.fromJSON(object.deep) : undefined,
+    };
   },
 
   toJSON(message: Nested_InnerMessage): unknown {
@@ -635,9 +635,9 @@ export const Nested_InnerMessage_DeepMessage = {
   },
 
   fromJSON(object: any): Nested_InnerMessage_DeepMessage {
-    const message = createBaseNested_InnerMessage_DeepMessage();
-    message.name = isSet(object.name) ? String(object.name) : '';
-    return message;
+    return {
+      name: isSet(object.name) ? String(object.name) : '',
+    };
   },
 
   toJSON(message: Nested_InnerMessage_DeepMessage): unknown {
@@ -692,10 +692,10 @@ export const OneOfMessage = {
   },
 
   fromJSON(object: any): OneOfMessage {
-    const message = createBaseOneOfMessage();
-    message.first = isSet(object.first) ? String(object.first) : undefined;
-    message.last = isSet(object.last) ? String(object.last) : undefined;
-    return message;
+    return {
+      first: isSet(object.first) ? String(object.first) : undefined,
+      last: isSet(object.last) ? String(object.last) : undefined,
+    };
   },
 
   toJSON(message: OneOfMessage): unknown {
@@ -768,13 +768,13 @@ export const SimpleWithWrappers = {
   },
 
   fromJSON(object: any): SimpleWithWrappers {
-    const message = createBaseSimpleWithWrappers();
-    message.name = isSet(object.name) ? String(object.name) : undefined;
-    message.age = isSet(object.age) ? Number(object.age) : undefined;
-    message.enabled = isSet(object.enabled) ? Boolean(object.enabled) : undefined;
-    message.coins = Array.isArray(object?.coins) ? object.coins.map((e: any) => Number(e)) : [];
-    message.snacks = Array.isArray(object?.snacks) ? object.snacks.map((e: any) => String(e)) : [];
-    return message;
+    return {
+      name: isSet(object.name) ? String(object.name) : undefined,
+      age: isSet(object.age) ? Number(object.age) : undefined,
+      enabled: isSet(object.enabled) ? Boolean(object.enabled) : undefined,
+      coins: Array.isArray(object?.coins) ? object.coins.map((e: any) => Number(e)) : [],
+      snacks: Array.isArray(object?.snacks) ? object.snacks.map((e: any) => String(e)) : [],
+    };
   },
 
   toJSON(message: SimpleWithWrappers): unknown {
@@ -837,9 +837,9 @@ export const Entity = {
   },
 
   fromJSON(object: any): Entity {
-    const message = createBaseEntity();
-    message.id = isSet(object.id) ? Number(object.id) : 0;
-    return message;
+    return {
+      id: isSet(object.id) ? Number(object.id) : 0,
+    };
   },
 
   toJSON(message: Entity): unknown {
@@ -907,29 +907,26 @@ export const SimpleWithMap = {
   },
 
   fromJSON(object: any): SimpleWithMap {
-    const message = createBaseSimpleWithMap();
-    message.entitiesById = Object.entries(object.entitiesById ?? {}).reduce<{ [key: number]: Entity }>(
-      (acc, [key, value]) => {
-        acc[Number(key)] = Entity.fromJSON(value);
-        return acc;
-      },
-      {}
-    );
-    message.nameLookup = Object.entries(object.nameLookup ?? {}).reduce<{ [key: string]: string }>(
-      (acc, [key, value]) => {
-        acc[key] = String(value);
-        return acc;
-      },
-      {}
-    );
-    message.intLookup = Object.entries(object.intLookup ?? {}).reduce<{ [key: number]: number }>(
-      (acc, [key, value]) => {
-        acc[Number(key)] = Number(value);
-        return acc;
-      },
-      {}
-    );
-    return message;
+    return {
+      entitiesById: isObject(object.entitiesById)
+        ? Object.entries(object.entitiesById).reduce<{ [key: number]: Entity }>((acc, [key, value]) => {
+            acc[Number(key)] = Entity.fromJSON(value);
+            return acc;
+          }, {})
+        : {},
+      nameLookup: isObject(object.nameLookup)
+        ? Object.entries(object.nameLookup).reduce<{ [key: string]: string }>((acc, [key, value]) => {
+            acc[key] = String(value);
+            return acc;
+          }, {})
+        : {},
+      intLookup: isObject(object.intLookup)
+        ? Object.entries(object.intLookup).reduce<{ [key: number]: number }>((acc, [key, value]) => {
+            acc[Number(key)] = Number(value);
+            return acc;
+          }, {})
+        : {},
+    };
   },
 
   toJSON(message: SimpleWithMap): unknown {
@@ -1025,10 +1022,10 @@ export const SimpleWithMap_EntitiesByIdEntry = {
   },
 
   fromJSON(object: any): SimpleWithMap_EntitiesByIdEntry {
-    const message = createBaseSimpleWithMap_EntitiesByIdEntry();
-    message.key = isSet(object.key) ? Number(object.key) : 0;
-    message.value = isSet(object.value) ? Entity.fromJSON(object.value) : undefined;
-    return message;
+    return {
+      key: isSet(object.key) ? Number(object.key) : 0,
+      value: isSet(object.value) ? Entity.fromJSON(object.value) : undefined,
+    };
   },
 
   toJSON(message: SimpleWithMap_EntitiesByIdEntry): unknown {
@@ -1085,10 +1082,10 @@ export const SimpleWithMap_NameLookupEntry = {
   },
 
   fromJSON(object: any): SimpleWithMap_NameLookupEntry {
-    const message = createBaseSimpleWithMap_NameLookupEntry();
-    message.key = isSet(object.key) ? String(object.key) : '';
-    message.value = isSet(object.value) ? String(object.value) : '';
-    return message;
+    return {
+      key: isSet(object.key) ? String(object.key) : '',
+      value: isSet(object.value) ? String(object.value) : '',
+    };
   },
 
   toJSON(message: SimpleWithMap_NameLookupEntry): unknown {
@@ -1145,10 +1142,10 @@ export const SimpleWithMap_IntLookupEntry = {
   },
 
   fromJSON(object: any): SimpleWithMap_IntLookupEntry {
-    const message = createBaseSimpleWithMap_IntLookupEntry();
-    message.key = isSet(object.key) ? Number(object.key) : 0;
-    message.value = isSet(object.value) ? Number(object.value) : 0;
-    return message;
+    return {
+      key: isSet(object.key) ? Number(object.key) : 0,
+      value: isSet(object.value) ? Number(object.value) : 0,
+    };
   },
 
   toJSON(message: SimpleWithMap_IntLookupEntry): unknown {
@@ -1200,15 +1197,14 @@ export const SimpleWithSnakeCaseMap = {
   },
 
   fromJSON(object: any): SimpleWithSnakeCaseMap {
-    const message = createBaseSimpleWithSnakeCaseMap();
-    message.entitiesById = Object.entries(object.entitiesById ?? {}).reduce<{ [key: number]: Entity }>(
-      (acc, [key, value]) => {
-        acc[Number(key)] = Entity.fromJSON(value);
-        return acc;
-      },
-      {}
-    );
-    return message;
+    return {
+      entitiesById: isObject(object.entitiesById)
+        ? Object.entries(object.entitiesById).reduce<{ [key: number]: Entity }>((acc, [key, value]) => {
+            acc[Number(key)] = Entity.fromJSON(value);
+            return acc;
+          }, {})
+        : {},
+    };
   },
 
   toJSON(message: SimpleWithSnakeCaseMap): unknown {
@@ -1274,10 +1270,10 @@ export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
   },
 
   fromJSON(object: any): SimpleWithSnakeCaseMap_EntitiesByIdEntry {
-    const message = createBaseSimpleWithSnakeCaseMap_EntitiesByIdEntry();
-    message.key = isSet(object.key) ? Number(object.key) : 0;
-    message.value = isSet(object.value) ? Entity.fromJSON(object.value) : undefined;
-    return message;
+    return {
+      key: isSet(object.key) ? Number(object.key) : 0,
+      value: isSet(object.value) ? Entity.fromJSON(object.value) : undefined,
+    };
   },
 
   toJSON(message: SimpleWithSnakeCaseMap_EntitiesByIdEntry): unknown {
@@ -1328,9 +1324,9 @@ export const PingRequest = {
   },
 
   fromJSON(object: any): PingRequest {
-    const message = createBasePingRequest();
-    message.input = isSet(object.input) ? String(object.input) : '';
-    return message;
+    return {
+      input: isSet(object.input) ? String(object.input) : '',
+    };
   },
 
   toJSON(message: PingRequest): unknown {
@@ -1377,9 +1373,9 @@ export const PingResponse = {
   },
 
   fromJSON(object: any): PingResponse {
-    const message = createBasePingResponse();
-    message.output = isSet(object.output) ? String(object.output) : '';
-    return message;
+    return {
+      output: isSet(object.output) ? String(object.output) : '',
+    };
   },
 
   toJSON(message: PingResponse): unknown {
@@ -1505,20 +1501,20 @@ export const Numbers = {
   },
 
   fromJSON(object: any): Numbers {
-    const message = createBaseNumbers();
-    message.double = isSet(object.double) ? Number(object.double) : 0;
-    message.float = isSet(object.float) ? Number(object.float) : 0;
-    message.int32 = isSet(object.int32) ? Number(object.int32) : 0;
-    message.int64 = isSet(object.int64) ? Number(object.int64) : 0;
-    message.uint32 = isSet(object.uint32) ? Number(object.uint32) : 0;
-    message.uint64 = isSet(object.uint64) ? Number(object.uint64) : 0;
-    message.sint32 = isSet(object.sint32) ? Number(object.sint32) : 0;
-    message.sint64 = isSet(object.sint64) ? Number(object.sint64) : 0;
-    message.fixed32 = isSet(object.fixed32) ? Number(object.fixed32) : 0;
-    message.fixed64 = isSet(object.fixed64) ? Number(object.fixed64) : 0;
-    message.sfixed32 = isSet(object.sfixed32) ? Number(object.sfixed32) : 0;
-    message.sfixed64 = isSet(object.sfixed64) ? Number(object.sfixed64) : 0;
-    return message;
+    return {
+      double: isSet(object.double) ? Number(object.double) : 0,
+      float: isSet(object.float) ? Number(object.float) : 0,
+      int32: isSet(object.int32) ? Number(object.int32) : 0,
+      int64: isSet(object.int64) ? Number(object.int64) : 0,
+      uint32: isSet(object.uint32) ? Number(object.uint32) : 0,
+      uint64: isSet(object.uint64) ? Number(object.uint64) : 0,
+      sint32: isSet(object.sint32) ? Number(object.sint32) : 0,
+      sint64: isSet(object.sint64) ? Number(object.sint64) : 0,
+      fixed32: isSet(object.fixed32) ? Number(object.fixed32) : 0,
+      fixed64: isSet(object.fixed64) ? Number(object.fixed64) : 0,
+      sfixed32: isSet(object.sfixed32) ? Number(object.sfixed32) : 0,
+      sfixed64: isSet(object.sfixed64) ? Number(object.sfixed64) : 0,
+    };
   },
 
   toJSON(message: Numbers): unknown {
@@ -1639,6 +1635,10 @@ function longToNumber(long: Long): number {
 if (util.Long !== Long) {
   util.Long = Long as any;
   configure();
+}
+
+function isObject(value: any): boolean {
+  return typeof value === 'object' && value !== null;
 }
 
 function isSet(value: any): boolean {

--- a/integration/simple-optionals/thing.ts
+++ b/integration/simple-optionals/thing.ts
@@ -40,9 +40,9 @@ export const ImportedThing = {
   },
 
   fromJSON(object: any): ImportedThing {
-    const message = createBaseImportedThing();
-    message.createdAt = isSet(object.createdAt) ? fromJsonTimestamp(object.createdAt) : undefined;
-    return message;
+    return {
+      createdAt: isSet(object.createdAt) ? fromJsonTimestamp(object.createdAt) : undefined,
+    };
   },
 
   toJSON(message: ImportedThing): unknown {

--- a/integration/simple-proto2/simple.ts
+++ b/integration/simple-proto2/simple.ts
@@ -71,9 +71,9 @@ export const Issue56 = {
   },
 
   fromJSON(object: any): Issue56 {
-    const message = createBaseIssue56();
-    message.test = isSet(object.test) ? enumWithoutZeroFromJSON(object.test) : 1;
-    return message;
+    return {
+      test: isSet(object.test) ? enumWithoutZeroFromJSON(object.test) : 1,
+    };
   },
 
   toJSON(message: Issue56): unknown {

--- a/integration/simple-snake/google/protobuf/timestamp.ts
+++ b/integration/simple-snake/google/protobuf/timestamp.ts
@@ -150,10 +150,10 @@ export const Timestamp = {
   },
 
   fromJSON(object: any): Timestamp {
-    const message = createBaseTimestamp();
-    message.seconds = isSet(object.seconds) ? Number(object.seconds) : 0;
-    message.nanos = isSet(object.nanos) ? Number(object.nanos) : 0;
-    return message;
+    return {
+      seconds: isSet(object.seconds) ? Number(object.seconds) : 0,
+      nanos: isSet(object.nanos) ? Number(object.nanos) : 0,
+    };
   },
 
   toJSON(message: Timestamp): unknown {

--- a/integration/simple-snake/google/protobuf/wrappers.ts
+++ b/integration/simple-snake/google/protobuf/wrappers.ts
@@ -125,9 +125,9 @@ export const DoubleValue = {
   },
 
   fromJSON(object: any): DoubleValue {
-    const message = createBaseDoubleValue();
-    message.value = isSet(object.value) ? Number(object.value) : 0;
-    return message;
+    return {
+      value: isSet(object.value) ? Number(object.value) : 0,
+    };
   },
 
   toJSON(message: DoubleValue): unknown {
@@ -174,9 +174,9 @@ export const FloatValue = {
   },
 
   fromJSON(object: any): FloatValue {
-    const message = createBaseFloatValue();
-    message.value = isSet(object.value) ? Number(object.value) : 0;
-    return message;
+    return {
+      value: isSet(object.value) ? Number(object.value) : 0,
+    };
   },
 
   toJSON(message: FloatValue): unknown {
@@ -223,9 +223,9 @@ export const Int64Value = {
   },
 
   fromJSON(object: any): Int64Value {
-    const message = createBaseInt64Value();
-    message.value = isSet(object.value) ? Number(object.value) : 0;
-    return message;
+    return {
+      value: isSet(object.value) ? Number(object.value) : 0,
+    };
   },
 
   toJSON(message: Int64Value): unknown {
@@ -272,9 +272,9 @@ export const UInt64Value = {
   },
 
   fromJSON(object: any): UInt64Value {
-    const message = createBaseUInt64Value();
-    message.value = isSet(object.value) ? Number(object.value) : 0;
-    return message;
+    return {
+      value: isSet(object.value) ? Number(object.value) : 0,
+    };
   },
 
   toJSON(message: UInt64Value): unknown {
@@ -321,9 +321,9 @@ export const Int32Value = {
   },
 
   fromJSON(object: any): Int32Value {
-    const message = createBaseInt32Value();
-    message.value = isSet(object.value) ? Number(object.value) : 0;
-    return message;
+    return {
+      value: isSet(object.value) ? Number(object.value) : 0,
+    };
   },
 
   toJSON(message: Int32Value): unknown {
@@ -370,9 +370,9 @@ export const UInt32Value = {
   },
 
   fromJSON(object: any): UInt32Value {
-    const message = createBaseUInt32Value();
-    message.value = isSet(object.value) ? Number(object.value) : 0;
-    return message;
+    return {
+      value: isSet(object.value) ? Number(object.value) : 0,
+    };
   },
 
   toJSON(message: UInt32Value): unknown {
@@ -419,9 +419,9 @@ export const BoolValue = {
   },
 
   fromJSON(object: any): BoolValue {
-    const message = createBaseBoolValue();
-    message.value = isSet(object.value) ? Boolean(object.value) : false;
-    return message;
+    return {
+      value: isSet(object.value) ? Boolean(object.value) : false,
+    };
   },
 
   toJSON(message: BoolValue): unknown {
@@ -468,9 +468,9 @@ export const StringValue = {
   },
 
   fromJSON(object: any): StringValue {
-    const message = createBaseStringValue();
-    message.value = isSet(object.value) ? String(object.value) : '';
-    return message;
+    return {
+      value: isSet(object.value) ? String(object.value) : '',
+    };
   },
 
   toJSON(message: StringValue): unknown {
@@ -517,9 +517,9 @@ export const BytesValue = {
   },
 
   fromJSON(object: any): BytesValue {
-    const message = createBaseBytesValue();
-    message.value = isSet(object.value) ? bytesFromBase64(object.value) : new Uint8Array();
-    return message;
+    return {
+      value: isSet(object.value) ? bytesFromBase64(object.value) : new Uint8Array(),
+    };
   },
 
   toJSON(message: BytesValue): unknown {

--- a/integration/simple-snake/import_dir/thing.ts
+++ b/integration/simple-snake/import_dir/thing.ts
@@ -40,9 +40,9 @@ export const ImportedThing = {
   },
 
   fromJSON(object: any): ImportedThing {
-    const message = createBaseImportedThing();
-    message.created_at = isSet(object.created_at) ? fromJsonTimestamp(object.created_at) : undefined;
-    return message;
+    return {
+      created_at: isSet(object.created_at) ? fromJsonTimestamp(object.created_at) : undefined,
+    };
   },
 
   toJSON(message: ImportedThing): unknown {

--- a/integration/simple-snake/simple.ts
+++ b/integration/simple-snake/simple.ts
@@ -349,22 +349,20 @@ export const Simple = {
   },
 
   fromJSON(object: any): Simple {
-    const message = createBaseSimple();
-    message.name = isSet(object.name) ? String(object.name) : '';
-    message.age = isSet(object.age) ? Number(object.age) : 0;
-    message.created_at = isSet(object.created_at) ? fromJsonTimestamp(object.created_at) : undefined;
-    message.child = isSet(object.child) ? Child.fromJSON(object.child) : undefined;
-    message.state = isSet(object.state) ? stateEnumFromJSON(object.state) : 0;
-    message.grand_children = Array.isArray(object?.grand_children)
-      ? object.grand_children.map((e: any) => Child.fromJSON(e))
-      : [];
-    message.coins = Array.isArray(object?.coins) ? object.coins.map((e: any) => Number(e)) : [];
-    message.snacks = Array.isArray(object?.snacks) ? object.snacks.map((e: any) => String(e)) : [];
-    message.old_states = Array.isArray(object?.old_states)
-      ? object.old_states.map((e: any) => stateEnumFromJSON(e))
-      : [];
-    message.thing = isSet(object.thing) ? ImportedThing.fromJSON(object.thing) : undefined;
-    return message;
+    return {
+      name: isSet(object.name) ? String(object.name) : '',
+      age: isSet(object.age) ? Number(object.age) : 0,
+      created_at: isSet(object.created_at) ? fromJsonTimestamp(object.created_at) : undefined,
+      child: isSet(object.child) ? Child.fromJSON(object.child) : undefined,
+      state: isSet(object.state) ? stateEnumFromJSON(object.state) : 0,
+      grand_children: Array.isArray(object?.grand_children)
+        ? object.grand_children.map((e: any) => Child.fromJSON(e))
+        : [],
+      coins: Array.isArray(object?.coins) ? object.coins.map((e: any) => Number(e)) : [],
+      snacks: Array.isArray(object?.snacks) ? object.snacks.map((e: any) => String(e)) : [],
+      old_states: Array.isArray(object?.old_states) ? object.old_states.map((e: any) => stateEnumFromJSON(e)) : [],
+      thing: isSet(object.thing) ? ImportedThing.fromJSON(object.thing) : undefined,
+    };
   },
 
   toJSON(message: Simple): unknown {
@@ -452,10 +450,10 @@ export const Child = {
   },
 
   fromJSON(object: any): Child {
-    const message = createBaseChild();
-    message.name = isSet(object.name) ? String(object.name) : '';
-    message.type = isSet(object.type) ? child_TypeFromJSON(object.type) : 0;
-    return message;
+    return {
+      name: isSet(object.name) ? String(object.name) : '',
+      type: isSet(object.type) ? child_TypeFromJSON(object.type) : 0,
+    };
   },
 
   toJSON(message: Child): unknown {
@@ -516,11 +514,11 @@ export const Nested = {
   },
 
   fromJSON(object: any): Nested {
-    const message = createBaseNested();
-    message.name = isSet(object.name) ? String(object.name) : '';
-    message.message = isSet(object.message) ? Nested_InnerMessage.fromJSON(object.message) : undefined;
-    message.state = isSet(object.state) ? nested_InnerEnumFromJSON(object.state) : 0;
-    return message;
+    return {
+      name: isSet(object.name) ? String(object.name) : '',
+      message: isSet(object.message) ? Nested_InnerMessage.fromJSON(object.message) : undefined,
+      state: isSet(object.state) ? nested_InnerEnumFromJSON(object.state) : 0,
+    };
   },
 
   toJSON(message: Nested): unknown {
@@ -581,10 +579,10 @@ export const Nested_InnerMessage = {
   },
 
   fromJSON(object: any): Nested_InnerMessage {
-    const message = createBaseNested_InnerMessage();
-    message.name = isSet(object.name) ? String(object.name) : '';
-    message.deep = isSet(object.deep) ? Nested_InnerMessage_DeepMessage.fromJSON(object.deep) : undefined;
-    return message;
+    return {
+      name: isSet(object.name) ? String(object.name) : '',
+      deep: isSet(object.deep) ? Nested_InnerMessage_DeepMessage.fromJSON(object.deep) : undefined,
+    };
   },
 
   toJSON(message: Nested_InnerMessage): unknown {
@@ -637,9 +635,9 @@ export const Nested_InnerMessage_DeepMessage = {
   },
 
   fromJSON(object: any): Nested_InnerMessage_DeepMessage {
-    const message = createBaseNested_InnerMessage_DeepMessage();
-    message.name = isSet(object.name) ? String(object.name) : '';
-    return message;
+    return {
+      name: isSet(object.name) ? String(object.name) : '',
+    };
   },
 
   toJSON(message: Nested_InnerMessage_DeepMessage): unknown {
@@ -694,10 +692,10 @@ export const OneOfMessage = {
   },
 
   fromJSON(object: any): OneOfMessage {
-    const message = createBaseOneOfMessage();
-    message.first = isSet(object.first) ? String(object.first) : undefined;
-    message.last = isSet(object.last) ? String(object.last) : undefined;
-    return message;
+    return {
+      first: isSet(object.first) ? String(object.first) : undefined,
+      last: isSet(object.last) ? String(object.last) : undefined,
+    };
   },
 
   toJSON(message: OneOfMessage): unknown {
@@ -770,13 +768,13 @@ export const SimpleWithWrappers = {
   },
 
   fromJSON(object: any): SimpleWithWrappers {
-    const message = createBaseSimpleWithWrappers();
-    message.name = isSet(object.name) ? String(object.name) : undefined;
-    message.age = isSet(object.age) ? Number(object.age) : undefined;
-    message.enabled = isSet(object.enabled) ? Boolean(object.enabled) : undefined;
-    message.coins = Array.isArray(object?.coins) ? object.coins.map((e: any) => Number(e)) : [];
-    message.snacks = Array.isArray(object?.snacks) ? object.snacks.map((e: any) => String(e)) : [];
-    return message;
+    return {
+      name: isSet(object.name) ? String(object.name) : undefined,
+      age: isSet(object.age) ? Number(object.age) : undefined,
+      enabled: isSet(object.enabled) ? Boolean(object.enabled) : undefined,
+      coins: Array.isArray(object?.coins) ? object.coins.map((e: any) => Number(e)) : [],
+      snacks: Array.isArray(object?.snacks) ? object.snacks.map((e: any) => String(e)) : [],
+    };
   },
 
   toJSON(message: SimpleWithWrappers): unknown {
@@ -839,9 +837,9 @@ export const Entity = {
   },
 
   fromJSON(object: any): Entity {
-    const message = createBaseEntity();
-    message.id = isSet(object.id) ? Number(object.id) : 0;
-    return message;
+    return {
+      id: isSet(object.id) ? Number(object.id) : 0,
+    };
   },
 
   toJSON(message: Entity): unknown {
@@ -909,29 +907,26 @@ export const SimpleWithMap = {
   },
 
   fromJSON(object: any): SimpleWithMap {
-    const message = createBaseSimpleWithMap();
-    message.entitiesById = Object.entries(object.entitiesById ?? {}).reduce<{ [key: number]: Entity }>(
-      (acc, [key, value]) => {
-        acc[Number(key)] = Entity.fromJSON(value);
-        return acc;
-      },
-      {}
-    );
-    message.nameLookup = Object.entries(object.nameLookup ?? {}).reduce<{ [key: string]: string }>(
-      (acc, [key, value]) => {
-        acc[key] = String(value);
-        return acc;
-      },
-      {}
-    );
-    message.intLookup = Object.entries(object.intLookup ?? {}).reduce<{ [key: number]: number }>(
-      (acc, [key, value]) => {
-        acc[Number(key)] = Number(value);
-        return acc;
-      },
-      {}
-    );
-    return message;
+    return {
+      entitiesById: isObject(object.entitiesById)
+        ? Object.entries(object.entitiesById).reduce<{ [key: number]: Entity }>((acc, [key, value]) => {
+            acc[Number(key)] = Entity.fromJSON(value);
+            return acc;
+          }, {})
+        : {},
+      nameLookup: isObject(object.nameLookup)
+        ? Object.entries(object.nameLookup).reduce<{ [key: string]: string }>((acc, [key, value]) => {
+            acc[key] = String(value);
+            return acc;
+          }, {})
+        : {},
+      intLookup: isObject(object.intLookup)
+        ? Object.entries(object.intLookup).reduce<{ [key: number]: number }>((acc, [key, value]) => {
+            acc[Number(key)] = Number(value);
+            return acc;
+          }, {})
+        : {},
+    };
   },
 
   toJSON(message: SimpleWithMap): unknown {
@@ -1027,10 +1022,10 @@ export const SimpleWithMap_EntitiesByIdEntry = {
   },
 
   fromJSON(object: any): SimpleWithMap_EntitiesByIdEntry {
-    const message = createBaseSimpleWithMap_EntitiesByIdEntry();
-    message.key = isSet(object.key) ? Number(object.key) : 0;
-    message.value = isSet(object.value) ? Entity.fromJSON(object.value) : undefined;
-    return message;
+    return {
+      key: isSet(object.key) ? Number(object.key) : 0,
+      value: isSet(object.value) ? Entity.fromJSON(object.value) : undefined,
+    };
   },
 
   toJSON(message: SimpleWithMap_EntitiesByIdEntry): unknown {
@@ -1087,10 +1082,10 @@ export const SimpleWithMap_NameLookupEntry = {
   },
 
   fromJSON(object: any): SimpleWithMap_NameLookupEntry {
-    const message = createBaseSimpleWithMap_NameLookupEntry();
-    message.key = isSet(object.key) ? String(object.key) : '';
-    message.value = isSet(object.value) ? String(object.value) : '';
-    return message;
+    return {
+      key: isSet(object.key) ? String(object.key) : '',
+      value: isSet(object.value) ? String(object.value) : '',
+    };
   },
 
   toJSON(message: SimpleWithMap_NameLookupEntry): unknown {
@@ -1147,10 +1142,10 @@ export const SimpleWithMap_IntLookupEntry = {
   },
 
   fromJSON(object: any): SimpleWithMap_IntLookupEntry {
-    const message = createBaseSimpleWithMap_IntLookupEntry();
-    message.key = isSet(object.key) ? Number(object.key) : 0;
-    message.value = isSet(object.value) ? Number(object.value) : 0;
-    return message;
+    return {
+      key: isSet(object.key) ? Number(object.key) : 0,
+      value: isSet(object.value) ? Number(object.value) : 0,
+    };
   },
 
   toJSON(message: SimpleWithMap_IntLookupEntry): unknown {
@@ -1202,15 +1197,14 @@ export const SimpleWithSnakeCaseMap = {
   },
 
   fromJSON(object: any): SimpleWithSnakeCaseMap {
-    const message = createBaseSimpleWithSnakeCaseMap();
-    message.entities_by_id = Object.entries(object.entities_by_id ?? {}).reduce<{ [key: number]: Entity }>(
-      (acc, [key, value]) => {
-        acc[Number(key)] = Entity.fromJSON(value);
-        return acc;
-      },
-      {}
-    );
-    return message;
+    return {
+      entities_by_id: isObject(object.entities_by_id)
+        ? Object.entries(object.entities_by_id).reduce<{ [key: number]: Entity }>((acc, [key, value]) => {
+            acc[Number(key)] = Entity.fromJSON(value);
+            return acc;
+          }, {})
+        : {},
+    };
   },
 
   toJSON(message: SimpleWithSnakeCaseMap): unknown {
@@ -1276,10 +1270,10 @@ export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
   },
 
   fromJSON(object: any): SimpleWithSnakeCaseMap_EntitiesByIdEntry {
-    const message = createBaseSimpleWithSnakeCaseMap_EntitiesByIdEntry();
-    message.key = isSet(object.key) ? Number(object.key) : 0;
-    message.value = isSet(object.value) ? Entity.fromJSON(object.value) : undefined;
-    return message;
+    return {
+      key: isSet(object.key) ? Number(object.key) : 0,
+      value: isSet(object.value) ? Entity.fromJSON(object.value) : undefined,
+    };
   },
 
   toJSON(message: SimpleWithSnakeCaseMap_EntitiesByIdEntry): unknown {
@@ -1330,9 +1324,9 @@ export const PingRequest = {
   },
 
   fromJSON(object: any): PingRequest {
-    const message = createBasePingRequest();
-    message.input = isSet(object.input) ? String(object.input) : '';
-    return message;
+    return {
+      input: isSet(object.input) ? String(object.input) : '',
+    };
   },
 
   toJSON(message: PingRequest): unknown {
@@ -1379,9 +1373,9 @@ export const PingResponse = {
   },
 
   fromJSON(object: any): PingResponse {
-    const message = createBasePingResponse();
-    message.output = isSet(object.output) ? String(object.output) : '';
-    return message;
+    return {
+      output: isSet(object.output) ? String(object.output) : '',
+    };
   },
 
   toJSON(message: PingResponse): unknown {
@@ -1507,20 +1501,20 @@ export const Numbers = {
   },
 
   fromJSON(object: any): Numbers {
-    const message = createBaseNumbers();
-    message.double = isSet(object.double) ? Number(object.double) : 0;
-    message.float = isSet(object.float) ? Number(object.float) : 0;
-    message.int32 = isSet(object.int32) ? Number(object.int32) : 0;
-    message.int64 = isSet(object.int64) ? Number(object.int64) : 0;
-    message.uint32 = isSet(object.uint32) ? Number(object.uint32) : 0;
-    message.uint64 = isSet(object.uint64) ? Number(object.uint64) : 0;
-    message.sint32 = isSet(object.sint32) ? Number(object.sint32) : 0;
-    message.sint64 = isSet(object.sint64) ? Number(object.sint64) : 0;
-    message.fixed32 = isSet(object.fixed32) ? Number(object.fixed32) : 0;
-    message.fixed64 = isSet(object.fixed64) ? Number(object.fixed64) : 0;
-    message.sfixed32 = isSet(object.sfixed32) ? Number(object.sfixed32) : 0;
-    message.sfixed64 = isSet(object.sfixed64) ? Number(object.sfixed64) : 0;
-    return message;
+    return {
+      double: isSet(object.double) ? Number(object.double) : 0,
+      float: isSet(object.float) ? Number(object.float) : 0,
+      int32: isSet(object.int32) ? Number(object.int32) : 0,
+      int64: isSet(object.int64) ? Number(object.int64) : 0,
+      uint32: isSet(object.uint32) ? Number(object.uint32) : 0,
+      uint64: isSet(object.uint64) ? Number(object.uint64) : 0,
+      sint32: isSet(object.sint32) ? Number(object.sint32) : 0,
+      sint64: isSet(object.sint64) ? Number(object.sint64) : 0,
+      fixed32: isSet(object.fixed32) ? Number(object.fixed32) : 0,
+      fixed64: isSet(object.fixed64) ? Number(object.fixed64) : 0,
+      sfixed32: isSet(object.sfixed32) ? Number(object.sfixed32) : 0,
+      sfixed64: isSet(object.sfixed64) ? Number(object.sfixed64) : 0,
+    };
   },
 
   toJSON(message: Numbers): unknown {
@@ -1641,6 +1635,10 @@ function longToNumber(long: Long): number {
 if (util.Long !== Long) {
   util.Long = Long as any;
   configure();
+}
+
+function isObject(value: any): boolean {
+  return typeof value === 'object' && value !== null;
 }
 
 function isSet(value: any): boolean {

--- a/integration/simple-string-enums/google/protobuf/struct.ts
+++ b/integration/simple-string-enums/google/protobuf/struct.ts
@@ -135,15 +135,14 @@ export const Struct = {
   },
 
   fromJSON(object: any): Struct {
-    const message = createBaseStruct();
-    message.fields = Object.entries(object.fields ?? {}).reduce<{ [key: string]: any | undefined }>(
-      (acc, [key, value]) => {
-        acc[key] = value as any | undefined;
-        return acc;
-      },
-      {}
-    );
-    return message;
+    return {
+      fields: isObject(object.fields)
+        ? Object.entries(object.fields).reduce<{ [key: string]: any | undefined }>((acc, [key, value]) => {
+            acc[key] = value as any | undefined;
+            return acc;
+          }, {})
+        : {},
+    };
   },
 
   toJSON(message: Struct): unknown {
@@ -227,10 +226,10 @@ export const Struct_FieldsEntry = {
   },
 
   fromJSON(object: any): Struct_FieldsEntry {
-    const message = createBaseStruct_FieldsEntry();
-    message.key = isSet(object.key) ? String(object.key) : '';
-    message.value = isSet(object?.value) ? object.value : undefined;
-    return message;
+    return {
+      key: isSet(object.key) ? String(object.key) : '',
+      value: isSet(object?.value) ? object.value : undefined,
+    };
   },
 
   toJSON(message: Struct_FieldsEntry): unknown {
@@ -316,14 +315,14 @@ export const Value = {
   },
 
   fromJSON(object: any): Value {
-    const message = createBaseValue();
-    message.nullValue = isSet(object.nullValue) ? nullValueFromJSON(object.nullValue) : undefined;
-    message.numberValue = isSet(object.numberValue) ? Number(object.numberValue) : undefined;
-    message.stringValue = isSet(object.stringValue) ? String(object.stringValue) : undefined;
-    message.boolValue = isSet(object.boolValue) ? Boolean(object.boolValue) : undefined;
-    message.structValue = isObject(object.structValue) ? object.structValue : undefined;
-    message.listValue = Array.isArray(object.listValue) ? [...object.listValue] : undefined;
-    return message;
+    return {
+      nullValue: isSet(object.nullValue) ? nullValueFromJSON(object.nullValue) : undefined,
+      numberValue: isSet(object.numberValue) ? Number(object.numberValue) : undefined,
+      stringValue: isSet(object.stringValue) ? String(object.stringValue) : undefined,
+      boolValue: isSet(object.boolValue) ? Boolean(object.boolValue) : undefined,
+      structValue: isObject(object.structValue) ? object.structValue : undefined,
+      listValue: Array.isArray(object.listValue) ? [...object.listValue] : undefined,
+    };
   },
 
   toJSON(message: Value): unknown {
@@ -418,9 +417,9 @@ export const ListValue = {
   },
 
   fromJSON(object: any): ListValue {
-    const message = createBaseListValue();
-    message.values = Array.isArray(object?.values) ? [...object.values] : [];
-    return message;
+    return {
+      values: Array.isArray(object?.values) ? [...object.values] : [],
+    };
   },
 
   toJSON(message: ListValue): unknown {

--- a/integration/simple-string-enums/simple.ts
+++ b/integration/simple-string-enums/simple.ts
@@ -121,12 +121,12 @@ export const Simple = {
   },
 
   fromJSON(object: any): Simple {
-    const message = createBaseSimple();
-    message.name = isSet(object.name) ? String(object.name) : '';
-    message.state = isSet(object.state) ? stateEnumFromJSON(object.state) : StateEnum.UNKNOWN;
-    message.states = Array.isArray(object?.states) ? object.states.map((e: any) => stateEnumFromJSON(e)) : [];
-    message.nullValue = isSet(object.nullValue) ? nullValueFromJSON(object.nullValue) : NullValue.NULL_VALUE;
-    return message;
+    return {
+      name: isSet(object.name) ? String(object.name) : '',
+      state: isSet(object.state) ? stateEnumFromJSON(object.state) : StateEnum.UNKNOWN,
+      states: Array.isArray(object?.states) ? object.states.map((e: any) => stateEnumFromJSON(e)) : [],
+      nullValue: isSet(object.nullValue) ? nullValueFromJSON(object.nullValue) : NullValue.NULL_VALUE,
+    };
   },
 
   toJSON(message: Simple): unknown {

--- a/integration/simple-unrecognized-enum/google/protobuf/timestamp.ts
+++ b/integration/simple-unrecognized-enum/google/protobuf/timestamp.ts
@@ -150,10 +150,10 @@ export const Timestamp = {
   },
 
   fromJSON(object: any): Timestamp {
-    const message = createBaseTimestamp();
-    message.seconds = isSet(object.seconds) ? Number(object.seconds) : 0;
-    message.nanos = isSet(object.nanos) ? Number(object.nanos) : 0;
-    return message;
+    return {
+      seconds: isSet(object.seconds) ? Number(object.seconds) : 0,
+      nanos: isSet(object.nanos) ? Number(object.nanos) : 0,
+    };
   },
 
   toJSON(message: Timestamp): unknown {

--- a/integration/simple-unrecognized-enum/google/protobuf/wrappers.ts
+++ b/integration/simple-unrecognized-enum/google/protobuf/wrappers.ts
@@ -125,9 +125,9 @@ export const DoubleValue = {
   },
 
   fromJSON(object: any): DoubleValue {
-    const message = createBaseDoubleValue();
-    message.value = isSet(object.value) ? Number(object.value) : 0;
-    return message;
+    return {
+      value: isSet(object.value) ? Number(object.value) : 0,
+    };
   },
 
   toJSON(message: DoubleValue): unknown {
@@ -174,9 +174,9 @@ export const FloatValue = {
   },
 
   fromJSON(object: any): FloatValue {
-    const message = createBaseFloatValue();
-    message.value = isSet(object.value) ? Number(object.value) : 0;
-    return message;
+    return {
+      value: isSet(object.value) ? Number(object.value) : 0,
+    };
   },
 
   toJSON(message: FloatValue): unknown {
@@ -223,9 +223,9 @@ export const Int64Value = {
   },
 
   fromJSON(object: any): Int64Value {
-    const message = createBaseInt64Value();
-    message.value = isSet(object.value) ? Number(object.value) : 0;
-    return message;
+    return {
+      value: isSet(object.value) ? Number(object.value) : 0,
+    };
   },
 
   toJSON(message: Int64Value): unknown {
@@ -272,9 +272,9 @@ export const UInt64Value = {
   },
 
   fromJSON(object: any): UInt64Value {
-    const message = createBaseUInt64Value();
-    message.value = isSet(object.value) ? Number(object.value) : 0;
-    return message;
+    return {
+      value: isSet(object.value) ? Number(object.value) : 0,
+    };
   },
 
   toJSON(message: UInt64Value): unknown {
@@ -321,9 +321,9 @@ export const Int32Value = {
   },
 
   fromJSON(object: any): Int32Value {
-    const message = createBaseInt32Value();
-    message.value = isSet(object.value) ? Number(object.value) : 0;
-    return message;
+    return {
+      value: isSet(object.value) ? Number(object.value) : 0,
+    };
   },
 
   toJSON(message: Int32Value): unknown {
@@ -370,9 +370,9 @@ export const UInt32Value = {
   },
 
   fromJSON(object: any): UInt32Value {
-    const message = createBaseUInt32Value();
-    message.value = isSet(object.value) ? Number(object.value) : 0;
-    return message;
+    return {
+      value: isSet(object.value) ? Number(object.value) : 0,
+    };
   },
 
   toJSON(message: UInt32Value): unknown {
@@ -419,9 +419,9 @@ export const BoolValue = {
   },
 
   fromJSON(object: any): BoolValue {
-    const message = createBaseBoolValue();
-    message.value = isSet(object.value) ? Boolean(object.value) : false;
-    return message;
+    return {
+      value: isSet(object.value) ? Boolean(object.value) : false,
+    };
   },
 
   toJSON(message: BoolValue): unknown {
@@ -468,9 +468,9 @@ export const StringValue = {
   },
 
   fromJSON(object: any): StringValue {
-    const message = createBaseStringValue();
-    message.value = isSet(object.value) ? String(object.value) : '';
-    return message;
+    return {
+      value: isSet(object.value) ? String(object.value) : '',
+    };
   },
 
   toJSON(message: StringValue): unknown {
@@ -517,9 +517,9 @@ export const BytesValue = {
   },
 
   fromJSON(object: any): BytesValue {
-    const message = createBaseBytesValue();
-    message.value = isSet(object.value) ? bytesFromBase64(object.value) : new Uint8Array();
-    return message;
+    return {
+      value: isSet(object.value) ? bytesFromBase64(object.value) : new Uint8Array(),
+    };
   },
 
   toJSON(message: BytesValue): unknown {

--- a/integration/simple-unrecognized-enum/import_dir/thing.ts
+++ b/integration/simple-unrecognized-enum/import_dir/thing.ts
@@ -40,9 +40,9 @@ export const ImportedThing = {
   },
 
   fromJSON(object: any): ImportedThing {
-    const message = createBaseImportedThing();
-    message.createdAt = isSet(object.createdAt) ? fromJsonTimestamp(object.createdAt) : undefined;
-    return message;
+    return {
+      createdAt: isSet(object.createdAt) ? fromJsonTimestamp(object.createdAt) : undefined,
+    };
   },
 
   toJSON(message: ImportedThing): unknown {

--- a/integration/simple-unrecognized-enum/simple.ts
+++ b/integration/simple-unrecognized-enum/simple.ts
@@ -340,20 +340,20 @@ export const Simple = {
   },
 
   fromJSON(object: any): Simple {
-    const message = createBaseSimple();
-    message.name = isSet(object.name) ? String(object.name) : '';
-    message.age = isSet(object.age) ? Number(object.age) : 0;
-    message.createdAt = isSet(object.createdAt) ? fromJsonTimestamp(object.createdAt) : undefined;
-    message.child = isSet(object.child) ? Child.fromJSON(object.child) : undefined;
-    message.state = isSet(object.state) ? stateEnumFromJSON(object.state) : 0;
-    message.grandChildren = Array.isArray(object?.grandChildren)
-      ? object.grandChildren.map((e: any) => Child.fromJSON(e))
-      : [];
-    message.coins = Array.isArray(object?.coins) ? object.coins.map((e: any) => Number(e)) : [];
-    message.snacks = Array.isArray(object?.snacks) ? object.snacks.map((e: any) => String(e)) : [];
-    message.oldStates = Array.isArray(object?.oldStates) ? object.oldStates.map((e: any) => stateEnumFromJSON(e)) : [];
-    message.thing = isSet(object.thing) ? ImportedThing.fromJSON(object.thing) : undefined;
-    return message;
+    return {
+      name: isSet(object.name) ? String(object.name) : '',
+      age: isSet(object.age) ? Number(object.age) : 0,
+      createdAt: isSet(object.createdAt) ? fromJsonTimestamp(object.createdAt) : undefined,
+      child: isSet(object.child) ? Child.fromJSON(object.child) : undefined,
+      state: isSet(object.state) ? stateEnumFromJSON(object.state) : 0,
+      grandChildren: Array.isArray(object?.grandChildren)
+        ? object.grandChildren.map((e: any) => Child.fromJSON(e))
+        : [],
+      coins: Array.isArray(object?.coins) ? object.coins.map((e: any) => Number(e)) : [],
+      snacks: Array.isArray(object?.snacks) ? object.snacks.map((e: any) => String(e)) : [],
+      oldStates: Array.isArray(object?.oldStates) ? object.oldStates.map((e: any) => stateEnumFromJSON(e)) : [],
+      thing: isSet(object.thing) ? ImportedThing.fromJSON(object.thing) : undefined,
+    };
   },
 
   toJSON(message: Simple): unknown {
@@ -441,10 +441,10 @@ export const Child = {
   },
 
   fromJSON(object: any): Child {
-    const message = createBaseChild();
-    message.name = isSet(object.name) ? String(object.name) : '';
-    message.type = isSet(object.type) ? child_TypeFromJSON(object.type) : 0;
-    return message;
+    return {
+      name: isSet(object.name) ? String(object.name) : '',
+      type: isSet(object.type) ? child_TypeFromJSON(object.type) : 0,
+    };
   },
 
   toJSON(message: Child): unknown {
@@ -505,11 +505,11 @@ export const Nested = {
   },
 
   fromJSON(object: any): Nested {
-    const message = createBaseNested();
-    message.name = isSet(object.name) ? String(object.name) : '';
-    message.message = isSet(object.message) ? Nested_InnerMessage.fromJSON(object.message) : undefined;
-    message.state = isSet(object.state) ? nested_InnerEnumFromJSON(object.state) : 0;
-    return message;
+    return {
+      name: isSet(object.name) ? String(object.name) : '',
+      message: isSet(object.message) ? Nested_InnerMessage.fromJSON(object.message) : undefined,
+      state: isSet(object.state) ? nested_InnerEnumFromJSON(object.state) : 0,
+    };
   },
 
   toJSON(message: Nested): unknown {
@@ -570,10 +570,10 @@ export const Nested_InnerMessage = {
   },
 
   fromJSON(object: any): Nested_InnerMessage {
-    const message = createBaseNested_InnerMessage();
-    message.name = isSet(object.name) ? String(object.name) : '';
-    message.deep = isSet(object.deep) ? Nested_InnerMessage_DeepMessage.fromJSON(object.deep) : undefined;
-    return message;
+    return {
+      name: isSet(object.name) ? String(object.name) : '',
+      deep: isSet(object.deep) ? Nested_InnerMessage_DeepMessage.fromJSON(object.deep) : undefined,
+    };
   },
 
   toJSON(message: Nested_InnerMessage): unknown {
@@ -626,9 +626,9 @@ export const Nested_InnerMessage_DeepMessage = {
   },
 
   fromJSON(object: any): Nested_InnerMessage_DeepMessage {
-    const message = createBaseNested_InnerMessage_DeepMessage();
-    message.name = isSet(object.name) ? String(object.name) : '';
-    return message;
+    return {
+      name: isSet(object.name) ? String(object.name) : '',
+    };
   },
 
   toJSON(message: Nested_InnerMessage_DeepMessage): unknown {
@@ -683,10 +683,10 @@ export const OneOfMessage = {
   },
 
   fromJSON(object: any): OneOfMessage {
-    const message = createBaseOneOfMessage();
-    message.first = isSet(object.first) ? String(object.first) : undefined;
-    message.last = isSet(object.last) ? String(object.last) : undefined;
-    return message;
+    return {
+      first: isSet(object.first) ? String(object.first) : undefined,
+      last: isSet(object.last) ? String(object.last) : undefined,
+    };
   },
 
   toJSON(message: OneOfMessage): unknown {
@@ -759,13 +759,13 @@ export const SimpleWithWrappers = {
   },
 
   fromJSON(object: any): SimpleWithWrappers {
-    const message = createBaseSimpleWithWrappers();
-    message.name = isSet(object.name) ? String(object.name) : undefined;
-    message.age = isSet(object.age) ? Number(object.age) : undefined;
-    message.enabled = isSet(object.enabled) ? Boolean(object.enabled) : undefined;
-    message.coins = Array.isArray(object?.coins) ? object.coins.map((e: any) => Number(e)) : [];
-    message.snacks = Array.isArray(object?.snacks) ? object.snacks.map((e: any) => String(e)) : [];
-    return message;
+    return {
+      name: isSet(object.name) ? String(object.name) : undefined,
+      age: isSet(object.age) ? Number(object.age) : undefined,
+      enabled: isSet(object.enabled) ? Boolean(object.enabled) : undefined,
+      coins: Array.isArray(object?.coins) ? object.coins.map((e: any) => Number(e)) : [],
+      snacks: Array.isArray(object?.snacks) ? object.snacks.map((e: any) => String(e)) : [],
+    };
   },
 
   toJSON(message: SimpleWithWrappers): unknown {
@@ -828,9 +828,9 @@ export const Entity = {
   },
 
   fromJSON(object: any): Entity {
-    const message = createBaseEntity();
-    message.id = isSet(object.id) ? Number(object.id) : 0;
-    return message;
+    return {
+      id: isSet(object.id) ? Number(object.id) : 0,
+    };
   },
 
   toJSON(message: Entity): unknown {
@@ -898,29 +898,26 @@ export const SimpleWithMap = {
   },
 
   fromJSON(object: any): SimpleWithMap {
-    const message = createBaseSimpleWithMap();
-    message.entitiesById = Object.entries(object.entitiesById ?? {}).reduce<{ [key: number]: Entity }>(
-      (acc, [key, value]) => {
-        acc[Number(key)] = Entity.fromJSON(value);
-        return acc;
-      },
-      {}
-    );
-    message.nameLookup = Object.entries(object.nameLookup ?? {}).reduce<{ [key: string]: string }>(
-      (acc, [key, value]) => {
-        acc[key] = String(value);
-        return acc;
-      },
-      {}
-    );
-    message.intLookup = Object.entries(object.intLookup ?? {}).reduce<{ [key: number]: number }>(
-      (acc, [key, value]) => {
-        acc[Number(key)] = Number(value);
-        return acc;
-      },
-      {}
-    );
-    return message;
+    return {
+      entitiesById: isObject(object.entitiesById)
+        ? Object.entries(object.entitiesById).reduce<{ [key: number]: Entity }>((acc, [key, value]) => {
+            acc[Number(key)] = Entity.fromJSON(value);
+            return acc;
+          }, {})
+        : {},
+      nameLookup: isObject(object.nameLookup)
+        ? Object.entries(object.nameLookup).reduce<{ [key: string]: string }>((acc, [key, value]) => {
+            acc[key] = String(value);
+            return acc;
+          }, {})
+        : {},
+      intLookup: isObject(object.intLookup)
+        ? Object.entries(object.intLookup).reduce<{ [key: number]: number }>((acc, [key, value]) => {
+            acc[Number(key)] = Number(value);
+            return acc;
+          }, {})
+        : {},
+    };
   },
 
   toJSON(message: SimpleWithMap): unknown {
@@ -1016,10 +1013,10 @@ export const SimpleWithMap_EntitiesByIdEntry = {
   },
 
   fromJSON(object: any): SimpleWithMap_EntitiesByIdEntry {
-    const message = createBaseSimpleWithMap_EntitiesByIdEntry();
-    message.key = isSet(object.key) ? Number(object.key) : 0;
-    message.value = isSet(object.value) ? Entity.fromJSON(object.value) : undefined;
-    return message;
+    return {
+      key: isSet(object.key) ? Number(object.key) : 0,
+      value: isSet(object.value) ? Entity.fromJSON(object.value) : undefined,
+    };
   },
 
   toJSON(message: SimpleWithMap_EntitiesByIdEntry): unknown {
@@ -1076,10 +1073,10 @@ export const SimpleWithMap_NameLookupEntry = {
   },
 
   fromJSON(object: any): SimpleWithMap_NameLookupEntry {
-    const message = createBaseSimpleWithMap_NameLookupEntry();
-    message.key = isSet(object.key) ? String(object.key) : '';
-    message.value = isSet(object.value) ? String(object.value) : '';
-    return message;
+    return {
+      key: isSet(object.key) ? String(object.key) : '',
+      value: isSet(object.value) ? String(object.value) : '',
+    };
   },
 
   toJSON(message: SimpleWithMap_NameLookupEntry): unknown {
@@ -1136,10 +1133,10 @@ export const SimpleWithMap_IntLookupEntry = {
   },
 
   fromJSON(object: any): SimpleWithMap_IntLookupEntry {
-    const message = createBaseSimpleWithMap_IntLookupEntry();
-    message.key = isSet(object.key) ? Number(object.key) : 0;
-    message.value = isSet(object.value) ? Number(object.value) : 0;
-    return message;
+    return {
+      key: isSet(object.key) ? Number(object.key) : 0,
+      value: isSet(object.value) ? Number(object.value) : 0,
+    };
   },
 
   toJSON(message: SimpleWithMap_IntLookupEntry): unknown {
@@ -1191,15 +1188,14 @@ export const SimpleWithSnakeCaseMap = {
   },
 
   fromJSON(object: any): SimpleWithSnakeCaseMap {
-    const message = createBaseSimpleWithSnakeCaseMap();
-    message.entitiesById = Object.entries(object.entitiesById ?? {}).reduce<{ [key: number]: Entity }>(
-      (acc, [key, value]) => {
-        acc[Number(key)] = Entity.fromJSON(value);
-        return acc;
-      },
-      {}
-    );
-    return message;
+    return {
+      entitiesById: isObject(object.entitiesById)
+        ? Object.entries(object.entitiesById).reduce<{ [key: number]: Entity }>((acc, [key, value]) => {
+            acc[Number(key)] = Entity.fromJSON(value);
+            return acc;
+          }, {})
+        : {},
+    };
   },
 
   toJSON(message: SimpleWithSnakeCaseMap): unknown {
@@ -1265,10 +1261,10 @@ export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
   },
 
   fromJSON(object: any): SimpleWithSnakeCaseMap_EntitiesByIdEntry {
-    const message = createBaseSimpleWithSnakeCaseMap_EntitiesByIdEntry();
-    message.key = isSet(object.key) ? Number(object.key) : 0;
-    message.value = isSet(object.value) ? Entity.fromJSON(object.value) : undefined;
-    return message;
+    return {
+      key: isSet(object.key) ? Number(object.key) : 0,
+      value: isSet(object.value) ? Entity.fromJSON(object.value) : undefined,
+    };
   },
 
   toJSON(message: SimpleWithSnakeCaseMap_EntitiesByIdEntry): unknown {
@@ -1319,9 +1315,9 @@ export const PingRequest = {
   },
 
   fromJSON(object: any): PingRequest {
-    const message = createBasePingRequest();
-    message.input = isSet(object.input) ? String(object.input) : '';
-    return message;
+    return {
+      input: isSet(object.input) ? String(object.input) : '',
+    };
   },
 
   toJSON(message: PingRequest): unknown {
@@ -1368,9 +1364,9 @@ export const PingResponse = {
   },
 
   fromJSON(object: any): PingResponse {
-    const message = createBasePingResponse();
-    message.output = isSet(object.output) ? String(object.output) : '';
-    return message;
+    return {
+      output: isSet(object.output) ? String(object.output) : '',
+    };
   },
 
   toJSON(message: PingResponse): unknown {
@@ -1496,20 +1492,20 @@ export const Numbers = {
   },
 
   fromJSON(object: any): Numbers {
-    const message = createBaseNumbers();
-    message.double = isSet(object.double) ? Number(object.double) : 0;
-    message.float = isSet(object.float) ? Number(object.float) : 0;
-    message.int32 = isSet(object.int32) ? Number(object.int32) : 0;
-    message.int64 = isSet(object.int64) ? Number(object.int64) : 0;
-    message.uint32 = isSet(object.uint32) ? Number(object.uint32) : 0;
-    message.uint64 = isSet(object.uint64) ? Number(object.uint64) : 0;
-    message.sint32 = isSet(object.sint32) ? Number(object.sint32) : 0;
-    message.sint64 = isSet(object.sint64) ? Number(object.sint64) : 0;
-    message.fixed32 = isSet(object.fixed32) ? Number(object.fixed32) : 0;
-    message.fixed64 = isSet(object.fixed64) ? Number(object.fixed64) : 0;
-    message.sfixed32 = isSet(object.sfixed32) ? Number(object.sfixed32) : 0;
-    message.sfixed64 = isSet(object.sfixed64) ? Number(object.sfixed64) : 0;
-    return message;
+    return {
+      double: isSet(object.double) ? Number(object.double) : 0,
+      float: isSet(object.float) ? Number(object.float) : 0,
+      int32: isSet(object.int32) ? Number(object.int32) : 0,
+      int64: isSet(object.int64) ? Number(object.int64) : 0,
+      uint32: isSet(object.uint32) ? Number(object.uint32) : 0,
+      uint64: isSet(object.uint64) ? Number(object.uint64) : 0,
+      sint32: isSet(object.sint32) ? Number(object.sint32) : 0,
+      sint64: isSet(object.sint64) ? Number(object.sint64) : 0,
+      fixed32: isSet(object.fixed32) ? Number(object.fixed32) : 0,
+      fixed64: isSet(object.fixed64) ? Number(object.fixed64) : 0,
+      sfixed32: isSet(object.sfixed32) ? Number(object.sfixed32) : 0,
+      sfixed64: isSet(object.sfixed64) ? Number(object.sfixed64) : 0,
+    };
   },
 
   toJSON(message: Numbers): unknown {
@@ -1630,6 +1626,10 @@ function longToNumber(long: Long): number {
 if (util.Long !== Long) {
   util.Long = Long as any;
   configure();
+}
+
+function isObject(value: any): boolean {
+  return typeof value === 'object' && value !== null;
 }
 
 function isSet(value: any): boolean {

--- a/integration/simple/google/protobuf/timestamp.ts
+++ b/integration/simple/google/protobuf/timestamp.ts
@@ -150,10 +150,10 @@ export const Timestamp = {
   },
 
   fromJSON(object: any): Timestamp {
-    const message = createBaseTimestamp();
-    message.seconds = isSet(object.seconds) ? Number(object.seconds) : 0;
-    message.nanos = isSet(object.nanos) ? Number(object.nanos) : 0;
-    return message;
+    return {
+      seconds: isSet(object.seconds) ? Number(object.seconds) : 0,
+      nanos: isSet(object.nanos) ? Number(object.nanos) : 0,
+    };
   },
 
   toJSON(message: Timestamp): unknown {

--- a/integration/simple/google/protobuf/wrappers.ts
+++ b/integration/simple/google/protobuf/wrappers.ts
@@ -125,9 +125,9 @@ export const DoubleValue = {
   },
 
   fromJSON(object: any): DoubleValue {
-    const message = createBaseDoubleValue();
-    message.value = isSet(object.value) ? Number(object.value) : 0;
-    return message;
+    return {
+      value: isSet(object.value) ? Number(object.value) : 0,
+    };
   },
 
   toJSON(message: DoubleValue): unknown {
@@ -174,9 +174,9 @@ export const FloatValue = {
   },
 
   fromJSON(object: any): FloatValue {
-    const message = createBaseFloatValue();
-    message.value = isSet(object.value) ? Number(object.value) : 0;
-    return message;
+    return {
+      value: isSet(object.value) ? Number(object.value) : 0,
+    };
   },
 
   toJSON(message: FloatValue): unknown {
@@ -223,9 +223,9 @@ export const Int64Value = {
   },
 
   fromJSON(object: any): Int64Value {
-    const message = createBaseInt64Value();
-    message.value = isSet(object.value) ? Number(object.value) : 0;
-    return message;
+    return {
+      value: isSet(object.value) ? Number(object.value) : 0,
+    };
   },
 
   toJSON(message: Int64Value): unknown {
@@ -272,9 +272,9 @@ export const UInt64Value = {
   },
 
   fromJSON(object: any): UInt64Value {
-    const message = createBaseUInt64Value();
-    message.value = isSet(object.value) ? Number(object.value) : 0;
-    return message;
+    return {
+      value: isSet(object.value) ? Number(object.value) : 0,
+    };
   },
 
   toJSON(message: UInt64Value): unknown {
@@ -321,9 +321,9 @@ export const Int32Value = {
   },
 
   fromJSON(object: any): Int32Value {
-    const message = createBaseInt32Value();
-    message.value = isSet(object.value) ? Number(object.value) : 0;
-    return message;
+    return {
+      value: isSet(object.value) ? Number(object.value) : 0,
+    };
   },
 
   toJSON(message: Int32Value): unknown {
@@ -370,9 +370,9 @@ export const UInt32Value = {
   },
 
   fromJSON(object: any): UInt32Value {
-    const message = createBaseUInt32Value();
-    message.value = isSet(object.value) ? Number(object.value) : 0;
-    return message;
+    return {
+      value: isSet(object.value) ? Number(object.value) : 0,
+    };
   },
 
   toJSON(message: UInt32Value): unknown {
@@ -419,9 +419,9 @@ export const BoolValue = {
   },
 
   fromJSON(object: any): BoolValue {
-    const message = createBaseBoolValue();
-    message.value = isSet(object.value) ? Boolean(object.value) : false;
-    return message;
+    return {
+      value: isSet(object.value) ? Boolean(object.value) : false,
+    };
   },
 
   toJSON(message: BoolValue): unknown {
@@ -468,9 +468,9 @@ export const StringValue = {
   },
 
   fromJSON(object: any): StringValue {
-    const message = createBaseStringValue();
-    message.value = isSet(object.value) ? String(object.value) : '';
-    return message;
+    return {
+      value: isSet(object.value) ? String(object.value) : '',
+    };
   },
 
   toJSON(message: StringValue): unknown {
@@ -517,9 +517,9 @@ export const BytesValue = {
   },
 
   fromJSON(object: any): BytesValue {
-    const message = createBaseBytesValue();
-    message.value = isSet(object.value) ? bytesFromBase64(object.value) : new Uint8Array();
-    return message;
+    return {
+      value: isSet(object.value) ? bytesFromBase64(object.value) : new Uint8Array(),
+    };
   },
 
   toJSON(message: BytesValue): unknown {

--- a/integration/simple/google/type/date.ts
+++ b/integration/simple/google/type/date.ts
@@ -78,11 +78,11 @@ export const DateMessage = {
   },
 
   fromJSON(object: any): DateMessage {
-    const message = createBaseDateMessage();
-    message.year = isSet(object.year) ? Number(object.year) : 0;
-    message.month = isSet(object.month) ? Number(object.month) : 0;
-    message.day = isSet(object.day) ? Number(object.day) : 0;
-    return message;
+    return {
+      year: isSet(object.year) ? Number(object.year) : 0,
+      month: isSet(object.month) ? Number(object.month) : 0,
+      day: isSet(object.day) ? Number(object.day) : 0,
+    };
   },
 
   toJSON(message: DateMessage): unknown {

--- a/integration/simple/import_dir/thing.ts
+++ b/integration/simple/import_dir/thing.ts
@@ -40,9 +40,9 @@ export const ImportedThing = {
   },
 
   fromJSON(object: any): ImportedThing {
-    const message = createBaseImportedThing();
-    message.createdAt = isSet(object.createdAt) ? fromJsonTimestamp(object.createdAt) : undefined;
-    return message;
+    return {
+      createdAt: isSet(object.createdAt) ? fromJsonTimestamp(object.createdAt) : undefined,
+    };
   },
 
   toJSON(message: ImportedThing): unknown {

--- a/integration/simple/simple.ts
+++ b/integration/simple/simple.ts
@@ -425,23 +425,23 @@ export const Simple = {
   },
 
   fromJSON(object: any): Simple {
-    const message = createBaseSimple();
-    message.name = isSet(object.name) ? String(object.name) : '';
-    message.age = isSet(object.age) ? Number(object.age) : 0;
-    message.createdAt = isSet(object.createdAt) ? fromJsonTimestamp(object.createdAt) : undefined;
-    message.child = isSet(object.child) ? Child.fromJSON(object.child) : undefined;
-    message.state = isSet(object.state) ? stateEnumFromJSON(object.state) : 0;
-    message.grandChildren = Array.isArray(object?.grandChildren)
-      ? object.grandChildren.map((e: any) => Child.fromJSON(e))
-      : [];
-    message.coins = Array.isArray(object?.coins) ? object.coins.map((e: any) => Number(e)) : [];
-    message.snacks = Array.isArray(object?.snacks) ? object.snacks.map((e: any) => String(e)) : [];
-    message.oldStates = Array.isArray(object?.oldStates) ? object.oldStates.map((e: any) => stateEnumFromJSON(e)) : [];
-    message.thing = isSet(object.thing) ? ImportedThing.fromJSON(object.thing) : undefined;
-    message.blobs = Array.isArray(object?.blobs) ? object.blobs.map((e: any) => bytesFromBase64(e)) : [];
-    message.birthday = isSet(object.birthday) ? DateMessage.fromJSON(object.birthday) : undefined;
-    message.blob = isSet(object.blob) ? bytesFromBase64(object.blob) : new Uint8Array();
-    return message;
+    return {
+      name: isSet(object.name) ? String(object.name) : '',
+      age: isSet(object.age) ? Number(object.age) : 0,
+      createdAt: isSet(object.createdAt) ? fromJsonTimestamp(object.createdAt) : undefined,
+      child: isSet(object.child) ? Child.fromJSON(object.child) : undefined,
+      state: isSet(object.state) ? stateEnumFromJSON(object.state) : 0,
+      grandChildren: Array.isArray(object?.grandChildren)
+        ? object.grandChildren.map((e: any) => Child.fromJSON(e))
+        : [],
+      coins: Array.isArray(object?.coins) ? object.coins.map((e: any) => Number(e)) : [],
+      snacks: Array.isArray(object?.snacks) ? object.snacks.map((e: any) => String(e)) : [],
+      oldStates: Array.isArray(object?.oldStates) ? object.oldStates.map((e: any) => stateEnumFromJSON(e)) : [],
+      thing: isSet(object.thing) ? ImportedThing.fromJSON(object.thing) : undefined,
+      blobs: Array.isArray(object?.blobs) ? object.blobs.map((e: any) => bytesFromBase64(e)) : [],
+      birthday: isSet(object.birthday) ? DateMessage.fromJSON(object.birthday) : undefined,
+      blob: isSet(object.blob) ? bytesFromBase64(object.blob) : new Uint8Array(),
+    };
   },
 
   toJSON(message: Simple): unknown {
@@ -542,10 +542,10 @@ export const Child = {
   },
 
   fromJSON(object: any): Child {
-    const message = createBaseChild();
-    message.name = isSet(object.name) ? String(object.name) : '';
-    message.type = isSet(object.type) ? child_TypeFromJSON(object.type) : 0;
-    return message;
+    return {
+      name: isSet(object.name) ? String(object.name) : '',
+      type: isSet(object.type) ? child_TypeFromJSON(object.type) : 0,
+    };
   },
 
   toJSON(message: Child): unknown {
@@ -606,11 +606,11 @@ export const Nested = {
   },
 
   fromJSON(object: any): Nested {
-    const message = createBaseNested();
-    message.name = isSet(object.name) ? String(object.name) : '';
-    message.message = isSet(object.message) ? Nested_InnerMessage.fromJSON(object.message) : undefined;
-    message.state = isSet(object.state) ? nested_InnerEnumFromJSON(object.state) : 0;
-    return message;
+    return {
+      name: isSet(object.name) ? String(object.name) : '',
+      message: isSet(object.message) ? Nested_InnerMessage.fromJSON(object.message) : undefined,
+      state: isSet(object.state) ? nested_InnerEnumFromJSON(object.state) : 0,
+    };
   },
 
   toJSON(message: Nested): unknown {
@@ -671,10 +671,10 @@ export const Nested_InnerMessage = {
   },
 
   fromJSON(object: any): Nested_InnerMessage {
-    const message = createBaseNested_InnerMessage();
-    message.name = isSet(object.name) ? String(object.name) : '';
-    message.deep = isSet(object.deep) ? Nested_InnerMessage_DeepMessage.fromJSON(object.deep) : undefined;
-    return message;
+    return {
+      name: isSet(object.name) ? String(object.name) : '',
+      deep: isSet(object.deep) ? Nested_InnerMessage_DeepMessage.fromJSON(object.deep) : undefined,
+    };
   },
 
   toJSON(message: Nested_InnerMessage): unknown {
@@ -727,9 +727,9 @@ export const Nested_InnerMessage_DeepMessage = {
   },
 
   fromJSON(object: any): Nested_InnerMessage_DeepMessage {
-    const message = createBaseNested_InnerMessage_DeepMessage();
-    message.name = isSet(object.name) ? String(object.name) : '';
-    return message;
+    return {
+      name: isSet(object.name) ? String(object.name) : '',
+    };
   },
 
   toJSON(message: Nested_InnerMessage_DeepMessage): unknown {
@@ -784,10 +784,10 @@ export const OneOfMessage = {
   },
 
   fromJSON(object: any): OneOfMessage {
-    const message = createBaseOneOfMessage();
-    message.first = isSet(object.first) ? String(object.first) : undefined;
-    message.last = isSet(object.last) ? String(object.last) : undefined;
-    return message;
+    return {
+      first: isSet(object.first) ? String(object.first) : undefined,
+      last: isSet(object.last) ? String(object.last) : undefined,
+    };
   },
 
   toJSON(message: OneOfMessage): unknown {
@@ -866,14 +866,14 @@ export const SimpleWithWrappers = {
   },
 
   fromJSON(object: any): SimpleWithWrappers {
-    const message = createBaseSimpleWithWrappers();
-    message.name = isSet(object.name) ? String(object.name) : undefined;
-    message.age = isSet(object.age) ? Number(object.age) : undefined;
-    message.enabled = isSet(object.enabled) ? Boolean(object.enabled) : undefined;
-    message.coins = Array.isArray(object?.coins) ? object.coins.map((e: any) => Number(e)) : [];
-    message.snacks = Array.isArray(object?.snacks) ? object.snacks.map((e: any) => String(e)) : [];
-    message.id = isSet(object.id) ? new Uint8Array(object.id) : undefined;
-    return message;
+    return {
+      name: isSet(object.name) ? String(object.name) : undefined,
+      age: isSet(object.age) ? Number(object.age) : undefined,
+      enabled: isSet(object.enabled) ? Boolean(object.enabled) : undefined,
+      coins: Array.isArray(object?.coins) ? object.coins.map((e: any) => Number(e)) : [],
+      snacks: Array.isArray(object?.snacks) ? object.snacks.map((e: any) => String(e)) : [],
+      id: isSet(object.id) ? new Uint8Array(object.id) : undefined,
+    };
   },
 
   toJSON(message: SimpleWithWrappers): unknown {
@@ -938,9 +938,9 @@ export const Entity = {
   },
 
   fromJSON(object: any): Entity {
-    const message = createBaseEntity();
-    message.id = isSet(object.id) ? Number(object.id) : 0;
-    return message;
+    return {
+      id: isSet(object.id) ? Number(object.id) : 0,
+    };
   },
 
   toJSON(message: Entity): unknown {
@@ -1054,56 +1054,53 @@ export const SimpleWithMap = {
   },
 
   fromJSON(object: any): SimpleWithMap {
-    const message = createBaseSimpleWithMap();
-    message.entitiesById = Object.entries(object.entitiesById ?? {}).reduce<{ [key: number]: Entity }>(
-      (acc, [key, value]) => {
-        acc[Number(key)] = Entity.fromJSON(value);
-        return acc;
-      },
-      {}
-    );
-    message.nameLookup = Object.entries(object.nameLookup ?? {}).reduce<{ [key: string]: string }>(
-      (acc, [key, value]) => {
-        acc[key] = String(value);
-        return acc;
-      },
-      {}
-    );
-    message.intLookup = Object.entries(object.intLookup ?? {}).reduce<{ [key: number]: number }>(
-      (acc, [key, value]) => {
-        acc[Number(key)] = Number(value);
-        return acc;
-      },
-      {}
-    );
-    message.mapOfTimestamps = Object.entries(object.mapOfTimestamps ?? {}).reduce<{ [key: string]: Date }>(
-      (acc, [key, value]) => {
-        acc[key] = fromJsonTimestamp(value);
-        return acc;
-      },
-      {}
-    );
-    message.mapOfBytes = Object.entries(object.mapOfBytes ?? {}).reduce<{ [key: string]: Uint8Array }>(
-      (acc, [key, value]) => {
-        acc[key] = bytesFromBase64(value as string);
-        return acc;
-      },
-      {}
-    );
-    message.mapOfStringValues = Object.entries(object.mapOfStringValues ?? {}).reduce<{
-      [key: string]: string | undefined;
-    }>((acc, [key, value]) => {
-      acc[key] = value as string | undefined;
-      return acc;
-    }, {});
-    message.longLookup = Object.entries(object.longLookup ?? {}).reduce<{ [key: number]: number }>(
-      (acc, [key, value]) => {
-        acc[Number(key)] = Number(value);
-        return acc;
-      },
-      {}
-    );
-    return message;
+    return {
+      entitiesById: isObject(object.entitiesById)
+        ? Object.entries(object.entitiesById).reduce<{ [key: number]: Entity }>((acc, [key, value]) => {
+            acc[Number(key)] = Entity.fromJSON(value);
+            return acc;
+          }, {})
+        : {},
+      nameLookup: isObject(object.nameLookup)
+        ? Object.entries(object.nameLookup).reduce<{ [key: string]: string }>((acc, [key, value]) => {
+            acc[key] = String(value);
+            return acc;
+          }, {})
+        : {},
+      intLookup: isObject(object.intLookup)
+        ? Object.entries(object.intLookup).reduce<{ [key: number]: number }>((acc, [key, value]) => {
+            acc[Number(key)] = Number(value);
+            return acc;
+          }, {})
+        : {},
+      mapOfTimestamps: isObject(object.mapOfTimestamps)
+        ? Object.entries(object.mapOfTimestamps).reduce<{ [key: string]: Date }>((acc, [key, value]) => {
+            acc[key] = fromJsonTimestamp(value);
+            return acc;
+          }, {})
+        : {},
+      mapOfBytes: isObject(object.mapOfBytes)
+        ? Object.entries(object.mapOfBytes).reduce<{ [key: string]: Uint8Array }>((acc, [key, value]) => {
+            acc[key] = bytesFromBase64(value as string);
+            return acc;
+          }, {})
+        : {},
+      mapOfStringValues: isObject(object.mapOfStringValues)
+        ? Object.entries(object.mapOfStringValues).reduce<{ [key: string]: string | undefined }>(
+            (acc, [key, value]) => {
+              acc[key] = value as string | undefined;
+              return acc;
+            },
+            {}
+          )
+        : {},
+      longLookup: isObject(object.longLookup)
+        ? Object.entries(object.longLookup).reduce<{ [key: number]: number }>((acc, [key, value]) => {
+            acc[Number(key)] = Number(value);
+            return acc;
+          }, {})
+        : {},
+    };
   },
 
   toJSON(message: SimpleWithMap): unknown {
@@ -1258,10 +1255,10 @@ export const SimpleWithMap_EntitiesByIdEntry = {
   },
 
   fromJSON(object: any): SimpleWithMap_EntitiesByIdEntry {
-    const message = createBaseSimpleWithMap_EntitiesByIdEntry();
-    message.key = isSet(object.key) ? Number(object.key) : 0;
-    message.value = isSet(object.value) ? Entity.fromJSON(object.value) : undefined;
-    return message;
+    return {
+      key: isSet(object.key) ? Number(object.key) : 0,
+      value: isSet(object.value) ? Entity.fromJSON(object.value) : undefined,
+    };
   },
 
   toJSON(message: SimpleWithMap_EntitiesByIdEntry): unknown {
@@ -1318,10 +1315,10 @@ export const SimpleWithMap_NameLookupEntry = {
   },
 
   fromJSON(object: any): SimpleWithMap_NameLookupEntry {
-    const message = createBaseSimpleWithMap_NameLookupEntry();
-    message.key = isSet(object.key) ? String(object.key) : '';
-    message.value = isSet(object.value) ? String(object.value) : '';
-    return message;
+    return {
+      key: isSet(object.key) ? String(object.key) : '',
+      value: isSet(object.value) ? String(object.value) : '',
+    };
   },
 
   toJSON(message: SimpleWithMap_NameLookupEntry): unknown {
@@ -1378,10 +1375,10 @@ export const SimpleWithMap_IntLookupEntry = {
   },
 
   fromJSON(object: any): SimpleWithMap_IntLookupEntry {
-    const message = createBaseSimpleWithMap_IntLookupEntry();
-    message.key = isSet(object.key) ? Number(object.key) : 0;
-    message.value = isSet(object.value) ? Number(object.value) : 0;
-    return message;
+    return {
+      key: isSet(object.key) ? Number(object.key) : 0,
+      value: isSet(object.value) ? Number(object.value) : 0,
+    };
   },
 
   toJSON(message: SimpleWithMap_IntLookupEntry): unknown {
@@ -1436,10 +1433,10 @@ export const SimpleWithMap_MapOfTimestampsEntry = {
   },
 
   fromJSON(object: any): SimpleWithMap_MapOfTimestampsEntry {
-    const message = createBaseSimpleWithMap_MapOfTimestampsEntry();
-    message.key = isSet(object.key) ? String(object.key) : '';
-    message.value = isSet(object.value) ? fromJsonTimestamp(object.value) : undefined;
-    return message;
+    return {
+      key: isSet(object.key) ? String(object.key) : '',
+      value: isSet(object.value) ? fromJsonTimestamp(object.value) : undefined,
+    };
   },
 
   toJSON(message: SimpleWithMap_MapOfTimestampsEntry): unknown {
@@ -1496,10 +1493,10 @@ export const SimpleWithMap_MapOfBytesEntry = {
   },
 
   fromJSON(object: any): SimpleWithMap_MapOfBytesEntry {
-    const message = createBaseSimpleWithMap_MapOfBytesEntry();
-    message.key = isSet(object.key) ? String(object.key) : '';
-    message.value = isSet(object.value) ? bytesFromBase64(object.value) : new Uint8Array();
-    return message;
+    return {
+      key: isSet(object.key) ? String(object.key) : '',
+      value: isSet(object.value) ? bytesFromBase64(object.value) : new Uint8Array(),
+    };
   },
 
   toJSON(message: SimpleWithMap_MapOfBytesEntry): unknown {
@@ -1557,10 +1554,10 @@ export const SimpleWithMap_MapOfStringValuesEntry = {
   },
 
   fromJSON(object: any): SimpleWithMap_MapOfStringValuesEntry {
-    const message = createBaseSimpleWithMap_MapOfStringValuesEntry();
-    message.key = isSet(object.key) ? String(object.key) : '';
-    message.value = isSet(object.value) ? String(object.value) : undefined;
-    return message;
+    return {
+      key: isSet(object.key) ? String(object.key) : '',
+      value: isSet(object.value) ? String(object.value) : undefined,
+    };
   },
 
   toJSON(message: SimpleWithMap_MapOfStringValuesEntry): unknown {
@@ -1617,10 +1614,10 @@ export const SimpleWithMap_LongLookupEntry = {
   },
 
   fromJSON(object: any): SimpleWithMap_LongLookupEntry {
-    const message = createBaseSimpleWithMap_LongLookupEntry();
-    message.key = isSet(object.key) ? Number(object.key) : 0;
-    message.value = isSet(object.value) ? Number(object.value) : 0;
-    return message;
+    return {
+      key: isSet(object.key) ? Number(object.key) : 0,
+      value: isSet(object.value) ? Number(object.value) : 0,
+    };
   },
 
   toJSON(message: SimpleWithMap_LongLookupEntry): unknown {
@@ -1674,15 +1671,14 @@ export const SimpleWithSnakeCaseMap = {
   },
 
   fromJSON(object: any): SimpleWithSnakeCaseMap {
-    const message = createBaseSimpleWithSnakeCaseMap();
-    message.entitiesById = Object.entries(object.entitiesById ?? {}).reduce<{ [key: number]: Entity }>(
-      (acc, [key, value]) => {
-        acc[Number(key)] = Entity.fromJSON(value);
-        return acc;
-      },
-      {}
-    );
-    return message;
+    return {
+      entitiesById: isObject(object.entitiesById)
+        ? Object.entries(object.entitiesById).reduce<{ [key: number]: Entity }>((acc, [key, value]) => {
+            acc[Number(key)] = Entity.fromJSON(value);
+            return acc;
+          }, {})
+        : {},
+    };
   },
 
   toJSON(message: SimpleWithSnakeCaseMap): unknown {
@@ -1748,10 +1744,10 @@ export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
   },
 
   fromJSON(object: any): SimpleWithSnakeCaseMap_EntitiesByIdEntry {
-    const message = createBaseSimpleWithSnakeCaseMap_EntitiesByIdEntry();
-    message.key = isSet(object.key) ? Number(object.key) : 0;
-    message.value = isSet(object.value) ? Entity.fromJSON(object.value) : undefined;
-    return message;
+    return {
+      key: isSet(object.key) ? Number(object.key) : 0,
+      value: isSet(object.value) ? Entity.fromJSON(object.value) : undefined,
+    };
   },
 
   toJSON(message: SimpleWithSnakeCaseMap_EntitiesByIdEntry): unknown {
@@ -1805,15 +1801,14 @@ export const SimpleWithMapOfEnums = {
   },
 
   fromJSON(object: any): SimpleWithMapOfEnums {
-    const message = createBaseSimpleWithMapOfEnums();
-    message.enumsById = Object.entries(object.enumsById ?? {}).reduce<{ [key: number]: StateEnum }>(
-      (acc, [key, value]) => {
-        acc[Number(key)] = value as number;
-        return acc;
-      },
-      {}
-    );
-    return message;
+    return {
+      enumsById: isObject(object.enumsById)
+        ? Object.entries(object.enumsById).reduce<{ [key: number]: StateEnum }>((acc, [key, value]) => {
+            acc[Number(key)] = value as number;
+            return acc;
+          }, {})
+        : {},
+    };
   },
 
   toJSON(message: SimpleWithMapOfEnums): unknown {
@@ -1879,10 +1874,10 @@ export const SimpleWithMapOfEnums_EnumsByIdEntry = {
   },
 
   fromJSON(object: any): SimpleWithMapOfEnums_EnumsByIdEntry {
-    const message = createBaseSimpleWithMapOfEnums_EnumsByIdEntry();
-    message.key = isSet(object.key) ? Number(object.key) : 0;
-    message.value = isSet(object.value) ? stateEnumFromJSON(object.value) : 0;
-    return message;
+    return {
+      key: isSet(object.key) ? Number(object.key) : 0,
+      value: isSet(object.value) ? stateEnumFromJSON(object.value) : 0,
+    };
   },
 
   toJSON(message: SimpleWithMapOfEnums_EnumsByIdEntry): unknown {
@@ -1933,9 +1928,9 @@ export const PingRequest = {
   },
 
   fromJSON(object: any): PingRequest {
-    const message = createBasePingRequest();
-    message.input = isSet(object.input) ? String(object.input) : '';
-    return message;
+    return {
+      input: isSet(object.input) ? String(object.input) : '',
+    };
   },
 
   toJSON(message: PingRequest): unknown {
@@ -1982,9 +1977,9 @@ export const PingResponse = {
   },
 
   fromJSON(object: any): PingResponse {
-    const message = createBasePingResponse();
-    message.output = isSet(object.output) ? String(object.output) : '';
-    return message;
+    return {
+      output: isSet(object.output) ? String(object.output) : '',
+    };
   },
 
   toJSON(message: PingResponse): unknown {
@@ -2110,20 +2105,20 @@ export const Numbers = {
   },
 
   fromJSON(object: any): Numbers {
-    const message = createBaseNumbers();
-    message.double = isSet(object.double) ? Number(object.double) : 0;
-    message.float = isSet(object.float) ? Number(object.float) : 0;
-    message.int32 = isSet(object.int32) ? Number(object.int32) : 0;
-    message.int64 = isSet(object.int64) ? Number(object.int64) : 0;
-    message.uint32 = isSet(object.uint32) ? Number(object.uint32) : 0;
-    message.uint64 = isSet(object.uint64) ? Number(object.uint64) : 0;
-    message.sint32 = isSet(object.sint32) ? Number(object.sint32) : 0;
-    message.sint64 = isSet(object.sint64) ? Number(object.sint64) : 0;
-    message.fixed32 = isSet(object.fixed32) ? Number(object.fixed32) : 0;
-    message.fixed64 = isSet(object.fixed64) ? Number(object.fixed64) : 0;
-    message.sfixed32 = isSet(object.sfixed32) ? Number(object.sfixed32) : 0;
-    message.sfixed64 = isSet(object.sfixed64) ? Number(object.sfixed64) : 0;
-    return message;
+    return {
+      double: isSet(object.double) ? Number(object.double) : 0,
+      float: isSet(object.float) ? Number(object.float) : 0,
+      int32: isSet(object.int32) ? Number(object.int32) : 0,
+      int64: isSet(object.int64) ? Number(object.int64) : 0,
+      uint32: isSet(object.uint32) ? Number(object.uint32) : 0,
+      uint64: isSet(object.uint64) ? Number(object.uint64) : 0,
+      sint32: isSet(object.sint32) ? Number(object.sint32) : 0,
+      sint64: isSet(object.sint64) ? Number(object.sint64) : 0,
+      fixed32: isSet(object.fixed32) ? Number(object.fixed32) : 0,
+      fixed64: isSet(object.fixed64) ? Number(object.fixed64) : 0,
+      sfixed32: isSet(object.sfixed32) ? Number(object.sfixed32) : 0,
+      sfixed64: isSet(object.sfixed64) ? Number(object.sfixed64) : 0,
+    };
   },
 
   toJSON(message: Numbers): unknown {
@@ -2236,15 +2231,15 @@ export const SimpleButOptional = {
   },
 
   fromJSON(object: any): SimpleButOptional {
-    const message = createBaseSimpleButOptional();
-    message.name = isSet(object.name) ? String(object.name) : undefined;
-    message.age = isSet(object.age) ? Number(object.age) : undefined;
-    message.createdAt = isSet(object.createdAt) ? fromJsonTimestamp(object.createdAt) : undefined;
-    message.child = isSet(object.child) ? Child.fromJSON(object.child) : undefined;
-    message.state = isSet(object.state) ? stateEnumFromJSON(object.state) : undefined;
-    message.thing = isSet(object.thing) ? ImportedThing.fromJSON(object.thing) : undefined;
-    message.birthday = isSet(object.birthday) ? DateMessage.fromJSON(object.birthday) : undefined;
-    return message;
+    return {
+      name: isSet(object.name) ? String(object.name) : undefined,
+      age: isSet(object.age) ? Number(object.age) : undefined,
+      createdAt: isSet(object.createdAt) ? fromJsonTimestamp(object.createdAt) : undefined,
+      child: isSet(object.child) ? Child.fromJSON(object.child) : undefined,
+      state: isSet(object.state) ? stateEnumFromJSON(object.state) : undefined,
+      thing: isSet(object.thing) ? ImportedThing.fromJSON(object.thing) : undefined,
+      birthday: isSet(object.birthday) ? DateMessage.fromJSON(object.birthday) : undefined,
+    };
   },
 
   toJSON(message: SimpleButOptional): unknown {
@@ -2301,8 +2296,7 @@ export const Empty = {
   },
 
   fromJSON(_: any): Empty {
-    const message = createBaseEmpty();
-    return message;
+    return {};
   },
 
   toJSON(_: Empty): unknown {
@@ -2420,6 +2414,10 @@ function longToNumber(long: Long): number {
 if (util.Long !== Long) {
   util.Long = Long as any;
   configure();
+}
+
+function isObject(value: any): boolean {
+  return typeof value === 'object' && value !== null;
 }
 
 function isSet(value: any): boolean {

--- a/integration/struct/google/protobuf/struct.ts
+++ b/integration/struct/google/protobuf/struct.ts
@@ -126,15 +126,14 @@ export const Struct = {
   },
 
   fromJSON(object: any): Struct {
-    const message = createBaseStruct();
-    message.fields = Object.entries(object.fields ?? {}).reduce<{ [key: string]: any | undefined }>(
-      (acc, [key, value]) => {
-        acc[key] = value as any | undefined;
-        return acc;
-      },
-      {}
-    );
-    return message;
+    return {
+      fields: isObject(object.fields)
+        ? Object.entries(object.fields).reduce<{ [key: string]: any | undefined }>((acc, [key, value]) => {
+            acc[key] = value as any | undefined;
+            return acc;
+          }, {})
+        : {},
+    };
   },
 
   toJSON(message: Struct): unknown {
@@ -218,10 +217,10 @@ export const Struct_FieldsEntry = {
   },
 
   fromJSON(object: any): Struct_FieldsEntry {
-    const message = createBaseStruct_FieldsEntry();
-    message.key = isSet(object.key) ? String(object.key) : '';
-    message.value = isSet(object?.value) ? object.value : undefined;
-    return message;
+    return {
+      key: isSet(object.key) ? String(object.key) : '',
+      value: isSet(object?.value) ? object.value : undefined,
+    };
   },
 
   toJSON(message: Struct_FieldsEntry): unknown {
@@ -307,14 +306,14 @@ export const Value = {
   },
 
   fromJSON(object: any): Value {
-    const message = createBaseValue();
-    message.nullValue = isSet(object.nullValue) ? nullValueFromJSON(object.nullValue) : undefined;
-    message.numberValue = isSet(object.numberValue) ? Number(object.numberValue) : undefined;
-    message.stringValue = isSet(object.stringValue) ? String(object.stringValue) : undefined;
-    message.boolValue = isSet(object.boolValue) ? Boolean(object.boolValue) : undefined;
-    message.structValue = isObject(object.structValue) ? object.structValue : undefined;
-    message.listValue = Array.isArray(object.listValue) ? [...object.listValue] : undefined;
-    return message;
+    return {
+      nullValue: isSet(object.nullValue) ? nullValueFromJSON(object.nullValue) : undefined,
+      numberValue: isSet(object.numberValue) ? Number(object.numberValue) : undefined,
+      stringValue: isSet(object.stringValue) ? String(object.stringValue) : undefined,
+      boolValue: isSet(object.boolValue) ? Boolean(object.boolValue) : undefined,
+      structValue: isObject(object.structValue) ? object.structValue : undefined,
+      listValue: Array.isArray(object.listValue) ? [...object.listValue] : undefined,
+    };
   },
 
   toJSON(message: Value): unknown {
@@ -409,9 +408,9 @@ export const ListValue = {
   },
 
   fromJSON(object: any): ListValue {
-    const message = createBaseListValue();
-    message.values = Array.isArray(object?.values) ? [...object.values] : [];
-    return message;
+    return {
+      values: Array.isArray(object?.values) ? [...object.values] : [],
+    };
   },
 
   toJSON(message: ListValue): unknown {

--- a/integration/struct/struct.ts
+++ b/integration/struct/struct.ts
@@ -40,9 +40,9 @@ export const StructMessage = {
   },
 
   fromJSON(object: any): StructMessage {
-    const message = createBaseStructMessage();
-    message.value = isObject(object.value) ? object.value : undefined;
-    return message;
+    return {
+      value: isObject(object.value) ? object.value : undefined,
+    };
   },
 
   toJSON(message: StructMessage): unknown {

--- a/integration/type-registry/bar/bar.ts
+++ b/integration/type-registry/bar/bar.ts
@@ -44,9 +44,10 @@ export const Bar = {
   },
 
   fromJSON(object: any): Bar {
-    const message = createBaseBar();
-    message.foo = isSet(object.foo) ? Foo.fromJSON(object.foo) : undefined;
-    return message;
+    return {
+      $type: Bar.$type,
+      foo: isSet(object.foo) ? Foo.fromJSON(object.foo) : undefined,
+    };
   },
 
   toJSON(message: Bar): unknown {

--- a/integration/type-registry/foo.ts
+++ b/integration/type-registry/foo.ts
@@ -49,9 +49,10 @@ export const Foo = {
   },
 
   fromJSON(object: any): Foo {
-    const message = createBaseFoo();
-    message.timestamp = isSet(object.timestamp) ? fromJsonTimestamp(object.timestamp) : undefined;
-    return message;
+    return {
+      $type: Foo.$type,
+      timestamp: isSet(object.timestamp) ? fromJsonTimestamp(object.timestamp) : undefined,
+    };
   },
 
   toJSON(message: Foo): unknown {
@@ -102,9 +103,10 @@ export const Foo2 = {
   },
 
   fromJSON(object: any): Foo2 {
-    const message = createBaseFoo2();
-    message.timestamp = isSet(object.timestamp) ? fromJsonTimestamp(object.timestamp) : undefined;
-    return message;
+    return {
+      $type: Foo2.$type,
+      timestamp: isSet(object.timestamp) ? fromJsonTimestamp(object.timestamp) : undefined,
+    };
   },
 
   toJSON(message: Foo2): unknown {

--- a/integration/type-registry/google/protobuf/timestamp.ts
+++ b/integration/type-registry/google/protobuf/timestamp.ts
@@ -154,10 +154,11 @@ export const Timestamp = {
   },
 
   fromJSON(object: any): Timestamp {
-    const message = createBaseTimestamp();
-    message.seconds = isSet(object.seconds) ? Number(object.seconds) : 0;
-    message.nanos = isSet(object.nanos) ? Number(object.nanos) : 0;
-    return message;
+    return {
+      $type: Timestamp.$type,
+      seconds: isSet(object.seconds) ? Number(object.seconds) : 0,
+      nanos: isSet(object.nanos) ? Number(object.nanos) : 0,
+    };
   },
 
   toJSON(message: Timestamp): unknown {

--- a/integration/types-with-underscores/file.ts
+++ b/integration/types-with-underscores/file.ts
@@ -41,9 +41,9 @@ export const Baz = {
   },
 
   fromJSON(object: any): Baz {
-    const message = createBaseBaz();
-    message.foo = isSet(object.foo) ? FooBar.fromJSON(object.foo) : undefined;
-    return message;
+    return {
+      foo: isSet(object.foo) ? FooBar.fromJSON(object.foo) : undefined,
+    };
   },
 
   toJSON(message: Baz): unknown {
@@ -84,8 +84,7 @@ export const FooBar = {
   },
 
   fromJSON(_: any): FooBar {
-    const message = createBaseFooBar();
-    return message;
+    return {};
   },
 
   toJSON(_: FooBar): unknown {

--- a/integration/use-date-false/google/protobuf/timestamp.ts
+++ b/integration/use-date-false/google/protobuf/timestamp.ts
@@ -150,10 +150,10 @@ export const Timestamp = {
   },
 
   fromJSON(object: any): Timestamp {
-    const message = createBaseTimestamp();
-    message.seconds = isSet(object.seconds) ? Number(object.seconds) : 0;
-    message.nanos = isSet(object.nanos) ? Number(object.nanos) : 0;
-    return message;
+    return {
+      seconds: isSet(object.seconds) ? Number(object.seconds) : 0,
+      nanos: isSet(object.nanos) ? Number(object.nanos) : 0,
+    };
   },
 
   toJSON(message: Timestamp): unknown {

--- a/integration/use-date-false/metadata.ts
+++ b/integration/use-date-false/metadata.ts
@@ -40,9 +40,9 @@ export const Metadata = {
   },
 
   fromJSON(object: any): Metadata {
-    const message = createBaseMetadata();
-    message.lastEdited = isSet(object.lastEdited) ? fromJsonTimestamp(object.lastEdited) : undefined;
-    return message;
+    return {
+      lastEdited: isSet(object.lastEdited) ? fromJsonTimestamp(object.lastEdited) : undefined,
+    };
   },
 
   toJSON(message: Metadata): unknown {

--- a/integration/use-date-string/google/protobuf/timestamp.ts
+++ b/integration/use-date-string/google/protobuf/timestamp.ts
@@ -150,10 +150,10 @@ export const Timestamp = {
   },
 
   fromJSON(object: any): Timestamp {
-    const message = createBaseTimestamp();
-    message.seconds = isSet(object.seconds) ? Number(object.seconds) : 0;
-    message.nanos = isSet(object.nanos) ? Number(object.nanos) : 0;
-    return message;
+    return {
+      seconds: isSet(object.seconds) ? Number(object.seconds) : 0,
+      nanos: isSet(object.nanos) ? Number(object.nanos) : 0,
+    };
   },
 
   toJSON(message: Timestamp): unknown {

--- a/integration/use-date-string/use-date-string.ts
+++ b/integration/use-date-string/use-date-string.ts
@@ -76,21 +76,20 @@ export const Todo = {
   },
 
   fromJSON(object: any): Todo {
-    const message = createBaseTodo();
-    message.id = isSet(object.id) ? String(object.id) : '';
-    message.timestamp = isSet(object.timestamp) ? String(object.timestamp) : undefined;
-    message.repeatedTimestamp = Array.isArray(object?.repeatedTimestamp)
-      ? object.repeatedTimestamp.map((e: any) => String(e))
-      : [];
-    message.optionalTimestamp = isSet(object.optionalTimestamp) ? String(object.optionalTimestamp) : undefined;
-    message.mapOfTimestamps = Object.entries(object.mapOfTimestamps ?? {}).reduce<{ [key: string]: string }>(
-      (acc, [key, value]) => {
-        acc[key] = String(value);
-        return acc;
-      },
-      {}
-    );
-    return message;
+    return {
+      id: isSet(object.id) ? String(object.id) : '',
+      timestamp: isSet(object.timestamp) ? String(object.timestamp) : undefined,
+      repeatedTimestamp: Array.isArray(object?.repeatedTimestamp)
+        ? object.repeatedTimestamp.map((e: any) => String(e))
+        : [],
+      optionalTimestamp: isSet(object.optionalTimestamp) ? String(object.optionalTimestamp) : undefined,
+      mapOfTimestamps: isObject(object.mapOfTimestamps)
+        ? Object.entries(object.mapOfTimestamps).reduce<{ [key: string]: string }>((acc, [key, value]) => {
+            acc[key] = String(value);
+            return acc;
+          }, {})
+        : {},
+    };
   },
 
   toJSON(message: Todo): unknown {
@@ -168,10 +167,10 @@ export const Todo_MapOfTimestampsEntry = {
   },
 
   fromJSON(object: any): Todo_MapOfTimestampsEntry {
-    const message = createBaseTodo_MapOfTimestampsEntry();
-    message.key = isSet(object.key) ? String(object.key) : '';
-    message.value = isSet(object.value) ? String(object.value) : undefined;
-    return message;
+    return {
+      key: isSet(object.key) ? String(object.key) : '',
+      value: isSet(object.value) ? String(object.value) : undefined,
+    };
   },
 
   toJSON(message: Todo_MapOfTimestampsEntry): unknown {
@@ -224,6 +223,10 @@ function fromTimestamp(t: Timestamp): string {
 if (util.Long !== Long) {
   util.Long = Long as any;
   configure();
+}
+
+function isObject(value: any): boolean {
+  return typeof value === 'object' && value !== null;
 }
 
 function isSet(value: any): boolean {

--- a/integration/use-date-true/google/protobuf/timestamp.ts
+++ b/integration/use-date-true/google/protobuf/timestamp.ts
@@ -150,10 +150,10 @@ export const Timestamp = {
   },
 
   fromJSON(object: any): Timestamp {
-    const message = createBaseTimestamp();
-    message.seconds = isSet(object.seconds) ? Number(object.seconds) : 0;
-    message.nanos = isSet(object.nanos) ? Number(object.nanos) : 0;
-    return message;
+    return {
+      seconds: isSet(object.seconds) ? Number(object.seconds) : 0,
+      nanos: isSet(object.nanos) ? Number(object.nanos) : 0,
+    };
   },
 
   toJSON(message: Timestamp): unknown {

--- a/integration/use-date-true/use-date-true.ts
+++ b/integration/use-date-true/use-date-true.ts
@@ -76,23 +76,20 @@ export const Todo = {
   },
 
   fromJSON(object: any): Todo {
-    const message = createBaseTodo();
-    message.id = isSet(object.id) ? String(object.id) : '';
-    message.timestamp = isSet(object.timestamp) ? fromJsonTimestamp(object.timestamp) : undefined;
-    message.repeatedTimestamp = Array.isArray(object?.repeatedTimestamp)
-      ? object.repeatedTimestamp.map((e: any) => fromJsonTimestamp(e))
-      : [];
-    message.optionalTimestamp = isSet(object.optionalTimestamp)
-      ? fromJsonTimestamp(object.optionalTimestamp)
-      : undefined;
-    message.mapOfTimestamps = Object.entries(object.mapOfTimestamps ?? {}).reduce<{ [key: string]: Date }>(
-      (acc, [key, value]) => {
-        acc[key] = fromJsonTimestamp(value);
-        return acc;
-      },
-      {}
-    );
-    return message;
+    return {
+      id: isSet(object.id) ? String(object.id) : '',
+      timestamp: isSet(object.timestamp) ? fromJsonTimestamp(object.timestamp) : undefined,
+      repeatedTimestamp: Array.isArray(object?.repeatedTimestamp)
+        ? object.repeatedTimestamp.map((e: any) => fromJsonTimestamp(e))
+        : [],
+      optionalTimestamp: isSet(object.optionalTimestamp) ? fromJsonTimestamp(object.optionalTimestamp) : undefined,
+      mapOfTimestamps: isObject(object.mapOfTimestamps)
+        ? Object.entries(object.mapOfTimestamps).reduce<{ [key: string]: Date }>((acc, [key, value]) => {
+            acc[key] = fromJsonTimestamp(value);
+            return acc;
+          }, {})
+        : {},
+    };
   },
 
   toJSON(message: Todo): unknown {
@@ -170,10 +167,10 @@ export const Todo_MapOfTimestampsEntry = {
   },
 
   fromJSON(object: any): Todo_MapOfTimestampsEntry {
-    const message = createBaseTodo_MapOfTimestampsEntry();
-    message.key = isSet(object.key) ? String(object.key) : '';
-    message.value = isSet(object.value) ? fromJsonTimestamp(object.value) : undefined;
-    return message;
+    return {
+      key: isSet(object.key) ? String(object.key) : '',
+      value: isSet(object.value) ? fromJsonTimestamp(object.value) : undefined,
+    };
   },
 
   toJSON(message: Todo_MapOfTimestampsEntry): unknown {
@@ -235,6 +232,10 @@ function fromJsonTimestamp(o: any): Date {
 if (util.Long !== Long) {
   util.Long = Long as any;
   configure();
+}
+
+function isObject(value: any): boolean {
+  return typeof value === 'object' && value !== null;
 }
 
 function isSet(value: any): boolean {

--- a/integration/use-exact-types-false/foo.ts
+++ b/integration/use-exact-types-false/foo.ts
@@ -46,10 +46,10 @@ export const Foo = {
   },
 
   fromJSON(object: any): Foo {
-    const message = createBaseFoo();
-    message.bar = isSet(object.bar) ? String(object.bar) : '';
-    message.baz = isSet(object.baz) ? String(object.baz) : '';
-    return message;
+    return {
+      bar: isSet(object.bar) ? String(object.bar) : '',
+      baz: isSet(object.baz) ? String(object.baz) : '',
+    };
   },
 
   toJSON(message: Foo): unknown {

--- a/integration/use-optionals-all/test.ts
+++ b/integration/use-optionals-all/test.ts
@@ -307,38 +307,35 @@ export const OptionalsTest = {
   },
 
   fromJSON(object: any): OptionalsTest {
-    const message = createBaseOptionalsTest();
-    message.id = isSet(object.id) ? Number(object.id) : 0;
-    message.child = isSet(object.child) ? Child.fromJSON(object.child) : undefined;
-    message.state = isSet(object.state) ? stateEnumFromJSON(object.state) : 0;
-    message.long = isSet(object.long) ? Number(object.long) : 0;
-    message.truth = isSet(object.truth) ? Boolean(object.truth) : false;
-    message.description = isSet(object.description) ? String(object.description) : '';
-    message.data = isSet(object.data) ? bytesFromBase64(object.data) : new Uint8Array();
-    message.repId = Array.isArray(object?.repId) ? object.repId.map((e: any) => Number(e)) : [];
-    message.repChild = Array.isArray(object?.repChild) ? object.repChild.map((e: any) => Child.fromJSON(e)) : [];
-    message.repState = Array.isArray(object?.repState) ? object.repState.map((e: any) => stateEnumFromJSON(e)) : [];
-    message.repLong = Array.isArray(object?.repLong) ? object.repLong.map((e: any) => Number(e)) : [];
-    message.repTruth = Array.isArray(object?.repTruth) ? object.repTruth.map((e: any) => Boolean(e)) : [];
-    message.repDescription = Array.isArray(object?.repDescription)
-      ? object.repDescription.map((e: any) => String(e))
-      : [];
-    message.repData = Array.isArray(object?.repData) ? object.repData.map((e: any) => bytesFromBase64(e)) : [];
-    message.optId = isSet(object.optId) ? Number(object.optId) : undefined;
-    message.optChild = isSet(object.optChild) ? Child.fromJSON(object.optChild) : undefined;
-    message.optState = isSet(object.optState) ? stateEnumFromJSON(object.optState) : undefined;
-    message.optLong = isSet(object.optLong) ? Number(object.optLong) : undefined;
-    message.optTruth = isSet(object.optTruth) ? Boolean(object.optTruth) : undefined;
-    message.optDescription = isSet(object.optDescription) ? String(object.optDescription) : undefined;
-    message.optData = isSet(object.optData) ? bytesFromBase64(object.optData) : undefined;
-    message.translations = Object.entries(object.translations ?? {}).reduce<{ [key: string]: string }>(
-      (acc, [key, value]) => {
-        acc[key] = String(value);
-        return acc;
-      },
-      {}
-    );
-    return message;
+    return {
+      id: isSet(object.id) ? Number(object.id) : 0,
+      child: isSet(object.child) ? Child.fromJSON(object.child) : undefined,
+      state: isSet(object.state) ? stateEnumFromJSON(object.state) : 0,
+      long: isSet(object.long) ? Number(object.long) : 0,
+      truth: isSet(object.truth) ? Boolean(object.truth) : false,
+      description: isSet(object.description) ? String(object.description) : '',
+      data: isSet(object.data) ? bytesFromBase64(object.data) : new Uint8Array(),
+      repId: Array.isArray(object?.repId) ? object.repId.map((e: any) => Number(e)) : [],
+      repChild: Array.isArray(object?.repChild) ? object.repChild.map((e: any) => Child.fromJSON(e)) : [],
+      repState: Array.isArray(object?.repState) ? object.repState.map((e: any) => stateEnumFromJSON(e)) : [],
+      repLong: Array.isArray(object?.repLong) ? object.repLong.map((e: any) => Number(e)) : [],
+      repTruth: Array.isArray(object?.repTruth) ? object.repTruth.map((e: any) => Boolean(e)) : [],
+      repDescription: Array.isArray(object?.repDescription) ? object.repDescription.map((e: any) => String(e)) : [],
+      repData: Array.isArray(object?.repData) ? object.repData.map((e: any) => bytesFromBase64(e)) : [],
+      optId: isSet(object.optId) ? Number(object.optId) : undefined,
+      optChild: isSet(object.optChild) ? Child.fromJSON(object.optChild) : undefined,
+      optState: isSet(object.optState) ? stateEnumFromJSON(object.optState) : undefined,
+      optLong: isSet(object.optLong) ? Number(object.optLong) : undefined,
+      optTruth: isSet(object.optTruth) ? Boolean(object.optTruth) : undefined,
+      optDescription: isSet(object.optDescription) ? String(object.optDescription) : undefined,
+      optData: isSet(object.optData) ? bytesFromBase64(object.optData) : undefined,
+      translations: isObject(object.translations)
+        ? Object.entries(object.translations).reduce<{ [key: string]: string }>((acc, [key, value]) => {
+            acc[key] = String(value);
+            return acc;
+          }, {})
+        : {},
+    };
   },
 
   toJSON(message: OptionalsTest): unknown {
@@ -478,10 +475,10 @@ export const OptionalsTest_TranslationsEntry = {
   },
 
   fromJSON(object: any): OptionalsTest_TranslationsEntry {
-    const message = createBaseOptionalsTest_TranslationsEntry();
-    message.key = isSet(object.key) ? String(object.key) : '';
-    message.value = isSet(object.value) ? String(object.value) : '';
-    return message;
+    return {
+      key: isSet(object.key) ? String(object.key) : '',
+      value: isSet(object.value) ? String(object.value) : '',
+    };
   },
 
   toJSON(message: OptionalsTest_TranslationsEntry): unknown {
@@ -526,8 +523,7 @@ export const Child = {
   },
 
   fromJSON(_: any): Child {
-    const message = createBaseChild();
-    return message;
+    return {};
   },
 
   toJSON(_: Child): unknown {
@@ -602,6 +598,10 @@ function longToNumber(long: Long): number {
 if (util.Long !== Long) {
   util.Long = Long as any;
   configure();
+}
+
+function isObject(value: any): boolean {
+  return typeof value === 'object' && value !== null;
 }
 
 function isSet(value: any): boolean {

--- a/integration/value/google/protobuf/struct.ts
+++ b/integration/value/google/protobuf/struct.ts
@@ -126,15 +126,14 @@ export const Struct = {
   },
 
   fromJSON(object: any): Struct {
-    const message = createBaseStruct();
-    message.fields = Object.entries(object.fields ?? {}).reduce<{ [key: string]: any | undefined }>(
-      (acc, [key, value]) => {
-        acc[key] = value as any | undefined;
-        return acc;
-      },
-      {}
-    );
-    return message;
+    return {
+      fields: isObject(object.fields)
+        ? Object.entries(object.fields).reduce<{ [key: string]: any | undefined }>((acc, [key, value]) => {
+            acc[key] = value as any | undefined;
+            return acc;
+          }, {})
+        : {},
+    };
   },
 
   toJSON(message: Struct): unknown {
@@ -218,10 +217,10 @@ export const Struct_FieldsEntry = {
   },
 
   fromJSON(object: any): Struct_FieldsEntry {
-    const message = createBaseStruct_FieldsEntry();
-    message.key = isSet(object.key) ? String(object.key) : '';
-    message.value = isSet(object?.value) ? object.value : undefined;
-    return message;
+    return {
+      key: isSet(object.key) ? String(object.key) : '',
+      value: isSet(object?.value) ? object.value : undefined,
+    };
   },
 
   toJSON(message: Struct_FieldsEntry): unknown {
@@ -307,14 +306,14 @@ export const Value = {
   },
 
   fromJSON(object: any): Value {
-    const message = createBaseValue();
-    message.nullValue = isSet(object.nullValue) ? nullValueFromJSON(object.nullValue) : undefined;
-    message.numberValue = isSet(object.numberValue) ? Number(object.numberValue) : undefined;
-    message.stringValue = isSet(object.stringValue) ? String(object.stringValue) : undefined;
-    message.boolValue = isSet(object.boolValue) ? Boolean(object.boolValue) : undefined;
-    message.structValue = isObject(object.structValue) ? object.structValue : undefined;
-    message.listValue = Array.isArray(object.listValue) ? [...object.listValue] : undefined;
-    return message;
+    return {
+      nullValue: isSet(object.nullValue) ? nullValueFromJSON(object.nullValue) : undefined,
+      numberValue: isSet(object.numberValue) ? Number(object.numberValue) : undefined,
+      stringValue: isSet(object.stringValue) ? String(object.stringValue) : undefined,
+      boolValue: isSet(object.boolValue) ? Boolean(object.boolValue) : undefined,
+      structValue: isObject(object.structValue) ? object.structValue : undefined,
+      listValue: Array.isArray(object.listValue) ? [...object.listValue] : undefined,
+    };
   },
 
   toJSON(message: Value): unknown {
@@ -409,9 +408,9 @@ export const ListValue = {
   },
 
   fromJSON(object: any): ListValue {
-    const message = createBaseListValue();
-    message.values = Array.isArray(object?.values) ? [...object.values] : [];
-    return message;
+    return {
+      values: Array.isArray(object?.values) ? [...object.values] : [],
+    };
   },
 
   toJSON(message: ListValue): unknown {

--- a/integration/value/google/protobuf/wrappers.ts
+++ b/integration/value/google/protobuf/wrappers.ts
@@ -125,9 +125,9 @@ export const DoubleValue = {
   },
 
   fromJSON(object: any): DoubleValue {
-    const message = createBaseDoubleValue();
-    message.value = isSet(object.value) ? Number(object.value) : 0;
-    return message;
+    return {
+      value: isSet(object.value) ? Number(object.value) : 0,
+    };
   },
 
   toJSON(message: DoubleValue): unknown {
@@ -174,9 +174,9 @@ export const FloatValue = {
   },
 
   fromJSON(object: any): FloatValue {
-    const message = createBaseFloatValue();
-    message.value = isSet(object.value) ? Number(object.value) : 0;
-    return message;
+    return {
+      value: isSet(object.value) ? Number(object.value) : 0,
+    };
   },
 
   toJSON(message: FloatValue): unknown {
@@ -223,9 +223,9 @@ export const Int64Value = {
   },
 
   fromJSON(object: any): Int64Value {
-    const message = createBaseInt64Value();
-    message.value = isSet(object.value) ? Number(object.value) : 0;
-    return message;
+    return {
+      value: isSet(object.value) ? Number(object.value) : 0,
+    };
   },
 
   toJSON(message: Int64Value): unknown {
@@ -272,9 +272,9 @@ export const UInt64Value = {
   },
 
   fromJSON(object: any): UInt64Value {
-    const message = createBaseUInt64Value();
-    message.value = isSet(object.value) ? Number(object.value) : 0;
-    return message;
+    return {
+      value: isSet(object.value) ? Number(object.value) : 0,
+    };
   },
 
   toJSON(message: UInt64Value): unknown {
@@ -321,9 +321,9 @@ export const Int32Value = {
   },
 
   fromJSON(object: any): Int32Value {
-    const message = createBaseInt32Value();
-    message.value = isSet(object.value) ? Number(object.value) : 0;
-    return message;
+    return {
+      value: isSet(object.value) ? Number(object.value) : 0,
+    };
   },
 
   toJSON(message: Int32Value): unknown {
@@ -370,9 +370,9 @@ export const UInt32Value = {
   },
 
   fromJSON(object: any): UInt32Value {
-    const message = createBaseUInt32Value();
-    message.value = isSet(object.value) ? Number(object.value) : 0;
-    return message;
+    return {
+      value: isSet(object.value) ? Number(object.value) : 0,
+    };
   },
 
   toJSON(message: UInt32Value): unknown {
@@ -419,9 +419,9 @@ export const BoolValue = {
   },
 
   fromJSON(object: any): BoolValue {
-    const message = createBaseBoolValue();
-    message.value = isSet(object.value) ? Boolean(object.value) : false;
-    return message;
+    return {
+      value: isSet(object.value) ? Boolean(object.value) : false,
+    };
   },
 
   toJSON(message: BoolValue): unknown {
@@ -468,9 +468,9 @@ export const StringValue = {
   },
 
   fromJSON(object: any): StringValue {
-    const message = createBaseStringValue();
-    message.value = isSet(object.value) ? String(object.value) : '';
-    return message;
+    return {
+      value: isSet(object.value) ? String(object.value) : '',
+    };
   },
 
   toJSON(message: StringValue): unknown {
@@ -517,9 +517,9 @@ export const BytesValue = {
   },
 
   fromJSON(object: any): BytesValue {
-    const message = createBaseBytesValue();
-    message.value = isSet(object.value) ? bytesFromBase64(object.value) : new Uint8Array();
-    return message;
+    return {
+      value: isSet(object.value) ? bytesFromBase64(object.value) : new Uint8Array(),
+    };
   },
 
   toJSON(message: BytesValue): unknown {

--- a/integration/value/value.ts
+++ b/integration/value/value.ts
@@ -69,15 +69,13 @@ export const ValueMessage = {
   },
 
   fromJSON(object: any): ValueMessage {
-    const message = createBaseValueMessage();
-    message.value = isSet(object?.value) ? object.value : undefined;
-    message.anyList = Array.isArray(object.anyList) ? [...object.anyList] : undefined;
-    message.repeatedAny = Array.isArray(object?.repeatedAny) ? [...object.repeatedAny] : [];
-    message.repeatedStrings = Array.isArray(object?.repeatedStrings)
-      ? object.repeatedStrings.map((e: any) => String(e))
-      : [];
-    message.structValue = isObject(object.structValue) ? object.structValue : undefined;
-    return message;
+    return {
+      value: isSet(object?.value) ? object.value : undefined,
+      anyList: Array.isArray(object.anyList) ? [...object.anyList] : undefined,
+      repeatedAny: Array.isArray(object?.repeatedAny) ? [...object.repeatedAny] : [],
+      repeatedStrings: Array.isArray(object?.repeatedStrings) ? object.repeatedStrings.map((e: any) => String(e)) : [],
+      structValue: isObject(object.structValue) ? object.structValue : undefined,
+    };
   },
 
   toJSON(message: ValueMessage): unknown {

--- a/integration/vector-tile/vector_tile.ts
+++ b/integration/vector-tile/vector_tile.ts
@@ -109,9 +109,9 @@ export const Tile = {
   },
 
   fromJSON(object: any): Tile {
-    const message = createBaseTile();
-    message.layers = Array.isArray(object?.layers) ? object.layers.map((e: any) => Tile_Layer.fromJSON(e)) : [];
-    return message;
+    return {
+      layers: Array.isArray(object?.layers) ? object.layers.map((e: any) => Tile_Layer.fromJSON(e)) : [],
+    };
   },
 
   toJSON(message: Tile): unknown {
@@ -198,15 +198,15 @@ export const Tile_Value = {
   },
 
   fromJSON(object: any): Tile_Value {
-    const message = createBaseTile_Value();
-    message.stringValue = isSet(object.stringValue) ? String(object.stringValue) : '';
-    message.floatValue = isSet(object.floatValue) ? Number(object.floatValue) : 0;
-    message.doubleValue = isSet(object.doubleValue) ? Number(object.doubleValue) : 0;
-    message.intValue = isSet(object.intValue) ? Number(object.intValue) : 0;
-    message.uintValue = isSet(object.uintValue) ? Number(object.uintValue) : 0;
-    message.sintValue = isSet(object.sintValue) ? Number(object.sintValue) : 0;
-    message.boolValue = isSet(object.boolValue) ? Boolean(object.boolValue) : false;
-    return message;
+    return {
+      stringValue: isSet(object.stringValue) ? String(object.stringValue) : '',
+      floatValue: isSet(object.floatValue) ? Number(object.floatValue) : 0,
+      doubleValue: isSet(object.doubleValue) ? Number(object.doubleValue) : 0,
+      intValue: isSet(object.intValue) ? Number(object.intValue) : 0,
+      uintValue: isSet(object.uintValue) ? Number(object.uintValue) : 0,
+      sintValue: isSet(object.sintValue) ? Number(object.sintValue) : 0,
+      boolValue: isSet(object.boolValue) ? Boolean(object.boolValue) : false,
+    };
   },
 
   toJSON(message: Tile_Value): unknown {
@@ -301,12 +301,12 @@ export const Tile_Feature = {
   },
 
   fromJSON(object: any): Tile_Feature {
-    const message = createBaseTile_Feature();
-    message.id = isSet(object.id) ? Number(object.id) : 0;
-    message.tags = Array.isArray(object?.tags) ? object.tags.map((e: any) => Number(e)) : [];
-    message.type = isSet(object.type) ? tile_GeomTypeFromJSON(object.type) : 0;
-    message.geometry = Array.isArray(object?.geometry) ? object.geometry.map((e: any) => Number(e)) : [];
-    return message;
+    return {
+      id: isSet(object.id) ? Number(object.id) : 0,
+      tags: Array.isArray(object?.tags) ? object.tags.map((e: any) => Number(e)) : [],
+      type: isSet(object.type) ? tile_GeomTypeFromJSON(object.type) : 0,
+      geometry: Array.isArray(object?.geometry) ? object.geometry.map((e: any) => Number(e)) : [],
+    };
   },
 
   toJSON(message: Tile_Feature): unknown {
@@ -397,14 +397,14 @@ export const Tile_Layer = {
   },
 
   fromJSON(object: any): Tile_Layer {
-    const message = createBaseTile_Layer();
-    message.version = isSet(object.version) ? Number(object.version) : 0;
-    message.name = isSet(object.name) ? String(object.name) : '';
-    message.features = Array.isArray(object?.features) ? object.features.map((e: any) => Tile_Feature.fromJSON(e)) : [];
-    message.keys = Array.isArray(object?.keys) ? object.keys.map((e: any) => String(e)) : [];
-    message.values = Array.isArray(object?.values) ? object.values.map((e: any) => Tile_Value.fromJSON(e)) : [];
-    message.extent = isSet(object.extent) ? Number(object.extent) : 0;
-    return message;
+    return {
+      version: isSet(object.version) ? Number(object.version) : 0,
+      name: isSet(object.name) ? String(object.name) : '',
+      features: Array.isArray(object?.features) ? object.features.map((e: any) => Tile_Feature.fromJSON(e)) : [],
+      keys: Array.isArray(object?.keys) ? object.keys.map((e: any) => String(e)) : [],
+      values: Array.isArray(object?.values) ? object.values.map((e: any) => Tile_Value.fromJSON(e)) : [],
+      extent: isSet(object.extent) ? Number(object.extent) : 0,
+    };
   },
 
   toJSON(message: Tile_Layer): unknown {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1137,7 +1137,7 @@ function generateFromJson(ctx: Context, fullName: string, messageDesc: Descripto
     } else if (isWithinOneOfThatShouldBeUnion(options, field)) {
       const oneofFields = messageDesc.field
         .filter(isWithinOneOf)
-        .filter(otherField => otherField.oneofIndex === field.oneofIndex)
+        .filter((otherField) => otherField.oneofIndex === field.oneofIndex);
 
       const oneofName = maybeSnakeToCamel(messageDesc.oneofDecl[field.oneofIndex].name, options);
 
@@ -1148,7 +1148,7 @@ function generateFromJson(ctx: Context, fullName: string, messageDesc: Descripto
 
       const ternaryIf = code`${ctx.utils.isSet}(object.${jsonName})`;
       const ternaryThen = code`{ $case: '${fieldName}', ${fieldName}: ${readSnippet(`object.${jsonName}`)}`;
-      chunks.push(code `${ternaryIf} ? ${ternaryThen}} : `)
+      chunks.push(code`${ternaryIf} ? ${ternaryThen}} : `);
 
       if (field === oneofFields[oneofFields.length - 1]) {
         chunks.push(code`undefined,`);
@@ -1162,7 +1162,7 @@ function generateFromJson(ctx: Context, fullName: string, messageDesc: Descripto
       chunks.push(
         code`${fieldName}: ${ctx.utils.isObject}(object.${jsonName})
           ? ${readSnippet(`object.${jsonName}`)}
-          : undefined,`,
+          : undefined,`
       );
     } else if (isListValueType(field)) {
       chunks.push(code`


### PR DESCRIPTION
Felt like doing something useful and understood from https://github.com/stephenh/ts-proto/pull/462/files/2649b9aeb6c35779dc8294575fa70b7a35c5f79d#r778884590 that the plan was to return objects directly from `fromJSON`, rather than constructing a base object and assigning the fields.

But I may have been too quick, as then I found out that @aikoven is already working on this as well, so please close this PR if needed.

before:

```ts
 fromJSON(object: any): Simple {
    const message = createBaseSimple();
    message.name = isSet(object.name) ? String(object.name) : '';
    message.age = isSet(object.age) ? Number(object.age) : 0;
    return message;
  };
```

after:
```ts
fromJSON(object: any): Simple {
    return {
      name: isSet(object.name) ? String(object.name) : '',
      age: isSet(object.age) ? Number(object.age) : 0,
    };
 },
```