### PR TITLE
fix: fieldmask wrap method with type registry

### DIFF
--- a/integration/fieldmask/google/protobuf/field_mask.ts
+++ b/integration/fieldmask/google/protobuf/field_mask.ts
@@ -261,7 +261,11 @@ export const FieldMask = {
   },
 
   wrap(paths: string[]): FieldMask {
-    return { paths: paths };
+    const result = createBaseFieldMask();
+
+    result.paths = paths;
+
+    return result;
   },
 
   unwrap(message: FieldMask): string[] {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1684,7 +1684,11 @@ function generateWrap(ctx: Context, fullProtoTypeName: string, fieldNames: Struc
 
   if (isFieldMaskTypeName(fullProtoTypeName)) {
     chunks.push(code`wrap(paths: string[]): FieldMask {
-      return {paths: paths};
+      const result = createBaseFieldMask();
+
+      result.paths = paths;
+
+      return result;
     }`);
   }
 


### PR DESCRIPTION
Fixes the following type error:
```
../protos/dist/google/protobuf/field_mask.ts:274:5 - error TS2741: Property '$type' is missing in type '{ paths: string[]; }' but required in type 'FieldMask'.

274     return { paths: paths };
        ~~~~~~~~~~~~~~~~~~~~~~~~

  ../protos/dist/google/protobuf/field_mask.ts:209:3
    209   $type: 'google.protobuf.FieldMask';
          ~~~~~
    '$type' is declared here.
```

When ts-proto is run with `outputTypeRegistry=true`.