### PR TITLE
feat: add meta-data to stream error

### DIFF
--- a/integration/grpc-web/example.ts
+++ b/integration/grpc-web/example.ts
@@ -876,13 +876,16 @@ export class GrpcWebImpl {
           metadata: maybeCombinedMetadata,
           debug: this.options.debug,
           onMessage: (next) => observer.next(next),
-          onEnd: (code: grpc.Code, message: string) => {
+          onEnd: (code: grpc.Code, message: string, trailers: grpc.Metadata) => {
             if (code === 0) {
               observer.complete();
             } else if (upStreamCodes.includes(code)) {
               setTimeout(upStream, DEFAULT_TIMEOUT_TIME);
             } else {
-              observer.error(new Error(`Error ${code} ${message}`));
+              const err = new Error(message) as any;
+              err.code = code;
+              err.metadata = trailers;
+              observer.error(err);
             }
           },
         });

--- a/src/generate-grpc-web.ts
+++ b/src/generate-grpc-web.ts
@@ -316,7 +316,7 @@ function createInvokeMethod(ctx: Context) {
             metadata: maybeCombinedMetadata,
             debug: this.options.debug,
             onMessage: (next) => observer.next(next),
-            onEnd: (code: ${grpc}.Code, message: string, trailers: grpc.Metadata) => {
+            onEnd: (code: ${grpc}.Code, message: string, trailers: ${grpc}.Metadata) => {
               if (code === 0) {
                 observer.complete();
               } else if (upStreamCodes.includes(code)) {

--- a/src/generate-grpc-web.ts
+++ b/src/generate-grpc-web.ts
@@ -316,13 +316,16 @@ function createInvokeMethod(ctx: Context) {
             metadata: maybeCombinedMetadata,
             debug: this.options.debug,
             onMessage: (next) => observer.next(next),
-            onEnd: (code: ${grpc}.Code, message: string) => {
+            onEnd: (code: ${grpc}.Code, message: string, trailers: grpc.Metadata) => {
               if (code === 0) {
                 observer.complete();
               } else if (upStreamCodes.includes(code)) {
                 setTimeout(upStream, DEFAULT_TIMEOUT_TIME);
               } else {
-                observer.error(new Error(\`Error \${code} \${message}\`));
+                const err = new Error(message) as any;
+                err.code = code;
+                err.metadata = trailers;
+                observer.error(err);
               }
             },
           });


### PR DESCRIPTION
This PR introduces metadata support in Stream (invoke) during catch as in Unary. It's required to read gRPC richer errors.
S