### PR TITLE
feat: conditionally add "Service" to nice-grpc's generated service interface name

### DIFF
--- a/src/generate-nice-grpc.ts
+++ b/src/generate-nice-grpc.ts
@@ -29,7 +29,7 @@ export function generateNiceGrpcService(
 function generateServerStub(ctx: Context, sourceInfo: SourceInfo, serviceDesc: ServiceDescriptorProto) {
   const chunks: Code[] = [];
 
-  chunks.push(code`export interface ${def(`${serviceDesc.name}ServiceImplementation`)}<CallContextExt = {}> {`);
+  chunks.push(code`export interface ${def(`${serviceDesc.name}${serviceDesc.name.endsWith('Service') ? '' : 'Service'}Implementation`)}<CallContextExt = {}> {`);
 
   for (const [index, methodDesc] of serviceDesc.method.entries()) {
     assertInstanceOf(methodDesc, FormattedMethodDescriptor);

--- a/src/generate-nice-grpc.ts
+++ b/src/generate-nice-grpc.ts
@@ -29,7 +29,8 @@ export function generateNiceGrpcService(
 function generateServerStub(ctx: Context, sourceInfo: SourceInfo, serviceDesc: ServiceDescriptorProto) {
   const chunks: Code[] = [];
 
-  chunks.push(code`export interface ${def(`${serviceDesc.name}${serviceDesc.name.endsWith('Service') ? '' : 'Service'}Implementation`)}<CallContextExt = {}> {`);
+  const maybeSuffix = serviceDesc.name.endsWith("Service") ? "" : "Service";
+  chunks.push(code`export interface ${def(`${serviceDesc.name}${maybeSuffix}Implementation`)}<CallContextExt = {}> {`);
 
   for (const [index, methodDesc] of serviceDesc.method.entries()) {
     assertInstanceOf(methodDesc, FormattedMethodDescriptor);


### PR DESCRIPTION
Considering the fact that [Buf](https://buf.build) is gaining popularity and that their [default lint](https://docs.buf.build/tour/lint-your-api) configuration expects a "Service" suffix, it might be nice to avoid adding it to `nice-grpc`'s interface name automatically.

Also, in Google's Resource Oriented Design documentation, services are suffixed with "Service" ([here](https://cloud.google.com/apis/design/resource_names#resource_name_as_string), `service LibraryService`).

If you prefer, I can implement it using an option (`--ts_proto_opt=niceGrpcServiceSuffix`).
