### PR TITLE
feat: include service and definition types with implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,32 @@
+## [next](https://github.com/stephenh/ts-proto/compare/v1.110.4...main) (????-??-??)
+
+### Features
+
+* When outputing service and service definition implementations, include types. Eg, before:
+
+  ```ts
+  export const TestDefinition = {
+    name: 'Test',
+    fullName: 'simple.Test',
+    methods: {
+      …
+    },
+  } as const;
+  ```
+
+  Now:
+
+  ```ts
+  export type TestDefinition = typeof TestDefinition;
+  export const TestDefinition = {
+    name: 'Test',
+    fullName: 'simple.Test',
+    methods: {
+      …
+    },
+  } as const;
+  ```
+
 ## [1.110.4](https://github.com/stephenh/ts-proto/compare/v1.110.3...v1.110.4) (2022-04-08)
 
 

--- a/integration/generic-metadata/hero.ts
+++ b/integration/generic-metadata/hero.ts
@@ -272,6 +272,7 @@ export class HeroServiceClientImpl implements HeroService {
   }
 }
 
+export type HeroServiceDefinition = typeof HeroServiceDefinition;
 export const HeroServiceDefinition = {
   name: 'HeroService',
   fullName: 'hero.HeroService',

--- a/integration/generic-service-definitions-and-services/simple.ts
+++ b/integration/generic-service-definitions-and-services/simple.ts
@@ -58,6 +58,7 @@ export const TestMessage = {
 };
 
 /** @deprecated */
+export type TestDefinition = typeof TestDefinition;
 export const TestDefinition = {
   name: 'Test',
   fullName: 'simple.Test',

--- a/integration/generic-service-definitions/simple.ts
+++ b/integration/generic-service-definitions/simple.ts
@@ -58,6 +58,7 @@ export const TestMessage = {
 };
 
 /** @deprecated */
+export type TestDefinition = typeof TestDefinition;
 export const TestDefinition = {
   name: 'Test',
   fullName: 'simple.Test',

--- a/integration/grpc-js/simple.ts
+++ b/integration/grpc-js/simple.ts
@@ -94,6 +94,7 @@ export const TestMessage = {
  *
  * @deprecated
  */
+export type TestService = typeof TestService;
 export const TestService = {
   /**
    * Unary

--- a/integration/use-date-true/use-date-true.ts
+++ b/integration/use-date-true/use-date-true.ts
@@ -206,6 +206,7 @@ export class ClockClientImpl implements Clock {
   }
 }
 
+export type ClockDefinition = typeof ClockDefinition;
 export const ClockDefinition = {
   name: 'Clock',
   fullName: 'Clock',

--- a/src/generate-generic-service-definition.ts
+++ b/src/generate-generic-service-definition.ts
@@ -25,9 +25,15 @@ export function generateGenericServiceDefinition(
 
   maybeAddComment(sourceInfo, chunks, serviceDesc.options?.deprecated);
 
+  // Service definition type
+  const name = def(`${serviceDesc.name}Definition`);
+  chunks.push(code`
+    export type ${name} = typeof ${name};
+  `);
+
   // Service definition
   chunks.push(code`
-    export const ${def(`${serviceDesc.name}Definition`)} = {
+    export const ${name} = {
   `);
 
   serviceDesc.options?.uninterpretedOption;

--- a/src/generate-grpc-js.ts
+++ b/src/generate-grpc-js.ts
@@ -57,9 +57,15 @@ function generateServiceDefinition(
 
   maybeAddComment(sourceInfo, chunks, serviceDesc.options?.deprecated);
 
+  // Service definition type
+  const name = def(`${serviceDesc.name}Service`);
+  chunks.push(code`
+    export type ${name} = typeof ${name};
+  `);
+
   // Service definition
   chunks.push(code`
-    export const ${def(`${serviceDesc.name}Service`)} = {
+    export const ${name} = {
   `);
 
   for (const [index, methodDesc] of serviceDesc.method.entries()) {


### PR DESCRIPTION
When exporting a service or service definition, also export it as a
type. Previously, you would have to import the value then `typeof` off
of it which is cumbersome. Automate this as it has no runtime overhead
and seems more intuitive.

Before:

```ts
export const TestDefinition = {
  name: 'Test',
  fullName: 'simple.Test',
  methods: {
    …
  },
} as const;
```

After:

```ts
export type TestDefinition = typeof TestDefinition;
export const TestDefinition = {
  name: 'Test',
  fullName: 'simple.Test',
  methods: {
    …
  },
} as const;
```