### PR TITLE
docs: add `node_modules` exclusion

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -99,6 +99,13 @@ plugins:
     path: ../node_modules/ts-proto/protoc-gen-ts_proto
 ```
 
+To prevent `buf push` from reading irrelevent `.proto` files, configure `buf.yaml` like so:
+
+```yaml
+build:
+  excludes: [node_modules]
+```
+
 You can also use the official plugin published to the Buf Registry.
 
 ```yaml


### PR DESCRIPTION
resolves `Failure: node_modules/protobufjs/google/api/annotations.proto:5:8:google/api/http.proto: does not exist`

Note: This assumes `buf.yaml` is in the top-level project directory, next to `node_modules`