### PR TITLE
fix: respect generateClientImpl=false in grpc-js (#471)

### DIFF
--- a/src/generate-grpc-js.ts
+++ b/src/generate-grpc-js.ts
@@ -34,12 +34,15 @@ export function generateGrpcJsService(
   sourceInfo: SourceInfo,
   serviceDesc: ServiceDescriptorProto
 ): Code {
+  const { options } = ctx;
   const chunks: Code[] = [];
 
   chunks.push(generateServiceDefinition(ctx, fileDesc, sourceInfo, serviceDesc));
   chunks.push(generateServerStub(ctx, sourceInfo, serviceDesc));
-  chunks.push(generateClientStub(ctx, sourceInfo, serviceDesc));
-  chunks.push(generateClientConstructor(fileDesc, serviceDesc));
+  if (options.outputClientImpl) {
+    chunks.push(generateClientStub(ctx, sourceInfo, serviceDesc));
+    chunks.push(generateClientConstructor(fileDesc, serviceDesc));
+  }
 
   return joinCode(chunks, { on: '\n\n' });
 }


### PR DESCRIPTION
Do not generate client stub and constructor when `outputServices=grpc-js` and `outputClientImpl=false`