### PR TITLE
fix: Use jsonName even with snakeToCamel=false.

### DIFF
--- a/src/case.ts
+++ b/src/case.ts
@@ -1,27 +1,28 @@
 import { Options } from './options';
 
-export function maybeSnakeToCamel(s: string, options: Pick<Options, 'snakeToCamel'>): string {
-  if (options.snakeToCamel.includes('keys') && s.includes('_')) {
-    const hasLowerCase = !!s.match(/[a-z]/);
-    return s
-      .split('_')
-      .map((word, i) => {
-        // If the word is already mixed case, leave the exist case as-is
-        word = hasLowerCase ? word : word.toLowerCase();
-        return i === 0 ? word : capitalize(word);
-      })
-      .join('');
+/** Converts `key` to TS/JS camel-case idiom, unless overridden not to. */
+export function maybeSnakeToCamel(key: string, options: Pick<Options, 'snakeToCamel'>): string {
+  if (options.snakeToCamel.includes('keys') && key.includes('_')) {
+    return snakeToCamel(key);
   } else {
-    return s;
+    return key;
   }
 }
 
-export function camelToSnake(s: string): string {
+export function snakeToCamel(s: string): string {
+  const hasLowerCase = !!s.match(/[a-z]/);
   return s
-    .replace(/[\w]([A-Z])/g, function (m) {
-      return m[0] + '_' + m[1];
+    .split('_')
+    .map((word, i) => {
+      // If the word is already mixed case, leave the existing case as-is
+      word = hasLowerCase ? word : word.toLowerCase();
+      return i === 0 ? word : capitalize(word);
     })
-    .toUpperCase();
+    .join('');
+}
+
+export function camelToSnake(s: string): string {
+  return s.replace(/\w([A-Z])/g, (m) => m[0] + '_' + m[1]).toUpperCase();
 }
 
 export function capitalize(s: string): string {

--- a/tests/case-test.ts
+++ b/tests/case-test.ts
@@ -1,5 +1,6 @@
 import { maybeSnakeToCamel } from '../src/case';
 import { Options, optionsFromParameter } from '../src/options';
+import { getFieldJsonName } from '../src/utils';
 
 const keys = optionsFromParameter('snakeToCamel=keys');
 
@@ -44,5 +45,15 @@ describe('case', () => {
 
   it('converts snake to camel with first underscore and camelize other', () => {
     expect(maybeSnakeToCamel('_uuid_foo', { snakeToCamel: ['keys'] })).toEqual('UuidFoo');
+  });
+
+  describe('getFieldJsonName', () => {
+    it('keeps snake case when jsonName is probably not set', () => {
+      expect(getFieldJsonName({ name: 'foo_bar', jsonName: 'fooBar' }, { snakeToCamel: [] })).toBe('foo_bar');
+    });
+
+    it('uses jsonName when it is set', () => {
+      expect(getFieldJsonName({ name: 'foo_bar', jsonName: 'foo' }, { snakeToCamel: [] })).toBe('foo');
+    });
   });
 });


### PR DESCRIPTION
Previously we only checked jsonName if snakeToCamel=json was enabled,
b/c protobuf _always_ set jsonName to the camelized key name OR the
jsonName attribute value.

Because of this, we couldn't do logic like "if jsonName is explicitly
set, use that, otherwise keep the field name as-is".

Now we guess about whether jsonName is explicitly set by doing our
own snake-field-name -> camel-json-name, and if our camel-json-name
matches jsonName, then we assume the user has _not_ set jsonName,
and we should keep using snake-field-name.

But if those two values, camel-json-name and jsonName, are different,
then the user has probably manually set jsonName in the proto file,
and we'll use that instead.

Fixes #635