### PR TITLE
feat: option useSnakeTypeName

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -464,6 +464,24 @@ Generated code will be placed in the Gradle build directory.
 
 - With `--ts_proto_opt=useReadonlyTypes=true`, the generated types will be declared as immutable using typescript's `readonly` modifer.
 
+- With `--ts_proto_opt=useSnakeTypeName=false` will remove snake casing from types. 
+  
+  Example Protobuf
+  ```protobuf
+  message Box {
+      message Element {
+            message Image {
+                  enum Alignment {
+                        LEFT = 1;
+                        CENTER = 2;
+                        RIGHT = 3;
+                  }
+            }
+        }
+  }
+  ```
+  by default this is enabled which would generate a type of `Box_Element_Image_Alignment`. By disabling this option the type that is generated would be `BoxElementImageAlignment`. 
+
 ### NestJS Support
 
 We have a great way of working together with [nestjs](https://docs.nestjs.com/microservices/grpc). `ts-proto` generates `interfaces` and `decorators` for you controller, client. For more information see the [nestjs readme](NESTJS.markdown).

--- a/src/options.ts
+++ b/src/options.ts
@@ -74,6 +74,7 @@ export type Options = {
   initializeFieldsAsUndefined: boolean;
   useMapType: boolean;
   useReadonlyTypes: boolean;
+  useSnakeTypeName: boolean;
   M: { [from: string]: string };
 };
 
@@ -119,6 +120,7 @@ export function defaultOptions(): Options {
     initializeFieldsAsUndefined: true,
     useMapType: false,
     useReadonlyTypes: false,
+    useSnakeTypeName: true,
     M: {},
   };
 }

--- a/src/visit.ts
+++ b/src/visit.ts
@@ -53,7 +53,8 @@ export function visit(
     const tsFullName = tsPrefix + maybeSnakeToCamel(messageName(message), options);
     const nestedSourceInfo = sourceInfo.open(childType, index);
     messageFn(tsFullName, message, nestedSourceInfo, protoFullName);
-    visit(message, nestedSourceInfo, messageFn, options, enumFn, tsFullName + "_", protoFullName + ".");
+    const delim = options.useSnakeTypeName ? "_" : "";
+    visit(message, nestedSourceInfo, messageFn, options, enumFn, tsFullName + delim, protoFullName + ".");
   });
 }
 

--- a/tests/options-test.ts
+++ b/tests/options-test.ts
@@ -50,6 +50,7 @@ describe("options", () => {
         "useOptionals": "none",
         "usePrototypeForDefaults": false,
         "useReadonlyTypes": false,
+        "useSnakeTypeName": true,
       }
     `);
   });
@@ -133,6 +134,13 @@ describe("options", () => {
     const options = optionsFromParameter("useJsonWireFormat=true");
     expect(options).toMatchObject({
       useJsonWireFormat: false,
+    });
+  });
+
+  it("useSnakeTypeName", () => {
+    const options = optionsFromParameter("useSnakeTypeName=false");
+    expect(options).toMatchObject({
+      useSnakeTypeName: false,
     });
   });
 


### PR DESCRIPTION
### Summary
Adding option to change out the types that are generated. 
Example Proto:
```ProtoBuf
message Box {
     message Element {
           message Image {
                 enum Alignment {
                      LEFT = 1;
                      CENTER = 2;
                      RIGHT = 3;
                 }
           }
      }
}
```
before this change would generate a type `Box_Element_Image_Alignment`.  Now with this change it will allow the ability to remove the extra snake casing on the type names and generate `BoxElementImageAlignment`. 