### PR TITLE
docs(readme): fix gRPC example

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -482,7 +482,7 @@ const sendRequest: RpcImpl = (service, method, data) => {
   // Conventionally in gRPC, the request path looks like
   //   "package.names.ServiceName/MethodName",
   // we therefore construct such a string
-  const path = `${service}/${method}`;
+  const path = `/${service}/${method}`;
 
   return new Promise((resolve, reject) => {
     // makeUnaryRequest transmits the result (and error) with a callback


### PR DESCRIPTION
tldr: envoy uses nghttp2, which reports `invalid frame: Violation in HTTP messaging rule on stream 1`

Long Story: If you use this example in a server node.js process in Kubernetes with an Istio Service Mesh, envoy will report something like
```
│ 2022-08-29T12:53:55.616404Z    debug    envoy http2    [C398] updating connection-level initial window size to 268435456                                                                                                                                                                                                   │
│ 2022-08-29T12:53:55.616663Z    debug    envoy http2    [C398] invalid frame: Violation in HTTP messaging rule on stream 1
```
if you try to call an gRPC request. Sadly, there is basically no documentation at all available for this behaviour.
The `Promise` will reject with `Connection dropped` and no other details.
Prepending the `/` to the path ensures that the behaviour is not violating the HTTP/2 standard, because appearently node http2 package does allow the path to not start with `/`.
See https://www.rfc-editor.org/rfc/rfc7540#section-8.1.2 8.1.2.3 and https://www.rfc-editor.org/rfc/rfc3986#section-3.3
> The ":path" pseudo-header field includes the path and query parts of the target URI (the "path-absolute" [...]

If you develop locally against a different gRPC server, such as the go grpc implementation, this error does _not_ occur, go will accept the missing `/` and simply work.

Thank you for this great project, really appreciate your work!