### PR TITLE
fix(options): initializes M opt to empty object

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -208,7 +208,7 @@ export function optionsFromParameter(parameter: string | undefined): Options {
 
 // A very naive parse function, eventually could/should use iots/runtypes
 function parseParameter(parameter: string): Options {
-  const options = {} as any;
+  const options = { M: {} } as any;
   parameter.split(",").forEach((param) => {
     // same as protoc-gen-go https://github.com/protocolbuffers/protobuf-go/blob/bf9455640daabb98c93b5b5e71628f3f813d57bb/compiler/protogen/protogen.go#L168-L171
     const optionSeparatorPos = param.indexOf("=");


### PR DESCRIPTION
So because the test for the `M` opt is really the output of `yarn build:test`
I didn't catch a bug I introduced in my last iteration of refactoring.
In `options`, `M` is `undefined` so passing `M` opts doesn't work
because it'll try `options.M['...']` and `options.M` is undefined.
`options` should start out with the default `M`.

Apologies for the bug!
