### PR TITLE
fix: enum type returns 'UNRECOGNIZED' or '-1' in xxxToJSON/xxxToNumber

### DIFF
--- a/integration/avoid-import-conflicts/simple.ts
+++ b/integration/avoid-import-conflicts/simple.ts
@@ -43,8 +43,9 @@ export function simpleEnumToJSON(object: SimpleEnum): string {
       return 'LOCAL_FOO';
     case SimpleEnum.LOCAL_BAR:
       return 'LOCAL_BAR';
+    case SimpleEnum.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return 'UNRECOGNIZED';
   }
 }
 

--- a/integration/avoid-import-conflicts/simple2.ts
+++ b/integration/avoid-import-conflicts/simple2.ts
@@ -37,8 +37,9 @@ export function simpleEnumToJSON(object: SimpleEnum): string {
       return 'IMPORT_FOO';
     case SimpleEnum.IMPORT_BAR:
       return 'IMPORT_BAR';
+    case SimpleEnum.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return 'UNRECOGNIZED';
   }
 }
 

--- a/integration/const-enum/const-enum.ts
+++ b/integration/const-enum/const-enum.ts
@@ -48,8 +48,9 @@ export function dividerData_DividerTypeToJSON(object: DividerData_DividerType): 
       return 'DASHED';
     case DividerData_DividerType.DOTTED:
       return 'DOTTED';
+    case DividerData_DividerType.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return 'UNRECOGNIZED';
   }
 }
 
@@ -63,8 +64,9 @@ export function dividerData_DividerTypeToNumber(object: DividerData_DividerType)
       return 2;
     case DividerData_DividerType.DOTTED:
       return 3;
+    case DividerData_DividerType.UNRECOGNIZED:
     default:
-      return 0;
+      return -1;
   }
 }
 

--- a/integration/enums-as-literals-with-string-enums/enums-as-literals-with-string-enums.ts
+++ b/integration/enums-as-literals-with-string-enums/enums-as-literals-with-string-enums.ts
@@ -49,8 +49,9 @@ export function dividerData_DividerTypeToJSON(object: DividerData_DividerType): 
       return 'DASHED';
     case DividerData_DividerType.DOTTED:
       return 'DOTTED';
+    case DividerData_DividerType.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return 'UNRECOGNIZED';
   }
 }
 
@@ -64,8 +65,9 @@ export function dividerData_DividerTypeToNumber(object: DividerData_DividerType)
       return 2;
     case DividerData_DividerType.DOTTED:
       return 3;
+    case DividerData_DividerType.UNRECOGNIZED:
     default:
-      return 0;
+      return -1;
   }
 }
 

--- a/integration/enums-as-literals/enums-as-literals.ts
+++ b/integration/enums-as-literals/enums-as-literals.ts
@@ -49,8 +49,9 @@ export function dividerData_DividerTypeToJSON(object: DividerData_DividerType): 
       return 'DASHED';
     case DividerData_DividerType.DOTTED:
       return 'DOTTED';
+    case DividerData_DividerType.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return 'UNRECOGNIZED';
   }
 }
 

--- a/integration/file-suffix/child.pb.ts
+++ b/integration/file-suffix/child.pb.ts
@@ -31,8 +31,9 @@ export function childEnumToJSON(object: ChildEnum): string {
       return 'DEFAULT';
     case ChildEnum.FOO:
       return 'FOO';
+    case ChildEnum.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return 'UNRECOGNIZED';
   }
 }
 

--- a/integration/grpc-js/google/protobuf/struct.ts
+++ b/integration/grpc-js/google/protobuf/struct.ts
@@ -32,8 +32,9 @@ export function nullValueToJSON(object: NullValue): string {
   switch (object) {
     case NullValue.NULL_VALUE:
       return 'NULL_VALUE';
+    case NullValue.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return 'UNRECOGNIZED';
   }
 }
 

--- a/integration/grpc-web-go-server/example.ts
+++ b/integration/grpc-web-go-server/example.ts
@@ -50,8 +50,9 @@ export function dashFlash_TypeToJSON(object: DashFlash_Type): string {
       return 'Warn';
     case DashFlash_Type.Error:
       return 'Error';
+    case DashFlash_Type.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return 'UNRECOGNIZED';
   }
 }
 

--- a/integration/grpc-web-no-streaming-observable/example.ts
+++ b/integration/grpc-web-no-streaming-observable/example.ts
@@ -52,8 +52,9 @@ export function dashFlash_TypeToJSON(object: DashFlash_Type): string {
       return 'Warn';
     case DashFlash_Type.Error:
       return 'Error';
+    case DashFlash_Type.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return 'UNRECOGNIZED';
   }
 }
 

--- a/integration/grpc-web-no-streaming/example.ts
+++ b/integration/grpc-web-no-streaming/example.ts
@@ -50,8 +50,9 @@ export function dashFlash_TypeToJSON(object: DashFlash_Type): string {
       return 'Warn';
     case DashFlash_Type.Error:
       return 'Error';
+    case DashFlash_Type.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return 'UNRECOGNIZED';
   }
 }
 

--- a/integration/grpc-web/example.ts
+++ b/integration/grpc-web/example.ts
@@ -52,8 +52,9 @@ export function dashFlash_TypeToJSON(object: DashFlash_Type): string {
       return 'Warn';
     case DashFlash_Type.Error:
       return 'Error';
+    case DashFlash_Type.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return 'UNRECOGNIZED';
   }
 }
 

--- a/integration/nice-grpc/google/protobuf/struct.ts
+++ b/integration/nice-grpc/google/protobuf/struct.ts
@@ -32,8 +32,9 @@ export function nullValueToJSON(object: NullValue): string {
   switch (object) {
     case NullValue.NULL_VALUE:
       return 'NULL_VALUE';
+    case NullValue.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return 'UNRECOGNIZED';
   }
 }
 

--- a/integration/oneof-properties/oneof.ts
+++ b/integration/oneof-properties/oneof.ts
@@ -63,8 +63,9 @@ export function pleaseChoose_StateEnumToJSON(object: PleaseChoose_StateEnum): st
       return 'ON';
     case PleaseChoose_StateEnum.OFF:
       return 'OFF';
+    case PleaseChoose_StateEnum.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return 'UNRECOGNIZED';
   }
 }
 

--- a/integration/oneof-unions/google/protobuf/struct.ts
+++ b/integration/oneof-unions/google/protobuf/struct.ts
@@ -32,8 +32,9 @@ export function nullValueToJSON(object: NullValue): string {
   switch (object) {
     case NullValue.NULL_VALUE:
       return 'NULL_VALUE';
+    case NullValue.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return 'UNRECOGNIZED';
   }
 }
 

--- a/integration/oneof-unions/oneof.ts
+++ b/integration/oneof-unions/oneof.ts
@@ -56,8 +56,9 @@ export function pleaseChoose_StateEnumToJSON(object: PleaseChoose_StateEnum): st
       return 'ON';
     case PleaseChoose_StateEnum.OFF:
       return 'OFF';
+    case PleaseChoose_StateEnum.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return 'UNRECOGNIZED';
   }
 }
 

--- a/integration/simple-optionals/simple.ts
+++ b/integration/simple-optionals/simple.ts
@@ -45,8 +45,9 @@ export function stateEnumToJSON(object: StateEnum): string {
       return 'ON';
     case StateEnum.OFF:
       return 'OFF';
+    case StateEnum.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return 'UNRECOGNIZED';
   }
 }
 
@@ -106,8 +107,9 @@ export function child_TypeToJSON(object: Child_Type): string {
       return 'GOOD';
     case Child_Type.BAD:
       return 'BAD';
+    case Child_Type.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return 'UNRECOGNIZED';
   }
 }
 
@@ -150,8 +152,9 @@ export function nested_InnerEnumToJSON(object: Nested_InnerEnum): string {
       return 'GOOD';
     case Nested_InnerEnum.BAD:
       return 'BAD';
+    case Nested_InnerEnum.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return 'UNRECOGNIZED';
   }
 }
 

--- a/integration/simple-proto2/simple.ts
+++ b/integration/simple-proto2/simple.ts
@@ -31,8 +31,9 @@ export function enumWithoutZeroToJSON(object: EnumWithoutZero): string {
       return 'A';
     case EnumWithoutZero.B:
       return 'B';
+    case EnumWithoutZero.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return 'UNRECOGNIZED';
   }
 }
 

--- a/integration/simple-prototype-defaults/simple.ts
+++ b/integration/simple-prototype-defaults/simple.ts
@@ -46,8 +46,9 @@ export function stateEnumToJSON(object: StateEnum): string {
       return 'ON';
     case StateEnum.OFF:
       return 'OFF';
+    case StateEnum.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return 'UNRECOGNIZED';
   }
 }
 
@@ -110,8 +111,9 @@ export function child_TypeToJSON(object: Child_Type): string {
       return 'GOOD';
     case Child_Type.BAD:
       return 'BAD';
+    case Child_Type.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return 'UNRECOGNIZED';
   }
 }
 
@@ -154,8 +156,9 @@ export function nested_InnerEnumToJSON(object: Nested_InnerEnum): string {
       return 'GOOD';
     case Nested_InnerEnum.BAD:
       return 'BAD';
+    case Nested_InnerEnum.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return 'UNRECOGNIZED';
   }
 }
 

--- a/integration/simple-snake/simple.ts
+++ b/integration/simple-snake/simple.ts
@@ -45,8 +45,9 @@ export function stateEnumToJSON(object: StateEnum): string {
       return 'ON';
     case StateEnum.OFF:
       return 'OFF';
+    case StateEnum.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return 'UNRECOGNIZED';
   }
 }
 
@@ -106,8 +107,9 @@ export function child_TypeToJSON(object: Child_Type): string {
       return 'GOOD';
     case Child_Type.BAD:
       return 'BAD';
+    case Child_Type.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return 'UNRECOGNIZED';
   }
 }
 
@@ -150,8 +152,9 @@ export function nested_InnerEnumToJSON(object: Nested_InnerEnum): string {
       return 'GOOD';
     case Nested_InnerEnum.BAD:
       return 'BAD';
+    case Nested_InnerEnum.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return 'UNRECOGNIZED';
   }
 }
 

--- a/integration/simple-string-enums/google/protobuf/struct.ts
+++ b/integration/simple-string-enums/google/protobuf/struct.ts
@@ -32,8 +32,9 @@ export function nullValueToJSON(object: NullValue): string {
   switch (object) {
     case NullValue.NULL_VALUE:
       return 'NULL_VALUE';
+    case NullValue.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return 'UNRECOGNIZED';
   }
 }
 
@@ -41,8 +42,9 @@ export function nullValueToNumber(object: NullValue): number {
   switch (object) {
     case NullValue.NULL_VALUE:
       return 0;
+    case NullValue.UNRECOGNIZED:
     default:
-      return 0;
+      return -1;
   }
 }
 

--- a/integration/simple-string-enums/simple.ts
+++ b/integration/simple-string-enums/simple.ts
@@ -38,8 +38,9 @@ export function stateEnumToJSON(object: StateEnum): string {
       return 'ON';
     case StateEnum.OFF:
       return 'OFF';
+    case StateEnum.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return 'UNRECOGNIZED';
   }
 }
 
@@ -51,8 +52,9 @@ export function stateEnumToNumber(object: StateEnum): number {
       return 2;
     case StateEnum.OFF:
       return 3;
+    case StateEnum.UNRECOGNIZED:
     default:
-      return 0;
+      return -1;
   }
 }
 

--- a/integration/simple-unrecognized-enum/simple.ts
+++ b/integration/simple-unrecognized-enum/simple.ts
@@ -43,7 +43,7 @@ export function stateEnumToJSON(object: StateEnum): string {
     case StateEnum.OFF:
       return 'OFF';
     default:
-      return 'UNKNOWN';
+      throw new globalThis.Error('Unrecognized enum value ' + object + ' for enum StateEnum');
   }
 }
 
@@ -101,7 +101,7 @@ export function child_TypeToJSON(object: Child_Type): string {
     case Child_Type.BAD:
       return 'BAD';
     default:
-      return 'UNKNOWN';
+      throw new globalThis.Error('Unrecognized enum value ' + object + ' for enum Child_Type');
   }
 }
 
@@ -142,7 +142,7 @@ export function nested_InnerEnumToJSON(object: Nested_InnerEnum): string {
     case Nested_InnerEnum.BAD:
       return 'BAD';
     default:
-      return 'UNKNOWN';
+      throw new globalThis.Error('Unrecognized enum value ' + object + ' for enum Nested_InnerEnum');
   }
 }
 

--- a/integration/simple/simple.ts
+++ b/integration/simple/simple.ts
@@ -46,8 +46,9 @@ export function stateEnumToJSON(object: StateEnum): string {
       return 'ON';
     case StateEnum.OFF:
       return 'OFF';
+    case StateEnum.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return 'UNRECOGNIZED';
   }
 }
 
@@ -110,8 +111,9 @@ export function child_TypeToJSON(object: Child_Type): string {
       return 'GOOD';
     case Child_Type.BAD:
       return 'BAD';
+    case Child_Type.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return 'UNRECOGNIZED';
   }
 }
 
@@ -154,8 +156,9 @@ export function nested_InnerEnumToJSON(object: Nested_InnerEnum): string {
       return 'GOOD';
     case Nested_InnerEnum.BAD:
       return 'BAD';
+    case Nested_InnerEnum.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return 'UNRECOGNIZED';
   }
 }
 

--- a/integration/struct/google/protobuf/struct.ts
+++ b/integration/struct/google/protobuf/struct.ts
@@ -32,8 +32,9 @@ export function nullValueToJSON(object: NullValue): string {
   switch (object) {
     case NullValue.NULL_VALUE:
       return 'NULL_VALUE';
+    case NullValue.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return 'UNRECOGNIZED';
   }
 }
 

--- a/integration/type-registry/google/protobuf/struct.ts
+++ b/integration/type-registry/google/protobuf/struct.ts
@@ -33,8 +33,9 @@ export function nullValueToJSON(object: NullValue): string {
   switch (object) {
     case NullValue.NULL_VALUE:
       return 'NULL_VALUE';
+    case NullValue.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return 'UNRECOGNIZED';
   }
 }
 

--- a/integration/use-optionals-all/test.ts
+++ b/integration/use-optionals-all/test.ts
@@ -37,8 +37,9 @@ export function stateEnumToJSON(object: StateEnum): string {
       return 'ON';
     case StateEnum.OFF:
       return 'OFF';
+    case StateEnum.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return 'UNRECOGNIZED';
   }
 }
 

--- a/integration/value/google/protobuf/struct.ts
+++ b/integration/value/google/protobuf/struct.ts
@@ -32,8 +32,9 @@ export function nullValueToJSON(object: NullValue): string {
   switch (object) {
     case NullValue.NULL_VALUE:
       return 'NULL_VALUE';
+    case NullValue.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return 'UNRECOGNIZED';
   }
 }
 

--- a/integration/vector-tile/vector_tile.ts
+++ b/integration/vector-tile/vector_tile.ts
@@ -47,8 +47,9 @@ export function tile_GeomTypeToJSON(object: Tile_GeomType): string {
       return 'LINESTRING';
     case Tile_GeomType.POLYGON:
       return 'POLYGON';
+    case Tile_GeomType.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return 'UNRECOGNIZED';
   }
 }
 

--- a/protos/google/protobuf/compiler/plugin.ts
+++ b/protos/google/protobuf/compiler/plugin.ts
@@ -95,8 +95,9 @@ export function codeGeneratorResponse_FeatureToJSON(object: CodeGeneratorRespons
       return 'FEATURE_NONE';
     case CodeGeneratorResponse_Feature.FEATURE_PROTO3_OPTIONAL:
       return 'FEATURE_PROTO3_OPTIONAL';
+    case CodeGeneratorResponse_Feature.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return 'UNRECOGNIZED';
   }
 }
 

--- a/protos/google/protobuf/descriptor.ts
+++ b/protos/google/protobuf/descriptor.ts
@@ -303,8 +303,9 @@ export function fieldDescriptorProto_TypeToJSON(object: FieldDescriptorProto_Typ
       return 'TYPE_SINT32';
     case FieldDescriptorProto_Type.TYPE_SINT64:
       return 'TYPE_SINT64';
+    case FieldDescriptorProto_Type.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return 'UNRECOGNIZED';
   }
 }
 
@@ -342,8 +343,9 @@ export function fieldDescriptorProto_LabelToJSON(object: FieldDescriptorProto_La
       return 'LABEL_REQUIRED';
     case FieldDescriptorProto_Label.LABEL_REPEATED:
       return 'LABEL_REPEATED';
+    case FieldDescriptorProto_Label.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return 'UNRECOGNIZED';
   }
 }
 
@@ -574,8 +576,9 @@ export function fileOptions_OptimizeModeToJSON(object: FileOptions_OptimizeMode)
       return 'CODE_SIZE';
     case FileOptions_OptimizeMode.LITE_RUNTIME:
       return 'LITE_RUNTIME';
+    case FileOptions_OptimizeMode.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return 'UNRECOGNIZED';
   }
 }
 
@@ -750,8 +753,9 @@ export function fieldOptions_CTypeToJSON(object: FieldOptions_CType): string {
       return 'CORD';
     case FieldOptions_CType.STRING_PIECE:
       return 'STRING_PIECE';
+    case FieldOptions_CType.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return 'UNRECOGNIZED';
   }
 }
 
@@ -791,8 +795,9 @@ export function fieldOptions_JSTypeToJSON(object: FieldOptions_JSType): string {
       return 'JS_STRING';
     case FieldOptions_JSType.JS_NUMBER:
       return 'JS_NUMBER';
+    case FieldOptions_JSType.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return 'UNRECOGNIZED';
   }
 }
 
@@ -895,8 +900,9 @@ export function methodOptions_IdempotencyLevelToJSON(object: MethodOptions_Idemp
       return 'NO_SIDE_EFFECTS';
     case MethodOptions_IdempotencyLevel.IDEMPOTENT:
       return 'IDEMPOTENT';
+    case MethodOptions_IdempotencyLevel.UNRECOGNIZED:
     default:
-      return 'UNKNOWN';
+      return 'UNRECOGNIZED';
   }
 }
 


### PR DESCRIPTION
Is returning 'unknown' or '0' in xxxToJSON/xxxToNumber as expected? It may conflict with the default enum value '0'

I'm not sure, so I correct it to 'UNRECOGNIZED' and '-1'

wdyt?