### PR TITLE
feat: enable unknown fields for descriptor protos

### DIFF
--- a/protos/build.sh
+++ b/protos/build.sh
@@ -6,7 +6,7 @@
 protoc \
   --plugin=./node_modules/ts-proto/protoc-gen-ts_proto \
   --ts_proto_out=. \
-  --ts_proto_opt=exportCommonSymbols=false \
+  --ts_proto_opt=exportCommonSymbols=false,unknownFields=true \
   ./google/protobuf/descriptor.proto \
   ./google/protobuf/compiler/plugin.proto
 
@@ -14,7 +14,7 @@ protoc \
   ./index.ts \
   ./google/protobuf/descriptor.ts \
   ./google/protobuf/compiler/plugin.ts \
-  --outDir dist --declaration
+  --outDir dist --declaration --downlevelIteration
 
 
 

--- a/protos/google/protobuf/compiler/plugin.ts
+++ b/protos/google/protobuf/compiler/plugin.ts
@@ -1,6 +1,6 @@
 /* eslint-disable */
-import * as Long from 'long';
 import { util, configure, Writer, Reader } from 'protobufjs/minimal';
+import * as Long from 'long';
 import { FileDescriptorProto, GeneratedCodeInfo } from '../../../google/protobuf/descriptor';
 
 /** The version number of protocol compiler. */
@@ -166,21 +166,45 @@ export interface CodeGeneratorResponse_File {
   generatedCodeInfo: GeneratedCodeInfo | undefined;
 }
 
-const baseVersion: object = { major: 0, minor: 0, patch: 0, suffix: '' };
+function createBaseVersion(): Version {
+  return { major: 0, minor: 0, patch: 0, suffix: '' };
+}
 
 export const Version = {
   encode(message: Version, writer: Writer = Writer.create()): Writer {
-    writer.uint32(8).int32(message.major);
-    writer.uint32(16).int32(message.minor);
-    writer.uint32(24).int32(message.patch);
-    writer.uint32(34).string(message.suffix);
+    if (message.major !== 0) {
+      writer.uint32(8).int32(message.major);
+    }
+    if (message.minor !== 0) {
+      writer.uint32(16).int32(message.minor);
+    }
+    if (message.patch !== 0) {
+      writer.uint32(24).int32(message.patch);
+    }
+    if (message.suffix !== '') {
+      writer.uint32(34).string(message.suffix);
+    }
+    if ('_unknownFields' in message) {
+      for (const key of Object.keys(message['_unknownFields'])) {
+        const values = message['_unknownFields'][key] as Uint8Array[];
+        for (const value of values) {
+          writer.uint32(parseInt(key, 10));
+          (writer as any)['_push'](
+            (val: Uint8Array, buf: Buffer, pos: number) => buf.set(val, pos),
+            value.length,
+            value
+          );
+        }
+      }
+    }
     return writer;
   },
 
   decode(input: Reader | Uint8Array, length?: number): Version {
-    const reader = input instanceof Uint8Array ? new Reader(input) : input;
+    const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = Object.create(baseVersion) as Version;
+    const message = createBaseVersion();
+    (message as any)._unknownFields = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -197,7 +221,12 @@ export const Version = {
           message.suffix = reader.string();
           break;
         default:
+          const startPos = reader.pos;
           reader.skipType(tag & 7);
+          (message as any)._unknownFields[tag] = [
+            ...((message as any)._unknownFields[tag] || []),
+            reader.buf.slice(startPos, reader.pos),
+          ];
           break;
       }
     }
@@ -205,88 +234,72 @@ export const Version = {
   },
 
   fromJSON(object: any): Version {
-    const message = Object.create(baseVersion) as Version;
-    if (object.major !== undefined && object.major !== null) {
-      message.major = Number(object.major);
-    } else {
-      message.major = 0;
-    }
-    if (object.minor !== undefined && object.minor !== null) {
-      message.minor = Number(object.minor);
-    } else {
-      message.minor = 0;
-    }
-    if (object.patch !== undefined && object.patch !== null) {
-      message.patch = Number(object.patch);
-    } else {
-      message.patch = 0;
-    }
-    if (object.suffix !== undefined && object.suffix !== null) {
-      message.suffix = String(object.suffix);
-    } else {
-      message.suffix = '';
-    }
-    return message;
-  },
-
-  fromPartial(object: DeepPartial<Version>): Version {
-    const message = { ...baseVersion } as Version;
-    if (object.major !== undefined && object.major !== null) {
-      message.major = object.major;
-    } else {
-      message.major = 0;
-    }
-    if (object.minor !== undefined && object.minor !== null) {
-      message.minor = object.minor;
-    } else {
-      message.minor = 0;
-    }
-    if (object.patch !== undefined && object.patch !== null) {
-      message.patch = object.patch;
-    } else {
-      message.patch = 0;
-    }
-    if (object.suffix !== undefined && object.suffix !== null) {
-      message.suffix = object.suffix;
-    } else {
-      message.suffix = '';
-    }
-    return message;
+    return {
+      major: isSet(object.major) ? Number(object.major) : 0,
+      minor: isSet(object.minor) ? Number(object.minor) : 0,
+      patch: isSet(object.patch) ? Number(object.patch) : 0,
+      suffix: isSet(object.suffix) ? String(object.suffix) : '',
+    };
   },
 
   toJSON(message: Version): unknown {
     const obj: any = {};
-    message.major !== undefined && (obj.major = message.major);
-    message.minor !== undefined && (obj.minor = message.minor);
-    message.patch !== undefined && (obj.patch = message.patch);
+    message.major !== undefined && (obj.major = Math.round(message.major));
+    message.minor !== undefined && (obj.minor = Math.round(message.minor));
+    message.patch !== undefined && (obj.patch = Math.round(message.patch));
     message.suffix !== undefined && (obj.suffix = message.suffix);
     return obj;
   },
+
+  fromPartial<I extends Exact<DeepPartial<Version>, I>>(object: I): Version {
+    const message = createBaseVersion();
+    message.major = object.major ?? 0;
+    message.minor = object.minor ?? 0;
+    message.patch = object.patch ?? 0;
+    message.suffix = object.suffix ?? '';
+    return message;
+  },
 };
 
-const baseCodeGeneratorRequest: object = { fileToGenerate: '', parameter: '' };
+function createBaseCodeGeneratorRequest(): CodeGeneratorRequest {
+  return { fileToGenerate: [], parameter: '', protoFile: [], compilerVersion: undefined };
+}
 
 export const CodeGeneratorRequest = {
   encode(message: CodeGeneratorRequest, writer: Writer = Writer.create()): Writer {
     for (const v of message.fileToGenerate) {
       writer.uint32(10).string(v!);
     }
-    writer.uint32(18).string(message.parameter);
+    if (message.parameter !== '') {
+      writer.uint32(18).string(message.parameter);
+    }
     for (const v of message.protoFile) {
       FileDescriptorProto.encode(v!, writer.uint32(122).fork()).ldelim();
     }
     if (message.compilerVersion !== undefined) {
       Version.encode(message.compilerVersion, writer.uint32(26).fork()).ldelim();
     }
+    if ('_unknownFields' in message) {
+      for (const key of Object.keys(message['_unknownFields'])) {
+        const values = message['_unknownFields'][key] as Uint8Array[];
+        for (const value of values) {
+          writer.uint32(parseInt(key, 10));
+          (writer as any)['_push'](
+            (val: Uint8Array, buf: Buffer, pos: number) => buf.set(val, pos),
+            value.length,
+            value
+          );
+        }
+      }
+    }
     return writer;
   },
 
   decode(input: Reader | Uint8Array, length?: number): CodeGeneratorRequest {
-    const reader = input instanceof Uint8Array ? new Reader(input) : input;
+    const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = Object.create(baseCodeGeneratorRequest) as CodeGeneratorRequest;
-    message.fileToGenerate = [];
-    message.protoFile = [];
+    const message = createBaseCodeGeneratorRequest();
+    (message as any)._unknownFields = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -303,7 +316,12 @@ export const CodeGeneratorRequest = {
           message.compilerVersion = Version.decode(reader, reader.uint32());
           break;
         default:
+          const startPos = reader.pos;
           reader.skipType(tag & 7);
+          (message as any)._unknownFields[tag] = [
+            ...((message as any)._unknownFields[tag] || []),
+            reader.buf.slice(startPos, reader.pos),
+          ];
           break;
       }
     }
@@ -311,57 +329,14 @@ export const CodeGeneratorRequest = {
   },
 
   fromJSON(object: any): CodeGeneratorRequest {
-    const message = Object.create(baseCodeGeneratorRequest) as CodeGeneratorRequest;
-    message.fileToGenerate = [];
-    message.protoFile = [];
-    if (object.fileToGenerate !== undefined && object.fileToGenerate !== null) {
-      for (const e of object.fileToGenerate) {
-        message.fileToGenerate.push(String(e));
-      }
-    }
-    if (object.parameter !== undefined && object.parameter !== null) {
-      message.parameter = String(object.parameter);
-    } else {
-      message.parameter = '';
-    }
-    if (object.protoFile !== undefined && object.protoFile !== null) {
-      for (const e of object.protoFile) {
-        message.protoFile.push(FileDescriptorProto.fromJSON(e));
-      }
-    }
-    if (object.compilerVersion !== undefined && object.compilerVersion !== null) {
-      message.compilerVersion = Version.fromJSON(object.compilerVersion);
-    } else {
-      message.compilerVersion = undefined;
-    }
-    return message;
-  },
-
-  fromPartial(object: DeepPartial<CodeGeneratorRequest>): CodeGeneratorRequest {
-    const message = { ...baseCodeGeneratorRequest } as CodeGeneratorRequest;
-    message.fileToGenerate = [];
-    message.protoFile = [];
-    if (object.fileToGenerate !== undefined && object.fileToGenerate !== null) {
-      for (const e of object.fileToGenerate) {
-        message.fileToGenerate.push(e);
-      }
-    }
-    if (object.parameter !== undefined && object.parameter !== null) {
-      message.parameter = object.parameter;
-    } else {
-      message.parameter = '';
-    }
-    if (object.protoFile !== undefined && object.protoFile !== null) {
-      for (const e of object.protoFile) {
-        message.protoFile.push(FileDescriptorProto.fromPartial(e));
-      }
-    }
-    if (object.compilerVersion !== undefined && object.compilerVersion !== null) {
-      message.compilerVersion = Version.fromPartial(object.compilerVersion);
-    } else {
-      message.compilerVersion = undefined;
-    }
-    return message;
+    return {
+      fileToGenerate: Array.isArray(object?.fileToGenerate) ? object.fileToGenerate.map((e: any) => String(e)) : [],
+      parameter: isSet(object.parameter) ? String(object.parameter) : '',
+      protoFile: Array.isArray(object?.protoFile)
+        ? object.protoFile.map((e: any) => FileDescriptorProto.fromJSON(e))
+        : [],
+      compilerVersion: isSet(object.compilerVersion) ? Version.fromJSON(object.compilerVersion) : undefined,
+    };
   },
 
   toJSON(message: CodeGeneratorRequest): unknown {
@@ -381,25 +356,56 @@ export const CodeGeneratorRequest = {
       (obj.compilerVersion = message.compilerVersion ? Version.toJSON(message.compilerVersion) : undefined);
     return obj;
   },
+
+  fromPartial<I extends Exact<DeepPartial<CodeGeneratorRequest>, I>>(object: I): CodeGeneratorRequest {
+    const message = createBaseCodeGeneratorRequest();
+    message.fileToGenerate = object.fileToGenerate?.map((e) => e) || [];
+    message.parameter = object.parameter ?? '';
+    message.protoFile = object.protoFile?.map((e) => FileDescriptorProto.fromPartial(e)) || [];
+    message.compilerVersion =
+      object.compilerVersion !== undefined && object.compilerVersion !== null
+        ? Version.fromPartial(object.compilerVersion)
+        : undefined;
+    return message;
+  },
 };
 
-const baseCodeGeneratorResponse: object = { error: '', supportedFeatures: 0 };
+function createBaseCodeGeneratorResponse(): CodeGeneratorResponse {
+  return { error: '', supportedFeatures: 0, file: [] };
+}
 
 export const CodeGeneratorResponse = {
   encode(message: CodeGeneratorResponse, writer: Writer = Writer.create()): Writer {
-    writer.uint32(10).string(message.error);
-    writer.uint32(16).uint64(message.supportedFeatures);
+    if (message.error !== '') {
+      writer.uint32(10).string(message.error);
+    }
+    if (message.supportedFeatures !== 0) {
+      writer.uint32(16).uint64(message.supportedFeatures);
+    }
     for (const v of message.file) {
       CodeGeneratorResponse_File.encode(v!, writer.uint32(122).fork()).ldelim();
+    }
+    if ('_unknownFields' in message) {
+      for (const key of Object.keys(message['_unknownFields'])) {
+        const values = message['_unknownFields'][key] as Uint8Array[];
+        for (const value of values) {
+          writer.uint32(parseInt(key, 10));
+          (writer as any)['_push'](
+            (val: Uint8Array, buf: Buffer, pos: number) => buf.set(val, pos),
+            value.length,
+            value
+          );
+        }
+      }
     }
     return writer;
   },
 
   decode(input: Reader | Uint8Array, length?: number): CodeGeneratorResponse {
-    const reader = input instanceof Uint8Array ? new Reader(input) : input;
+    const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = Object.create(baseCodeGeneratorResponse) as CodeGeneratorResponse;
-    message.file = [];
+    const message = createBaseCodeGeneratorResponse();
+    (message as any)._unknownFields = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -413,7 +419,12 @@ export const CodeGeneratorResponse = {
           message.file.push(CodeGeneratorResponse_File.decode(reader, reader.uint32()));
           break;
         default:
+          const startPos = reader.pos;
           reader.skipType(tag & 7);
+          (message as any)._unknownFields[tag] = [
+            ...((message as any)._unknownFields[tag] || []),
+            reader.buf.slice(startPos, reader.pos),
+          ];
           break;
       }
     }
@@ -421,51 +432,17 @@ export const CodeGeneratorResponse = {
   },
 
   fromJSON(object: any): CodeGeneratorResponse {
-    const message = Object.create(baseCodeGeneratorResponse) as CodeGeneratorResponse;
-    message.file = [];
-    if (object.error !== undefined && object.error !== null) {
-      message.error = String(object.error);
-    } else {
-      message.error = '';
-    }
-    if (object.supportedFeatures !== undefined && object.supportedFeatures !== null) {
-      message.supportedFeatures = Number(object.supportedFeatures);
-    } else {
-      message.supportedFeatures = 0;
-    }
-    if (object.file !== undefined && object.file !== null) {
-      for (const e of object.file) {
-        message.file.push(CodeGeneratorResponse_File.fromJSON(e));
-      }
-    }
-    return message;
-  },
-
-  fromPartial(object: DeepPartial<CodeGeneratorResponse>): CodeGeneratorResponse {
-    const message = { ...baseCodeGeneratorResponse } as CodeGeneratorResponse;
-    message.file = [];
-    if (object.error !== undefined && object.error !== null) {
-      message.error = object.error;
-    } else {
-      message.error = '';
-    }
-    if (object.supportedFeatures !== undefined && object.supportedFeatures !== null) {
-      message.supportedFeatures = object.supportedFeatures;
-    } else {
-      message.supportedFeatures = 0;
-    }
-    if (object.file !== undefined && object.file !== null) {
-      for (const e of object.file) {
-        message.file.push(CodeGeneratorResponse_File.fromPartial(e));
-      }
-    }
-    return message;
+    return {
+      error: isSet(object.error) ? String(object.error) : '',
+      supportedFeatures: isSet(object.supportedFeatures) ? Number(object.supportedFeatures) : 0,
+      file: Array.isArray(object?.file) ? object.file.map((e: any) => CodeGeneratorResponse_File.fromJSON(e)) : [],
+    };
   },
 
   toJSON(message: CodeGeneratorResponse): unknown {
     const obj: any = {};
     message.error !== undefined && (obj.error = message.error);
-    message.supportedFeatures !== undefined && (obj.supportedFeatures = message.supportedFeatures);
+    message.supportedFeatures !== undefined && (obj.supportedFeatures = Math.round(message.supportedFeatures));
     if (message.file) {
       obj.file = message.file.map((e) => (e ? CodeGeneratorResponse_File.toJSON(e) : undefined));
     } else {
@@ -473,25 +450,55 @@ export const CodeGeneratorResponse = {
     }
     return obj;
   },
+
+  fromPartial<I extends Exact<DeepPartial<CodeGeneratorResponse>, I>>(object: I): CodeGeneratorResponse {
+    const message = createBaseCodeGeneratorResponse();
+    message.error = object.error ?? '';
+    message.supportedFeatures = object.supportedFeatures ?? 0;
+    message.file = object.file?.map((e) => CodeGeneratorResponse_File.fromPartial(e)) || [];
+    return message;
+  },
 };
 
-const baseCodeGeneratorResponse_File: object = { name: '', insertionPoint: '', content: '' };
+function createBaseCodeGeneratorResponse_File(): CodeGeneratorResponse_File {
+  return { name: '', insertionPoint: '', content: '', generatedCodeInfo: undefined };
+}
 
 export const CodeGeneratorResponse_File = {
   encode(message: CodeGeneratorResponse_File, writer: Writer = Writer.create()): Writer {
-    writer.uint32(10).string(message.name);
-    writer.uint32(18).string(message.insertionPoint);
-    writer.uint32(122).string(message.content);
+    if (message.name !== '') {
+      writer.uint32(10).string(message.name);
+    }
+    if (message.insertionPoint !== '') {
+      writer.uint32(18).string(message.insertionPoint);
+    }
+    if (message.content !== '') {
+      writer.uint32(122).string(message.content);
+    }
     if (message.generatedCodeInfo !== undefined) {
       GeneratedCodeInfo.encode(message.generatedCodeInfo, writer.uint32(130).fork()).ldelim();
+    }
+    if ('_unknownFields' in message) {
+      for (const key of Object.keys(message['_unknownFields'])) {
+        const values = message['_unknownFields'][key] as Uint8Array[];
+        for (const value of values) {
+          writer.uint32(parseInt(key, 10));
+          (writer as any)['_push'](
+            (val: Uint8Array, buf: Buffer, pos: number) => buf.set(val, pos),
+            value.length,
+            value
+          );
+        }
+      }
     }
     return writer;
   },
 
   decode(input: Reader | Uint8Array, length?: number): CodeGeneratorResponse_File {
-    const reader = input instanceof Uint8Array ? new Reader(input) : input;
+    const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = Object.create(baseCodeGeneratorResponse_File) as CodeGeneratorResponse_File;
+    const message = createBaseCodeGeneratorResponse_File();
+    (message as any)._unknownFields = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -508,7 +515,12 @@ export const CodeGeneratorResponse_File = {
           message.generatedCodeInfo = GeneratedCodeInfo.decode(reader, reader.uint32());
           break;
         default:
+          const startPos = reader.pos;
           reader.skipType(tag & 7);
+          (message as any)._unknownFields[tag] = [
+            ...((message as any)._unknownFields[tag] || []),
+            reader.buf.slice(startPos, reader.pos),
+          ];
           break;
       }
     }
@@ -516,53 +528,14 @@ export const CodeGeneratorResponse_File = {
   },
 
   fromJSON(object: any): CodeGeneratorResponse_File {
-    const message = Object.create(baseCodeGeneratorResponse_File) as CodeGeneratorResponse_File;
-    if (object.name !== undefined && object.name !== null) {
-      message.name = String(object.name);
-    } else {
-      message.name = '';
-    }
-    if (object.insertionPoint !== undefined && object.insertionPoint !== null) {
-      message.insertionPoint = String(object.insertionPoint);
-    } else {
-      message.insertionPoint = '';
-    }
-    if (object.content !== undefined && object.content !== null) {
-      message.content = String(object.content);
-    } else {
-      message.content = '';
-    }
-    if (object.generatedCodeInfo !== undefined && object.generatedCodeInfo !== null) {
-      message.generatedCodeInfo = GeneratedCodeInfo.fromJSON(object.generatedCodeInfo);
-    } else {
-      message.generatedCodeInfo = undefined;
-    }
-    return message;
-  },
-
-  fromPartial(object: DeepPartial<CodeGeneratorResponse_File>): CodeGeneratorResponse_File {
-    const message = { ...baseCodeGeneratorResponse_File } as CodeGeneratorResponse_File;
-    if (object.name !== undefined && object.name !== null) {
-      message.name = object.name;
-    } else {
-      message.name = '';
-    }
-    if (object.insertionPoint !== undefined && object.insertionPoint !== null) {
-      message.insertionPoint = object.insertionPoint;
-    } else {
-      message.insertionPoint = '';
-    }
-    if (object.content !== undefined && object.content !== null) {
-      message.content = object.content;
-    } else {
-      message.content = '';
-    }
-    if (object.generatedCodeInfo !== undefined && object.generatedCodeInfo !== null) {
-      message.generatedCodeInfo = GeneratedCodeInfo.fromPartial(object.generatedCodeInfo);
-    } else {
-      message.generatedCodeInfo = undefined;
-    }
-    return message;
+    return {
+      name: isSet(object.name) ? String(object.name) : '',
+      insertionPoint: isSet(object.insertionPoint) ? String(object.insertionPoint) : '',
+      content: isSet(object.content) ? String(object.content) : '',
+      generatedCodeInfo: isSet(object.generatedCodeInfo)
+        ? GeneratedCodeInfo.fromJSON(object.generatedCodeInfo)
+        : undefined,
+    };
   },
 
   toJSON(message: CodeGeneratorResponse_File): unknown {
@@ -576,6 +549,18 @@ export const CodeGeneratorResponse_File = {
         : undefined);
     return obj;
   },
+
+  fromPartial<I extends Exact<DeepPartial<CodeGeneratorResponse_File>, I>>(object: I): CodeGeneratorResponse_File {
+    const message = createBaseCodeGeneratorResponse_File();
+    message.name = object.name ?? '';
+    message.insertionPoint = object.insertionPoint ?? '';
+    message.content = object.content ?? '';
+    message.generatedCodeInfo =
+      object.generatedCodeInfo !== undefined && object.generatedCodeInfo !== null
+        ? GeneratedCodeInfo.fromPartial(object.generatedCodeInfo)
+        : undefined;
+    return message;
+  },
 };
 
 declare var self: any | undefined;
@@ -586,10 +571,11 @@ var globalThis: any = (() => {
   if (typeof self !== 'undefined') return self;
   if (typeof window !== 'undefined') return window;
   if (typeof global !== 'undefined') return global;
-  throw new Error('Unable to locate global object');
+  throw 'Unable to locate global object';
 })();
 
-type Builtin = Date | Function | Uint8Array | string | number | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
+
 type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>
@@ -600,6 +586,11 @@ type DeepPartial<T> = T extends Builtin
   ? { [K in keyof T]?: DeepPartial<T[K]> }
   : Partial<T>;
 
+type KeysOfUnion<T> = T extends T ? keyof T : never;
+type Exact<P, I extends P> = P extends Builtin
+  ? P
+  : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<Exclude<keyof I, KeysOfUnion<P>>, never>;
+
 function longToNumber(long: Long): number {
   if (long.gt(Number.MAX_SAFE_INTEGER)) {
     throw new globalThis.Error('Value is larger than Number.MAX_SAFE_INTEGER');
@@ -607,7 +598,13 @@ function longToNumber(long: Long): number {
   return long.toNumber();
 }
 
+// If you get a compile-error about 'Constructor<Long> and ... have no overlap',
+// add '--ts_proto_opt=esModuleInterop=true' as a flag when calling 'protoc'.
 if (util.Long !== Long) {
   util.Long = Long as any;
   configure();
+}
+
+function isSet(value: any): boolean {
+  return value !== null && value !== undefined;
 }

--- a/protos/google/protobuf/descriptor.ts
+++ b/protos/google/protobuf/descriptor.ts
@@ -1,6 +1,6 @@
 /* eslint-disable */
-import * as Long from 'long';
 import { util, configure, Writer, Reader } from 'protobufjs/minimal';
+import * as Long from 'long';
 
 /**
  * The protocol compiler can output a FileDescriptorSet containing the .proto
@@ -1110,21 +1110,36 @@ export interface GeneratedCodeInfo_Annotation {
   end: number;
 }
 
-const baseFileDescriptorSet: object = {};
+function createBaseFileDescriptorSet(): FileDescriptorSet {
+  return { file: [] };
+}
 
 export const FileDescriptorSet = {
   encode(message: FileDescriptorSet, writer: Writer = Writer.create()): Writer {
     for (const v of message.file) {
       FileDescriptorProto.encode(v!, writer.uint32(10).fork()).ldelim();
     }
+    if ('_unknownFields' in message) {
+      for (const key of Object.keys(message['_unknownFields'])) {
+        const values = message['_unknownFields'][key] as Uint8Array[];
+        for (const value of values) {
+          writer.uint32(parseInt(key, 10));
+          (writer as any)['_push'](
+            (val: Uint8Array, buf: Buffer, pos: number) => buf.set(val, pos),
+            value.length,
+            value
+          );
+        }
+      }
+    }
     return writer;
   },
 
   decode(input: Reader | Uint8Array, length?: number): FileDescriptorSet {
-    const reader = input instanceof Uint8Array ? new Reader(input) : input;
+    const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = Object.create(baseFileDescriptorSet) as FileDescriptorSet;
-    message.file = [];
+    const message = createBaseFileDescriptorSet();
+    (message as any)._unknownFields = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -1132,7 +1147,12 @@ export const FileDescriptorSet = {
           message.file.push(FileDescriptorProto.decode(reader, reader.uint32()));
           break;
         default:
+          const startPos = reader.pos;
           reader.skipType(tag & 7);
+          (message as any)._unknownFields[tag] = [
+            ...((message as any)._unknownFields[tag] || []),
+            reader.buf.slice(startPos, reader.pos),
+          ];
           break;
       }
     }
@@ -1140,25 +1160,9 @@ export const FileDescriptorSet = {
   },
 
   fromJSON(object: any): FileDescriptorSet {
-    const message = Object.create(baseFileDescriptorSet) as FileDescriptorSet;
-    message.file = [];
-    if (object.file !== undefined && object.file !== null) {
-      for (const e of object.file) {
-        message.file.push(FileDescriptorProto.fromJSON(e));
-      }
-    }
-    return message;
-  },
-
-  fromPartial(object: DeepPartial<FileDescriptorSet>): FileDescriptorSet {
-    const message = { ...baseFileDescriptorSet } as FileDescriptorSet;
-    message.file = [];
-    if (object.file !== undefined && object.file !== null) {
-      for (const e of object.file) {
-        message.file.push(FileDescriptorProto.fromPartial(e));
-      }
-    }
-    return message;
+    return {
+      file: Array.isArray(object?.file) ? object.file.map((e: any) => FileDescriptorProto.fromJSON(e)) : [],
+    };
   },
 
   toJSON(message: FileDescriptorSet): unknown {
@@ -1170,21 +1174,39 @@ export const FileDescriptorSet = {
     }
     return obj;
   },
+
+  fromPartial<I extends Exact<DeepPartial<FileDescriptorSet>, I>>(object: I): FileDescriptorSet {
+    const message = createBaseFileDescriptorSet();
+    message.file = object.file?.map((e) => FileDescriptorProto.fromPartial(e)) || [];
+    return message;
+  },
 };
 
-const baseFileDescriptorProto: object = {
-  name: '',
-  package: '',
-  dependency: '',
-  publicDependency: 0,
-  weakDependency: 0,
-  syntax: '',
-};
+function createBaseFileDescriptorProto(): FileDescriptorProto {
+  return {
+    name: '',
+    package: '',
+    dependency: [],
+    publicDependency: [],
+    weakDependency: [],
+    messageType: [],
+    enumType: [],
+    service: [],
+    extension: [],
+    options: undefined,
+    sourceCodeInfo: undefined,
+    syntax: '',
+  };
+}
 
 export const FileDescriptorProto = {
   encode(message: FileDescriptorProto, writer: Writer = Writer.create()): Writer {
-    writer.uint32(10).string(message.name);
-    writer.uint32(18).string(message.package);
+    if (message.name !== '') {
+      writer.uint32(10).string(message.name);
+    }
+    if (message.package !== '') {
+      writer.uint32(18).string(message.package);
+    }
     for (const v of message.dependency) {
       writer.uint32(26).string(v!);
     }
@@ -1216,21 +1238,30 @@ export const FileDescriptorProto = {
     if (message.sourceCodeInfo !== undefined) {
       SourceCodeInfo.encode(message.sourceCodeInfo, writer.uint32(74).fork()).ldelim();
     }
-    writer.uint32(98).string(message.syntax);
+    if (message.syntax !== '') {
+      writer.uint32(98).string(message.syntax);
+    }
+    if ('_unknownFields' in message) {
+      for (const key of Object.keys(message['_unknownFields'])) {
+        const values = message['_unknownFields'][key] as Uint8Array[];
+        for (const value of values) {
+          writer.uint32(parseInt(key, 10));
+          (writer as any)['_push'](
+            (val: Uint8Array, buf: Buffer, pos: number) => buf.set(val, pos),
+            value.length,
+            value
+          );
+        }
+      }
+    }
     return writer;
   },
 
   decode(input: Reader | Uint8Array, length?: number): FileDescriptorProto {
-    const reader = input instanceof Uint8Array ? new Reader(input) : input;
+    const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = Object.create(baseFileDescriptorProto) as FileDescriptorProto;
-    message.dependency = [];
-    message.publicDependency = [];
-    message.weakDependency = [];
-    message.messageType = [];
-    message.enumType = [];
-    message.service = [];
-    message.extension = [];
+    const message = createBaseFileDescriptorProto();
+    (message as any)._unknownFields = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -1285,7 +1316,12 @@ export const FileDescriptorProto = {
           message.syntax = reader.string();
           break;
         default:
+          const startPos = reader.pos;
           reader.skipType(tag & 7);
+          (message as any)._unknownFields[tag] = [
+            ...((message as any)._unknownFields[tag] || []),
+            reader.buf.slice(startPos, reader.pos),
+          ];
           break;
       }
     }
@@ -1293,147 +1329,26 @@ export const FileDescriptorProto = {
   },
 
   fromJSON(object: any): FileDescriptorProto {
-    const message = Object.create(baseFileDescriptorProto) as FileDescriptorProto;
-    message.dependency = [];
-    message.publicDependency = [];
-    message.weakDependency = [];
-    message.messageType = [];
-    message.enumType = [];
-    message.service = [];
-    message.extension = [];
-    if (object.name !== undefined && object.name !== null) {
-      message.name = String(object.name);
-    } else {
-      message.name = '';
-    }
-    if (object.package !== undefined && object.package !== null) {
-      message.package = String(object.package);
-    } else {
-      message.package = '';
-    }
-    if (object.dependency !== undefined && object.dependency !== null) {
-      for (const e of object.dependency) {
-        message.dependency.push(String(e));
-      }
-    }
-    if (object.publicDependency !== undefined && object.publicDependency !== null) {
-      for (const e of object.publicDependency) {
-        message.publicDependency.push(Number(e));
-      }
-    }
-    if (object.weakDependency !== undefined && object.weakDependency !== null) {
-      for (const e of object.weakDependency) {
-        message.weakDependency.push(Number(e));
-      }
-    }
-    if (object.messageType !== undefined && object.messageType !== null) {
-      for (const e of object.messageType) {
-        message.messageType.push(DescriptorProto.fromJSON(e));
-      }
-    }
-    if (object.enumType !== undefined && object.enumType !== null) {
-      for (const e of object.enumType) {
-        message.enumType.push(EnumDescriptorProto.fromJSON(e));
-      }
-    }
-    if (object.service !== undefined && object.service !== null) {
-      for (const e of object.service) {
-        message.service.push(ServiceDescriptorProto.fromJSON(e));
-      }
-    }
-    if (object.extension !== undefined && object.extension !== null) {
-      for (const e of object.extension) {
-        message.extension.push(FieldDescriptorProto.fromJSON(e));
-      }
-    }
-    if (object.options !== undefined && object.options !== null) {
-      message.options = FileOptions.fromJSON(object.options);
-    } else {
-      message.options = undefined;
-    }
-    if (object.sourceCodeInfo !== undefined && object.sourceCodeInfo !== null) {
-      message.sourceCodeInfo = SourceCodeInfo.fromJSON(object.sourceCodeInfo);
-    } else {
-      message.sourceCodeInfo = undefined;
-    }
-    if (object.syntax !== undefined && object.syntax !== null) {
-      message.syntax = String(object.syntax);
-    } else {
-      message.syntax = '';
-    }
-    return message;
-  },
-
-  fromPartial(object: DeepPartial<FileDescriptorProto>): FileDescriptorProto {
-    const message = { ...baseFileDescriptorProto } as FileDescriptorProto;
-    message.dependency = [];
-    message.publicDependency = [];
-    message.weakDependency = [];
-    message.messageType = [];
-    message.enumType = [];
-    message.service = [];
-    message.extension = [];
-    if (object.name !== undefined && object.name !== null) {
-      message.name = object.name;
-    } else {
-      message.name = '';
-    }
-    if (object.package !== undefined && object.package !== null) {
-      message.package = object.package;
-    } else {
-      message.package = '';
-    }
-    if (object.dependency !== undefined && object.dependency !== null) {
-      for (const e of object.dependency) {
-        message.dependency.push(e);
-      }
-    }
-    if (object.publicDependency !== undefined && object.publicDependency !== null) {
-      for (const e of object.publicDependency) {
-        message.publicDependency.push(e);
-      }
-    }
-    if (object.weakDependency !== undefined && object.weakDependency !== null) {
-      for (const e of object.weakDependency) {
-        message.weakDependency.push(e);
-      }
-    }
-    if (object.messageType !== undefined && object.messageType !== null) {
-      for (const e of object.messageType) {
-        message.messageType.push(DescriptorProto.fromPartial(e));
-      }
-    }
-    if (object.enumType !== undefined && object.enumType !== null) {
-      for (const e of object.enumType) {
-        message.enumType.push(EnumDescriptorProto.fromPartial(e));
-      }
-    }
-    if (object.service !== undefined && object.service !== null) {
-      for (const e of object.service) {
-        message.service.push(ServiceDescriptorProto.fromPartial(e));
-      }
-    }
-    if (object.extension !== undefined && object.extension !== null) {
-      for (const e of object.extension) {
-        message.extension.push(FieldDescriptorProto.fromPartial(e));
-      }
-    }
-    if (object.options !== undefined && object.options !== null) {
-      message.options = FileOptions.fromPartial(object.options);
-    } else {
-      message.options = undefined;
-    }
-    if (object.sourceCodeInfo !== undefined && object.sourceCodeInfo !== null) {
-      message.sourceCodeInfo = SourceCodeInfo.fromPartial(object.sourceCodeInfo);
-    } else {
-      message.sourceCodeInfo = undefined;
-    }
-    if (object.syntax !== undefined && object.syntax !== null) {
-      message.syntax = object.syntax;
-    } else {
-      message.syntax = '';
-    }
-    return message;
+    return {
+      name: isSet(object.name) ? String(object.name) : '',
+      package: isSet(object.package) ? String(object.package) : '',
+      dependency: Array.isArray(object?.dependency) ? object.dependency.map((e: any) => String(e)) : [],
+      publicDependency: Array.isArray(object?.publicDependency)
+        ? object.publicDependency.map((e: any) => Number(e))
+        : [],
+      weakDependency: Array.isArray(object?.weakDependency) ? object.weakDependency.map((e: any) => Number(e)) : [],
+      messageType: Array.isArray(object?.messageType)
+        ? object.messageType.map((e: any) => DescriptorProto.fromJSON(e))
+        : [],
+      enumType: Array.isArray(object?.enumType) ? object.enumType.map((e: any) => EnumDescriptorProto.fromJSON(e)) : [],
+      service: Array.isArray(object?.service) ? object.service.map((e: any) => ServiceDescriptorProto.fromJSON(e)) : [],
+      extension: Array.isArray(object?.extension)
+        ? object.extension.map((e: any) => FieldDescriptorProto.fromJSON(e))
+        : [],
+      options: isSet(object.options) ? FileOptions.fromJSON(object.options) : undefined,
+      sourceCodeInfo: isSet(object.sourceCodeInfo) ? SourceCodeInfo.fromJSON(object.sourceCodeInfo) : undefined,
+      syntax: isSet(object.syntax) ? String(object.syntax) : '',
+    };
   },
 
   toJSON(message: FileDescriptorProto): unknown {
@@ -1446,12 +1361,12 @@ export const FileDescriptorProto = {
       obj.dependency = [];
     }
     if (message.publicDependency) {
-      obj.publicDependency = message.publicDependency.map((e) => e);
+      obj.publicDependency = message.publicDependency.map((e) => Math.round(e));
     } else {
       obj.publicDependency = [];
     }
     if (message.weakDependency) {
-      obj.weakDependency = message.weakDependency.map((e) => e);
+      obj.weakDependency = message.weakDependency.map((e) => Math.round(e));
     } else {
       obj.weakDependency = [];
     }
@@ -1481,13 +1396,49 @@ export const FileDescriptorProto = {
     message.syntax !== undefined && (obj.syntax = message.syntax);
     return obj;
   },
+
+  fromPartial<I extends Exact<DeepPartial<FileDescriptorProto>, I>>(object: I): FileDescriptorProto {
+    const message = createBaseFileDescriptorProto();
+    message.name = object.name ?? '';
+    message.package = object.package ?? '';
+    message.dependency = object.dependency?.map((e) => e) || [];
+    message.publicDependency = object.publicDependency?.map((e) => e) || [];
+    message.weakDependency = object.weakDependency?.map((e) => e) || [];
+    message.messageType = object.messageType?.map((e) => DescriptorProto.fromPartial(e)) || [];
+    message.enumType = object.enumType?.map((e) => EnumDescriptorProto.fromPartial(e)) || [];
+    message.service = object.service?.map((e) => ServiceDescriptorProto.fromPartial(e)) || [];
+    message.extension = object.extension?.map((e) => FieldDescriptorProto.fromPartial(e)) || [];
+    message.options =
+      object.options !== undefined && object.options !== null ? FileOptions.fromPartial(object.options) : undefined;
+    message.sourceCodeInfo =
+      object.sourceCodeInfo !== undefined && object.sourceCodeInfo !== null
+        ? SourceCodeInfo.fromPartial(object.sourceCodeInfo)
+        : undefined;
+    message.syntax = object.syntax ?? '';
+    return message;
+  },
 };
 
-const baseDescriptorProto: object = { name: '', reservedName: '' };
+function createBaseDescriptorProto(): DescriptorProto {
+  return {
+    name: '',
+    field: [],
+    extension: [],
+    nestedType: [],
+    enumType: [],
+    extensionRange: [],
+    oneofDecl: [],
+    options: undefined,
+    reservedRange: [],
+    reservedName: [],
+  };
+}
 
 export const DescriptorProto = {
   encode(message: DescriptorProto, writer: Writer = Writer.create()): Writer {
-    writer.uint32(10).string(message.name);
+    if (message.name !== '') {
+      writer.uint32(10).string(message.name);
+    }
     for (const v of message.field) {
       FieldDescriptorProto.encode(v!, writer.uint32(18).fork()).ldelim();
     }
@@ -1515,21 +1466,27 @@ export const DescriptorProto = {
     for (const v of message.reservedName) {
       writer.uint32(82).string(v!);
     }
+    if ('_unknownFields' in message) {
+      for (const key of Object.keys(message['_unknownFields'])) {
+        const values = message['_unknownFields'][key] as Uint8Array[];
+        for (const value of values) {
+          writer.uint32(parseInt(key, 10));
+          (writer as any)['_push'](
+            (val: Uint8Array, buf: Buffer, pos: number) => buf.set(val, pos),
+            value.length,
+            value
+          );
+        }
+      }
+    }
     return writer;
   },
 
   decode(input: Reader | Uint8Array, length?: number): DescriptorProto {
-    const reader = input instanceof Uint8Array ? new Reader(input) : input;
+    const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = Object.create(baseDescriptorProto) as DescriptorProto;
-    message.field = [];
-    message.extension = [];
-    message.nestedType = [];
-    message.enumType = [];
-    message.extensionRange = [];
-    message.oneofDecl = [];
-    message.reservedRange = [];
-    message.reservedName = [];
+    const message = createBaseDescriptorProto();
+    (message as any)._unknownFields = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -1564,7 +1521,12 @@ export const DescriptorProto = {
           message.reservedName.push(reader.string());
           break;
         default:
+          const startPos = reader.pos;
           reader.skipType(tag & 7);
+          (message as any)._unknownFields[tag] = [
+            ...((message as any)._unknownFields[tag] || []),
+            reader.buf.slice(startPos, reader.pos),
+          ];
           break;
       }
     }
@@ -1572,129 +1534,28 @@ export const DescriptorProto = {
   },
 
   fromJSON(object: any): DescriptorProto {
-    const message = Object.create(baseDescriptorProto) as DescriptorProto;
-    message.field = [];
-    message.extension = [];
-    message.nestedType = [];
-    message.enumType = [];
-    message.extensionRange = [];
-    message.oneofDecl = [];
-    message.reservedRange = [];
-    message.reservedName = [];
-    if (object.name !== undefined && object.name !== null) {
-      message.name = String(object.name);
-    } else {
-      message.name = '';
-    }
-    if (object.field !== undefined && object.field !== null) {
-      for (const e of object.field) {
-        message.field.push(FieldDescriptorProto.fromJSON(e));
-      }
-    }
-    if (object.extension !== undefined && object.extension !== null) {
-      for (const e of object.extension) {
-        message.extension.push(FieldDescriptorProto.fromJSON(e));
-      }
-    }
-    if (object.nestedType !== undefined && object.nestedType !== null) {
-      for (const e of object.nestedType) {
-        message.nestedType.push(DescriptorProto.fromJSON(e));
-      }
-    }
-    if (object.enumType !== undefined && object.enumType !== null) {
-      for (const e of object.enumType) {
-        message.enumType.push(EnumDescriptorProto.fromJSON(e));
-      }
-    }
-    if (object.extensionRange !== undefined && object.extensionRange !== null) {
-      for (const e of object.extensionRange) {
-        message.extensionRange.push(DescriptorProto_ExtensionRange.fromJSON(e));
-      }
-    }
-    if (object.oneofDecl !== undefined && object.oneofDecl !== null) {
-      for (const e of object.oneofDecl) {
-        message.oneofDecl.push(OneofDescriptorProto.fromJSON(e));
-      }
-    }
-    if (object.options !== undefined && object.options !== null) {
-      message.options = MessageOptions.fromJSON(object.options);
-    } else {
-      message.options = undefined;
-    }
-    if (object.reservedRange !== undefined && object.reservedRange !== null) {
-      for (const e of object.reservedRange) {
-        message.reservedRange.push(DescriptorProto_ReservedRange.fromJSON(e));
-      }
-    }
-    if (object.reservedName !== undefined && object.reservedName !== null) {
-      for (const e of object.reservedName) {
-        message.reservedName.push(String(e));
-      }
-    }
-    return message;
-  },
-
-  fromPartial(object: DeepPartial<DescriptorProto>): DescriptorProto {
-    const message = { ...baseDescriptorProto } as DescriptorProto;
-    message.field = [];
-    message.extension = [];
-    message.nestedType = [];
-    message.enumType = [];
-    message.extensionRange = [];
-    message.oneofDecl = [];
-    message.reservedRange = [];
-    message.reservedName = [];
-    if (object.name !== undefined && object.name !== null) {
-      message.name = object.name;
-    } else {
-      message.name = '';
-    }
-    if (object.field !== undefined && object.field !== null) {
-      for (const e of object.field) {
-        message.field.push(FieldDescriptorProto.fromPartial(e));
-      }
-    }
-    if (object.extension !== undefined && object.extension !== null) {
-      for (const e of object.extension) {
-        message.extension.push(FieldDescriptorProto.fromPartial(e));
-      }
-    }
-    if (object.nestedType !== undefined && object.nestedType !== null) {
-      for (const e of object.nestedType) {
-        message.nestedType.push(DescriptorProto.fromPartial(e));
-      }
-    }
-    if (object.enumType !== undefined && object.enumType !== null) {
-      for (const e of object.enumType) {
-        message.enumType.push(EnumDescriptorProto.fromPartial(e));
-      }
-    }
-    if (object.extensionRange !== undefined && object.extensionRange !== null) {
-      for (const e of object.extensionRange) {
-        message.extensionRange.push(DescriptorProto_ExtensionRange.fromPartial(e));
-      }
-    }
-    if (object.oneofDecl !== undefined && object.oneofDecl !== null) {
-      for (const e of object.oneofDecl) {
-        message.oneofDecl.push(OneofDescriptorProto.fromPartial(e));
-      }
-    }
-    if (object.options !== undefined && object.options !== null) {
-      message.options = MessageOptions.fromPartial(object.options);
-    } else {
-      message.options = undefined;
-    }
-    if (object.reservedRange !== undefined && object.reservedRange !== null) {
-      for (const e of object.reservedRange) {
-        message.reservedRange.push(DescriptorProto_ReservedRange.fromPartial(e));
-      }
-    }
-    if (object.reservedName !== undefined && object.reservedName !== null) {
-      for (const e of object.reservedName) {
-        message.reservedName.push(e);
-      }
-    }
-    return message;
+    return {
+      name: isSet(object.name) ? String(object.name) : '',
+      field: Array.isArray(object?.field) ? object.field.map((e: any) => FieldDescriptorProto.fromJSON(e)) : [],
+      extension: Array.isArray(object?.extension)
+        ? object.extension.map((e: any) => FieldDescriptorProto.fromJSON(e))
+        : [],
+      nestedType: Array.isArray(object?.nestedType)
+        ? object.nestedType.map((e: any) => DescriptorProto.fromJSON(e))
+        : [],
+      enumType: Array.isArray(object?.enumType) ? object.enumType.map((e: any) => EnumDescriptorProto.fromJSON(e)) : [],
+      extensionRange: Array.isArray(object?.extensionRange)
+        ? object.extensionRange.map((e: any) => DescriptorProto_ExtensionRange.fromJSON(e))
+        : [],
+      oneofDecl: Array.isArray(object?.oneofDecl)
+        ? object.oneofDecl.map((e: any) => OneofDescriptorProto.fromJSON(e))
+        : [],
+      options: isSet(object.options) ? MessageOptions.fromJSON(object.options) : undefined,
+      reservedRange: Array.isArray(object?.reservedRange)
+        ? object.reservedRange.map((e: any) => DescriptorProto_ReservedRange.fromJSON(e))
+        : [],
+      reservedName: Array.isArray(object?.reservedName) ? object.reservedName.map((e: any) => String(e)) : [],
+    };
   },
 
   toJSON(message: DescriptorProto): unknown {
@@ -1746,24 +1607,60 @@ export const DescriptorProto = {
     }
     return obj;
   },
+
+  fromPartial<I extends Exact<DeepPartial<DescriptorProto>, I>>(object: I): DescriptorProto {
+    const message = createBaseDescriptorProto();
+    message.name = object.name ?? '';
+    message.field = object.field?.map((e) => FieldDescriptorProto.fromPartial(e)) || [];
+    message.extension = object.extension?.map((e) => FieldDescriptorProto.fromPartial(e)) || [];
+    message.nestedType = object.nestedType?.map((e) => DescriptorProto.fromPartial(e)) || [];
+    message.enumType = object.enumType?.map((e) => EnumDescriptorProto.fromPartial(e)) || [];
+    message.extensionRange = object.extensionRange?.map((e) => DescriptorProto_ExtensionRange.fromPartial(e)) || [];
+    message.oneofDecl = object.oneofDecl?.map((e) => OneofDescriptorProto.fromPartial(e)) || [];
+    message.options =
+      object.options !== undefined && object.options !== null ? MessageOptions.fromPartial(object.options) : undefined;
+    message.reservedRange = object.reservedRange?.map((e) => DescriptorProto_ReservedRange.fromPartial(e)) || [];
+    message.reservedName = object.reservedName?.map((e) => e) || [];
+    return message;
+  },
 };
 
-const baseDescriptorProto_ExtensionRange: object = { start: 0, end: 0 };
+function createBaseDescriptorProto_ExtensionRange(): DescriptorProto_ExtensionRange {
+  return { start: 0, end: 0, options: undefined };
+}
 
 export const DescriptorProto_ExtensionRange = {
   encode(message: DescriptorProto_ExtensionRange, writer: Writer = Writer.create()): Writer {
-    writer.uint32(8).int32(message.start);
-    writer.uint32(16).int32(message.end);
+    if (message.start !== 0) {
+      writer.uint32(8).int32(message.start);
+    }
+    if (message.end !== 0) {
+      writer.uint32(16).int32(message.end);
+    }
     if (message.options !== undefined) {
       ExtensionRangeOptions.encode(message.options, writer.uint32(26).fork()).ldelim();
+    }
+    if ('_unknownFields' in message) {
+      for (const key of Object.keys(message['_unknownFields'])) {
+        const values = message['_unknownFields'][key] as Uint8Array[];
+        for (const value of values) {
+          writer.uint32(parseInt(key, 10));
+          (writer as any)['_push'](
+            (val: Uint8Array, buf: Buffer, pos: number) => buf.set(val, pos),
+            value.length,
+            value
+          );
+        }
+      }
     }
     return writer;
   },
 
   decode(input: Reader | Uint8Array, length?: number): DescriptorProto_ExtensionRange {
-    const reader = input instanceof Uint8Array ? new Reader(input) : input;
+    const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = Object.create(baseDescriptorProto_ExtensionRange) as DescriptorProto_ExtensionRange;
+    const message = createBaseDescriptorProto_ExtensionRange();
+    (message as any)._unknownFields = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -1777,7 +1674,12 @@ export const DescriptorProto_ExtensionRange = {
           message.options = ExtensionRangeOptions.decode(reader, reader.uint32());
           break;
         default:
+          const startPos = reader.pos;
           reader.skipType(tag & 7);
+          (message as any)._unknownFields[tag] = [
+            ...((message as any)._unknownFields[tag] || []),
+            reader.buf.slice(startPos, reader.pos),
+          ];
           break;
       }
     }
@@ -1785,68 +1687,69 @@ export const DescriptorProto_ExtensionRange = {
   },
 
   fromJSON(object: any): DescriptorProto_ExtensionRange {
-    const message = Object.create(baseDescriptorProto_ExtensionRange) as DescriptorProto_ExtensionRange;
-    if (object.start !== undefined && object.start !== null) {
-      message.start = Number(object.start);
-    } else {
-      message.start = 0;
-    }
-    if (object.end !== undefined && object.end !== null) {
-      message.end = Number(object.end);
-    } else {
-      message.end = 0;
-    }
-    if (object.options !== undefined && object.options !== null) {
-      message.options = ExtensionRangeOptions.fromJSON(object.options);
-    } else {
-      message.options = undefined;
-    }
-    return message;
-  },
-
-  fromPartial(object: DeepPartial<DescriptorProto_ExtensionRange>): DescriptorProto_ExtensionRange {
-    const message = { ...baseDescriptorProto_ExtensionRange } as DescriptorProto_ExtensionRange;
-    if (object.start !== undefined && object.start !== null) {
-      message.start = object.start;
-    } else {
-      message.start = 0;
-    }
-    if (object.end !== undefined && object.end !== null) {
-      message.end = object.end;
-    } else {
-      message.end = 0;
-    }
-    if (object.options !== undefined && object.options !== null) {
-      message.options = ExtensionRangeOptions.fromPartial(object.options);
-    } else {
-      message.options = undefined;
-    }
-    return message;
+    return {
+      start: isSet(object.start) ? Number(object.start) : 0,
+      end: isSet(object.end) ? Number(object.end) : 0,
+      options: isSet(object.options) ? ExtensionRangeOptions.fromJSON(object.options) : undefined,
+    };
   },
 
   toJSON(message: DescriptorProto_ExtensionRange): unknown {
     const obj: any = {};
-    message.start !== undefined && (obj.start = message.start);
-    message.end !== undefined && (obj.end = message.end);
+    message.start !== undefined && (obj.start = Math.round(message.start));
+    message.end !== undefined && (obj.end = Math.round(message.end));
     message.options !== undefined &&
       (obj.options = message.options ? ExtensionRangeOptions.toJSON(message.options) : undefined);
     return obj;
   },
+
+  fromPartial<I extends Exact<DeepPartial<DescriptorProto_ExtensionRange>, I>>(
+    object: I
+  ): DescriptorProto_ExtensionRange {
+    const message = createBaseDescriptorProto_ExtensionRange();
+    message.start = object.start ?? 0;
+    message.end = object.end ?? 0;
+    message.options =
+      object.options !== undefined && object.options !== null
+        ? ExtensionRangeOptions.fromPartial(object.options)
+        : undefined;
+    return message;
+  },
 };
 
-const baseDescriptorProto_ReservedRange: object = { start: 0, end: 0 };
+function createBaseDescriptorProto_ReservedRange(): DescriptorProto_ReservedRange {
+  return { start: 0, end: 0 };
+}
 
 export const DescriptorProto_ReservedRange = {
   encode(message: DescriptorProto_ReservedRange, writer: Writer = Writer.create()): Writer {
-    writer.uint32(8).int32(message.start);
-    writer.uint32(16).int32(message.end);
+    if (message.start !== 0) {
+      writer.uint32(8).int32(message.start);
+    }
+    if (message.end !== 0) {
+      writer.uint32(16).int32(message.end);
+    }
+    if ('_unknownFields' in message) {
+      for (const key of Object.keys(message['_unknownFields'])) {
+        const values = message['_unknownFields'][key] as Uint8Array[];
+        for (const value of values) {
+          writer.uint32(parseInt(key, 10));
+          (writer as any)['_push'](
+            (val: Uint8Array, buf: Buffer, pos: number) => buf.set(val, pos),
+            value.length,
+            value
+          );
+        }
+      }
+    }
     return writer;
   },
 
   decode(input: Reader | Uint8Array, length?: number): DescriptorProto_ReservedRange {
-    const reader = input instanceof Uint8Array ? new Reader(input) : input;
+    const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = Object.create(baseDescriptorProto_ReservedRange) as DescriptorProto_ReservedRange;
+    const message = createBaseDescriptorProto_ReservedRange();
+    (message as any)._unknownFields = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -1857,7 +1760,12 @@ export const DescriptorProto_ReservedRange = {
           message.end = reader.int32();
           break;
         default:
+          const startPos = reader.pos;
           reader.skipType(tag & 7);
+          (message as any)._unknownFields[tag] = [
+            ...((message as any)._unknownFields[tag] || []),
+            reader.buf.slice(startPos, reader.pos),
+          ];
           break;
       }
     }
@@ -1865,58 +1773,59 @@ export const DescriptorProto_ReservedRange = {
   },
 
   fromJSON(object: any): DescriptorProto_ReservedRange {
-    const message = Object.create(baseDescriptorProto_ReservedRange) as DescriptorProto_ReservedRange;
-    if (object.start !== undefined && object.start !== null) {
-      message.start = Number(object.start);
-    } else {
-      message.start = 0;
-    }
-    if (object.end !== undefined && object.end !== null) {
-      message.end = Number(object.end);
-    } else {
-      message.end = 0;
-    }
-    return message;
-  },
-
-  fromPartial(object: DeepPartial<DescriptorProto_ReservedRange>): DescriptorProto_ReservedRange {
-    const message = { ...baseDescriptorProto_ReservedRange } as DescriptorProto_ReservedRange;
-    if (object.start !== undefined && object.start !== null) {
-      message.start = object.start;
-    } else {
-      message.start = 0;
-    }
-    if (object.end !== undefined && object.end !== null) {
-      message.end = object.end;
-    } else {
-      message.end = 0;
-    }
-    return message;
+    return {
+      start: isSet(object.start) ? Number(object.start) : 0,
+      end: isSet(object.end) ? Number(object.end) : 0,
+    };
   },
 
   toJSON(message: DescriptorProto_ReservedRange): unknown {
     const obj: any = {};
-    message.start !== undefined && (obj.start = message.start);
-    message.end !== undefined && (obj.end = message.end);
+    message.start !== undefined && (obj.start = Math.round(message.start));
+    message.end !== undefined && (obj.end = Math.round(message.end));
     return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<DescriptorProto_ReservedRange>, I>>(
+    object: I
+  ): DescriptorProto_ReservedRange {
+    const message = createBaseDescriptorProto_ReservedRange();
+    message.start = object.start ?? 0;
+    message.end = object.end ?? 0;
+    return message;
   },
 };
 
-const baseExtensionRangeOptions: object = {};
+function createBaseExtensionRangeOptions(): ExtensionRangeOptions {
+  return { uninterpretedOption: [] };
+}
 
 export const ExtensionRangeOptions = {
   encode(message: ExtensionRangeOptions, writer: Writer = Writer.create()): Writer {
     for (const v of message.uninterpretedOption) {
       UninterpretedOption.encode(v!, writer.uint32(7994).fork()).ldelim();
     }
+    if ('_unknownFields' in message) {
+      for (const key of Object.keys(message['_unknownFields'])) {
+        const values = message['_unknownFields'][key] as Uint8Array[];
+        for (const value of values) {
+          writer.uint32(parseInt(key, 10));
+          (writer as any)['_push'](
+            (val: Uint8Array, buf: Buffer, pos: number) => buf.set(val, pos),
+            value.length,
+            value
+          );
+        }
+      }
+    }
     return writer;
   },
 
   decode(input: Reader | Uint8Array, length?: number): ExtensionRangeOptions {
-    const reader = input instanceof Uint8Array ? new Reader(input) : input;
+    const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = Object.create(baseExtensionRangeOptions) as ExtensionRangeOptions;
-    message.uninterpretedOption = [];
+    const message = createBaseExtensionRangeOptions();
+    (message as any)._unknownFields = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -1924,7 +1833,12 @@ export const ExtensionRangeOptions = {
           message.uninterpretedOption.push(UninterpretedOption.decode(reader, reader.uint32()));
           break;
         default:
+          const startPos = reader.pos;
           reader.skipType(tag & 7);
+          (message as any)._unknownFields[tag] = [
+            ...((message as any)._unknownFields[tag] || []),
+            reader.buf.slice(startPos, reader.pos),
+          ];
           break;
       }
     }
@@ -1932,25 +1846,11 @@ export const ExtensionRangeOptions = {
   },
 
   fromJSON(object: any): ExtensionRangeOptions {
-    const message = Object.create(baseExtensionRangeOptions) as ExtensionRangeOptions;
-    message.uninterpretedOption = [];
-    if (object.uninterpretedOption !== undefined && object.uninterpretedOption !== null) {
-      for (const e of object.uninterpretedOption) {
-        message.uninterpretedOption.push(UninterpretedOption.fromJSON(e));
-      }
-    }
-    return message;
-  },
-
-  fromPartial(object: DeepPartial<ExtensionRangeOptions>): ExtensionRangeOptions {
-    const message = { ...baseExtensionRangeOptions } as ExtensionRangeOptions;
-    message.uninterpretedOption = [];
-    if (object.uninterpretedOption !== undefined && object.uninterpretedOption !== null) {
-      for (const e of object.uninterpretedOption) {
-        message.uninterpretedOption.push(UninterpretedOption.fromPartial(e));
-      }
-    }
-    return message;
+    return {
+      uninterpretedOption: Array.isArray(object?.uninterpretedOption)
+        ? object.uninterpretedOption.map((e: any) => UninterpretedOption.fromJSON(e))
+        : [],
+    };
   },
 
   toJSON(message: ExtensionRangeOptions): unknown {
@@ -1962,43 +1862,86 @@ export const ExtensionRangeOptions = {
     }
     return obj;
   },
+
+  fromPartial<I extends Exact<DeepPartial<ExtensionRangeOptions>, I>>(object: I): ExtensionRangeOptions {
+    const message = createBaseExtensionRangeOptions();
+    message.uninterpretedOption = object.uninterpretedOption?.map((e) => UninterpretedOption.fromPartial(e)) || [];
+    return message;
+  },
 };
 
-const baseFieldDescriptorProto: object = {
-  name: '',
-  number: 0,
-  label: 1,
-  type: 1,
-  typeName: '',
-  extendee: '',
-  defaultValue: '',
-  oneofIndex: 0,
-  jsonName: '',
-  proto3Optional: false,
-};
+function createBaseFieldDescriptorProto(): FieldDescriptorProto {
+  return {
+    name: '',
+    number: 0,
+    label: 1,
+    type: 1,
+    typeName: '',
+    extendee: '',
+    defaultValue: '',
+    oneofIndex: 0,
+    jsonName: '',
+    options: undefined,
+    proto3Optional: false,
+  };
+}
 
 export const FieldDescriptorProto = {
   encode(message: FieldDescriptorProto, writer: Writer = Writer.create()): Writer {
-    writer.uint32(10).string(message.name);
-    writer.uint32(24).int32(message.number);
-    writer.uint32(32).int32(message.label);
-    writer.uint32(40).int32(message.type);
-    writer.uint32(50).string(message.typeName);
-    writer.uint32(18).string(message.extendee);
-    writer.uint32(58).string(message.defaultValue);
-    writer.uint32(72).int32(message.oneofIndex);
-    writer.uint32(82).string(message.jsonName);
+    if (message.name !== '') {
+      writer.uint32(10).string(message.name);
+    }
+    if (message.number !== 0) {
+      writer.uint32(24).int32(message.number);
+    }
+    if (message.label !== 1) {
+      writer.uint32(32).int32(message.label);
+    }
+    if (message.type !== 1) {
+      writer.uint32(40).int32(message.type);
+    }
+    if (message.typeName !== '') {
+      writer.uint32(50).string(message.typeName);
+    }
+    if (message.extendee !== '') {
+      writer.uint32(18).string(message.extendee);
+    }
+    if (message.defaultValue !== '') {
+      writer.uint32(58).string(message.defaultValue);
+    }
+    if (message.oneofIndex !== 0) {
+      writer.uint32(72).int32(message.oneofIndex);
+    }
+    if (message.jsonName !== '') {
+      writer.uint32(82).string(message.jsonName);
+    }
     if (message.options !== undefined) {
       FieldOptions.encode(message.options, writer.uint32(66).fork()).ldelim();
     }
-    writer.uint32(136).bool(message.proto3Optional);
+    if (message.proto3Optional === true) {
+      writer.uint32(136).bool(message.proto3Optional);
+    }
+    if ('_unknownFields' in message) {
+      for (const key of Object.keys(message['_unknownFields'])) {
+        const values = message['_unknownFields'][key] as Uint8Array[];
+        for (const value of values) {
+          writer.uint32(parseInt(key, 10));
+          (writer as any)['_push'](
+            (val: Uint8Array, buf: Buffer, pos: number) => buf.set(val, pos),
+            value.length,
+            value
+          );
+        }
+      }
+    }
     return writer;
   },
 
   decode(input: Reader | Uint8Array, length?: number): FieldDescriptorProto {
-    const reader = input instanceof Uint8Array ? new Reader(input) : input;
+    const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = Object.create(baseFieldDescriptorProto) as FieldDescriptorProto;
+    const message = createBaseFieldDescriptorProto();
+    (message as any)._unknownFields = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -2036,7 +1979,12 @@ export const FieldDescriptorProto = {
           message.proto3Optional = reader.bool();
           break;
         default:
+          const startPos = reader.pos;
           reader.skipType(tag & 7);
+          (message as any)._unknownFields[tag] = [
+            ...((message as any)._unknownFields[tag] || []),
+            reader.buf.slice(startPos, reader.pos),
+          ];
           break;
       }
     }
@@ -2044,157 +1992,88 @@ export const FieldDescriptorProto = {
   },
 
   fromJSON(object: any): FieldDescriptorProto {
-    const message = Object.create(baseFieldDescriptorProto) as FieldDescriptorProto;
-    if (object.name !== undefined && object.name !== null) {
-      message.name = String(object.name);
-    } else {
-      message.name = '';
-    }
-    if (object.number !== undefined && object.number !== null) {
-      message.number = Number(object.number);
-    } else {
-      message.number = 0;
-    }
-    if (object.label !== undefined && object.label !== null) {
-      message.label = fieldDescriptorProto_LabelFromJSON(object.label);
-    } else {
-      message.label = 1;
-    }
-    if (object.type !== undefined && object.type !== null) {
-      message.type = fieldDescriptorProto_TypeFromJSON(object.type);
-    } else {
-      message.type = 1;
-    }
-    if (object.typeName !== undefined && object.typeName !== null) {
-      message.typeName = String(object.typeName);
-    } else {
-      message.typeName = '';
-    }
-    if (object.extendee !== undefined && object.extendee !== null) {
-      message.extendee = String(object.extendee);
-    } else {
-      message.extendee = '';
-    }
-    if (object.defaultValue !== undefined && object.defaultValue !== null) {
-      message.defaultValue = String(object.defaultValue);
-    } else {
-      message.defaultValue = '';
-    }
-    if (object.oneofIndex !== undefined && object.oneofIndex !== null) {
-      message.oneofIndex = Number(object.oneofIndex);
-    } else {
-      message.oneofIndex = 0;
-    }
-    if (object.jsonName !== undefined && object.jsonName !== null) {
-      message.jsonName = String(object.jsonName);
-    } else {
-      message.jsonName = '';
-    }
-    if (object.options !== undefined && object.options !== null) {
-      message.options = FieldOptions.fromJSON(object.options);
-    } else {
-      message.options = undefined;
-    }
-    if (object.proto3Optional !== undefined && object.proto3Optional !== null) {
-      message.proto3Optional = Boolean(object.proto3Optional);
-    } else {
-      message.proto3Optional = false;
-    }
-    return message;
-  },
-
-  fromPartial(object: DeepPartial<FieldDescriptorProto>): FieldDescriptorProto {
-    const message = { ...baseFieldDescriptorProto } as FieldDescriptorProto;
-    if (object.name !== undefined && object.name !== null) {
-      message.name = object.name;
-    } else {
-      message.name = '';
-    }
-    if (object.number !== undefined && object.number !== null) {
-      message.number = object.number;
-    } else {
-      message.number = 0;
-    }
-    if (object.label !== undefined && object.label !== null) {
-      message.label = object.label;
-    } else {
-      message.label = 1;
-    }
-    if (object.type !== undefined && object.type !== null) {
-      message.type = object.type;
-    } else {
-      message.type = 1;
-    }
-    if (object.typeName !== undefined && object.typeName !== null) {
-      message.typeName = object.typeName;
-    } else {
-      message.typeName = '';
-    }
-    if (object.extendee !== undefined && object.extendee !== null) {
-      message.extendee = object.extendee;
-    } else {
-      message.extendee = '';
-    }
-    if (object.defaultValue !== undefined && object.defaultValue !== null) {
-      message.defaultValue = object.defaultValue;
-    } else {
-      message.defaultValue = '';
-    }
-    if (object.oneofIndex !== undefined && object.oneofIndex !== null) {
-      message.oneofIndex = object.oneofIndex;
-    } else {
-      message.oneofIndex = 0;
-    }
-    if (object.jsonName !== undefined && object.jsonName !== null) {
-      message.jsonName = object.jsonName;
-    } else {
-      message.jsonName = '';
-    }
-    if (object.options !== undefined && object.options !== null) {
-      message.options = FieldOptions.fromPartial(object.options);
-    } else {
-      message.options = undefined;
-    }
-    if (object.proto3Optional !== undefined && object.proto3Optional !== null) {
-      message.proto3Optional = object.proto3Optional;
-    } else {
-      message.proto3Optional = false;
-    }
-    return message;
+    return {
+      name: isSet(object.name) ? String(object.name) : '',
+      number: isSet(object.number) ? Number(object.number) : 0,
+      label: isSet(object.label) ? fieldDescriptorProto_LabelFromJSON(object.label) : 1,
+      type: isSet(object.type) ? fieldDescriptorProto_TypeFromJSON(object.type) : 1,
+      typeName: isSet(object.typeName) ? String(object.typeName) : '',
+      extendee: isSet(object.extendee) ? String(object.extendee) : '',
+      defaultValue: isSet(object.defaultValue) ? String(object.defaultValue) : '',
+      oneofIndex: isSet(object.oneofIndex) ? Number(object.oneofIndex) : 0,
+      jsonName: isSet(object.jsonName) ? String(object.jsonName) : '',
+      options: isSet(object.options) ? FieldOptions.fromJSON(object.options) : undefined,
+      proto3Optional: isSet(object.proto3Optional) ? Boolean(object.proto3Optional) : false,
+    };
   },
 
   toJSON(message: FieldDescriptorProto): unknown {
     const obj: any = {};
     message.name !== undefined && (obj.name = message.name);
-    message.number !== undefined && (obj.number = message.number);
+    message.number !== undefined && (obj.number = Math.round(message.number));
     message.label !== undefined && (obj.label = fieldDescriptorProto_LabelToJSON(message.label));
     message.type !== undefined && (obj.type = fieldDescriptorProto_TypeToJSON(message.type));
     message.typeName !== undefined && (obj.typeName = message.typeName);
     message.extendee !== undefined && (obj.extendee = message.extendee);
     message.defaultValue !== undefined && (obj.defaultValue = message.defaultValue);
-    message.oneofIndex !== undefined && (obj.oneofIndex = message.oneofIndex);
+    message.oneofIndex !== undefined && (obj.oneofIndex = Math.round(message.oneofIndex));
     message.jsonName !== undefined && (obj.jsonName = message.jsonName);
     message.options !== undefined && (obj.options = message.options ? FieldOptions.toJSON(message.options) : undefined);
     message.proto3Optional !== undefined && (obj.proto3Optional = message.proto3Optional);
     return obj;
   },
+
+  fromPartial<I extends Exact<DeepPartial<FieldDescriptorProto>, I>>(object: I): FieldDescriptorProto {
+    const message = createBaseFieldDescriptorProto();
+    message.name = object.name ?? '';
+    message.number = object.number ?? 0;
+    message.label = object.label ?? 1;
+    message.type = object.type ?? 1;
+    message.typeName = object.typeName ?? '';
+    message.extendee = object.extendee ?? '';
+    message.defaultValue = object.defaultValue ?? '';
+    message.oneofIndex = object.oneofIndex ?? 0;
+    message.jsonName = object.jsonName ?? '';
+    message.options =
+      object.options !== undefined && object.options !== null ? FieldOptions.fromPartial(object.options) : undefined;
+    message.proto3Optional = object.proto3Optional ?? false;
+    return message;
+  },
 };
 
-const baseOneofDescriptorProto: object = { name: '' };
+function createBaseOneofDescriptorProto(): OneofDescriptorProto {
+  return { name: '', options: undefined };
+}
 
 export const OneofDescriptorProto = {
   encode(message: OneofDescriptorProto, writer: Writer = Writer.create()): Writer {
-    writer.uint32(10).string(message.name);
+    if (message.name !== '') {
+      writer.uint32(10).string(message.name);
+    }
     if (message.options !== undefined) {
       OneofOptions.encode(message.options, writer.uint32(18).fork()).ldelim();
+    }
+    if ('_unknownFields' in message) {
+      for (const key of Object.keys(message['_unknownFields'])) {
+        const values = message['_unknownFields'][key] as Uint8Array[];
+        for (const value of values) {
+          writer.uint32(parseInt(key, 10));
+          (writer as any)['_push'](
+            (val: Uint8Array, buf: Buffer, pos: number) => buf.set(val, pos),
+            value.length,
+            value
+          );
+        }
+      }
     }
     return writer;
   },
 
   decode(input: Reader | Uint8Array, length?: number): OneofDescriptorProto {
-    const reader = input instanceof Uint8Array ? new Reader(input) : input;
+    const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = Object.create(baseOneofDescriptorProto) as OneofDescriptorProto;
+    const message = createBaseOneofDescriptorProto();
+    (message as any)._unknownFields = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -2205,7 +2084,12 @@ export const OneofDescriptorProto = {
           message.options = OneofOptions.decode(reader, reader.uint32());
           break;
         default:
+          const startPos = reader.pos;
           reader.skipType(tag & 7);
+          (message as any)._unknownFields[tag] = [
+            ...((message as any)._unknownFields[tag] || []),
+            reader.buf.slice(startPos, reader.pos),
+          ];
           break;
       }
     }
@@ -2213,33 +2097,10 @@ export const OneofDescriptorProto = {
   },
 
   fromJSON(object: any): OneofDescriptorProto {
-    const message = Object.create(baseOneofDescriptorProto) as OneofDescriptorProto;
-    if (object.name !== undefined && object.name !== null) {
-      message.name = String(object.name);
-    } else {
-      message.name = '';
-    }
-    if (object.options !== undefined && object.options !== null) {
-      message.options = OneofOptions.fromJSON(object.options);
-    } else {
-      message.options = undefined;
-    }
-    return message;
-  },
-
-  fromPartial(object: DeepPartial<OneofDescriptorProto>): OneofDescriptorProto {
-    const message = { ...baseOneofDescriptorProto } as OneofDescriptorProto;
-    if (object.name !== undefined && object.name !== null) {
-      message.name = object.name;
-    } else {
-      message.name = '';
-    }
-    if (object.options !== undefined && object.options !== null) {
-      message.options = OneofOptions.fromPartial(object.options);
-    } else {
-      message.options = undefined;
-    }
-    return message;
+    return {
+      name: isSet(object.name) ? String(object.name) : '',
+      options: isSet(object.options) ? OneofOptions.fromJSON(object.options) : undefined,
+    };
   },
 
   toJSON(message: OneofDescriptorProto): unknown {
@@ -2248,13 +2109,25 @@ export const OneofDescriptorProto = {
     message.options !== undefined && (obj.options = message.options ? OneofOptions.toJSON(message.options) : undefined);
     return obj;
   },
+
+  fromPartial<I extends Exact<DeepPartial<OneofDescriptorProto>, I>>(object: I): OneofDescriptorProto {
+    const message = createBaseOneofDescriptorProto();
+    message.name = object.name ?? '';
+    message.options =
+      object.options !== undefined && object.options !== null ? OneofOptions.fromPartial(object.options) : undefined;
+    return message;
+  },
 };
 
-const baseEnumDescriptorProto: object = { name: '', reservedName: '' };
+function createBaseEnumDescriptorProto(): EnumDescriptorProto {
+  return { name: '', value: [], options: undefined, reservedRange: [], reservedName: [] };
+}
 
 export const EnumDescriptorProto = {
   encode(message: EnumDescriptorProto, writer: Writer = Writer.create()): Writer {
-    writer.uint32(10).string(message.name);
+    if (message.name !== '') {
+      writer.uint32(10).string(message.name);
+    }
     for (const v of message.value) {
       EnumValueDescriptorProto.encode(v!, writer.uint32(18).fork()).ldelim();
     }
@@ -2267,16 +2140,27 @@ export const EnumDescriptorProto = {
     for (const v of message.reservedName) {
       writer.uint32(42).string(v!);
     }
+    if ('_unknownFields' in message) {
+      for (const key of Object.keys(message['_unknownFields'])) {
+        const values = message['_unknownFields'][key] as Uint8Array[];
+        for (const value of values) {
+          writer.uint32(parseInt(key, 10));
+          (writer as any)['_push'](
+            (val: Uint8Array, buf: Buffer, pos: number) => buf.set(val, pos),
+            value.length,
+            value
+          );
+        }
+      }
+    }
     return writer;
   },
 
   decode(input: Reader | Uint8Array, length?: number): EnumDescriptorProto {
-    const reader = input instanceof Uint8Array ? new Reader(input) : input;
+    const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = Object.create(baseEnumDescriptorProto) as EnumDescriptorProto;
-    message.value = [];
-    message.reservedRange = [];
-    message.reservedName = [];
+    const message = createBaseEnumDescriptorProto();
+    (message as any)._unknownFields = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -2296,7 +2180,12 @@ export const EnumDescriptorProto = {
           message.reservedName.push(reader.string());
           break;
         default:
+          const startPos = reader.pos;
           reader.skipType(tag & 7);
+          (message as any)._unknownFields[tag] = [
+            ...((message as any)._unknownFields[tag] || []),
+            reader.buf.slice(startPos, reader.pos),
+          ];
           break;
       }
     }
@@ -2304,69 +2193,15 @@ export const EnumDescriptorProto = {
   },
 
   fromJSON(object: any): EnumDescriptorProto {
-    const message = Object.create(baseEnumDescriptorProto) as EnumDescriptorProto;
-    message.value = [];
-    message.reservedRange = [];
-    message.reservedName = [];
-    if (object.name !== undefined && object.name !== null) {
-      message.name = String(object.name);
-    } else {
-      message.name = '';
-    }
-    if (object.value !== undefined && object.value !== null) {
-      for (const e of object.value) {
-        message.value.push(EnumValueDescriptorProto.fromJSON(e));
-      }
-    }
-    if (object.options !== undefined && object.options !== null) {
-      message.options = EnumOptions.fromJSON(object.options);
-    } else {
-      message.options = undefined;
-    }
-    if (object.reservedRange !== undefined && object.reservedRange !== null) {
-      for (const e of object.reservedRange) {
-        message.reservedRange.push(EnumDescriptorProto_EnumReservedRange.fromJSON(e));
-      }
-    }
-    if (object.reservedName !== undefined && object.reservedName !== null) {
-      for (const e of object.reservedName) {
-        message.reservedName.push(String(e));
-      }
-    }
-    return message;
-  },
-
-  fromPartial(object: DeepPartial<EnumDescriptorProto>): EnumDescriptorProto {
-    const message = { ...baseEnumDescriptorProto } as EnumDescriptorProto;
-    message.value = [];
-    message.reservedRange = [];
-    message.reservedName = [];
-    if (object.name !== undefined && object.name !== null) {
-      message.name = object.name;
-    } else {
-      message.name = '';
-    }
-    if (object.value !== undefined && object.value !== null) {
-      for (const e of object.value) {
-        message.value.push(EnumValueDescriptorProto.fromPartial(e));
-      }
-    }
-    if (object.options !== undefined && object.options !== null) {
-      message.options = EnumOptions.fromPartial(object.options);
-    } else {
-      message.options = undefined;
-    }
-    if (object.reservedRange !== undefined && object.reservedRange !== null) {
-      for (const e of object.reservedRange) {
-        message.reservedRange.push(EnumDescriptorProto_EnumReservedRange.fromPartial(e));
-      }
-    }
-    if (object.reservedName !== undefined && object.reservedName !== null) {
-      for (const e of object.reservedName) {
-        message.reservedName.push(e);
-      }
-    }
-    return message;
+    return {
+      name: isSet(object.name) ? String(object.name) : '',
+      value: Array.isArray(object?.value) ? object.value.map((e: any) => EnumValueDescriptorProto.fromJSON(e)) : [],
+      options: isSet(object.options) ? EnumOptions.fromJSON(object.options) : undefined,
+      reservedRange: Array.isArray(object?.reservedRange)
+        ? object.reservedRange.map((e: any) => EnumDescriptorProto_EnumReservedRange.fromJSON(e))
+        : [],
+      reservedName: Array.isArray(object?.reservedName) ? object.reservedName.map((e: any) => String(e)) : [],
+    };
   },
 
   toJSON(message: EnumDescriptorProto): unknown {
@@ -2392,21 +2227,53 @@ export const EnumDescriptorProto = {
     }
     return obj;
   },
+
+  fromPartial<I extends Exact<DeepPartial<EnumDescriptorProto>, I>>(object: I): EnumDescriptorProto {
+    const message = createBaseEnumDescriptorProto();
+    message.name = object.name ?? '';
+    message.value = object.value?.map((e) => EnumValueDescriptorProto.fromPartial(e)) || [];
+    message.options =
+      object.options !== undefined && object.options !== null ? EnumOptions.fromPartial(object.options) : undefined;
+    message.reservedRange =
+      object.reservedRange?.map((e) => EnumDescriptorProto_EnumReservedRange.fromPartial(e)) || [];
+    message.reservedName = object.reservedName?.map((e) => e) || [];
+    return message;
+  },
 };
 
-const baseEnumDescriptorProto_EnumReservedRange: object = { start: 0, end: 0 };
+function createBaseEnumDescriptorProto_EnumReservedRange(): EnumDescriptorProto_EnumReservedRange {
+  return { start: 0, end: 0 };
+}
 
 export const EnumDescriptorProto_EnumReservedRange = {
   encode(message: EnumDescriptorProto_EnumReservedRange, writer: Writer = Writer.create()): Writer {
-    writer.uint32(8).int32(message.start);
-    writer.uint32(16).int32(message.end);
+    if (message.start !== 0) {
+      writer.uint32(8).int32(message.start);
+    }
+    if (message.end !== 0) {
+      writer.uint32(16).int32(message.end);
+    }
+    if ('_unknownFields' in message) {
+      for (const key of Object.keys(message['_unknownFields'])) {
+        const values = message['_unknownFields'][key] as Uint8Array[];
+        for (const value of values) {
+          writer.uint32(parseInt(key, 10));
+          (writer as any)['_push'](
+            (val: Uint8Array, buf: Buffer, pos: number) => buf.set(val, pos),
+            value.length,
+            value
+          );
+        }
+      }
+    }
     return writer;
   },
 
   decode(input: Reader | Uint8Array, length?: number): EnumDescriptorProto_EnumReservedRange {
-    const reader = input instanceof Uint8Array ? new Reader(input) : input;
+    const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = Object.create(baseEnumDescriptorProto_EnumReservedRange) as EnumDescriptorProto_EnumReservedRange;
+    const message = createBaseEnumDescriptorProto_EnumReservedRange();
+    (message as any)._unknownFields = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -2417,7 +2284,12 @@ export const EnumDescriptorProto_EnumReservedRange = {
           message.end = reader.int32();
           break;
         default:
+          const startPos = reader.pos;
           reader.skipType(tag & 7);
+          (message as any)._unknownFields[tag] = [
+            ...((message as any)._unknownFields[tag] || []),
+            reader.buf.slice(startPos, reader.pos),
+          ];
           break;
       }
     }
@@ -2425,59 +2297,65 @@ export const EnumDescriptorProto_EnumReservedRange = {
   },
 
   fromJSON(object: any): EnumDescriptorProto_EnumReservedRange {
-    const message = Object.create(baseEnumDescriptorProto_EnumReservedRange) as EnumDescriptorProto_EnumReservedRange;
-    if (object.start !== undefined && object.start !== null) {
-      message.start = Number(object.start);
-    } else {
-      message.start = 0;
-    }
-    if (object.end !== undefined && object.end !== null) {
-      message.end = Number(object.end);
-    } else {
-      message.end = 0;
-    }
-    return message;
-  },
-
-  fromPartial(object: DeepPartial<EnumDescriptorProto_EnumReservedRange>): EnumDescriptorProto_EnumReservedRange {
-    const message = { ...baseEnumDescriptorProto_EnumReservedRange } as EnumDescriptorProto_EnumReservedRange;
-    if (object.start !== undefined && object.start !== null) {
-      message.start = object.start;
-    } else {
-      message.start = 0;
-    }
-    if (object.end !== undefined && object.end !== null) {
-      message.end = object.end;
-    } else {
-      message.end = 0;
-    }
-    return message;
+    return {
+      start: isSet(object.start) ? Number(object.start) : 0,
+      end: isSet(object.end) ? Number(object.end) : 0,
+    };
   },
 
   toJSON(message: EnumDescriptorProto_EnumReservedRange): unknown {
     const obj: any = {};
-    message.start !== undefined && (obj.start = message.start);
-    message.end !== undefined && (obj.end = message.end);
+    message.start !== undefined && (obj.start = Math.round(message.start));
+    message.end !== undefined && (obj.end = Math.round(message.end));
     return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<EnumDescriptorProto_EnumReservedRange>, I>>(
+    object: I
+  ): EnumDescriptorProto_EnumReservedRange {
+    const message = createBaseEnumDescriptorProto_EnumReservedRange();
+    message.start = object.start ?? 0;
+    message.end = object.end ?? 0;
+    return message;
   },
 };
 
-const baseEnumValueDescriptorProto: object = { name: '', number: 0 };
+function createBaseEnumValueDescriptorProto(): EnumValueDescriptorProto {
+  return { name: '', number: 0, options: undefined };
+}
 
 export const EnumValueDescriptorProto = {
   encode(message: EnumValueDescriptorProto, writer: Writer = Writer.create()): Writer {
-    writer.uint32(10).string(message.name);
-    writer.uint32(16).int32(message.number);
+    if (message.name !== '') {
+      writer.uint32(10).string(message.name);
+    }
+    if (message.number !== 0) {
+      writer.uint32(16).int32(message.number);
+    }
     if (message.options !== undefined) {
       EnumValueOptions.encode(message.options, writer.uint32(26).fork()).ldelim();
+    }
+    if ('_unknownFields' in message) {
+      for (const key of Object.keys(message['_unknownFields'])) {
+        const values = message['_unknownFields'][key] as Uint8Array[];
+        for (const value of values) {
+          writer.uint32(parseInt(key, 10));
+          (writer as any)['_push'](
+            (val: Uint8Array, buf: Buffer, pos: number) => buf.set(val, pos),
+            value.length,
+            value
+          );
+        }
+      }
     }
     return writer;
   },
 
   decode(input: Reader | Uint8Array, length?: number): EnumValueDescriptorProto {
-    const reader = input instanceof Uint8Array ? new Reader(input) : input;
+    const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = Object.create(baseEnumValueDescriptorProto) as EnumValueDescriptorProto;
+    const message = createBaseEnumValueDescriptorProto();
+    (message as any)._unknownFields = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -2491,7 +2369,12 @@ export const EnumValueDescriptorProto = {
           message.options = EnumValueOptions.decode(reader, reader.uint32());
           break;
         default:
+          const startPos = reader.pos;
           reader.skipType(tag & 7);
+          (message as any)._unknownFields[tag] = [
+            ...((message as any)._unknownFields[tag] || []),
+            reader.buf.slice(startPos, reader.pos),
+          ];
           break;
       }
     }
@@ -2499,74 +2382,70 @@ export const EnumValueDescriptorProto = {
   },
 
   fromJSON(object: any): EnumValueDescriptorProto {
-    const message = Object.create(baseEnumValueDescriptorProto) as EnumValueDescriptorProto;
-    if (object.name !== undefined && object.name !== null) {
-      message.name = String(object.name);
-    } else {
-      message.name = '';
-    }
-    if (object.number !== undefined && object.number !== null) {
-      message.number = Number(object.number);
-    } else {
-      message.number = 0;
-    }
-    if (object.options !== undefined && object.options !== null) {
-      message.options = EnumValueOptions.fromJSON(object.options);
-    } else {
-      message.options = undefined;
-    }
-    return message;
-  },
-
-  fromPartial(object: DeepPartial<EnumValueDescriptorProto>): EnumValueDescriptorProto {
-    const message = { ...baseEnumValueDescriptorProto } as EnumValueDescriptorProto;
-    if (object.name !== undefined && object.name !== null) {
-      message.name = object.name;
-    } else {
-      message.name = '';
-    }
-    if (object.number !== undefined && object.number !== null) {
-      message.number = object.number;
-    } else {
-      message.number = 0;
-    }
-    if (object.options !== undefined && object.options !== null) {
-      message.options = EnumValueOptions.fromPartial(object.options);
-    } else {
-      message.options = undefined;
-    }
-    return message;
+    return {
+      name: isSet(object.name) ? String(object.name) : '',
+      number: isSet(object.number) ? Number(object.number) : 0,
+      options: isSet(object.options) ? EnumValueOptions.fromJSON(object.options) : undefined,
+    };
   },
 
   toJSON(message: EnumValueDescriptorProto): unknown {
     const obj: any = {};
     message.name !== undefined && (obj.name = message.name);
-    message.number !== undefined && (obj.number = message.number);
+    message.number !== undefined && (obj.number = Math.round(message.number));
     message.options !== undefined &&
       (obj.options = message.options ? EnumValueOptions.toJSON(message.options) : undefined);
     return obj;
   },
+
+  fromPartial<I extends Exact<DeepPartial<EnumValueDescriptorProto>, I>>(object: I): EnumValueDescriptorProto {
+    const message = createBaseEnumValueDescriptorProto();
+    message.name = object.name ?? '';
+    message.number = object.number ?? 0;
+    message.options =
+      object.options !== undefined && object.options !== null
+        ? EnumValueOptions.fromPartial(object.options)
+        : undefined;
+    return message;
+  },
 };
 
-const baseServiceDescriptorProto: object = { name: '' };
+function createBaseServiceDescriptorProto(): ServiceDescriptorProto {
+  return { name: '', method: [], options: undefined };
+}
 
 export const ServiceDescriptorProto = {
   encode(message: ServiceDescriptorProto, writer: Writer = Writer.create()): Writer {
-    writer.uint32(10).string(message.name);
+    if (message.name !== '') {
+      writer.uint32(10).string(message.name);
+    }
     for (const v of message.method) {
       MethodDescriptorProto.encode(v!, writer.uint32(18).fork()).ldelim();
     }
     if (message.options !== undefined) {
       ServiceOptions.encode(message.options, writer.uint32(26).fork()).ldelim();
     }
+    if ('_unknownFields' in message) {
+      for (const key of Object.keys(message['_unknownFields'])) {
+        const values = message['_unknownFields'][key] as Uint8Array[];
+        for (const value of values) {
+          writer.uint32(parseInt(key, 10));
+          (writer as any)['_push'](
+            (val: Uint8Array, buf: Buffer, pos: number) => buf.set(val, pos),
+            value.length,
+            value
+          );
+        }
+      }
+    }
     return writer;
   },
 
   decode(input: Reader | Uint8Array, length?: number): ServiceDescriptorProto {
-    const reader = input instanceof Uint8Array ? new Reader(input) : input;
+    const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = Object.create(baseServiceDescriptorProto) as ServiceDescriptorProto;
-    message.method = [];
+    const message = createBaseServiceDescriptorProto();
+    (message as any)._unknownFields = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -2580,7 +2459,12 @@ export const ServiceDescriptorProto = {
           message.options = ServiceOptions.decode(reader, reader.uint32());
           break;
         default:
+          const startPos = reader.pos;
           reader.skipType(tag & 7);
+          (message as any)._unknownFields[tag] = [
+            ...((message as any)._unknownFields[tag] || []),
+            reader.buf.slice(startPos, reader.pos),
+          ];
           break;
       }
     }
@@ -2588,45 +2472,11 @@ export const ServiceDescriptorProto = {
   },
 
   fromJSON(object: any): ServiceDescriptorProto {
-    const message = Object.create(baseServiceDescriptorProto) as ServiceDescriptorProto;
-    message.method = [];
-    if (object.name !== undefined && object.name !== null) {
-      message.name = String(object.name);
-    } else {
-      message.name = '';
-    }
-    if (object.method !== undefined && object.method !== null) {
-      for (const e of object.method) {
-        message.method.push(MethodDescriptorProto.fromJSON(e));
-      }
-    }
-    if (object.options !== undefined && object.options !== null) {
-      message.options = ServiceOptions.fromJSON(object.options);
-    } else {
-      message.options = undefined;
-    }
-    return message;
-  },
-
-  fromPartial(object: DeepPartial<ServiceDescriptorProto>): ServiceDescriptorProto {
-    const message = { ...baseServiceDescriptorProto } as ServiceDescriptorProto;
-    message.method = [];
-    if (object.name !== undefined && object.name !== null) {
-      message.name = object.name;
-    } else {
-      message.name = '';
-    }
-    if (object.method !== undefined && object.method !== null) {
-      for (const e of object.method) {
-        message.method.push(MethodDescriptorProto.fromPartial(e));
-      }
-    }
-    if (object.options !== undefined && object.options !== null) {
-      message.options = ServiceOptions.fromPartial(object.options);
-    } else {
-      message.options = undefined;
-    }
-    return message;
+    return {
+      name: isSet(object.name) ? String(object.name) : '',
+      method: Array.isArray(object?.method) ? object.method.map((e: any) => MethodDescriptorProto.fromJSON(e)) : [],
+      options: isSet(object.options) ? ServiceOptions.fromJSON(object.options) : undefined,
+    };
   },
 
   toJSON(message: ServiceDescriptorProto): unknown {
@@ -2641,33 +2491,69 @@ export const ServiceDescriptorProto = {
       (obj.options = message.options ? ServiceOptions.toJSON(message.options) : undefined);
     return obj;
   },
+
+  fromPartial<I extends Exact<DeepPartial<ServiceDescriptorProto>, I>>(object: I): ServiceDescriptorProto {
+    const message = createBaseServiceDescriptorProto();
+    message.name = object.name ?? '';
+    message.method = object.method?.map((e) => MethodDescriptorProto.fromPartial(e)) || [];
+    message.options =
+      object.options !== undefined && object.options !== null ? ServiceOptions.fromPartial(object.options) : undefined;
+    return message;
+  },
 };
 
-const baseMethodDescriptorProto: object = {
-  name: '',
-  inputType: '',
-  outputType: '',
-  clientStreaming: false,
-  serverStreaming: false,
-};
+function createBaseMethodDescriptorProto(): MethodDescriptorProto {
+  return {
+    name: '',
+    inputType: '',
+    outputType: '',
+    options: undefined,
+    clientStreaming: false,
+    serverStreaming: false,
+  };
+}
 
 export const MethodDescriptorProto = {
   encode(message: MethodDescriptorProto, writer: Writer = Writer.create()): Writer {
-    writer.uint32(10).string(message.name);
-    writer.uint32(18).string(message.inputType);
-    writer.uint32(26).string(message.outputType);
+    if (message.name !== '') {
+      writer.uint32(10).string(message.name);
+    }
+    if (message.inputType !== '') {
+      writer.uint32(18).string(message.inputType);
+    }
+    if (message.outputType !== '') {
+      writer.uint32(26).string(message.outputType);
+    }
     if (message.options !== undefined) {
       MethodOptions.encode(message.options, writer.uint32(34).fork()).ldelim();
     }
-    writer.uint32(40).bool(message.clientStreaming);
-    writer.uint32(48).bool(message.serverStreaming);
+    if (message.clientStreaming === true) {
+      writer.uint32(40).bool(message.clientStreaming);
+    }
+    if (message.serverStreaming === true) {
+      writer.uint32(48).bool(message.serverStreaming);
+    }
+    if ('_unknownFields' in message) {
+      for (const key of Object.keys(message['_unknownFields'])) {
+        const values = message['_unknownFields'][key] as Uint8Array[];
+        for (const value of values) {
+          writer.uint32(parseInt(key, 10));
+          (writer as any)['_push'](
+            (val: Uint8Array, buf: Buffer, pos: number) => buf.set(val, pos),
+            value.length,
+            value
+          );
+        }
+      }
+    }
     return writer;
   },
 
   decode(input: Reader | Uint8Array, length?: number): MethodDescriptorProto {
-    const reader = input instanceof Uint8Array ? new Reader(input) : input;
+    const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = Object.create(baseMethodDescriptorProto) as MethodDescriptorProto;
+    const message = createBaseMethodDescriptorProto();
+    (message as any)._unknownFields = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -2690,7 +2576,12 @@ export const MethodDescriptorProto = {
           message.serverStreaming = reader.bool();
           break;
         default:
+          const startPos = reader.pos;
           reader.skipType(tag & 7);
+          (message as any)._unknownFields[tag] = [
+            ...((message as any)._unknownFields[tag] || []),
+            reader.buf.slice(startPos, reader.pos),
+          ];
           break;
       }
     }
@@ -2698,73 +2589,14 @@ export const MethodDescriptorProto = {
   },
 
   fromJSON(object: any): MethodDescriptorProto {
-    const message = Object.create(baseMethodDescriptorProto) as MethodDescriptorProto;
-    if (object.name !== undefined && object.name !== null) {
-      message.name = String(object.name);
-    } else {
-      message.name = '';
-    }
-    if (object.inputType !== undefined && object.inputType !== null) {
-      message.inputType = String(object.inputType);
-    } else {
-      message.inputType = '';
-    }
-    if (object.outputType !== undefined && object.outputType !== null) {
-      message.outputType = String(object.outputType);
-    } else {
-      message.outputType = '';
-    }
-    if (object.options !== undefined && object.options !== null) {
-      message.options = MethodOptions.fromJSON(object.options);
-    } else {
-      message.options = undefined;
-    }
-    if (object.clientStreaming !== undefined && object.clientStreaming !== null) {
-      message.clientStreaming = Boolean(object.clientStreaming);
-    } else {
-      message.clientStreaming = false;
-    }
-    if (object.serverStreaming !== undefined && object.serverStreaming !== null) {
-      message.serverStreaming = Boolean(object.serverStreaming);
-    } else {
-      message.serverStreaming = false;
-    }
-    return message;
-  },
-
-  fromPartial(object: DeepPartial<MethodDescriptorProto>): MethodDescriptorProto {
-    const message = { ...baseMethodDescriptorProto } as MethodDescriptorProto;
-    if (object.name !== undefined && object.name !== null) {
-      message.name = object.name;
-    } else {
-      message.name = '';
-    }
-    if (object.inputType !== undefined && object.inputType !== null) {
-      message.inputType = object.inputType;
-    } else {
-      message.inputType = '';
-    }
-    if (object.outputType !== undefined && object.outputType !== null) {
-      message.outputType = object.outputType;
-    } else {
-      message.outputType = '';
-    }
-    if (object.options !== undefined && object.options !== null) {
-      message.options = MethodOptions.fromPartial(object.options);
-    } else {
-      message.options = undefined;
-    }
-    if (object.clientStreaming !== undefined && object.clientStreaming !== null) {
-      message.clientStreaming = object.clientStreaming;
-    } else {
-      message.clientStreaming = false;
-    }
-    if (object.serverStreaming !== undefined && object.serverStreaming !== null) {
-      message.serverStreaming = object.serverStreaming;
-    } else {
-      message.serverStreaming = false;
-    }
-    return message;
+    return {
+      name: isSet(object.name) ? String(object.name) : '',
+      inputType: isSet(object.inputType) ? String(object.inputType) : '',
+      outputType: isSet(object.outputType) ? String(object.outputType) : '',
+      options: isSet(object.options) ? MethodOptions.fromJSON(object.options) : undefined,
+      clientStreaming: isSet(object.clientStreaming) ? Boolean(object.clientStreaming) : false,
+      serverStreaming: isSet(object.serverStreaming) ? Boolean(object.serverStreaming) : false,
+    };
   },
 
   toJSON(message: MethodDescriptorProto): unknown {
@@ -2778,64 +2610,132 @@ export const MethodDescriptorProto = {
     message.serverStreaming !== undefined && (obj.serverStreaming = message.serverStreaming);
     return obj;
   },
+
+  fromPartial<I extends Exact<DeepPartial<MethodDescriptorProto>, I>>(object: I): MethodDescriptorProto {
+    const message = createBaseMethodDescriptorProto();
+    message.name = object.name ?? '';
+    message.inputType = object.inputType ?? '';
+    message.outputType = object.outputType ?? '';
+    message.options =
+      object.options !== undefined && object.options !== null ? MethodOptions.fromPartial(object.options) : undefined;
+    message.clientStreaming = object.clientStreaming ?? false;
+    message.serverStreaming = object.serverStreaming ?? false;
+    return message;
+  },
 };
 
-const baseFileOptions: object = {
-  javaPackage: '',
-  javaOuterClassname: '',
-  javaMultipleFiles: false,
-  javaGenerateEqualsAndHash: false,
-  javaStringCheckUtf8: false,
-  optimizeFor: 1,
-  goPackage: '',
-  ccGenericServices: false,
-  javaGenericServices: false,
-  pyGenericServices: false,
-  phpGenericServices: false,
-  deprecated: false,
-  ccEnableArenas: false,
-  objcClassPrefix: '',
-  csharpNamespace: '',
-  swiftPrefix: '',
-  phpClassPrefix: '',
-  phpNamespace: '',
-  phpMetadataNamespace: '',
-  rubyPackage: '',
-};
+function createBaseFileOptions(): FileOptions {
+  return {
+    javaPackage: '',
+    javaOuterClassname: '',
+    javaMultipleFiles: false,
+    javaGenerateEqualsAndHash: false,
+    javaStringCheckUtf8: false,
+    optimizeFor: 1,
+    goPackage: '',
+    ccGenericServices: false,
+    javaGenericServices: false,
+    pyGenericServices: false,
+    phpGenericServices: false,
+    deprecated: false,
+    ccEnableArenas: false,
+    objcClassPrefix: '',
+    csharpNamespace: '',
+    swiftPrefix: '',
+    phpClassPrefix: '',
+    phpNamespace: '',
+    phpMetadataNamespace: '',
+    rubyPackage: '',
+    uninterpretedOption: [],
+  };
+}
 
 export const FileOptions = {
   encode(message: FileOptions, writer: Writer = Writer.create()): Writer {
-    writer.uint32(10).string(message.javaPackage);
-    writer.uint32(66).string(message.javaOuterClassname);
-    writer.uint32(80).bool(message.javaMultipleFiles);
-    writer.uint32(160).bool(message.javaGenerateEqualsAndHash);
-    writer.uint32(216).bool(message.javaStringCheckUtf8);
-    writer.uint32(72).int32(message.optimizeFor);
-    writer.uint32(90).string(message.goPackage);
-    writer.uint32(128).bool(message.ccGenericServices);
-    writer.uint32(136).bool(message.javaGenericServices);
-    writer.uint32(144).bool(message.pyGenericServices);
-    writer.uint32(336).bool(message.phpGenericServices);
-    writer.uint32(184).bool(message.deprecated);
-    writer.uint32(248).bool(message.ccEnableArenas);
-    writer.uint32(290).string(message.objcClassPrefix);
-    writer.uint32(298).string(message.csharpNamespace);
-    writer.uint32(314).string(message.swiftPrefix);
-    writer.uint32(322).string(message.phpClassPrefix);
-    writer.uint32(330).string(message.phpNamespace);
-    writer.uint32(354).string(message.phpMetadataNamespace);
-    writer.uint32(362).string(message.rubyPackage);
+    if (message.javaPackage !== '') {
+      writer.uint32(10).string(message.javaPackage);
+    }
+    if (message.javaOuterClassname !== '') {
+      writer.uint32(66).string(message.javaOuterClassname);
+    }
+    if (message.javaMultipleFiles === true) {
+      writer.uint32(80).bool(message.javaMultipleFiles);
+    }
+    if (message.javaGenerateEqualsAndHash === true) {
+      writer.uint32(160).bool(message.javaGenerateEqualsAndHash);
+    }
+    if (message.javaStringCheckUtf8 === true) {
+      writer.uint32(216).bool(message.javaStringCheckUtf8);
+    }
+    if (message.optimizeFor !== 1) {
+      writer.uint32(72).int32(message.optimizeFor);
+    }
+    if (message.goPackage !== '') {
+      writer.uint32(90).string(message.goPackage);
+    }
+    if (message.ccGenericServices === true) {
+      writer.uint32(128).bool(message.ccGenericServices);
+    }
+    if (message.javaGenericServices === true) {
+      writer.uint32(136).bool(message.javaGenericServices);
+    }
+    if (message.pyGenericServices === true) {
+      writer.uint32(144).bool(message.pyGenericServices);
+    }
+    if (message.phpGenericServices === true) {
+      writer.uint32(336).bool(message.phpGenericServices);
+    }
+    if (message.deprecated === true) {
+      writer.uint32(184).bool(message.deprecated);
+    }
+    if (message.ccEnableArenas === true) {
+      writer.uint32(248).bool(message.ccEnableArenas);
+    }
+    if (message.objcClassPrefix !== '') {
+      writer.uint32(290).string(message.objcClassPrefix);
+    }
+    if (message.csharpNamespace !== '') {
+      writer.uint32(298).string(message.csharpNamespace);
+    }
+    if (message.swiftPrefix !== '') {
+      writer.uint32(314).string(message.swiftPrefix);
+    }
+    if (message.phpClassPrefix !== '') {
+      writer.uint32(322).string(message.phpClassPrefix);
+    }
+    if (message.phpNamespace !== '') {
+      writer.uint32(330).string(message.phpNamespace);
+    }
+    if (message.phpMetadataNamespace !== '') {
+      writer.uint32(354).string(message.phpMetadataNamespace);
+    }
+    if (message.rubyPackage !== '') {
+      writer.uint32(362).string(message.rubyPackage);
+    }
     for (const v of message.uninterpretedOption) {
       UninterpretedOption.encode(v!, writer.uint32(7994).fork()).ldelim();
+    }
+    if ('_unknownFields' in message) {
+      for (const key of Object.keys(message['_unknownFields'])) {
+        const values = message['_unknownFields'][key] as Uint8Array[];
+        for (const value of values) {
+          writer.uint32(parseInt(key, 10));
+          (writer as any)['_push'](
+            (val: Uint8Array, buf: Buffer, pos: number) => buf.set(val, pos),
+            value.length,
+            value
+          );
+        }
+      }
     }
     return writer;
   },
 
   decode(input: Reader | Uint8Array, length?: number): FileOptions {
-    const reader = input instanceof Uint8Array ? new Reader(input) : input;
+    const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = Object.create(baseFileOptions) as FileOptions;
-    message.uninterpretedOption = [];
+    const message = createBaseFileOptions();
+    (message as any)._unknownFields = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -2903,7 +2803,12 @@ export const FileOptions = {
           message.uninterpretedOption.push(UninterpretedOption.decode(reader, reader.uint32()));
           break;
         default:
+          const startPos = reader.pos;
           reader.skipType(tag & 7);
+          (message as any)._unknownFields[tag] = [
+            ...((message as any)._unknownFields[tag] || []),
+            reader.buf.slice(startPos, reader.pos),
+          ];
           break;
       }
     }
@@ -2911,225 +2816,33 @@ export const FileOptions = {
   },
 
   fromJSON(object: any): FileOptions {
-    const message = Object.create(baseFileOptions) as FileOptions;
-    message.uninterpretedOption = [];
-    if (object.javaPackage !== undefined && object.javaPackage !== null) {
-      message.javaPackage = String(object.javaPackage);
-    } else {
-      message.javaPackage = '';
-    }
-    if (object.javaOuterClassname !== undefined && object.javaOuterClassname !== null) {
-      message.javaOuterClassname = String(object.javaOuterClassname);
-    } else {
-      message.javaOuterClassname = '';
-    }
-    if (object.javaMultipleFiles !== undefined && object.javaMultipleFiles !== null) {
-      message.javaMultipleFiles = Boolean(object.javaMultipleFiles);
-    } else {
-      message.javaMultipleFiles = false;
-    }
-    if (object.javaGenerateEqualsAndHash !== undefined && object.javaGenerateEqualsAndHash !== null) {
-      message.javaGenerateEqualsAndHash = Boolean(object.javaGenerateEqualsAndHash);
-    } else {
-      message.javaGenerateEqualsAndHash = false;
-    }
-    if (object.javaStringCheckUtf8 !== undefined && object.javaStringCheckUtf8 !== null) {
-      message.javaStringCheckUtf8 = Boolean(object.javaStringCheckUtf8);
-    } else {
-      message.javaStringCheckUtf8 = false;
-    }
-    if (object.optimizeFor !== undefined && object.optimizeFor !== null) {
-      message.optimizeFor = fileOptions_OptimizeModeFromJSON(object.optimizeFor);
-    } else {
-      message.optimizeFor = 1;
-    }
-    if (object.goPackage !== undefined && object.goPackage !== null) {
-      message.goPackage = String(object.goPackage);
-    } else {
-      message.goPackage = '';
-    }
-    if (object.ccGenericServices !== undefined && object.ccGenericServices !== null) {
-      message.ccGenericServices = Boolean(object.ccGenericServices);
-    } else {
-      message.ccGenericServices = false;
-    }
-    if (object.javaGenericServices !== undefined && object.javaGenericServices !== null) {
-      message.javaGenericServices = Boolean(object.javaGenericServices);
-    } else {
-      message.javaGenericServices = false;
-    }
-    if (object.pyGenericServices !== undefined && object.pyGenericServices !== null) {
-      message.pyGenericServices = Boolean(object.pyGenericServices);
-    } else {
-      message.pyGenericServices = false;
-    }
-    if (object.phpGenericServices !== undefined && object.phpGenericServices !== null) {
-      message.phpGenericServices = Boolean(object.phpGenericServices);
-    } else {
-      message.phpGenericServices = false;
-    }
-    if (object.deprecated !== undefined && object.deprecated !== null) {
-      message.deprecated = Boolean(object.deprecated);
-    } else {
-      message.deprecated = false;
-    }
-    if (object.ccEnableArenas !== undefined && object.ccEnableArenas !== null) {
-      message.ccEnableArenas = Boolean(object.ccEnableArenas);
-    } else {
-      message.ccEnableArenas = false;
-    }
-    if (object.objcClassPrefix !== undefined && object.objcClassPrefix !== null) {
-      message.objcClassPrefix = String(object.objcClassPrefix);
-    } else {
-      message.objcClassPrefix = '';
-    }
-    if (object.csharpNamespace !== undefined && object.csharpNamespace !== null) {
-      message.csharpNamespace = String(object.csharpNamespace);
-    } else {
-      message.csharpNamespace = '';
-    }
-    if (object.swiftPrefix !== undefined && object.swiftPrefix !== null) {
-      message.swiftPrefix = String(object.swiftPrefix);
-    } else {
-      message.swiftPrefix = '';
-    }
-    if (object.phpClassPrefix !== undefined && object.phpClassPrefix !== null) {
-      message.phpClassPrefix = String(object.phpClassPrefix);
-    } else {
-      message.phpClassPrefix = '';
-    }
-    if (object.phpNamespace !== undefined && object.phpNamespace !== null) {
-      message.phpNamespace = String(object.phpNamespace);
-    } else {
-      message.phpNamespace = '';
-    }
-    if (object.phpMetadataNamespace !== undefined && object.phpMetadataNamespace !== null) {
-      message.phpMetadataNamespace = String(object.phpMetadataNamespace);
-    } else {
-      message.phpMetadataNamespace = '';
-    }
-    if (object.rubyPackage !== undefined && object.rubyPackage !== null) {
-      message.rubyPackage = String(object.rubyPackage);
-    } else {
-      message.rubyPackage = '';
-    }
-    if (object.uninterpretedOption !== undefined && object.uninterpretedOption !== null) {
-      for (const e of object.uninterpretedOption) {
-        message.uninterpretedOption.push(UninterpretedOption.fromJSON(e));
-      }
-    }
-    return message;
-  },
-
-  fromPartial(object: DeepPartial<FileOptions>): FileOptions {
-    const message = { ...baseFileOptions } as FileOptions;
-    message.uninterpretedOption = [];
-    if (object.javaPackage !== undefined && object.javaPackage !== null) {
-      message.javaPackage = object.javaPackage;
-    } else {
-      message.javaPackage = '';
-    }
-    if (object.javaOuterClassname !== undefined && object.javaOuterClassname !== null) {
-      message.javaOuterClassname = object.javaOuterClassname;
-    } else {
-      message.javaOuterClassname = '';
-    }
-    if (object.javaMultipleFiles !== undefined && object.javaMultipleFiles !== null) {
-      message.javaMultipleFiles = object.javaMultipleFiles;
-    } else {
-      message.javaMultipleFiles = false;
-    }
-    if (object.javaGenerateEqualsAndHash !== undefined && object.javaGenerateEqualsAndHash !== null) {
-      message.javaGenerateEqualsAndHash = object.javaGenerateEqualsAndHash;
-    } else {
-      message.javaGenerateEqualsAndHash = false;
-    }
-    if (object.javaStringCheckUtf8 !== undefined && object.javaStringCheckUtf8 !== null) {
-      message.javaStringCheckUtf8 = object.javaStringCheckUtf8;
-    } else {
-      message.javaStringCheckUtf8 = false;
-    }
-    if (object.optimizeFor !== undefined && object.optimizeFor !== null) {
-      message.optimizeFor = object.optimizeFor;
-    } else {
-      message.optimizeFor = 1;
-    }
-    if (object.goPackage !== undefined && object.goPackage !== null) {
-      message.goPackage = object.goPackage;
-    } else {
-      message.goPackage = '';
-    }
-    if (object.ccGenericServices !== undefined && object.ccGenericServices !== null) {
-      message.ccGenericServices = object.ccGenericServices;
-    } else {
-      message.ccGenericServices = false;
-    }
-    if (object.javaGenericServices !== undefined && object.javaGenericServices !== null) {
-      message.javaGenericServices = object.javaGenericServices;
-    } else {
-      message.javaGenericServices = false;
-    }
-    if (object.pyGenericServices !== undefined && object.pyGenericServices !== null) {
-      message.pyGenericServices = object.pyGenericServices;
-    } else {
-      message.pyGenericServices = false;
-    }
-    if (object.phpGenericServices !== undefined && object.phpGenericServices !== null) {
-      message.phpGenericServices = object.phpGenericServices;
-    } else {
-      message.phpGenericServices = false;
-    }
-    if (object.deprecated !== undefined && object.deprecated !== null) {
-      message.deprecated = object.deprecated;
-    } else {
-      message.deprecated = false;
-    }
-    if (object.ccEnableArenas !== undefined && object.ccEnableArenas !== null) {
-      message.ccEnableArenas = object.ccEnableArenas;
-    } else {
-      message.ccEnableArenas = false;
-    }
-    if (object.objcClassPrefix !== undefined && object.objcClassPrefix !== null) {
-      message.objcClassPrefix = object.objcClassPrefix;
-    } else {
-      message.objcClassPrefix = '';
-    }
-    if (object.csharpNamespace !== undefined && object.csharpNamespace !== null) {
-      message.csharpNamespace = object.csharpNamespace;
-    } else {
-      message.csharpNamespace = '';
-    }
-    if (object.swiftPrefix !== undefined && object.swiftPrefix !== null) {
-      message.swiftPrefix = object.swiftPrefix;
-    } else {
-      message.swiftPrefix = '';
-    }
-    if (object.phpClassPrefix !== undefined && object.phpClassPrefix !== null) {
-      message.phpClassPrefix = object.phpClassPrefix;
-    } else {
-      message.phpClassPrefix = '';
-    }
-    if (object.phpNamespace !== undefined && object.phpNamespace !== null) {
-      message.phpNamespace = object.phpNamespace;
-    } else {
-      message.phpNamespace = '';
-    }
-    if (object.phpMetadataNamespace !== undefined && object.phpMetadataNamespace !== null) {
-      message.phpMetadataNamespace = object.phpMetadataNamespace;
-    } else {
-      message.phpMetadataNamespace = '';
-    }
-    if (object.rubyPackage !== undefined && object.rubyPackage !== null) {
-      message.rubyPackage = object.rubyPackage;
-    } else {
-      message.rubyPackage = '';
-    }
-    if (object.uninterpretedOption !== undefined && object.uninterpretedOption !== null) {
-      for (const e of object.uninterpretedOption) {
-        message.uninterpretedOption.push(UninterpretedOption.fromPartial(e));
-      }
-    }
-    return message;
+    return {
+      javaPackage: isSet(object.javaPackage) ? String(object.javaPackage) : '',
+      javaOuterClassname: isSet(object.javaOuterClassname) ? String(object.javaOuterClassname) : '',
+      javaMultipleFiles: isSet(object.javaMultipleFiles) ? Boolean(object.javaMultipleFiles) : false,
+      javaGenerateEqualsAndHash: isSet(object.javaGenerateEqualsAndHash)
+        ? Boolean(object.javaGenerateEqualsAndHash)
+        : false,
+      javaStringCheckUtf8: isSet(object.javaStringCheckUtf8) ? Boolean(object.javaStringCheckUtf8) : false,
+      optimizeFor: isSet(object.optimizeFor) ? fileOptions_OptimizeModeFromJSON(object.optimizeFor) : 1,
+      goPackage: isSet(object.goPackage) ? String(object.goPackage) : '',
+      ccGenericServices: isSet(object.ccGenericServices) ? Boolean(object.ccGenericServices) : false,
+      javaGenericServices: isSet(object.javaGenericServices) ? Boolean(object.javaGenericServices) : false,
+      pyGenericServices: isSet(object.pyGenericServices) ? Boolean(object.pyGenericServices) : false,
+      phpGenericServices: isSet(object.phpGenericServices) ? Boolean(object.phpGenericServices) : false,
+      deprecated: isSet(object.deprecated) ? Boolean(object.deprecated) : false,
+      ccEnableArenas: isSet(object.ccEnableArenas) ? Boolean(object.ccEnableArenas) : false,
+      objcClassPrefix: isSet(object.objcClassPrefix) ? String(object.objcClassPrefix) : '',
+      csharpNamespace: isSet(object.csharpNamespace) ? String(object.csharpNamespace) : '',
+      swiftPrefix: isSet(object.swiftPrefix) ? String(object.swiftPrefix) : '',
+      phpClassPrefix: isSet(object.phpClassPrefix) ? String(object.phpClassPrefix) : '',
+      phpNamespace: isSet(object.phpNamespace) ? String(object.phpNamespace) : '',
+      phpMetadataNamespace: isSet(object.phpMetadataNamespace) ? String(object.phpMetadataNamespace) : '',
+      rubyPackage: isSet(object.rubyPackage) ? String(object.rubyPackage) : '',
+      uninterpretedOption: Array.isArray(object?.uninterpretedOption)
+        ? object.uninterpretedOption.map((e: any) => UninterpretedOption.fromJSON(e))
+        : [],
+    };
   },
 
   toJSON(message: FileOptions): unknown {
@@ -3162,32 +2875,82 @@ export const FileOptions = {
     }
     return obj;
   },
+
+  fromPartial<I extends Exact<DeepPartial<FileOptions>, I>>(object: I): FileOptions {
+    const message = createBaseFileOptions();
+    message.javaPackage = object.javaPackage ?? '';
+    message.javaOuterClassname = object.javaOuterClassname ?? '';
+    message.javaMultipleFiles = object.javaMultipleFiles ?? false;
+    message.javaGenerateEqualsAndHash = object.javaGenerateEqualsAndHash ?? false;
+    message.javaStringCheckUtf8 = object.javaStringCheckUtf8 ?? false;
+    message.optimizeFor = object.optimizeFor ?? 1;
+    message.goPackage = object.goPackage ?? '';
+    message.ccGenericServices = object.ccGenericServices ?? false;
+    message.javaGenericServices = object.javaGenericServices ?? false;
+    message.pyGenericServices = object.pyGenericServices ?? false;
+    message.phpGenericServices = object.phpGenericServices ?? false;
+    message.deprecated = object.deprecated ?? false;
+    message.ccEnableArenas = object.ccEnableArenas ?? false;
+    message.objcClassPrefix = object.objcClassPrefix ?? '';
+    message.csharpNamespace = object.csharpNamespace ?? '';
+    message.swiftPrefix = object.swiftPrefix ?? '';
+    message.phpClassPrefix = object.phpClassPrefix ?? '';
+    message.phpNamespace = object.phpNamespace ?? '';
+    message.phpMetadataNamespace = object.phpMetadataNamespace ?? '';
+    message.rubyPackage = object.rubyPackage ?? '';
+    message.uninterpretedOption = object.uninterpretedOption?.map((e) => UninterpretedOption.fromPartial(e)) || [];
+    return message;
+  },
 };
 
-const baseMessageOptions: object = {
-  messageSetWireFormat: false,
-  noStandardDescriptorAccessor: false,
-  deprecated: false,
-  mapEntry: false,
-};
+function createBaseMessageOptions(): MessageOptions {
+  return {
+    messageSetWireFormat: false,
+    noStandardDescriptorAccessor: false,
+    deprecated: false,
+    mapEntry: false,
+    uninterpretedOption: [],
+  };
+}
 
 export const MessageOptions = {
   encode(message: MessageOptions, writer: Writer = Writer.create()): Writer {
-    writer.uint32(8).bool(message.messageSetWireFormat);
-    writer.uint32(16).bool(message.noStandardDescriptorAccessor);
-    writer.uint32(24).bool(message.deprecated);
-    writer.uint32(56).bool(message.mapEntry);
+    if (message.messageSetWireFormat === true) {
+      writer.uint32(8).bool(message.messageSetWireFormat);
+    }
+    if (message.noStandardDescriptorAccessor === true) {
+      writer.uint32(16).bool(message.noStandardDescriptorAccessor);
+    }
+    if (message.deprecated === true) {
+      writer.uint32(24).bool(message.deprecated);
+    }
+    if (message.mapEntry === true) {
+      writer.uint32(56).bool(message.mapEntry);
+    }
     for (const v of message.uninterpretedOption) {
       UninterpretedOption.encode(v!, writer.uint32(7994).fork()).ldelim();
+    }
+    if ('_unknownFields' in message) {
+      for (const key of Object.keys(message['_unknownFields'])) {
+        const values = message['_unknownFields'][key] as Uint8Array[];
+        for (const value of values) {
+          writer.uint32(parseInt(key, 10));
+          (writer as any)['_push'](
+            (val: Uint8Array, buf: Buffer, pos: number) => buf.set(val, pos),
+            value.length,
+            value
+          );
+        }
+      }
     }
     return writer;
   },
 
   decode(input: Reader | Uint8Array, length?: number): MessageOptions {
-    const reader = input instanceof Uint8Array ? new Reader(input) : input;
+    const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = Object.create(baseMessageOptions) as MessageOptions;
-    message.uninterpretedOption = [];
+    const message = createBaseMessageOptions();
+    (message as any)._unknownFields = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -3207,7 +2970,12 @@ export const MessageOptions = {
           message.uninterpretedOption.push(UninterpretedOption.decode(reader, reader.uint32()));
           break;
         default:
+          const startPos = reader.pos;
           reader.skipType(tag & 7);
+          (message as any)._unknownFields[tag] = [
+            ...((message as any)._unknownFields[tag] || []),
+            reader.buf.slice(startPos, reader.pos),
+          ];
           break;
       }
     }
@@ -3215,65 +2983,17 @@ export const MessageOptions = {
   },
 
   fromJSON(object: any): MessageOptions {
-    const message = Object.create(baseMessageOptions) as MessageOptions;
-    message.uninterpretedOption = [];
-    if (object.messageSetWireFormat !== undefined && object.messageSetWireFormat !== null) {
-      message.messageSetWireFormat = Boolean(object.messageSetWireFormat);
-    } else {
-      message.messageSetWireFormat = false;
-    }
-    if (object.noStandardDescriptorAccessor !== undefined && object.noStandardDescriptorAccessor !== null) {
-      message.noStandardDescriptorAccessor = Boolean(object.noStandardDescriptorAccessor);
-    } else {
-      message.noStandardDescriptorAccessor = false;
-    }
-    if (object.deprecated !== undefined && object.deprecated !== null) {
-      message.deprecated = Boolean(object.deprecated);
-    } else {
-      message.deprecated = false;
-    }
-    if (object.mapEntry !== undefined && object.mapEntry !== null) {
-      message.mapEntry = Boolean(object.mapEntry);
-    } else {
-      message.mapEntry = false;
-    }
-    if (object.uninterpretedOption !== undefined && object.uninterpretedOption !== null) {
-      for (const e of object.uninterpretedOption) {
-        message.uninterpretedOption.push(UninterpretedOption.fromJSON(e));
-      }
-    }
-    return message;
-  },
-
-  fromPartial(object: DeepPartial<MessageOptions>): MessageOptions {
-    const message = { ...baseMessageOptions } as MessageOptions;
-    message.uninterpretedOption = [];
-    if (object.messageSetWireFormat !== undefined && object.messageSetWireFormat !== null) {
-      message.messageSetWireFormat = object.messageSetWireFormat;
-    } else {
-      message.messageSetWireFormat = false;
-    }
-    if (object.noStandardDescriptorAccessor !== undefined && object.noStandardDescriptorAccessor !== null) {
-      message.noStandardDescriptorAccessor = object.noStandardDescriptorAccessor;
-    } else {
-      message.noStandardDescriptorAccessor = false;
-    }
-    if (object.deprecated !== undefined && object.deprecated !== null) {
-      message.deprecated = object.deprecated;
-    } else {
-      message.deprecated = false;
-    }
-    if (object.mapEntry !== undefined && object.mapEntry !== null) {
-      message.mapEntry = object.mapEntry;
-    } else {
-      message.mapEntry = false;
-    }
-    if (object.uninterpretedOption !== undefined && object.uninterpretedOption !== null) {
-      for (const e of object.uninterpretedOption) {
-        message.uninterpretedOption.push(UninterpretedOption.fromPartial(e));
-      }
-    }
-    return message;
+    return {
+      messageSetWireFormat: isSet(object.messageSetWireFormat) ? Boolean(object.messageSetWireFormat) : false,
+      noStandardDescriptorAccessor: isSet(object.noStandardDescriptorAccessor)
+        ? Boolean(object.noStandardDescriptorAccessor)
+        : false,
+      deprecated: isSet(object.deprecated) ? Boolean(object.deprecated) : false,
+      mapEntry: isSet(object.mapEntry) ? Boolean(object.mapEntry) : false,
+      uninterpretedOption: Array.isArray(object?.uninterpretedOption)
+        ? object.uninterpretedOption.map((e: any) => UninterpretedOption.fromJSON(e))
+        : [],
+    };
   },
 
   toJSON(message: MessageOptions): unknown {
@@ -3290,29 +3010,66 @@ export const MessageOptions = {
     }
     return obj;
   },
+
+  fromPartial<I extends Exact<DeepPartial<MessageOptions>, I>>(object: I): MessageOptions {
+    const message = createBaseMessageOptions();
+    message.messageSetWireFormat = object.messageSetWireFormat ?? false;
+    message.noStandardDescriptorAccessor = object.noStandardDescriptorAccessor ?? false;
+    message.deprecated = object.deprecated ?? false;
+    message.mapEntry = object.mapEntry ?? false;
+    message.uninterpretedOption = object.uninterpretedOption?.map((e) => UninterpretedOption.fromPartial(e)) || [];
+    return message;
+  },
 };
 
-const baseFieldOptions: object = { ctype: 0, packed: false, jstype: 0, lazy: false, deprecated: false, weak: false };
+function createBaseFieldOptions(): FieldOptions {
+  return { ctype: 0, packed: false, jstype: 0, lazy: false, deprecated: false, weak: false, uninterpretedOption: [] };
+}
 
 export const FieldOptions = {
   encode(message: FieldOptions, writer: Writer = Writer.create()): Writer {
-    writer.uint32(8).int32(message.ctype);
-    writer.uint32(16).bool(message.packed);
-    writer.uint32(48).int32(message.jstype);
-    writer.uint32(40).bool(message.lazy);
-    writer.uint32(24).bool(message.deprecated);
-    writer.uint32(80).bool(message.weak);
+    if (message.ctype !== 0) {
+      writer.uint32(8).int32(message.ctype);
+    }
+    if (message.packed === true) {
+      writer.uint32(16).bool(message.packed);
+    }
+    if (message.jstype !== 0) {
+      writer.uint32(48).int32(message.jstype);
+    }
+    if (message.lazy === true) {
+      writer.uint32(40).bool(message.lazy);
+    }
+    if (message.deprecated === true) {
+      writer.uint32(24).bool(message.deprecated);
+    }
+    if (message.weak === true) {
+      writer.uint32(80).bool(message.weak);
+    }
     for (const v of message.uninterpretedOption) {
       UninterpretedOption.encode(v!, writer.uint32(7994).fork()).ldelim();
+    }
+    if ('_unknownFields' in message) {
+      for (const key of Object.keys(message['_unknownFields'])) {
+        const values = message['_unknownFields'][key] as Uint8Array[];
+        for (const value of values) {
+          writer.uint32(parseInt(key, 10));
+          (writer as any)['_push'](
+            (val: Uint8Array, buf: Buffer, pos: number) => buf.set(val, pos),
+            value.length,
+            value
+          );
+        }
+      }
     }
     return writer;
   },
 
   decode(input: Reader | Uint8Array, length?: number): FieldOptions {
-    const reader = input instanceof Uint8Array ? new Reader(input) : input;
+    const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = Object.create(baseFieldOptions) as FieldOptions;
-    message.uninterpretedOption = [];
+    const message = createBaseFieldOptions();
+    (message as any)._unknownFields = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -3338,7 +3095,12 @@ export const FieldOptions = {
           message.uninterpretedOption.push(UninterpretedOption.decode(reader, reader.uint32()));
           break;
         default:
+          const startPos = reader.pos;
           reader.skipType(tag & 7);
+          (message as any)._unknownFields[tag] = [
+            ...((message as any)._unknownFields[tag] || []),
+            reader.buf.slice(startPos, reader.pos),
+          ];
           break;
       }
     }
@@ -3346,85 +3108,17 @@ export const FieldOptions = {
   },
 
   fromJSON(object: any): FieldOptions {
-    const message = Object.create(baseFieldOptions) as FieldOptions;
-    message.uninterpretedOption = [];
-    if (object.ctype !== undefined && object.ctype !== null) {
-      message.ctype = fieldOptions_CTypeFromJSON(object.ctype);
-    } else {
-      message.ctype = 0;
-    }
-    if (object.packed !== undefined && object.packed !== null) {
-      message.packed = Boolean(object.packed);
-    } else {
-      message.packed = false;
-    }
-    if (object.jstype !== undefined && object.jstype !== null) {
-      message.jstype = fieldOptions_JSTypeFromJSON(object.jstype);
-    } else {
-      message.jstype = 0;
-    }
-    if (object.lazy !== undefined && object.lazy !== null) {
-      message.lazy = Boolean(object.lazy);
-    } else {
-      message.lazy = false;
-    }
-    if (object.deprecated !== undefined && object.deprecated !== null) {
-      message.deprecated = Boolean(object.deprecated);
-    } else {
-      message.deprecated = false;
-    }
-    if (object.weak !== undefined && object.weak !== null) {
-      message.weak = Boolean(object.weak);
-    } else {
-      message.weak = false;
-    }
-    if (object.uninterpretedOption !== undefined && object.uninterpretedOption !== null) {
-      for (const e of object.uninterpretedOption) {
-        message.uninterpretedOption.push(UninterpretedOption.fromJSON(e));
-      }
-    }
-    return message;
-  },
-
-  fromPartial(object: DeepPartial<FieldOptions>): FieldOptions {
-    const message = { ...baseFieldOptions } as FieldOptions;
-    message.uninterpretedOption = [];
-    if (object.ctype !== undefined && object.ctype !== null) {
-      message.ctype = object.ctype;
-    } else {
-      message.ctype = 0;
-    }
-    if (object.packed !== undefined && object.packed !== null) {
-      message.packed = object.packed;
-    } else {
-      message.packed = false;
-    }
-    if (object.jstype !== undefined && object.jstype !== null) {
-      message.jstype = object.jstype;
-    } else {
-      message.jstype = 0;
-    }
-    if (object.lazy !== undefined && object.lazy !== null) {
-      message.lazy = object.lazy;
-    } else {
-      message.lazy = false;
-    }
-    if (object.deprecated !== undefined && object.deprecated !== null) {
-      message.deprecated = object.deprecated;
-    } else {
-      message.deprecated = false;
-    }
-    if (object.weak !== undefined && object.weak !== null) {
-      message.weak = object.weak;
-    } else {
-      message.weak = false;
-    }
-    if (object.uninterpretedOption !== undefined && object.uninterpretedOption !== null) {
-      for (const e of object.uninterpretedOption) {
-        message.uninterpretedOption.push(UninterpretedOption.fromPartial(e));
-      }
-    }
-    return message;
+    return {
+      ctype: isSet(object.ctype) ? fieldOptions_CTypeFromJSON(object.ctype) : 0,
+      packed: isSet(object.packed) ? Boolean(object.packed) : false,
+      jstype: isSet(object.jstype) ? fieldOptions_JSTypeFromJSON(object.jstype) : 0,
+      lazy: isSet(object.lazy) ? Boolean(object.lazy) : false,
+      deprecated: isSet(object.deprecated) ? Boolean(object.deprecated) : false,
+      weak: isSet(object.weak) ? Boolean(object.weak) : false,
+      uninterpretedOption: Array.isArray(object?.uninterpretedOption)
+        ? object.uninterpretedOption.map((e: any) => UninterpretedOption.fromJSON(e))
+        : [],
+    };
   },
 
   toJSON(message: FieldOptions): unknown {
@@ -3442,23 +3136,50 @@ export const FieldOptions = {
     }
     return obj;
   },
+
+  fromPartial<I extends Exact<DeepPartial<FieldOptions>, I>>(object: I): FieldOptions {
+    const message = createBaseFieldOptions();
+    message.ctype = object.ctype ?? 0;
+    message.packed = object.packed ?? false;
+    message.jstype = object.jstype ?? 0;
+    message.lazy = object.lazy ?? false;
+    message.deprecated = object.deprecated ?? false;
+    message.weak = object.weak ?? false;
+    message.uninterpretedOption = object.uninterpretedOption?.map((e) => UninterpretedOption.fromPartial(e)) || [];
+    return message;
+  },
 };
 
-const baseOneofOptions: object = {};
+function createBaseOneofOptions(): OneofOptions {
+  return { uninterpretedOption: [] };
+}
 
 export const OneofOptions = {
   encode(message: OneofOptions, writer: Writer = Writer.create()): Writer {
     for (const v of message.uninterpretedOption) {
       UninterpretedOption.encode(v!, writer.uint32(7994).fork()).ldelim();
     }
+    if ('_unknownFields' in message) {
+      for (const key of Object.keys(message['_unknownFields'])) {
+        const values = message['_unknownFields'][key] as Uint8Array[];
+        for (const value of values) {
+          writer.uint32(parseInt(key, 10));
+          (writer as any)['_push'](
+            (val: Uint8Array, buf: Buffer, pos: number) => buf.set(val, pos),
+            value.length,
+            value
+          );
+        }
+      }
+    }
     return writer;
   },
 
   decode(input: Reader | Uint8Array, length?: number): OneofOptions {
-    const reader = input instanceof Uint8Array ? new Reader(input) : input;
+    const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = Object.create(baseOneofOptions) as OneofOptions;
-    message.uninterpretedOption = [];
+    const message = createBaseOneofOptions();
+    (message as any)._unknownFields = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -3466,7 +3187,12 @@ export const OneofOptions = {
           message.uninterpretedOption.push(UninterpretedOption.decode(reader, reader.uint32()));
           break;
         default:
+          const startPos = reader.pos;
           reader.skipType(tag & 7);
+          (message as any)._unknownFields[tag] = [
+            ...((message as any)._unknownFields[tag] || []),
+            reader.buf.slice(startPos, reader.pos),
+          ];
           break;
       }
     }
@@ -3474,25 +3200,11 @@ export const OneofOptions = {
   },
 
   fromJSON(object: any): OneofOptions {
-    const message = Object.create(baseOneofOptions) as OneofOptions;
-    message.uninterpretedOption = [];
-    if (object.uninterpretedOption !== undefined && object.uninterpretedOption !== null) {
-      for (const e of object.uninterpretedOption) {
-        message.uninterpretedOption.push(UninterpretedOption.fromJSON(e));
-      }
-    }
-    return message;
-  },
-
-  fromPartial(object: DeepPartial<OneofOptions>): OneofOptions {
-    const message = { ...baseOneofOptions } as OneofOptions;
-    message.uninterpretedOption = [];
-    if (object.uninterpretedOption !== undefined && object.uninterpretedOption !== null) {
-      for (const e of object.uninterpretedOption) {
-        message.uninterpretedOption.push(UninterpretedOption.fromPartial(e));
-      }
-    }
-    return message;
+    return {
+      uninterpretedOption: Array.isArray(object?.uninterpretedOption)
+        ? object.uninterpretedOption.map((e: any) => UninterpretedOption.fromJSON(e))
+        : [],
+    };
   },
 
   toJSON(message: OneofOptions): unknown {
@@ -3504,25 +3216,50 @@ export const OneofOptions = {
     }
     return obj;
   },
+
+  fromPartial<I extends Exact<DeepPartial<OneofOptions>, I>>(object: I): OneofOptions {
+    const message = createBaseOneofOptions();
+    message.uninterpretedOption = object.uninterpretedOption?.map((e) => UninterpretedOption.fromPartial(e)) || [];
+    return message;
+  },
 };
 
-const baseEnumOptions: object = { allowAlias: false, deprecated: false };
+function createBaseEnumOptions(): EnumOptions {
+  return { allowAlias: false, deprecated: false, uninterpretedOption: [] };
+}
 
 export const EnumOptions = {
   encode(message: EnumOptions, writer: Writer = Writer.create()): Writer {
-    writer.uint32(16).bool(message.allowAlias);
-    writer.uint32(24).bool(message.deprecated);
+    if (message.allowAlias === true) {
+      writer.uint32(16).bool(message.allowAlias);
+    }
+    if (message.deprecated === true) {
+      writer.uint32(24).bool(message.deprecated);
+    }
     for (const v of message.uninterpretedOption) {
       UninterpretedOption.encode(v!, writer.uint32(7994).fork()).ldelim();
+    }
+    if ('_unknownFields' in message) {
+      for (const key of Object.keys(message['_unknownFields'])) {
+        const values = message['_unknownFields'][key] as Uint8Array[];
+        for (const value of values) {
+          writer.uint32(parseInt(key, 10));
+          (writer as any)['_push'](
+            (val: Uint8Array, buf: Buffer, pos: number) => buf.set(val, pos),
+            value.length,
+            value
+          );
+        }
+      }
     }
     return writer;
   },
 
   decode(input: Reader | Uint8Array, length?: number): EnumOptions {
-    const reader = input instanceof Uint8Array ? new Reader(input) : input;
+    const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = Object.create(baseEnumOptions) as EnumOptions;
-    message.uninterpretedOption = [];
+    const message = createBaseEnumOptions();
+    (message as any)._unknownFields = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -3536,7 +3273,12 @@ export const EnumOptions = {
           message.uninterpretedOption.push(UninterpretedOption.decode(reader, reader.uint32()));
           break;
         default:
+          const startPos = reader.pos;
           reader.skipType(tag & 7);
+          (message as any)._unknownFields[tag] = [
+            ...((message as any)._unknownFields[tag] || []),
+            reader.buf.slice(startPos, reader.pos),
+          ];
           break;
       }
     }
@@ -3544,45 +3286,13 @@ export const EnumOptions = {
   },
 
   fromJSON(object: any): EnumOptions {
-    const message = Object.create(baseEnumOptions) as EnumOptions;
-    message.uninterpretedOption = [];
-    if (object.allowAlias !== undefined && object.allowAlias !== null) {
-      message.allowAlias = Boolean(object.allowAlias);
-    } else {
-      message.allowAlias = false;
-    }
-    if (object.deprecated !== undefined && object.deprecated !== null) {
-      message.deprecated = Boolean(object.deprecated);
-    } else {
-      message.deprecated = false;
-    }
-    if (object.uninterpretedOption !== undefined && object.uninterpretedOption !== null) {
-      for (const e of object.uninterpretedOption) {
-        message.uninterpretedOption.push(UninterpretedOption.fromJSON(e));
-      }
-    }
-    return message;
-  },
-
-  fromPartial(object: DeepPartial<EnumOptions>): EnumOptions {
-    const message = { ...baseEnumOptions } as EnumOptions;
-    message.uninterpretedOption = [];
-    if (object.allowAlias !== undefined && object.allowAlias !== null) {
-      message.allowAlias = object.allowAlias;
-    } else {
-      message.allowAlias = false;
-    }
-    if (object.deprecated !== undefined && object.deprecated !== null) {
-      message.deprecated = object.deprecated;
-    } else {
-      message.deprecated = false;
-    }
-    if (object.uninterpretedOption !== undefined && object.uninterpretedOption !== null) {
-      for (const e of object.uninterpretedOption) {
-        message.uninterpretedOption.push(UninterpretedOption.fromPartial(e));
-      }
-    }
-    return message;
+    return {
+      allowAlias: isSet(object.allowAlias) ? Boolean(object.allowAlias) : false,
+      deprecated: isSet(object.deprecated) ? Boolean(object.deprecated) : false,
+      uninterpretedOption: Array.isArray(object?.uninterpretedOption)
+        ? object.uninterpretedOption.map((e: any) => UninterpretedOption.fromJSON(e))
+        : [],
+    };
   },
 
   toJSON(message: EnumOptions): unknown {
@@ -3596,24 +3306,49 @@ export const EnumOptions = {
     }
     return obj;
   },
+
+  fromPartial<I extends Exact<DeepPartial<EnumOptions>, I>>(object: I): EnumOptions {
+    const message = createBaseEnumOptions();
+    message.allowAlias = object.allowAlias ?? false;
+    message.deprecated = object.deprecated ?? false;
+    message.uninterpretedOption = object.uninterpretedOption?.map((e) => UninterpretedOption.fromPartial(e)) || [];
+    return message;
+  },
 };
 
-const baseEnumValueOptions: object = { deprecated: false };
+function createBaseEnumValueOptions(): EnumValueOptions {
+  return { deprecated: false, uninterpretedOption: [] };
+}
 
 export const EnumValueOptions = {
   encode(message: EnumValueOptions, writer: Writer = Writer.create()): Writer {
-    writer.uint32(8).bool(message.deprecated);
+    if (message.deprecated === true) {
+      writer.uint32(8).bool(message.deprecated);
+    }
     for (const v of message.uninterpretedOption) {
       UninterpretedOption.encode(v!, writer.uint32(7994).fork()).ldelim();
+    }
+    if ('_unknownFields' in message) {
+      for (const key of Object.keys(message['_unknownFields'])) {
+        const values = message['_unknownFields'][key] as Uint8Array[];
+        for (const value of values) {
+          writer.uint32(parseInt(key, 10));
+          (writer as any)['_push'](
+            (val: Uint8Array, buf: Buffer, pos: number) => buf.set(val, pos),
+            value.length,
+            value
+          );
+        }
+      }
     }
     return writer;
   },
 
   decode(input: Reader | Uint8Array, length?: number): EnumValueOptions {
-    const reader = input instanceof Uint8Array ? new Reader(input) : input;
+    const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = Object.create(baseEnumValueOptions) as EnumValueOptions;
-    message.uninterpretedOption = [];
+    const message = createBaseEnumValueOptions();
+    (message as any)._unknownFields = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -3624,7 +3359,12 @@ export const EnumValueOptions = {
           message.uninterpretedOption.push(UninterpretedOption.decode(reader, reader.uint32()));
           break;
         default:
+          const startPos = reader.pos;
           reader.skipType(tag & 7);
+          (message as any)._unknownFields[tag] = [
+            ...((message as any)._unknownFields[tag] || []),
+            reader.buf.slice(startPos, reader.pos),
+          ];
           break;
       }
     }
@@ -3632,35 +3372,12 @@ export const EnumValueOptions = {
   },
 
   fromJSON(object: any): EnumValueOptions {
-    const message = Object.create(baseEnumValueOptions) as EnumValueOptions;
-    message.uninterpretedOption = [];
-    if (object.deprecated !== undefined && object.deprecated !== null) {
-      message.deprecated = Boolean(object.deprecated);
-    } else {
-      message.deprecated = false;
-    }
-    if (object.uninterpretedOption !== undefined && object.uninterpretedOption !== null) {
-      for (const e of object.uninterpretedOption) {
-        message.uninterpretedOption.push(UninterpretedOption.fromJSON(e));
-      }
-    }
-    return message;
-  },
-
-  fromPartial(object: DeepPartial<EnumValueOptions>): EnumValueOptions {
-    const message = { ...baseEnumValueOptions } as EnumValueOptions;
-    message.uninterpretedOption = [];
-    if (object.deprecated !== undefined && object.deprecated !== null) {
-      message.deprecated = object.deprecated;
-    } else {
-      message.deprecated = false;
-    }
-    if (object.uninterpretedOption !== undefined && object.uninterpretedOption !== null) {
-      for (const e of object.uninterpretedOption) {
-        message.uninterpretedOption.push(UninterpretedOption.fromPartial(e));
-      }
-    }
-    return message;
+    return {
+      deprecated: isSet(object.deprecated) ? Boolean(object.deprecated) : false,
+      uninterpretedOption: Array.isArray(object?.uninterpretedOption)
+        ? object.uninterpretedOption.map((e: any) => UninterpretedOption.fromJSON(e))
+        : [],
+    };
   },
 
   toJSON(message: EnumValueOptions): unknown {
@@ -3673,24 +3390,48 @@ export const EnumValueOptions = {
     }
     return obj;
   },
+
+  fromPartial<I extends Exact<DeepPartial<EnumValueOptions>, I>>(object: I): EnumValueOptions {
+    const message = createBaseEnumValueOptions();
+    message.deprecated = object.deprecated ?? false;
+    message.uninterpretedOption = object.uninterpretedOption?.map((e) => UninterpretedOption.fromPartial(e)) || [];
+    return message;
+  },
 };
 
-const baseServiceOptions: object = { deprecated: false };
+function createBaseServiceOptions(): ServiceOptions {
+  return { deprecated: false, uninterpretedOption: [] };
+}
 
 export const ServiceOptions = {
   encode(message: ServiceOptions, writer: Writer = Writer.create()): Writer {
-    writer.uint32(264).bool(message.deprecated);
+    if (message.deprecated === true) {
+      writer.uint32(264).bool(message.deprecated);
+    }
     for (const v of message.uninterpretedOption) {
       UninterpretedOption.encode(v!, writer.uint32(7994).fork()).ldelim();
+    }
+    if ('_unknownFields' in message) {
+      for (const key of Object.keys(message['_unknownFields'])) {
+        const values = message['_unknownFields'][key] as Uint8Array[];
+        for (const value of values) {
+          writer.uint32(parseInt(key, 10));
+          (writer as any)['_push'](
+            (val: Uint8Array, buf: Buffer, pos: number) => buf.set(val, pos),
+            value.length,
+            value
+          );
+        }
+      }
     }
     return writer;
   },
 
   decode(input: Reader | Uint8Array, length?: number): ServiceOptions {
-    const reader = input instanceof Uint8Array ? new Reader(input) : input;
+    const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = Object.create(baseServiceOptions) as ServiceOptions;
-    message.uninterpretedOption = [];
+    const message = createBaseServiceOptions();
+    (message as any)._unknownFields = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -3701,7 +3442,12 @@ export const ServiceOptions = {
           message.uninterpretedOption.push(UninterpretedOption.decode(reader, reader.uint32()));
           break;
         default:
+          const startPos = reader.pos;
           reader.skipType(tag & 7);
+          (message as any)._unknownFields[tag] = [
+            ...((message as any)._unknownFields[tag] || []),
+            reader.buf.slice(startPos, reader.pos),
+          ];
           break;
       }
     }
@@ -3709,35 +3455,12 @@ export const ServiceOptions = {
   },
 
   fromJSON(object: any): ServiceOptions {
-    const message = Object.create(baseServiceOptions) as ServiceOptions;
-    message.uninterpretedOption = [];
-    if (object.deprecated !== undefined && object.deprecated !== null) {
-      message.deprecated = Boolean(object.deprecated);
-    } else {
-      message.deprecated = false;
-    }
-    if (object.uninterpretedOption !== undefined && object.uninterpretedOption !== null) {
-      for (const e of object.uninterpretedOption) {
-        message.uninterpretedOption.push(UninterpretedOption.fromJSON(e));
-      }
-    }
-    return message;
-  },
-
-  fromPartial(object: DeepPartial<ServiceOptions>): ServiceOptions {
-    const message = { ...baseServiceOptions } as ServiceOptions;
-    message.uninterpretedOption = [];
-    if (object.deprecated !== undefined && object.deprecated !== null) {
-      message.deprecated = object.deprecated;
-    } else {
-      message.deprecated = false;
-    }
-    if (object.uninterpretedOption !== undefined && object.uninterpretedOption !== null) {
-      for (const e of object.uninterpretedOption) {
-        message.uninterpretedOption.push(UninterpretedOption.fromPartial(e));
-      }
-    }
-    return message;
+    return {
+      deprecated: isSet(object.deprecated) ? Boolean(object.deprecated) : false,
+      uninterpretedOption: Array.isArray(object?.uninterpretedOption)
+        ? object.uninterpretedOption.map((e: any) => UninterpretedOption.fromJSON(e))
+        : [],
+    };
   },
 
   toJSON(message: ServiceOptions): unknown {
@@ -3750,25 +3473,51 @@ export const ServiceOptions = {
     }
     return obj;
   },
+
+  fromPartial<I extends Exact<DeepPartial<ServiceOptions>, I>>(object: I): ServiceOptions {
+    const message = createBaseServiceOptions();
+    message.deprecated = object.deprecated ?? false;
+    message.uninterpretedOption = object.uninterpretedOption?.map((e) => UninterpretedOption.fromPartial(e)) || [];
+    return message;
+  },
 };
 
-const baseMethodOptions: object = { deprecated: false, idempotencyLevel: 0 };
+function createBaseMethodOptions(): MethodOptions {
+  return { deprecated: false, idempotencyLevel: 0, uninterpretedOption: [] };
+}
 
 export const MethodOptions = {
   encode(message: MethodOptions, writer: Writer = Writer.create()): Writer {
-    writer.uint32(264).bool(message.deprecated);
-    writer.uint32(272).int32(message.idempotencyLevel);
+    if (message.deprecated === true) {
+      writer.uint32(264).bool(message.deprecated);
+    }
+    if (message.idempotencyLevel !== 0) {
+      writer.uint32(272).int32(message.idempotencyLevel);
+    }
     for (const v of message.uninterpretedOption) {
       UninterpretedOption.encode(v!, writer.uint32(7994).fork()).ldelim();
+    }
+    if ('_unknownFields' in message) {
+      for (const key of Object.keys(message['_unknownFields'])) {
+        const values = message['_unknownFields'][key] as Uint8Array[];
+        for (const value of values) {
+          writer.uint32(parseInt(key, 10));
+          (writer as any)['_push'](
+            (val: Uint8Array, buf: Buffer, pos: number) => buf.set(val, pos),
+            value.length,
+            value
+          );
+        }
+      }
     }
     return writer;
   },
 
   decode(input: Reader | Uint8Array, length?: number): MethodOptions {
-    const reader = input instanceof Uint8Array ? new Reader(input) : input;
+    const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = Object.create(baseMethodOptions) as MethodOptions;
-    message.uninterpretedOption = [];
+    const message = createBaseMethodOptions();
+    (message as any)._unknownFields = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -3782,7 +3531,12 @@ export const MethodOptions = {
           message.uninterpretedOption.push(UninterpretedOption.decode(reader, reader.uint32()));
           break;
         default:
+          const startPos = reader.pos;
           reader.skipType(tag & 7);
+          (message as any)._unknownFields[tag] = [
+            ...((message as any)._unknownFields[tag] || []),
+            reader.buf.slice(startPos, reader.pos),
+          ];
           break;
       }
     }
@@ -3790,45 +3544,15 @@ export const MethodOptions = {
   },
 
   fromJSON(object: any): MethodOptions {
-    const message = Object.create(baseMethodOptions) as MethodOptions;
-    message.uninterpretedOption = [];
-    if (object.deprecated !== undefined && object.deprecated !== null) {
-      message.deprecated = Boolean(object.deprecated);
-    } else {
-      message.deprecated = false;
-    }
-    if (object.idempotencyLevel !== undefined && object.idempotencyLevel !== null) {
-      message.idempotencyLevel = methodOptions_IdempotencyLevelFromJSON(object.idempotencyLevel);
-    } else {
-      message.idempotencyLevel = 0;
-    }
-    if (object.uninterpretedOption !== undefined && object.uninterpretedOption !== null) {
-      for (const e of object.uninterpretedOption) {
-        message.uninterpretedOption.push(UninterpretedOption.fromJSON(e));
-      }
-    }
-    return message;
-  },
-
-  fromPartial(object: DeepPartial<MethodOptions>): MethodOptions {
-    const message = { ...baseMethodOptions } as MethodOptions;
-    message.uninterpretedOption = [];
-    if (object.deprecated !== undefined && object.deprecated !== null) {
-      message.deprecated = object.deprecated;
-    } else {
-      message.deprecated = false;
-    }
-    if (object.idempotencyLevel !== undefined && object.idempotencyLevel !== null) {
-      message.idempotencyLevel = object.idempotencyLevel;
-    } else {
-      message.idempotencyLevel = 0;
-    }
-    if (object.uninterpretedOption !== undefined && object.uninterpretedOption !== null) {
-      for (const e of object.uninterpretedOption) {
-        message.uninterpretedOption.push(UninterpretedOption.fromPartial(e));
-      }
-    }
-    return message;
+    return {
+      deprecated: isSet(object.deprecated) ? Boolean(object.deprecated) : false,
+      idempotencyLevel: isSet(object.idempotencyLevel)
+        ? methodOptions_IdempotencyLevelFromJSON(object.idempotencyLevel)
+        : 0,
+      uninterpretedOption: Array.isArray(object?.uninterpretedOption)
+        ? object.uninterpretedOption.map((e: any) => UninterpretedOption.fromJSON(e))
+        : [],
+    };
   },
 
   toJSON(message: MethodOptions): unknown {
@@ -3843,35 +3567,72 @@ export const MethodOptions = {
     }
     return obj;
   },
+
+  fromPartial<I extends Exact<DeepPartial<MethodOptions>, I>>(object: I): MethodOptions {
+    const message = createBaseMethodOptions();
+    message.deprecated = object.deprecated ?? false;
+    message.idempotencyLevel = object.idempotencyLevel ?? 0;
+    message.uninterpretedOption = object.uninterpretedOption?.map((e) => UninterpretedOption.fromPartial(e)) || [];
+    return message;
+  },
 };
 
-const baseUninterpretedOption: object = {
-  identifierValue: '',
-  positiveIntValue: 0,
-  negativeIntValue: 0,
-  doubleValue: 0,
-  aggregateValue: '',
-};
+function createBaseUninterpretedOption(): UninterpretedOption {
+  return {
+    name: [],
+    identifierValue: '',
+    positiveIntValue: 0,
+    negativeIntValue: 0,
+    doubleValue: 0,
+    stringValue: new Uint8Array(),
+    aggregateValue: '',
+  };
+}
 
 export const UninterpretedOption = {
   encode(message: UninterpretedOption, writer: Writer = Writer.create()): Writer {
     for (const v of message.name) {
       UninterpretedOption_NamePart.encode(v!, writer.uint32(18).fork()).ldelim();
     }
-    writer.uint32(26).string(message.identifierValue);
-    writer.uint32(32).uint64(message.positiveIntValue);
-    writer.uint32(40).int64(message.negativeIntValue);
-    writer.uint32(49).double(message.doubleValue);
-    writer.uint32(58).bytes(message.stringValue);
-    writer.uint32(66).string(message.aggregateValue);
+    if (message.identifierValue !== '') {
+      writer.uint32(26).string(message.identifierValue);
+    }
+    if (message.positiveIntValue !== 0) {
+      writer.uint32(32).uint64(message.positiveIntValue);
+    }
+    if (message.negativeIntValue !== 0) {
+      writer.uint32(40).int64(message.negativeIntValue);
+    }
+    if (message.doubleValue !== 0) {
+      writer.uint32(49).double(message.doubleValue);
+    }
+    if (message.stringValue.length !== 0) {
+      writer.uint32(58).bytes(message.stringValue);
+    }
+    if (message.aggregateValue !== '') {
+      writer.uint32(66).string(message.aggregateValue);
+    }
+    if ('_unknownFields' in message) {
+      for (const key of Object.keys(message['_unknownFields'])) {
+        const values = message['_unknownFields'][key] as Uint8Array[];
+        for (const value of values) {
+          writer.uint32(parseInt(key, 10));
+          (writer as any)['_push'](
+            (val: Uint8Array, buf: Buffer, pos: number) => buf.set(val, pos),
+            value.length,
+            value
+          );
+        }
+      }
+    }
     return writer;
   },
 
   decode(input: Reader | Uint8Array, length?: number): UninterpretedOption {
-    const reader = input instanceof Uint8Array ? new Reader(input) : input;
+    const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = Object.create(baseUninterpretedOption) as UninterpretedOption;
-    message.name = [];
+    const message = createBaseUninterpretedOption();
+    (message as any)._unknownFields = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -3897,7 +3658,12 @@ export const UninterpretedOption = {
           message.aggregateValue = reader.string();
           break;
         default:
+          const startPos = reader.pos;
           reader.skipType(tag & 7);
+          (message as any)._unknownFields[tag] = [
+            ...((message as any)._unknownFields[tag] || []),
+            reader.buf.slice(startPos, reader.pos),
+          ];
           break;
       }
     }
@@ -3905,83 +3671,15 @@ export const UninterpretedOption = {
   },
 
   fromJSON(object: any): UninterpretedOption {
-    const message = Object.create(baseUninterpretedOption) as UninterpretedOption;
-    message.name = [];
-    if (object.name !== undefined && object.name !== null) {
-      for (const e of object.name) {
-        message.name.push(UninterpretedOption_NamePart.fromJSON(e));
-      }
-    }
-    if (object.identifierValue !== undefined && object.identifierValue !== null) {
-      message.identifierValue = String(object.identifierValue);
-    } else {
-      message.identifierValue = '';
-    }
-    if (object.positiveIntValue !== undefined && object.positiveIntValue !== null) {
-      message.positiveIntValue = Number(object.positiveIntValue);
-    } else {
-      message.positiveIntValue = 0;
-    }
-    if (object.negativeIntValue !== undefined && object.negativeIntValue !== null) {
-      message.negativeIntValue = Number(object.negativeIntValue);
-    } else {
-      message.negativeIntValue = 0;
-    }
-    if (object.doubleValue !== undefined && object.doubleValue !== null) {
-      message.doubleValue = Number(object.doubleValue);
-    } else {
-      message.doubleValue = 0;
-    }
-    if (object.stringValue !== undefined && object.stringValue !== null) {
-      message.stringValue = bytesFromBase64(object.stringValue);
-    }
-    if (object.aggregateValue !== undefined && object.aggregateValue !== null) {
-      message.aggregateValue = String(object.aggregateValue);
-    } else {
-      message.aggregateValue = '';
-    }
-    return message;
-  },
-
-  fromPartial(object: DeepPartial<UninterpretedOption>): UninterpretedOption {
-    const message = { ...baseUninterpretedOption } as UninterpretedOption;
-    message.name = [];
-    if (object.name !== undefined && object.name !== null) {
-      for (const e of object.name) {
-        message.name.push(UninterpretedOption_NamePart.fromPartial(e));
-      }
-    }
-    if (object.identifierValue !== undefined && object.identifierValue !== null) {
-      message.identifierValue = object.identifierValue;
-    } else {
-      message.identifierValue = '';
-    }
-    if (object.positiveIntValue !== undefined && object.positiveIntValue !== null) {
-      message.positiveIntValue = object.positiveIntValue;
-    } else {
-      message.positiveIntValue = 0;
-    }
-    if (object.negativeIntValue !== undefined && object.negativeIntValue !== null) {
-      message.negativeIntValue = object.negativeIntValue;
-    } else {
-      message.negativeIntValue = 0;
-    }
-    if (object.doubleValue !== undefined && object.doubleValue !== null) {
-      message.doubleValue = object.doubleValue;
-    } else {
-      message.doubleValue = 0;
-    }
-    if (object.stringValue !== undefined && object.stringValue !== null) {
-      message.stringValue = object.stringValue;
-    } else {
-      message.stringValue = new Uint8Array();
-    }
-    if (object.aggregateValue !== undefined && object.aggregateValue !== null) {
-      message.aggregateValue = object.aggregateValue;
-    } else {
-      message.aggregateValue = '';
-    }
-    return message;
+    return {
+      name: Array.isArray(object?.name) ? object.name.map((e: any) => UninterpretedOption_NamePart.fromJSON(e)) : [],
+      identifierValue: isSet(object.identifierValue) ? String(object.identifierValue) : '',
+      positiveIntValue: isSet(object.positiveIntValue) ? Number(object.positiveIntValue) : 0,
+      negativeIntValue: isSet(object.negativeIntValue) ? Number(object.negativeIntValue) : 0,
+      doubleValue: isSet(object.doubleValue) ? Number(object.doubleValue) : 0,
+      stringValue: isSet(object.stringValue) ? bytesFromBase64(object.stringValue) : new Uint8Array(),
+      aggregateValue: isSet(object.aggregateValue) ? String(object.aggregateValue) : '',
+    };
   },
 
   toJSON(message: UninterpretedOption): unknown {
@@ -3992,29 +3690,61 @@ export const UninterpretedOption = {
       obj.name = [];
     }
     message.identifierValue !== undefined && (obj.identifierValue = message.identifierValue);
-    message.positiveIntValue !== undefined && (obj.positiveIntValue = message.positiveIntValue);
-    message.negativeIntValue !== undefined && (obj.negativeIntValue = message.negativeIntValue);
+    message.positiveIntValue !== undefined && (obj.positiveIntValue = Math.round(message.positiveIntValue));
+    message.negativeIntValue !== undefined && (obj.negativeIntValue = Math.round(message.negativeIntValue));
     message.doubleValue !== undefined && (obj.doubleValue = message.doubleValue);
     message.stringValue !== undefined &&
       (obj.stringValue = base64FromBytes(message.stringValue !== undefined ? message.stringValue : new Uint8Array()));
     message.aggregateValue !== undefined && (obj.aggregateValue = message.aggregateValue);
     return obj;
   },
+
+  fromPartial<I extends Exact<DeepPartial<UninterpretedOption>, I>>(object: I): UninterpretedOption {
+    const message = createBaseUninterpretedOption();
+    message.name = object.name?.map((e) => UninterpretedOption_NamePart.fromPartial(e)) || [];
+    message.identifierValue = object.identifierValue ?? '';
+    message.positiveIntValue = object.positiveIntValue ?? 0;
+    message.negativeIntValue = object.negativeIntValue ?? 0;
+    message.doubleValue = object.doubleValue ?? 0;
+    message.stringValue = object.stringValue ?? new Uint8Array();
+    message.aggregateValue = object.aggregateValue ?? '';
+    return message;
+  },
 };
 
-const baseUninterpretedOption_NamePart: object = { namePart: '', isExtension: false };
+function createBaseUninterpretedOption_NamePart(): UninterpretedOption_NamePart {
+  return { namePart: '', isExtension: false };
+}
 
 export const UninterpretedOption_NamePart = {
   encode(message: UninterpretedOption_NamePart, writer: Writer = Writer.create()): Writer {
-    writer.uint32(10).string(message.namePart);
-    writer.uint32(16).bool(message.isExtension);
+    if (message.namePart !== '') {
+      writer.uint32(10).string(message.namePart);
+    }
+    if (message.isExtension === true) {
+      writer.uint32(16).bool(message.isExtension);
+    }
+    if ('_unknownFields' in message) {
+      for (const key of Object.keys(message['_unknownFields'])) {
+        const values = message['_unknownFields'][key] as Uint8Array[];
+        for (const value of values) {
+          writer.uint32(parseInt(key, 10));
+          (writer as any)['_push'](
+            (val: Uint8Array, buf: Buffer, pos: number) => buf.set(val, pos),
+            value.length,
+            value
+          );
+        }
+      }
+    }
     return writer;
   },
 
   decode(input: Reader | Uint8Array, length?: number): UninterpretedOption_NamePart {
-    const reader = input instanceof Uint8Array ? new Reader(input) : input;
+    const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = Object.create(baseUninterpretedOption_NamePart) as UninterpretedOption_NamePart;
+    const message = createBaseUninterpretedOption_NamePart();
+    (message as any)._unknownFields = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -4025,7 +3755,12 @@ export const UninterpretedOption_NamePart = {
           message.isExtension = reader.bool();
           break;
         default:
+          const startPos = reader.pos;
           reader.skipType(tag & 7);
+          (message as any)._unknownFields[tag] = [
+            ...((message as any)._unknownFields[tag] || []),
+            reader.buf.slice(startPos, reader.pos),
+          ];
           break;
       }
     }
@@ -4033,33 +3768,10 @@ export const UninterpretedOption_NamePart = {
   },
 
   fromJSON(object: any): UninterpretedOption_NamePart {
-    const message = Object.create(baseUninterpretedOption_NamePart) as UninterpretedOption_NamePart;
-    if (object.namePart !== undefined && object.namePart !== null) {
-      message.namePart = String(object.namePart);
-    } else {
-      message.namePart = '';
-    }
-    if (object.isExtension !== undefined && object.isExtension !== null) {
-      message.isExtension = Boolean(object.isExtension);
-    } else {
-      message.isExtension = false;
-    }
-    return message;
-  },
-
-  fromPartial(object: DeepPartial<UninterpretedOption_NamePart>): UninterpretedOption_NamePart {
-    const message = { ...baseUninterpretedOption_NamePart } as UninterpretedOption_NamePart;
-    if (object.namePart !== undefined && object.namePart !== null) {
-      message.namePart = object.namePart;
-    } else {
-      message.namePart = '';
-    }
-    if (object.isExtension !== undefined && object.isExtension !== null) {
-      message.isExtension = object.isExtension;
-    } else {
-      message.isExtension = false;
-    }
-    return message;
+    return {
+      namePart: isSet(object.namePart) ? String(object.namePart) : '',
+      isExtension: isSet(object.isExtension) ? Boolean(object.isExtension) : false,
+    };
   },
 
   toJSON(message: UninterpretedOption_NamePart): unknown {
@@ -4068,23 +3780,45 @@ export const UninterpretedOption_NamePart = {
     message.isExtension !== undefined && (obj.isExtension = message.isExtension);
     return obj;
   },
+
+  fromPartial<I extends Exact<DeepPartial<UninterpretedOption_NamePart>, I>>(object: I): UninterpretedOption_NamePart {
+    const message = createBaseUninterpretedOption_NamePart();
+    message.namePart = object.namePart ?? '';
+    message.isExtension = object.isExtension ?? false;
+    return message;
+  },
 };
 
-const baseSourceCodeInfo: object = {};
+function createBaseSourceCodeInfo(): SourceCodeInfo {
+  return { location: [] };
+}
 
 export const SourceCodeInfo = {
   encode(message: SourceCodeInfo, writer: Writer = Writer.create()): Writer {
     for (const v of message.location) {
       SourceCodeInfo_Location.encode(v!, writer.uint32(10).fork()).ldelim();
     }
+    if ('_unknownFields' in message) {
+      for (const key of Object.keys(message['_unknownFields'])) {
+        const values = message['_unknownFields'][key] as Uint8Array[];
+        for (const value of values) {
+          writer.uint32(parseInt(key, 10));
+          (writer as any)['_push'](
+            (val: Uint8Array, buf: Buffer, pos: number) => buf.set(val, pos),
+            value.length,
+            value
+          );
+        }
+      }
+    }
     return writer;
   },
 
   decode(input: Reader | Uint8Array, length?: number): SourceCodeInfo {
-    const reader = input instanceof Uint8Array ? new Reader(input) : input;
+    const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = Object.create(baseSourceCodeInfo) as SourceCodeInfo;
-    message.location = [];
+    const message = createBaseSourceCodeInfo();
+    (message as any)._unknownFields = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -4092,7 +3826,12 @@ export const SourceCodeInfo = {
           message.location.push(SourceCodeInfo_Location.decode(reader, reader.uint32()));
           break;
         default:
+          const startPos = reader.pos;
           reader.skipType(tag & 7);
+          (message as any)._unknownFields[tag] = [
+            ...((message as any)._unknownFields[tag] || []),
+            reader.buf.slice(startPos, reader.pos),
+          ];
           break;
       }
     }
@@ -4100,25 +3839,11 @@ export const SourceCodeInfo = {
   },
 
   fromJSON(object: any): SourceCodeInfo {
-    const message = Object.create(baseSourceCodeInfo) as SourceCodeInfo;
-    message.location = [];
-    if (object.location !== undefined && object.location !== null) {
-      for (const e of object.location) {
-        message.location.push(SourceCodeInfo_Location.fromJSON(e));
-      }
-    }
-    return message;
-  },
-
-  fromPartial(object: DeepPartial<SourceCodeInfo>): SourceCodeInfo {
-    const message = { ...baseSourceCodeInfo } as SourceCodeInfo;
-    message.location = [];
-    if (object.location !== undefined && object.location !== null) {
-      for (const e of object.location) {
-        message.location.push(SourceCodeInfo_Location.fromPartial(e));
-      }
-    }
-    return message;
+    return {
+      location: Array.isArray(object?.location)
+        ? object.location.map((e: any) => SourceCodeInfo_Location.fromJSON(e))
+        : [],
+    };
   },
 
   toJSON(message: SourceCodeInfo): unknown {
@@ -4130,15 +3855,17 @@ export const SourceCodeInfo = {
     }
     return obj;
   },
+
+  fromPartial<I extends Exact<DeepPartial<SourceCodeInfo>, I>>(object: I): SourceCodeInfo {
+    const message = createBaseSourceCodeInfo();
+    message.location = object.location?.map((e) => SourceCodeInfo_Location.fromPartial(e)) || [];
+    return message;
+  },
 };
 
-const baseSourceCodeInfo_Location: object = {
-  path: 0,
-  span: 0,
-  leadingComments: '',
-  trailingComments: '',
-  leadingDetachedComments: '',
-};
+function createBaseSourceCodeInfo_Location(): SourceCodeInfo_Location {
+  return { path: [], span: [], leadingComments: '', trailingComments: '', leadingDetachedComments: [] };
+}
 
 export const SourceCodeInfo_Location = {
   encode(message: SourceCodeInfo_Location, writer: Writer = Writer.create()): Writer {
@@ -4152,21 +3879,36 @@ export const SourceCodeInfo_Location = {
       writer.int32(v);
     }
     writer.ldelim();
-    writer.uint32(26).string(message.leadingComments);
-    writer.uint32(34).string(message.trailingComments);
+    if (message.leadingComments !== '') {
+      writer.uint32(26).string(message.leadingComments);
+    }
+    if (message.trailingComments !== '') {
+      writer.uint32(34).string(message.trailingComments);
+    }
     for (const v of message.leadingDetachedComments) {
       writer.uint32(50).string(v!);
+    }
+    if ('_unknownFields' in message) {
+      for (const key of Object.keys(message['_unknownFields'])) {
+        const values = message['_unknownFields'][key] as Uint8Array[];
+        for (const value of values) {
+          writer.uint32(parseInt(key, 10));
+          (writer as any)['_push'](
+            (val: Uint8Array, buf: Buffer, pos: number) => buf.set(val, pos),
+            value.length,
+            value
+          );
+        }
+      }
     }
     return writer;
   },
 
   decode(input: Reader | Uint8Array, length?: number): SourceCodeInfo_Location {
-    const reader = input instanceof Uint8Array ? new Reader(input) : input;
+    const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = Object.create(baseSourceCodeInfo_Location) as SourceCodeInfo_Location;
-    message.path = [];
-    message.span = [];
-    message.leadingDetachedComments = [];
+    const message = createBaseSourceCodeInfo_Location();
+    (message as any)._unknownFields = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -4200,7 +3942,12 @@ export const SourceCodeInfo_Location = {
           message.leadingDetachedComments.push(reader.string());
           break;
         default:
+          const startPos = reader.pos;
           reader.skipType(tag & 7);
+          (message as any)._unknownFields[tag] = [
+            ...((message as any)._unknownFields[tag] || []),
+            reader.buf.slice(startPos, reader.pos),
+          ];
           break;
       }
     }
@@ -4208,80 +3955,26 @@ export const SourceCodeInfo_Location = {
   },
 
   fromJSON(object: any): SourceCodeInfo_Location {
-    const message = Object.create(baseSourceCodeInfo_Location) as SourceCodeInfo_Location;
-    message.path = [];
-    message.span = [];
-    message.leadingDetachedComments = [];
-    if (object.path !== undefined && object.path !== null) {
-      for (const e of object.path) {
-        message.path.push(Number(e));
-      }
-    }
-    if (object.span !== undefined && object.span !== null) {
-      for (const e of object.span) {
-        message.span.push(Number(e));
-      }
-    }
-    if (object.leadingComments !== undefined && object.leadingComments !== null) {
-      message.leadingComments = String(object.leadingComments);
-    } else {
-      message.leadingComments = '';
-    }
-    if (object.trailingComments !== undefined && object.trailingComments !== null) {
-      message.trailingComments = String(object.trailingComments);
-    } else {
-      message.trailingComments = '';
-    }
-    if (object.leadingDetachedComments !== undefined && object.leadingDetachedComments !== null) {
-      for (const e of object.leadingDetachedComments) {
-        message.leadingDetachedComments.push(String(e));
-      }
-    }
-    return message;
-  },
-
-  fromPartial(object: DeepPartial<SourceCodeInfo_Location>): SourceCodeInfo_Location {
-    const message = { ...baseSourceCodeInfo_Location } as SourceCodeInfo_Location;
-    message.path = [];
-    message.span = [];
-    message.leadingDetachedComments = [];
-    if (object.path !== undefined && object.path !== null) {
-      for (const e of object.path) {
-        message.path.push(e);
-      }
-    }
-    if (object.span !== undefined && object.span !== null) {
-      for (const e of object.span) {
-        message.span.push(e);
-      }
-    }
-    if (object.leadingComments !== undefined && object.leadingComments !== null) {
-      message.leadingComments = object.leadingComments;
-    } else {
-      message.leadingComments = '';
-    }
-    if (object.trailingComments !== undefined && object.trailingComments !== null) {
-      message.trailingComments = object.trailingComments;
-    } else {
-      message.trailingComments = '';
-    }
-    if (object.leadingDetachedComments !== undefined && object.leadingDetachedComments !== null) {
-      for (const e of object.leadingDetachedComments) {
-        message.leadingDetachedComments.push(e);
-      }
-    }
-    return message;
+    return {
+      path: Array.isArray(object?.path) ? object.path.map((e: any) => Number(e)) : [],
+      span: Array.isArray(object?.span) ? object.span.map((e: any) => Number(e)) : [],
+      leadingComments: isSet(object.leadingComments) ? String(object.leadingComments) : '',
+      trailingComments: isSet(object.trailingComments) ? String(object.trailingComments) : '',
+      leadingDetachedComments: Array.isArray(object?.leadingDetachedComments)
+        ? object.leadingDetachedComments.map((e: any) => String(e))
+        : [],
+    };
   },
 
   toJSON(message: SourceCodeInfo_Location): unknown {
     const obj: any = {};
     if (message.path) {
-      obj.path = message.path.map((e) => e);
+      obj.path = message.path.map((e) => Math.round(e));
     } else {
       obj.path = [];
     }
     if (message.span) {
-      obj.span = message.span.map((e) => e);
+      obj.span = message.span.map((e) => Math.round(e));
     } else {
       obj.span = [];
     }
@@ -4294,23 +3987,48 @@ export const SourceCodeInfo_Location = {
     }
     return obj;
   },
+
+  fromPartial<I extends Exact<DeepPartial<SourceCodeInfo_Location>, I>>(object: I): SourceCodeInfo_Location {
+    const message = createBaseSourceCodeInfo_Location();
+    message.path = object.path?.map((e) => e) || [];
+    message.span = object.span?.map((e) => e) || [];
+    message.leadingComments = object.leadingComments ?? '';
+    message.trailingComments = object.trailingComments ?? '';
+    message.leadingDetachedComments = object.leadingDetachedComments?.map((e) => e) || [];
+    return message;
+  },
 };
 
-const baseGeneratedCodeInfo: object = {};
+function createBaseGeneratedCodeInfo(): GeneratedCodeInfo {
+  return { annotation: [] };
+}
 
 export const GeneratedCodeInfo = {
   encode(message: GeneratedCodeInfo, writer: Writer = Writer.create()): Writer {
     for (const v of message.annotation) {
       GeneratedCodeInfo_Annotation.encode(v!, writer.uint32(10).fork()).ldelim();
     }
+    if ('_unknownFields' in message) {
+      for (const key of Object.keys(message['_unknownFields'])) {
+        const values = message['_unknownFields'][key] as Uint8Array[];
+        for (const value of values) {
+          writer.uint32(parseInt(key, 10));
+          (writer as any)['_push'](
+            (val: Uint8Array, buf: Buffer, pos: number) => buf.set(val, pos),
+            value.length,
+            value
+          );
+        }
+      }
+    }
     return writer;
   },
 
   decode(input: Reader | Uint8Array, length?: number): GeneratedCodeInfo {
-    const reader = input instanceof Uint8Array ? new Reader(input) : input;
+    const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = Object.create(baseGeneratedCodeInfo) as GeneratedCodeInfo;
-    message.annotation = [];
+    const message = createBaseGeneratedCodeInfo();
+    (message as any)._unknownFields = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -4318,7 +4036,12 @@ export const GeneratedCodeInfo = {
           message.annotation.push(GeneratedCodeInfo_Annotation.decode(reader, reader.uint32()));
           break;
         default:
+          const startPos = reader.pos;
           reader.skipType(tag & 7);
+          (message as any)._unknownFields[tag] = [
+            ...((message as any)._unknownFields[tag] || []),
+            reader.buf.slice(startPos, reader.pos),
+          ];
           break;
       }
     }
@@ -4326,25 +4049,11 @@ export const GeneratedCodeInfo = {
   },
 
   fromJSON(object: any): GeneratedCodeInfo {
-    const message = Object.create(baseGeneratedCodeInfo) as GeneratedCodeInfo;
-    message.annotation = [];
-    if (object.annotation !== undefined && object.annotation !== null) {
-      for (const e of object.annotation) {
-        message.annotation.push(GeneratedCodeInfo_Annotation.fromJSON(e));
-      }
-    }
-    return message;
-  },
-
-  fromPartial(object: DeepPartial<GeneratedCodeInfo>): GeneratedCodeInfo {
-    const message = { ...baseGeneratedCodeInfo } as GeneratedCodeInfo;
-    message.annotation = [];
-    if (object.annotation !== undefined && object.annotation !== null) {
-      for (const e of object.annotation) {
-        message.annotation.push(GeneratedCodeInfo_Annotation.fromPartial(e));
-      }
-    }
-    return message;
+    return {
+      annotation: Array.isArray(object?.annotation)
+        ? object.annotation.map((e: any) => GeneratedCodeInfo_Annotation.fromJSON(e))
+        : [],
+    };
   },
 
   toJSON(message: GeneratedCodeInfo): unknown {
@@ -4356,9 +4065,17 @@ export const GeneratedCodeInfo = {
     }
     return obj;
   },
+
+  fromPartial<I extends Exact<DeepPartial<GeneratedCodeInfo>, I>>(object: I): GeneratedCodeInfo {
+    const message = createBaseGeneratedCodeInfo();
+    message.annotation = object.annotation?.map((e) => GeneratedCodeInfo_Annotation.fromPartial(e)) || [];
+    return message;
+  },
 };
 
-const baseGeneratedCodeInfo_Annotation: object = { path: 0, sourceFile: '', begin: 0, end: 0 };
+function createBaseGeneratedCodeInfo_Annotation(): GeneratedCodeInfo_Annotation {
+  return { path: [], sourceFile: '', begin: 0, end: 0 };
+}
 
 export const GeneratedCodeInfo_Annotation = {
   encode(message: GeneratedCodeInfo_Annotation, writer: Writer = Writer.create()): Writer {
@@ -4367,17 +4084,36 @@ export const GeneratedCodeInfo_Annotation = {
       writer.int32(v);
     }
     writer.ldelim();
-    writer.uint32(18).string(message.sourceFile);
-    writer.uint32(24).int32(message.begin);
-    writer.uint32(32).int32(message.end);
+    if (message.sourceFile !== '') {
+      writer.uint32(18).string(message.sourceFile);
+    }
+    if (message.begin !== 0) {
+      writer.uint32(24).int32(message.begin);
+    }
+    if (message.end !== 0) {
+      writer.uint32(32).int32(message.end);
+    }
+    if ('_unknownFields' in message) {
+      for (const key of Object.keys(message['_unknownFields'])) {
+        const values = message['_unknownFields'][key] as Uint8Array[];
+        for (const value of values) {
+          writer.uint32(parseInt(key, 10));
+          (writer as any)['_push'](
+            (val: Uint8Array, buf: Buffer, pos: number) => buf.set(val, pos),
+            value.length,
+            value
+          );
+        }
+      }
+    }
     return writer;
   },
 
   decode(input: Reader | Uint8Array, length?: number): GeneratedCodeInfo_Annotation {
-    const reader = input instanceof Uint8Array ? new Reader(input) : input;
+    const reader = input instanceof Reader ? input : new Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = Object.create(baseGeneratedCodeInfo_Annotation) as GeneratedCodeInfo_Annotation;
-    message.path = [];
+    const message = createBaseGeneratedCodeInfo_Annotation();
+    (message as any)._unknownFields = {};
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -4401,7 +4137,12 @@ export const GeneratedCodeInfo_Annotation = {
           message.end = reader.int32();
           break;
         default:
+          const startPos = reader.pos;
           reader.skipType(tag & 7);
+          (message as any)._unknownFields[tag] = [
+            ...((message as any)._unknownFields[tag] || []),
+            reader.buf.slice(startPos, reader.pos),
+          ];
           break;
       }
     }
@@ -4409,68 +4150,34 @@ export const GeneratedCodeInfo_Annotation = {
   },
 
   fromJSON(object: any): GeneratedCodeInfo_Annotation {
-    const message = Object.create(baseGeneratedCodeInfo_Annotation) as GeneratedCodeInfo_Annotation;
-    message.path = [];
-    if (object.path !== undefined && object.path !== null) {
-      for (const e of object.path) {
-        message.path.push(Number(e));
-      }
-    }
-    if (object.sourceFile !== undefined && object.sourceFile !== null) {
-      message.sourceFile = String(object.sourceFile);
-    } else {
-      message.sourceFile = '';
-    }
-    if (object.begin !== undefined && object.begin !== null) {
-      message.begin = Number(object.begin);
-    } else {
-      message.begin = 0;
-    }
-    if (object.end !== undefined && object.end !== null) {
-      message.end = Number(object.end);
-    } else {
-      message.end = 0;
-    }
-    return message;
-  },
-
-  fromPartial(object: DeepPartial<GeneratedCodeInfo_Annotation>): GeneratedCodeInfo_Annotation {
-    const message = { ...baseGeneratedCodeInfo_Annotation } as GeneratedCodeInfo_Annotation;
-    message.path = [];
-    if (object.path !== undefined && object.path !== null) {
-      for (const e of object.path) {
-        message.path.push(e);
-      }
-    }
-    if (object.sourceFile !== undefined && object.sourceFile !== null) {
-      message.sourceFile = object.sourceFile;
-    } else {
-      message.sourceFile = '';
-    }
-    if (object.begin !== undefined && object.begin !== null) {
-      message.begin = object.begin;
-    } else {
-      message.begin = 0;
-    }
-    if (object.end !== undefined && object.end !== null) {
-      message.end = object.end;
-    } else {
-      message.end = 0;
-    }
-    return message;
+    return {
+      path: Array.isArray(object?.path) ? object.path.map((e: any) => Number(e)) : [],
+      sourceFile: isSet(object.sourceFile) ? String(object.sourceFile) : '',
+      begin: isSet(object.begin) ? Number(object.begin) : 0,
+      end: isSet(object.end) ? Number(object.end) : 0,
+    };
   },
 
   toJSON(message: GeneratedCodeInfo_Annotation): unknown {
     const obj: any = {};
     if (message.path) {
-      obj.path = message.path.map((e) => e);
+      obj.path = message.path.map((e) => Math.round(e));
     } else {
       obj.path = [];
     }
     message.sourceFile !== undefined && (obj.sourceFile = message.sourceFile);
-    message.begin !== undefined && (obj.begin = message.begin);
-    message.end !== undefined && (obj.end = message.end);
+    message.begin !== undefined && (obj.begin = Math.round(message.begin));
+    message.end !== undefined && (obj.end = Math.round(message.end));
     return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<GeneratedCodeInfo_Annotation>, I>>(object: I): GeneratedCodeInfo_Annotation {
+    const message = createBaseGeneratedCodeInfo_Annotation();
+    message.path = object.path?.map((e) => e) || [];
+    message.sourceFile = object.sourceFile ?? '';
+    message.begin = object.begin ?? 0;
+    message.end = object.end ?? 0;
+    return message;
   },
 };
 
@@ -4482,7 +4189,7 @@ var globalThis: any = (() => {
   if (typeof self !== 'undefined') return self;
   if (typeof window !== 'undefined') return window;
   if (typeof global !== 'undefined') return global;
-  throw new Error('Unable to locate global object');
+  throw 'Unable to locate global object';
 })();
 
 const atob: (b64: string) => string =
@@ -4500,13 +4207,14 @@ const btoa: (bin: string) => string =
   globalThis.btoa || ((bin) => globalThis.Buffer.from(bin, 'binary').toString('base64'));
 function base64FromBytes(arr: Uint8Array): string {
   const bin: string[] = [];
-  for (let i = 0; i < arr.byteLength; ++i) {
-    bin.push(String.fromCharCode(arr[i]));
+  for (const byte of arr) {
+    bin.push(String.fromCharCode(byte));
   }
   return btoa(bin.join(''));
 }
 
-type Builtin = Date | Function | Uint8Array | string | number | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
+
 type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>
@@ -4517,6 +4225,11 @@ type DeepPartial<T> = T extends Builtin
   ? { [K in keyof T]?: DeepPartial<T[K]> }
   : Partial<T>;
 
+type KeysOfUnion<T> = T extends T ? keyof T : never;
+type Exact<P, I extends P> = P extends Builtin
+  ? P
+  : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<Exclude<keyof I, KeysOfUnion<P>>, never>;
+
 function longToNumber(long: Long): number {
   if (long.gt(Number.MAX_SAFE_INTEGER)) {
     throw new globalThis.Error('Value is larger than Number.MAX_SAFE_INTEGER');
@@ -4524,7 +4237,13 @@ function longToNumber(long: Long): number {
   return long.toNumber();
 }
 
+// If you get a compile-error about 'Constructor<Long> and ... have no overlap',
+// add '--ts_proto_opt=esModuleInterop=true' as a flag when calling 'protoc'.
 if (util.Long !== Long) {
   util.Long = Long as any;
   configure();
+}
+
+function isSet(value: any): boolean {
+  return value !== null && value !== undefined;
 }

--- a/protos/package.json
+++ b/protos/package.json
@@ -16,7 +16,7 @@
     "long": "^4.0.0"
   },
   "devDependencies": {
-    "ts-proto": "^1.61.0",
+    "ts-proto": "^1.101.0",
     "typescript": "^4.1.5"
   }
 }

--- a/protos/yarn.lock
+++ b/protos/yarn.lock
@@ -128,16 +128,25 @@ ts-poet@^4.5.0:
     lodash "^4.17.15"
     prettier "^2.0.2"
 
-ts-proto@^1.61.0:
-  version "1.61.0"
-  resolved "https://registry.yarnpkg.com/ts-proto/-/ts-proto-1.61.0.tgz#0ae36097f52b0be2dae3481e34b2436ab7e44564"
-  integrity sha512-F7FnsOPn22ij6fI3E+1lnOVEhYyILpYk1DLpqEEHVOF77ctA5Jz11G9DtwxWTqzlQ0mAvCEWkAhwdCNa0p7CBQ==
+ts-proto-descriptors@^1.2.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/ts-proto-descriptors/-/ts-proto-descriptors-1.3.1.tgz#760ebaaa19475b03662f7b358ffea45b9c5348f5"
+  integrity sha512-Cybb3fqceMwA6JzHdC32dIo8eVGVmXrM6TWhdk1XQVVHT/6OQqk0ioyX1dIdu3rCIBhRmWUhUE4HsyK+olmgMw==
+  dependencies:
+    long "^4.0.0"
+    protobufjs "^6.8.8"
+
+ts-proto@^1.101.0:
+  version "1.101.0"
+  resolved "https://registry.yarnpkg.com/ts-proto/-/ts-proto-1.101.0.tgz#f8ce4523a0cb32ff224ff8a5759c2c046bf96244"
+  integrity sha512-XUV0WKQ3icHMToOOpUjf0RCKF9md+Lu9TV00LQlZ6ailJhbBqLh0BXQJ1PFUGxEW8YV65Wc/N8vAir152OE2Sg==
   dependencies:
     "@types/object-hash" "^1.3.0"
     dataloader "^1.4.0"
     object-hash "^1.3.1"
     protobufjs "^6.8.8"
     ts-poet "^4.5.0"
+    ts-proto-descriptors "^1.2.1"
 
 typescript@^4.1.5:
   version "4.1.5"


### PR DESCRIPTION
Builds upon #473 to add support for options in #437.

I had to also enable `--downlevelIteration` tsc flag as that is now a requirement due to looping over `Uint8Array`.

The tests will most likely need to be updated after the package is published.