### PR TITLE
feat(client): allow overriding the service identifier

### DIFF
--- a/integration/async-iterable-services/simple.ts
+++ b/integration/async-iterable-services/simple.ts
@@ -101,7 +101,9 @@ export interface Echoer {
 
 export class EchoerClientImpl implements Echoer {
   private readonly rpc: Rpc;
-  constructor(rpc: Rpc) {
+  private readonly service: string;
+  constructor(rpc: Rpc, opts?: { service?: string }) {
+    this.service = opts?.service || "simple.Echoer";
     this.rpc = rpc;
     this.Echo = this.Echo.bind(this);
     this.EchoServerStream = this.EchoServerStream.bind(this);
@@ -110,25 +112,25 @@ export class EchoerClientImpl implements Echoer {
   }
   Echo(request: EchoMsg): Promise<EchoMsg> {
     const data = EchoMsg.encode(request).finish();
-    const promise = this.rpc.request("simple.Echoer", "Echo", data);
+    const promise = this.rpc.request(this.service, "Echo", data);
     return promise.then((data) => EchoMsg.decode(new _m0.Reader(data)));
   }
 
   EchoServerStream(request: EchoMsg): AsyncIterable<EchoMsg> {
     const data = EchoMsg.encode(request).finish();
-    const result = this.rpc.serverStreamingRequest("simple.Echoer", "EchoServerStream", data);
+    const result = this.rpc.serverStreamingRequest(this.service, "EchoServerStream", data);
     return EchoMsg.decodeTransform(result);
   }
 
   EchoClientStream(request: AsyncIterable<EchoMsg>): Promise<EchoMsg> {
     const data = EchoMsg.encodeTransform(request);
-    const promise = this.rpc.clientStreamingRequest("simple.Echoer", "EchoClientStream", data);
+    const promise = this.rpc.clientStreamingRequest(this.service, "EchoClientStream", data);
     return promise.then((data) => EchoMsg.decode(new _m0.Reader(data)));
   }
 
   EchoBidiStream(request: AsyncIterable<EchoMsg>): AsyncIterable<EchoMsg> {
     const data = EchoMsg.encodeTransform(request);
-    const result = this.rpc.bidirectionalStreamingRequest("simple.Echoer", "EchoBidiStream", data);
+    const result = this.rpc.bidirectionalStreamingRequest(this.service, "EchoBidiStream", data);
     return EchoMsg.decodeTransform(result);
   }
 }

--- a/integration/avoid-import-conflicts/simple.ts
+++ b/integration/avoid-import-conflicts/simple.ts
@@ -288,13 +288,15 @@ export interface FooService {
 
 export class FooServiceClientImpl implements FooService {
   private readonly rpc: Rpc;
-  constructor(rpc: Rpc) {
+  private readonly service: string;
+  constructor(rpc: Rpc, opts?: { service?: string }) {
+    this.service = opts?.service || "simple.FooService";
     this.rpc = rpc;
     this.Create = this.Create.bind(this);
   }
   Create(request: FooServiceCreateRequest): Promise<FooServiceCreateResponse> {
     const data = FooServiceCreateRequest.encode(request).finish();
-    const promise = this.rpc.request("simple.FooService", "Create", data);
+    const promise = this.rpc.request(this.service, "Create", data);
     return promise.then((data) => FooServiceCreateResponse.decode(new _m0.Reader(data)));
   }
 }

--- a/integration/batching-with-context/batching.ts
+++ b/integration/batching-with-context/batching.ts
@@ -578,7 +578,9 @@ export interface EntityService<Context extends DataLoaders> {
 
 export class EntityServiceClientImpl<Context extends DataLoaders> implements EntityService<Context> {
   private readonly rpc: Rpc<Context>;
-  constructor(rpc: Rpc<Context>) {
+  private readonly service: string;
+  constructor(rpc: Rpc<Context>, opts?: { service?: string }) {
+    this.service = opts?.service || "batching.EntityService";
     this.rpc = rpc;
     this.BatchQuery = this.BatchQuery.bind(this);
     this.BatchMapQuery = this.BatchMapQuery.bind(this);
@@ -597,7 +599,7 @@ export class EntityServiceClientImpl<Context extends DataLoaders> implements Ent
 
   BatchQuery(ctx: Context, request: BatchQueryRequest): Promise<BatchQueryResponse> {
     const data = BatchQueryRequest.encode(request).finish();
-    const promise = this.rpc.request(ctx, "batching.EntityService", "BatchQuery", data);
+    const promise = this.rpc.request(ctx, this.service, "BatchQuery", data);
     return promise.then((data) => BatchQueryResponse.decode(new _m0.Reader(data)));
   }
 
@@ -615,7 +617,7 @@ export class EntityServiceClientImpl<Context extends DataLoaders> implements Ent
 
   BatchMapQuery(ctx: Context, request: BatchMapQueryRequest): Promise<BatchMapQueryResponse> {
     const data = BatchMapQueryRequest.encode(request).finish();
-    const promise = this.rpc.request(ctx, "batching.EntityService", "BatchMapQuery", data);
+    const promise = this.rpc.request(ctx, this.service, "BatchMapQuery", data);
     return promise.then((data) => BatchMapQueryResponse.decode(new _m0.Reader(data)));
   }
 
@@ -635,7 +637,7 @@ export class EntityServiceClientImpl<Context extends DataLoaders> implements Ent
 
   WriteMethod(ctx: Context, request: WriteMethodRequest): Promise<WriteMethodResponse> {
     const data = WriteMethodRequest.encode(request).finish();
-    const promise = this.rpc.request(ctx, "batching.EntityService", "WriteMethod", data);
+    const promise = this.rpc.request(ctx, this.service, "WriteMethod", data);
     return promise.then((data) => WriteMethodResponse.decode(new _m0.Reader(data)));
   }
 }

--- a/integration/batching/batching.ts
+++ b/integration/batching/batching.ts
@@ -574,7 +574,9 @@ export interface EntityService {
 
 export class EntityServiceClientImpl implements EntityService {
   private readonly rpc: Rpc;
-  constructor(rpc: Rpc) {
+  private readonly service: string;
+  constructor(rpc: Rpc, opts?: { service?: string }) {
+    this.service = opts?.service || "batching.EntityService";
     this.rpc = rpc;
     this.BatchQuery = this.BatchQuery.bind(this);
     this.BatchMapQuery = this.BatchMapQuery.bind(this);
@@ -583,25 +585,25 @@ export class EntityServiceClientImpl implements EntityService {
   }
   BatchQuery(request: BatchQueryRequest): Promise<BatchQueryResponse> {
     const data = BatchQueryRequest.encode(request).finish();
-    const promise = this.rpc.request("batching.EntityService", "BatchQuery", data);
+    const promise = this.rpc.request(this.service, "BatchQuery", data);
     return promise.then((data) => BatchQueryResponse.decode(new _m0.Reader(data)));
   }
 
   BatchMapQuery(request: BatchMapQueryRequest): Promise<BatchMapQueryResponse> {
     const data = BatchMapQueryRequest.encode(request).finish();
-    const promise = this.rpc.request("batching.EntityService", "BatchMapQuery", data);
+    const promise = this.rpc.request(this.service, "BatchMapQuery", data);
     return promise.then((data) => BatchMapQueryResponse.decode(new _m0.Reader(data)));
   }
 
   GetOnlyMethod(request: GetOnlyMethodRequest): Promise<GetOnlyMethodResponse> {
     const data = GetOnlyMethodRequest.encode(request).finish();
-    const promise = this.rpc.request("batching.EntityService", "GetOnlyMethod", data);
+    const promise = this.rpc.request(this.service, "GetOnlyMethod", data);
     return promise.then((data) => GetOnlyMethodResponse.decode(new _m0.Reader(data)));
   }
 
   WriteMethod(request: WriteMethodRequest): Promise<WriteMethodResponse> {
     const data = WriteMethodRequest.encode(request).finish();
-    const promise = this.rpc.request("batching.EntityService", "WriteMethod", data);
+    const promise = this.rpc.request(this.service, "WriteMethod", data);
     return promise.then((data) => WriteMethodResponse.decode(new _m0.Reader(data)));
   }
 }

--- a/integration/generic-metadata/hero.ts
+++ b/integration/generic-metadata/hero.ts
@@ -236,7 +236,9 @@ export interface HeroService {
 
 export class HeroServiceClientImpl implements HeroService {
   private readonly rpc: Rpc;
-  constructor(rpc: Rpc) {
+  private readonly service: string;
+  constructor(rpc: Rpc, opts?: { service?: string }) {
+    this.service = opts?.service || "hero.HeroService";
     this.rpc = rpc;
     this.FindOneHero = this.FindOneHero.bind(this);
     this.FindOneVillain = this.FindOneVillain.bind(this);
@@ -244,19 +246,19 @@ export class HeroServiceClientImpl implements HeroService {
   }
   FindOneHero(request: HeroById): Promise<Hero> {
     const data = HeroById.encode(request).finish();
-    const promise = this.rpc.request("hero.HeroService", "FindOneHero", data);
+    const promise = this.rpc.request(this.service, "FindOneHero", data);
     return promise.then((data) => Hero.decode(new _m0.Reader(data)));
   }
 
   FindOneVillain(request: VillainById): Promise<Villain> {
     const data = VillainById.encode(request).finish();
-    const promise = this.rpc.request("hero.HeroService", "FindOneVillain", data);
+    const promise = this.rpc.request(this.service, "FindOneVillain", data);
     return promise.then((data) => Villain.decode(new _m0.Reader(data)));
   }
 
   FindManyVillain(request: Observable<VillainById>): Observable<Villain> {
     const data = request.pipe(map((request) => VillainById.encode(request).finish()));
-    const result = this.rpc.bidirectionalStreamingRequest("hero.HeroService", "FindManyVillain", data);
+    const result = this.rpc.bidirectionalStreamingRequest(this.service, "FindManyVillain", data);
     return result.pipe(map((data) => Villain.decode(new _m0.Reader(data))));
   }
 }

--- a/integration/grpc-web-go-server/example.ts
+++ b/integration/grpc-web-go-server/example.ts
@@ -597,20 +597,22 @@ export interface DashState {
 
 export class DashStateClientImpl implements DashState {
   private readonly rpc: Rpc;
-  constructor(rpc: Rpc) {
+  private readonly service: string;
+  constructor(rpc: Rpc, opts?: { service?: string }) {
+    this.service = opts?.service || "rpx.DashState";
     this.rpc = rpc;
     this.UserSettings = this.UserSettings.bind(this);
     this.ActiveUserSettingsStream = this.ActiveUserSettingsStream.bind(this);
   }
   UserSettings(request: Empty): Promise<DashUserSettingsState> {
     const data = Empty.encode(request).finish();
-    const promise = this.rpc.request("rpx.DashState", "UserSettings", data);
+    const promise = this.rpc.request(this.service, "UserSettings", data);
     return promise.then((data) => DashUserSettingsState.decode(new _m0.Reader(data)));
   }
 
   ActiveUserSettingsStream(request: Empty): Observable<DashUserSettingsState> {
     const data = Empty.encode(request).finish();
-    const result = this.rpc.serverStreamingRequest("rpx.DashState", "ActiveUserSettingsStream", data);
+    const result = this.rpc.serverStreamingRequest(this.service, "ActiveUserSettingsStream", data);
     return result.pipe(map((data) => DashUserSettingsState.decode(new _m0.Reader(data))));
   }
 }
@@ -628,7 +630,9 @@ export interface DashAPICreds {
 
 export class DashAPICredsClientImpl implements DashAPICreds {
   private readonly rpc: Rpc;
-  constructor(rpc: Rpc) {
+  private readonly service: string;
+  constructor(rpc: Rpc, opts?: { service?: string }) {
+    this.service = opts?.service || "rpx.DashAPICreds";
     this.rpc = rpc;
     this.Create = this.Create.bind(this);
     this.Update = this.Update.bind(this);
@@ -636,19 +640,19 @@ export class DashAPICredsClientImpl implements DashAPICreds {
   }
   Create(request: DashAPICredsCreateReq): Promise<DashCred> {
     const data = DashAPICredsCreateReq.encode(request).finish();
-    const promise = this.rpc.request("rpx.DashAPICreds", "Create", data);
+    const promise = this.rpc.request(this.service, "Create", data);
     return promise.then((data) => DashCred.decode(new _m0.Reader(data)));
   }
 
   Update(request: DashAPICredsUpdateReq): Promise<DashCred> {
     const data = DashAPICredsUpdateReq.encode(request).finish();
-    const promise = this.rpc.request("rpx.DashAPICreds", "Update", data);
+    const promise = this.rpc.request(this.service, "Update", data);
     return promise.then((data) => DashCred.decode(new _m0.Reader(data)));
   }
 
   Delete(request: DashAPICredsDeleteReq): Promise<DashCred> {
     const data = DashAPICredsDeleteReq.encode(request).finish();
-    const promise = this.rpc.request("rpx.DashAPICreds", "Delete", data);
+    const promise = this.rpc.request(this.service, "Delete", data);
     return promise.then((data) => DashCred.decode(new _m0.Reader(data)));
   }
 }

--- a/integration/lower-case-svc-methods/math.ts
+++ b/integration/lower-case-svc-methods/math.ts
@@ -189,7 +189,9 @@ export interface MathService<Context extends DataLoaders> {
 
 export class MathServiceClientImpl<Context extends DataLoaders> implements MathService<Context> {
   private readonly rpc: Rpc<Context>;
-  constructor(rpc: Rpc<Context>) {
+  private readonly service: string;
+  constructor(rpc: Rpc<Context>, opts?: { service?: string }) {
+    this.service = opts?.service || "MathService";
     this.rpc = rpc;
     this.add = this.add.bind(this);
     this.absoluteValue = this.absoluteValue.bind(this);
@@ -197,13 +199,13 @@ export class MathServiceClientImpl<Context extends DataLoaders> implements MathS
   }
   add(ctx: Context, request: NumPair): Promise<NumSingle> {
     const data = NumPair.encode(request).finish();
-    const promise = this.rpc.request(ctx, "MathService", "Add", data);
+    const promise = this.rpc.request(ctx, this.service, "Add", data);
     return promise.then((data) => NumSingle.decode(new _m0.Reader(data)));
   }
 
   absoluteValue(ctx: Context, request: NumSingle): Promise<NumSingle> {
     const data = NumSingle.encode(request).finish();
-    const promise = this.rpc.request(ctx, "MathService", "AbsoluteValue", data);
+    const promise = this.rpc.request(ctx, this.service, "AbsoluteValue", data);
     return promise.then((data) => NumSingle.decode(new _m0.Reader(data)));
   }
 
@@ -219,7 +221,7 @@ export class MathServiceClientImpl<Context extends DataLoaders> implements MathS
 
   batchDouble(ctx: Context, request: Numbers): Promise<Numbers> {
     const data = Numbers.encode(request).finish();
-    const promise = this.rpc.request(ctx, "MathService", "BatchDouble", data);
+    const promise = this.rpc.request(ctx, this.service, "BatchDouble", data);
     return promise.then((data) => Numbers.decode(new _m0.Reader(data)));
   }
 }

--- a/integration/meta-typings/simple.ts
+++ b/integration/meta-typings/simple.ts
@@ -1273,13 +1273,15 @@ export interface PingService {
 
 export class PingServiceClientImpl implements PingService {
   private readonly rpc: Rpc;
-  constructor(rpc: Rpc) {
+  private readonly service: string;
+  constructor(rpc: Rpc, opts?: { service?: string }) {
+    this.service = opts?.service || "simple.PingService";
     this.rpc = rpc;
     this.ping = this.ping.bind(this);
   }
   ping(request: PingRequest): Promise<PingResponse> {
     const data = PingRequest.encode(request).finish();
-    const promise = this.rpc.request("simple.PingService", "ping", data);
+    const promise = this.rpc.request(this.service, "ping", data);
     return promise.then((data) => PingResponse.decode(new _m0.Reader(data)));
   }
 }

--- a/integration/no-proto-package/no-proto-package.ts
+++ b/integration/no-proto-package/no-proto-package.ts
@@ -104,13 +104,15 @@ export interface UserState {
 
 export class UserStateClientImpl implements UserState {
   private readonly rpc: Rpc;
-  constructor(rpc: Rpc) {
+  private readonly service: string;
+  constructor(rpc: Rpc, opts?: { service?: string }) {
+    this.service = opts?.service || "UserState";
     this.rpc = rpc;
     this.GetUsers = this.GetUsers.bind(this);
   }
   GetUsers(request: Empty): Observable<User> {
     const data = Empty.encode(request).finish();
-    const result = this.rpc.serverStreamingRequest("UserState", "GetUsers", data);
+    const result = this.rpc.serverStreamingRequest(this.service, "GetUsers", data);
     return result.pipe(map((data) => User.decode(new _m0.Reader(data))));
   }
 }

--- a/integration/options/options.ts
+++ b/integration/options/options.ts
@@ -130,13 +130,15 @@ export interface MyService {
 
 export class MyServiceClientImpl implements MyService {
   private readonly rpc: Rpc;
-  constructor(rpc: Rpc) {
+  private readonly service: string;
+  constructor(rpc: Rpc, opts?: { service?: string }) {
+    this.service = opts?.service || "MyService";
     this.rpc = rpc;
     this.MyMethod = this.MyMethod.bind(this);
   }
   MyMethod(request: RequestType): Promise<ResponseType> {
     const data = RequestType.encode(request).finish();
-    const promise = this.rpc.request("MyService", "MyMethod", data);
+    const promise = this.rpc.request(this.service, "MyMethod", data);
     return promise.then((data) => ResponseType.decode(new _m0.Reader(data)));
   }
 }

--- a/integration/simple-optionals/simple.ts
+++ b/integration/simple-optionals/simple.ts
@@ -1550,13 +1550,15 @@ export interface PingService {
 
 export class PingServiceClientImpl implements PingService {
   private readonly rpc: Rpc;
-  constructor(rpc: Rpc) {
+  private readonly service: string;
+  constructor(rpc: Rpc, opts?: { service?: string }) {
+    this.service = opts?.service || "simple.PingService";
     this.rpc = rpc;
     this.ping = this.ping.bind(this);
   }
   ping(request: PingRequest): Promise<PingResponse> {
     const data = PingRequest.encode(request).finish();
-    const promise = this.rpc.request("simple.PingService", "ping", data);
+    const promise = this.rpc.request(this.service, "ping", data);
     return promise.then((data) => PingResponse.decode(new _m0.Reader(data)));
   }
 }

--- a/integration/simple-prototype-defaults/simple.ts
+++ b/integration/simple-prototype-defaults/simple.ts
@@ -2327,13 +2327,15 @@ export interface PingService {
 
 export class PingServiceClientImpl implements PingService {
   private readonly rpc: Rpc;
-  constructor(rpc: Rpc) {
+  private readonly service: string;
+  constructor(rpc: Rpc, opts?: { service?: string }) {
+    this.service = opts?.service || "simple.PingService";
     this.rpc = rpc;
     this.ping = this.ping.bind(this);
   }
   ping(request: PingRequest): Promise<PingResponse> {
     const data = PingRequest.encode(request).finish();
-    const promise = this.rpc.request("simple.PingService", "ping", data);
+    const promise = this.rpc.request(this.service, "ping", data);
     return promise.then((data) => PingResponse.decode(new _m0.Reader(data)));
   }
 }

--- a/integration/simple-snake/simple.ts
+++ b/integration/simple-snake/simple.ts
@@ -1602,13 +1602,15 @@ export interface PingService {
 
 export class PingServiceClientImpl implements PingService {
   private readonly rpc: Rpc;
-  constructor(rpc: Rpc) {
+  private readonly service: string;
+  constructor(rpc: Rpc, opts?: { service?: string }) {
+    this.service = opts?.service || "simple.PingService";
     this.rpc = rpc;
     this.ping = this.ping.bind(this);
   }
   ping(request: PingRequest): Promise<PingResponse> {
     const data = PingRequest.encode(request).finish();
-    const promise = this.rpc.request("simple.PingService", "ping", data);
+    const promise = this.rpc.request(this.service, "ping", data);
     return promise.then((data) => PingResponse.decode(new _m0.Reader(data)));
   }
 }

--- a/integration/simple-unrecognized-enum/simple.ts
+++ b/integration/simple-unrecognized-enum/simple.ts
@@ -1538,13 +1538,15 @@ export interface PingService {
 
 export class PingServiceClientImpl implements PingService {
   private readonly rpc: Rpc;
-  constructor(rpc: Rpc) {
+  private readonly service: string;
+  constructor(rpc: Rpc, opts?: { service?: string }) {
+    this.service = opts?.service || "simple.PingService";
     this.rpc = rpc;
     this.ping = this.ping.bind(this);
   }
   ping(request: PingRequest): Promise<PingResponse> {
     const data = PingRequest.encode(request).finish();
-    const promise = this.rpc.request("simple.PingService", "ping", data);
+    const promise = this.rpc.request(this.service, "ping", data);
     return promise.then((data) => PingResponse.decode(new _m0.Reader(data)));
   }
 }

--- a/integration/simple/simple-service-test.ts
+++ b/integration/simple/simple-service-test.ts
@@ -9,4 +9,18 @@ describe('simple', () => {
     const ping = client.ping;
     ping(PingRequest.fromPartial({}));
   })
+  it('overrides service id correctly', async () => {
+    const customServiceID = 'custom-service-id';
+    const rpc = {
+      request: async (service: string, method: string, data: Uint8Array): Promise<Uint8Array> => {
+        expect(service).toBe(customServiceID)
+        expect(method).toBe("ping")
+        expect(data.length).toBe(0)
+        return new Uint8Array(0)
+      },
+    };
+    const client = new PingServiceClientImpl(rpc, {service: customServiceID});
+    const ping = client.ping;
+    await ping(PingRequest.fromPartial({}));
+  })
 })

--- a/integration/simple/simple.ts
+++ b/integration/simple/simple.ts
@@ -2326,13 +2326,15 @@ export interface PingService {
 
 export class PingServiceClientImpl implements PingService {
   private readonly rpc: Rpc;
-  constructor(rpc: Rpc) {
+  private readonly service: string;
+  constructor(rpc: Rpc, opts?: { service?: string }) {
+    this.service = opts?.service || "simple.PingService";
     this.rpc = rpc;
     this.ping = this.ping.bind(this);
   }
   ping(request: PingRequest): Promise<PingResponse> {
     const data = PingRequest.encode(request).finish();
-    const promise = this.rpc.request("simple.PingService", "ping", data);
+    const promise = this.rpc.request(this.service, "ping", data);
     return promise.then((data) => PingResponse.decode(new _m0.Reader(data)));
   }
 }

--- a/integration/unknown-fields/options.ts
+++ b/integration/unknown-fields/options.ts
@@ -187,13 +187,15 @@ export interface MyService {
 
 export class MyServiceClientImpl implements MyService {
   private readonly rpc: Rpc;
-  constructor(rpc: Rpc) {
+  private readonly service: string;
+  constructor(rpc: Rpc, opts?: { service?: string }) {
+    this.service = opts?.service || "MyService";
     this.rpc = rpc;
     this.MyMethod = this.MyMethod.bind(this);
   }
   MyMethod(request: RequestType): Promise<ResponseType> {
     const data = RequestType.encode(request).finish();
-    const promise = this.rpc.request("MyService", "MyMethod", data);
+    const promise = this.rpc.request(this.service, "MyMethod", data);
     return promise.then((data) => ResponseType.decode(new _m0.Reader(data)));
   }
 }

--- a/integration/use-date-true/use-date-true.ts
+++ b/integration/use-date-true/use-date-true.ts
@@ -194,13 +194,15 @@ export interface Clock {
 
 export class ClockClientImpl implements Clock {
   private readonly rpc: Rpc;
-  constructor(rpc: Rpc) {
+  private readonly service: string;
+  constructor(rpc: Rpc, opts?: { service?: string }) {
+    this.service = opts?.service || "Clock";
     this.rpc = rpc;
     this.Now = this.Now.bind(this);
   }
   Now(request: Empty): Promise<Date> {
     const data = Empty.encode(request).finish();
-    const promise = this.rpc.request("Clock", "Now", data);
+    const promise = this.rpc.request(this.service, "Now", data);
     return promise.then((data) => fromTimestamp(Timestamp.decode(new _m0.Reader(data))));
   }
 }

--- a/src/generate-services.ts
+++ b/src/generate-services.ts
@@ -164,7 +164,7 @@ function generateRegularRpcMethod(
       const data = ${encode};
       const ${returnVariable} = this.rpc.${rpcMethod}(
         ${maybeCtx}
-        "${maybePrefixPackage(fileDesc, serviceDesc.name)}",
+        this.service,
         "${methodDesc.name}",
         data
       );
@@ -190,8 +190,12 @@ export function generateServiceClientImpl(
   // Create the constructor(rpc: Rpc)
   const rpcType = options.context ? "Rpc<Context>" : "Rpc";
   chunks.push(code`private readonly rpc: ${rpcType};`);
-  chunks.push(code`constructor(rpc: ${rpcType}) {`);
+  chunks.push(code`private readonly service: string;`);
+  chunks.push(code`constructor(rpc: ${rpcType}, opts?: {service?: string}) {`);
+  const serviceID = maybePrefixPackage(fileDesc, serviceDesc.name);
+  chunks.push(code`this.service = opts?.service || "${serviceID}";`);
   chunks.push(code`this.rpc = rpc;`);
+
   // Bind each FooService method to the FooServiceImpl class
   for (const methodDesc of serviceDesc.method) {
     assertInstanceOf(methodDesc, FormattedMethodDescriptor);


### PR DESCRIPTION
Currently the service identifier is the fully qualified "fullName" of the service, for example, "simple.Echoer"

This identifier is hard-coded in the auto-generated client with string literals.

Instead, allow overriding the service ID with a new optional argument in the client constructor, default the service ID to the fullName, and store the ID in a read-only field on the client object.

This allows the user to override the service ID if desired while still maintaining the old behavior otherwise.