### PR TITLE
feat: Add optional json field names map to message type

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -397,6 +397,8 @@ Generated code will be placed in the Gradle build directory.
 
 - With `--ts_proto_opt=outputTypeRegistry=true`, the type registry will be generated that can be used to resolve message types by fully-qualified name. Also, each message will get extra `$type` field containing fully-qualified name.
 
+- With `--ts_proto_opt=outputJsonFieldNames=true`, each message will get an extra `$jsonFields` object containing a mapping from each message key to it's corresponding JSON name.
+
 - With `--ts_proto_opt=outputServices=grpc-js`, ts-proto will output service definitions and server / client stubs in [grpc-js](https://github.com/grpc/grpc-node/tree/master/packages/grpc-js) format.
 
 - With `--ts_proto_opt=outputServices=generic-definitions`, ts-proto will output generic (framework-agnostic) service definitions. These definitions contain descriptors for each method with links to request and response types, which allows to generate server and client stubs at runtime, and also generate strong types for them at compile time. An example of a library that uses this approach is [nice-grpc](https://github.com/deeplay-io/nice-grpc).

--- a/src/main.ts
+++ b/src/main.ts
@@ -162,6 +162,9 @@ export function generateFile(ctx: Context, fileDesc: FileDescriptorProto): [stri
         if (options.outputTypeRegistry) {
           staticMembers.push(code`$type: '${fullTypeName}' as const`);
         }
+        if (options.outputJsonFieldNames) {
+          staticMembers.push(generateJsonFieldNames(options, message));
+        }
 
         if (options.outputEncodeMethods) {
           staticMembers.push(generateEncode(ctx, fullName, message));
@@ -333,6 +336,18 @@ export function makeUtils(options: Options): Utils {
     ...makeNiceGrpcServerStreamingMethodResult(),
     ...makeGrpcWebErrorClass(),
   };
+}
+
+function generateJsonFieldNames(options: Options, descriptor: DescriptorProto): Code {
+  const members = [];
+
+  for (let field of descriptor.field) {
+    const keyName = maybeSnakeToCamel(field.name, options);
+    const jsonName = getFieldJsonName(field, options);
+    members.push(code`${keyName}: "${jsonName}"`);
+  }
+
+  return code`$jsonFields: { ${joinCode(members, { on: ',\n' })} } as const`;
 }
 
 function makeLongUtils(options: Options, bytes: ReturnType<typeof makeByteUtils>) {

--- a/src/options.ts
+++ b/src/options.ts
@@ -44,6 +44,7 @@ export type Options = {
   outputJsonMethods: boolean;
   outputPartialMethods: boolean;
   outputTypeRegistry: boolean;
+  outputJsonFieldNames: boolean;
   stringEnums: boolean;
   constEnums: boolean;
   enumsAsLiterals: boolean;
@@ -86,6 +87,7 @@ export function defaultOptions(): Options {
     outputJsonMethods: true,
     outputPartialMethods: true,
     outputTypeRegistry: false,
+    outputJsonFieldNames: false,
     stringEnums: false,
     constEnums: false,
     enumsAsLiterals: false,

--- a/tests/options-test.ts
+++ b/tests/options-test.ts
@@ -30,6 +30,7 @@ describe('options', () => {
           "default",
         ],
         "outputTypeRegistry": false,
+        "outputJsonFieldNames": false,
         "returnObservable": false,
         "snakeToCamel": Array [
           "json",
@@ -76,6 +77,13 @@ describe('options', () => {
     const options = optionsFromParameter('outputServices=grpc-js');
     expect(options).toMatchObject({
       outputServices: [ServiceOption.GRPC],
+    });
+  });
+
+  it('can set outputJsonFieldNames to boolean', () => {
+    const options = optionsFromParameter('outputJsonFieldNames=true');
+    expect(options).toMatchObject({
+      outputJsonFieldNames: true,
     });
   });
 


### PR DESCRIPTION
Protobuf messages may be stored as JSON objects, for example in a database. Performing query or lookups on these objects often requires a string representation of the message's field names (keys). Currently, the programmer needs to hardcode these strings in their code, but if the underlying protobuf definition changes, there will be no warning that those field names are invalid. Providing an optionally generated mapping of each key to its corresponding JSON name allows Typescript to flag if that field does not exist. This can be enabled using `outputJsonFieldNames=true` which adds a map object to the message type named `$jsonFields`.

Example Proto:
```
message Foo {
  string bar = 1;
}
```

Typescript Generated Class Member:
```
const Foo = {
  $jsonFields: {
    bar: "bar"
  } as const,
  ...
}
```