### PR TITLE
fix: Pin ts-proto-descriptors to 1.3.1.

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,6 @@
     "object-hash": "^1.3.1",
     "protobufjs": "^6.8.8",
     "ts-poet": "^4.5.0",
-    "ts-proto-descriptors": "^1.2.1"
+    "ts-proto-descriptors": "1.3.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6275,10 +6275,10 @@ ts-poet@^4.5.0:
     lodash "^4.17.15"
     prettier "^2.0.2"
 
-ts-proto-descriptors@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.npmjs.org/ts-proto-descriptors/-/ts-proto-descriptors-1.2.1.tgz"
-  integrity sha512-iSHiQAaovi9sBwjiSCca/E089uv0IMt9Cfe0wV5AJwZppGa47yfih97Q+1006bdSLWkxf5Pk3VDQnt1yRTMV8w==
+ts-proto-descriptors@1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/ts-proto-descriptors/-/ts-proto-descriptors-1.3.1.tgz#760ebaaa19475b03662f7b358ffea45b9c5348f5"
+  integrity sha512-Cybb3fqceMwA6JzHdC32dIo8eVGVmXrM6TWhdk1XQVVHT/6OQqk0ioyX1dIdu3rCIBhRmWUhUE4HsyK+olmgMw==
   dependencies:
     long "^4.0.0"
     protobufjs "^6.8.8"


### PR DESCRIPTION
Fixes #480

Per discussion here:

https://github.com/stephenh/ts-proto/pull/479#issuecomment-1015438971

Because of `oneofIndex=0` being ambiguous about "is this set? or is this the first oneof?" and ts-proto's current like of `hazzer` methods, we need to pin to a specific version of ts-proto-descriptors that was built with temporary `hazzer` functionality that has since been reverted.