### PR TITLE
disabled the default check for the upstream encoder

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -445,6 +445,11 @@ Generated code will be placed in the Gradle build directory.
 
 - With `--ts_proto_opt=useNumericEnumForJson=true`, the JSON converter (`toJSON`) will encode enum values as int, rather than a string literal.
 
+- With `--ts_proto_opt=disableDefaultCheck=true`, this will disable the if conditional around the encoder for a field which implicitly enforces the default value. For example if
+  `if(message.name !== ''){ Writer.uint32(1).string(message.name)}` this will become ` Writer.uint32(1).string(message.name)` so you can potential send an undefined to the server.
+
+- With `--ts_proto_opt=disableDefaultEnumCheck=true`, the same as `--ts_proto_opt=disableDefaultCheck=true` but only applied to enums.
+
 ### NestJS Support
 
 We have a great way of working together with [nestjs](https://docs.nestjs.com/microservices/grpc). `ts-proto` generates `interfaces` and `decorators` for you controller, client. For more information see the [nestjs readme](NESTJS.markdown).

--- a/src/options.ts
+++ b/src/options.ts
@@ -67,6 +67,8 @@ export type Options = {
   usePrototypeForDefaults: boolean;
   useJsonWireFormat: boolean;
   useNumericEnumForJson: boolean;
+  disableDefaultEnumCheck: boolean;
+  disableDefaultCheck: boolean;
 };
 
 export function defaultOptions(): Options {
@@ -108,6 +110,8 @@ export function defaultOptions(): Options {
     usePrototypeForDefaults: false,
     useJsonWireFormat: false,
     useNumericEnumForJson: false,
+    disableDefaultEnumCheck: false,
+    disableDefaultCheck: false,
   };
 }
 

--- a/tests/options-test.ts
+++ b/tests/options-test.ts
@@ -8,6 +8,8 @@ describe('options', () => {
         "addNestjsRestParameter": false,
         "constEnums": false,
         "context": false,
+        "disableDefaultCheck": false,
+        "disableDefaultEnumCheck": false,
         "emitImportedFiles": true,
         "enumsAsLiterals": false,
         "env": "both",


### PR DESCRIPTION
this is a PR for the following issue
https://github.com/stephenh/ts-proto/issues/643

for the upstream encoder, this PR has the ability to disable the check for default enums, because for proto2 we may not have a default enum, so will have to disable the default behaviour. 