### PR TITLE
feat: Import CallContext and CallOptions as type

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -562,7 +562,7 @@ The commands below assume you have **Docker** installed. To use a **local** copy
 **Contributing**
 
 - Run `yarn build:test` and `yarn test` to make sure everything works.
-- Run `yarn prettier` to format the typescript files.
+- Run `yarn format` to format the typescript files.
 - Commit the changes:
   - Also include the generated `.bin` files for the tests where you added or modified `.proto` files.
     > These are checked into git so that the test suite can run without having to invoke the `protoc` build chain.

--- a/integration/nice-grpc/simple.ts
+++ b/integration/nice-grpc/simple.ts
@@ -1,5 +1,5 @@
 /* eslint-disable */
-import { CallContext, CallOptions } from "nice-grpc-common";
+import type { CallContext, CallOptions } from "nice-grpc-common";
 import * as _m0 from "protobufjs/minimal";
 import { Empty } from "./google/protobuf/empty";
 import { ListValue, Struct, Value } from "./google/protobuf/struct";

--- a/src/generate-nice-grpc.ts
+++ b/src/generate-nice-grpc.ts
@@ -6,8 +6,8 @@ import SourceInfo, { Fields } from "./sourceInfo";
 import { messageToTypeName } from "./types";
 import { assertInstanceOf, FormattedMethodDescriptor, maybeAddComment } from "./utils";
 
-const CallOptions = imp("CallOptions@nice-grpc-common");
-const CallContext = imp("CallContext@nice-grpc-common");
+const CallOptions = imp("t:CallOptions@nice-grpc-common");
+const CallContext = imp("t:CallContext@nice-grpc-common");
 
 /**
  * Generates server / client stubs for `nice-grpc` library.


### PR DESCRIPTION
This PR proposes two changes:
 - When generating the `nice-grpc` output, the `CallContext` and `CallOptions` are not needed at runtime, so a `type`-only import is sufficient.
 - Format code step in the documentation.

Closes #677

----

Great lib, thank you!