### PR TITLE
feat: add create utility function to message defintions

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -167,6 +167,10 @@ Along with `encode`/`decode` factory methods:
 
 ```typescript
 export const Simple = {
+  create(baseObject?: DeepPartial<Simple>): Simple {
+    ...
+  },
+
   encode(message: Simple, writer: Writer = Writer.create()): Writer {
     ...
   },
@@ -332,7 +336,7 @@ Generated code will be placed in the Gradle build directory.
 
   So, between typo-prevention, reader inconsistency, and proper initialization, ts-proto recommends using `useOptionals=none` as the "most safe" option.
 
-  All that said, this approach does require writers/creators to set every field (although `fromPartial` is meant to address this), so if you still want to have optional fields, you can set `useOptionals=messages` or `useOptionals=all`.
+  All that said, this approach does require writers/creators to set every field (although `fromPartial` and `create` are meant to address this), so if you still want to have optional fields, you can set `useOptionals=messages` or `useOptionals=all`.
 
   (See [this issue](https://github.com/stephenh/ts-proto/issues/120#issuecomment-678375833) and [this issue](https://github.com/stephenh/ts-proto/issues/397#issuecomment-977259118) for discussions on `useOptional`.)
 
@@ -368,7 +372,7 @@ Generated code will be placed in the Gradle build directory.
 
   This is also useful if you want "only types".
 
-- With `--ts_proto_opt=outputPartialMethods=false`, the `Message.fromPartial` methods for accepting partially-formed objects/object literals will not be output.
+- With `--ts_proto_opt=outputPartialMethods=false`, the `Message.fromPartial` and `Message.create` methods for accepting partially-formed objects/object literals will not be output.
 
 - With `--ts_proto_opt=stringEnums=true`, the generated enum types will be string-based instead of int-based.
 
@@ -433,9 +437,9 @@ Generated code will be placed in the Gradle build directory.
 
 - With `--ts_proto_opt=enumsAsLiterals=true`, the generated enum types will be enum-ish object with `as const`.
 
-- With `--ts_proto_opt=useExactTypes=false`, the generated `fromPartial` method will not use Exact types.
+- With `--ts_proto_opt=useExactTypes=false`, the generated `fromPartial` and `create` methods will not use Exact types.
 
-  The default behavior is `useExactTypes=true`, which makes `fromPartial` use Exact type for its argument to make TypeScript reject any unknown properties.
+  The default behavior is `useExactTypes=true`, which makes `fromPartial` and `create` use Exact type for its argument to make TypeScript reject any unknown properties.
 
 - With `--ts_proto_opt=unknownFields=true`, all unknown fields will be parsed and output as arrays of buffers.
 

--- a/integration/angular/simple-message.ts
+++ b/integration/angular/simple-message.ts
@@ -47,6 +47,10 @@ export const SimpleMessage = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<SimpleMessage>, I>>(base?: I): SimpleMessage {
+    return SimpleMessage.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<SimpleMessage>, I>>(object: I): SimpleMessage {
     const message = createBaseSimpleMessage();
     message.numberField = object.numberField ?? 0;

--- a/integration/async-iterable-services-abort-signal/simple.ts
+++ b/integration/async-iterable-services-abort-signal/simple.ts
@@ -80,6 +80,10 @@ export const EchoMsg = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<EchoMsg>, I>>(base?: I): EchoMsg {
+    return EchoMsg.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<EchoMsg>, I>>(object: I): EchoMsg {
     const message = createBaseEchoMsg();
     message.body = object.body ?? "";

--- a/integration/async-iterable-services/simple.ts
+++ b/integration/async-iterable-services/simple.ts
@@ -80,6 +80,10 @@ export const EchoMsg = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<EchoMsg>, I>>(base?: I): EchoMsg {
+    return EchoMsg.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<EchoMsg>, I>>(object: I): EchoMsg {
     const message = createBaseEchoMsg();
     message.body = object.body ?? "";

--- a/integration/avoid-import-conflicts/simple.ts
+++ b/integration/avoid-import-conflicts/simple.ts
@@ -120,6 +120,10 @@ export const Simple = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Simple>, I>>(base?: I): Simple {
+    return Simple.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Simple>, I>>(object: I): Simple {
     const message = createBaseSimple();
     message.name = object.name ?? "";
@@ -180,6 +184,10 @@ export const SimpleEnums = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<SimpleEnums>, I>>(base?: I): SimpleEnums {
+    return SimpleEnums.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<SimpleEnums>, I>>(object: I): SimpleEnums {
     const message = createBaseSimpleEnums();
     message.localEnum = object.localEnum ?? 0;
@@ -228,6 +236,10 @@ export const FooServiceCreateRequest = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<FooServiceCreateRequest>, I>>(base?: I): FooServiceCreateRequest {
+    return FooServiceCreateRequest.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<FooServiceCreateRequest>, I>>(object: I): FooServiceCreateRequest {
     const message = createBaseFooServiceCreateRequest();
     message.kind = object.kind ?? 0;
@@ -273,6 +285,10 @@ export const FooServiceCreateResponse = {
     const obj: any = {};
     message.kind !== undefined && (obj.kind = fooServiceToJSON(message.kind));
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<FooServiceCreateResponse>, I>>(base?: I): FooServiceCreateResponse {
+    return FooServiceCreateResponse.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<FooServiceCreateResponse>, I>>(object: I): FooServiceCreateResponse {

--- a/integration/avoid-import-conflicts/simple2.ts
+++ b/integration/avoid-import-conflicts/simple2.ts
@@ -133,6 +133,10 @@ export const Simple = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Simple>, I>>(base?: I): Simple {
+    return Simple.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Simple>, I>>(object: I): Simple {
     const message = createBaseSimple();
     message.name = object.name ?? "";

--- a/integration/barrel-imports/bar.ts
+++ b/integration/barrel-imports/bar.ts
@@ -53,6 +53,10 @@ export const Bar = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Bar>, I>>(base?: I): Bar {
+    return Bar.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Bar>, I>>(object: I): Bar {
     const message = createBaseBar();
     message.name = object.name ?? "";

--- a/integration/barrel-imports/foo.ts
+++ b/integration/barrel-imports/foo.ts
@@ -57,6 +57,10 @@ export const Foo = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Foo>, I>>(base?: I): Foo {
+    return Foo.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Foo>, I>>(object: I): Foo {
     const message = createBaseFoo();
     message.name = object.name ?? "";

--- a/integration/batching-with-context/batching.ts
+++ b/integration/batching-with-context/batching.ts
@@ -90,6 +90,10 @@ export const BatchQueryRequest = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<BatchQueryRequest>, I>>(base?: I): BatchQueryRequest {
+    return BatchQueryRequest.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<BatchQueryRequest>, I>>(object: I): BatchQueryRequest {
     const message = createBaseBatchQueryRequest();
     message.ids = object.ids?.map((e) => e) || [];
@@ -141,6 +145,10 @@ export const BatchQueryResponse = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<BatchQueryResponse>, I>>(base?: I): BatchQueryResponse {
+    return BatchQueryResponse.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<BatchQueryResponse>, I>>(object: I): BatchQueryResponse {
     const message = createBaseBatchQueryResponse();
     message.entities = object.entities?.map((e) => Entity.fromPartial(e)) || [];
@@ -190,6 +198,10 @@ export const BatchMapQueryRequest = {
       obj.ids = [];
     }
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<BatchMapQueryRequest>, I>>(base?: I): BatchMapQueryRequest {
+    return BatchMapQueryRequest.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<BatchMapQueryRequest>, I>>(object: I): BatchMapQueryRequest {
@@ -254,6 +266,10 @@ export const BatchMapQueryResponse = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<BatchMapQueryResponse>, I>>(base?: I): BatchMapQueryResponse {
+    return BatchMapQueryResponse.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<BatchMapQueryResponse>, I>>(object: I): BatchMapQueryResponse {
     const message = createBaseBatchMapQueryResponse();
     message.entities = Object.entries(object.entities ?? {}).reduce<{ [key: string]: Entity }>((acc, [key, value]) => {
@@ -316,6 +332,12 @@ export const BatchMapQueryResponse_EntitiesEntry = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<BatchMapQueryResponse_EntitiesEntry>, I>>(
+    base?: I,
+  ): BatchMapQueryResponse_EntitiesEntry {
+    return BatchMapQueryResponse_EntitiesEntry.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<BatchMapQueryResponse_EntitiesEntry>, I>>(
     object: I,
   ): BatchMapQueryResponse_EntitiesEntry {
@@ -368,6 +390,10 @@ export const GetOnlyMethodRequest = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<GetOnlyMethodRequest>, I>>(base?: I): GetOnlyMethodRequest {
+    return GetOnlyMethodRequest.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<GetOnlyMethodRequest>, I>>(object: I): GetOnlyMethodRequest {
     const message = createBaseGetOnlyMethodRequest();
     message.id = object.id ?? "";
@@ -413,6 +439,10 @@ export const GetOnlyMethodResponse = {
     const obj: any = {};
     message.entity !== undefined && (obj.entity = message.entity ? Entity.toJSON(message.entity) : undefined);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<GetOnlyMethodResponse>, I>>(base?: I): GetOnlyMethodResponse {
+    return GetOnlyMethodResponse.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<GetOnlyMethodResponse>, I>>(object: I): GetOnlyMethodResponse {
@@ -464,6 +494,10 @@ export const WriteMethodRequest = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<WriteMethodRequest>, I>>(base?: I): WriteMethodRequest {
+    return WriteMethodRequest.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<WriteMethodRequest>, I>>(object: I): WriteMethodRequest {
     const message = createBaseWriteMethodRequest();
     message.id = object.id ?? "";
@@ -502,6 +536,10 @@ export const WriteMethodResponse = {
   toJSON(_: WriteMethodResponse): unknown {
     const obj: any = {};
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<WriteMethodResponse>, I>>(base?: I): WriteMethodResponse {
+    return WriteMethodResponse.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<WriteMethodResponse>, I>>(_: I): WriteMethodResponse {
@@ -555,6 +593,10 @@ export const Entity = {
     message.id !== undefined && (obj.id = message.id);
     message.name !== undefined && (obj.name = message.name);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Entity>, I>>(base?: I): Entity {
+    return Entity.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<Entity>, I>>(object: I): Entity {

--- a/integration/batching/batching.ts
+++ b/integration/batching/batching.ts
@@ -88,6 +88,10 @@ export const BatchQueryRequest = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<BatchQueryRequest>, I>>(base?: I): BatchQueryRequest {
+    return BatchQueryRequest.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<BatchQueryRequest>, I>>(object: I): BatchQueryRequest {
     const message = createBaseBatchQueryRequest();
     message.ids = object.ids?.map((e) => e) || [];
@@ -139,6 +143,10 @@ export const BatchQueryResponse = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<BatchQueryResponse>, I>>(base?: I): BatchQueryResponse {
+    return BatchQueryResponse.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<BatchQueryResponse>, I>>(object: I): BatchQueryResponse {
     const message = createBaseBatchQueryResponse();
     message.entities = object.entities?.map((e) => Entity.fromPartial(e)) || [];
@@ -188,6 +196,10 @@ export const BatchMapQueryRequest = {
       obj.ids = [];
     }
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<BatchMapQueryRequest>, I>>(base?: I): BatchMapQueryRequest {
+    return BatchMapQueryRequest.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<BatchMapQueryRequest>, I>>(object: I): BatchMapQueryRequest {
@@ -252,6 +264,10 @@ export const BatchMapQueryResponse = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<BatchMapQueryResponse>, I>>(base?: I): BatchMapQueryResponse {
+    return BatchMapQueryResponse.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<BatchMapQueryResponse>, I>>(object: I): BatchMapQueryResponse {
     const message = createBaseBatchMapQueryResponse();
     message.entities = Object.entries(object.entities ?? {}).reduce<{ [key: string]: Entity }>((acc, [key, value]) => {
@@ -314,6 +330,12 @@ export const BatchMapQueryResponse_EntitiesEntry = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<BatchMapQueryResponse_EntitiesEntry>, I>>(
+    base?: I,
+  ): BatchMapQueryResponse_EntitiesEntry {
+    return BatchMapQueryResponse_EntitiesEntry.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<BatchMapQueryResponse_EntitiesEntry>, I>>(
     object: I,
   ): BatchMapQueryResponse_EntitiesEntry {
@@ -366,6 +388,10 @@ export const GetOnlyMethodRequest = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<GetOnlyMethodRequest>, I>>(base?: I): GetOnlyMethodRequest {
+    return GetOnlyMethodRequest.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<GetOnlyMethodRequest>, I>>(object: I): GetOnlyMethodRequest {
     const message = createBaseGetOnlyMethodRequest();
     message.id = object.id ?? "";
@@ -411,6 +437,10 @@ export const GetOnlyMethodResponse = {
     const obj: any = {};
     message.entity !== undefined && (obj.entity = message.entity ? Entity.toJSON(message.entity) : undefined);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<GetOnlyMethodResponse>, I>>(base?: I): GetOnlyMethodResponse {
+    return GetOnlyMethodResponse.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<GetOnlyMethodResponse>, I>>(object: I): GetOnlyMethodResponse {
@@ -462,6 +492,10 @@ export const WriteMethodRequest = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<WriteMethodRequest>, I>>(base?: I): WriteMethodRequest {
+    return WriteMethodRequest.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<WriteMethodRequest>, I>>(object: I): WriteMethodRequest {
     const message = createBaseWriteMethodRequest();
     message.id = object.id ?? "";
@@ -500,6 +534,10 @@ export const WriteMethodResponse = {
   toJSON(_: WriteMethodResponse): unknown {
     const obj: any = {};
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<WriteMethodResponse>, I>>(base?: I): WriteMethodResponse {
+    return WriteMethodResponse.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<WriteMethodResponse>, I>>(_: I): WriteMethodResponse {
@@ -553,6 +591,10 @@ export const Entity = {
     message.id !== undefined && (obj.id = message.id);
     message.name !== undefined && (obj.name = message.name);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Entity>, I>>(base?: I): Entity {
+    return Entity.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<Entity>, I>>(object: I): Entity {

--- a/integration/bytes-as-base64/message.ts
+++ b/integration/bytes-as-base64/message.ts
@@ -22,6 +22,10 @@ export const Message = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Message>, I>>(base?: I): Message {
+    return Message.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Message>, I>>(object: I): Message {
     const message = createBaseMessage();
     message.data = object.data ?? new Uint8Array();

--- a/integration/bytes-node/google/protobuf/wrappers.ts
+++ b/integration/bytes-node/google/protobuf/wrappers.ts
@@ -134,6 +134,10 @@ export const DoubleValue = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<DoubleValue>, I>>(base?: I): DoubleValue {
+    return DoubleValue.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<DoubleValue>, I>>(object: I): DoubleValue {
     const message = createBaseDoubleValue();
     message.value = object.value ?? 0;
@@ -179,6 +183,10 @@ export const FloatValue = {
     const obj: any = {};
     message.value !== undefined && (obj.value = message.value);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<FloatValue>, I>>(base?: I): FloatValue {
+    return FloatValue.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<FloatValue>, I>>(object: I): FloatValue {
@@ -228,6 +236,10 @@ export const Int64Value = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Int64Value>, I>>(base?: I): Int64Value {
+    return Int64Value.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Int64Value>, I>>(object: I): Int64Value {
     const message = createBaseInt64Value();
     message.value = object.value ?? 0;
@@ -273,6 +285,10 @@ export const UInt64Value = {
     const obj: any = {};
     message.value !== undefined && (obj.value = Math.round(message.value));
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<UInt64Value>, I>>(base?: I): UInt64Value {
+    return UInt64Value.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<UInt64Value>, I>>(object: I): UInt64Value {
@@ -322,6 +338,10 @@ export const Int32Value = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Int32Value>, I>>(base?: I): Int32Value {
+    return Int32Value.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Int32Value>, I>>(object: I): Int32Value {
     const message = createBaseInt32Value();
     message.value = object.value ?? 0;
@@ -367,6 +387,10 @@ export const UInt32Value = {
     const obj: any = {};
     message.value !== undefined && (obj.value = Math.round(message.value));
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<UInt32Value>, I>>(base?: I): UInt32Value {
+    return UInt32Value.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<UInt32Value>, I>>(object: I): UInt32Value {
@@ -416,6 +440,10 @@ export const BoolValue = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<BoolValue>, I>>(base?: I): BoolValue {
+    return BoolValue.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<BoolValue>, I>>(object: I): BoolValue {
     const message = createBaseBoolValue();
     message.value = object.value ?? false;
@@ -461,6 +489,10 @@ export const StringValue = {
     const obj: any = {};
     message.value !== undefined && (obj.value = message.value);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<StringValue>, I>>(base?: I): StringValue {
+    return StringValue.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<StringValue>, I>>(object: I): StringValue {
@@ -509,6 +541,10 @@ export const BytesValue = {
     message.value !== undefined &&
       (obj.value = base64FromBytes(message.value !== undefined ? message.value : Buffer.alloc(0)));
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<BytesValue>, I>>(base?: I): BytesValue {
+    return BytesValue.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<BytesValue>, I>>(object: I): BytesValue {

--- a/integration/bytes-node/point.ts
+++ b/integration/bytes-node/point.ts
@@ -60,6 +60,10 @@ export const Point = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Point>, I>>(base?: I): Point {
+    return Point.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Point>, I>>(object: I): Point {
     const message = createBasePoint();
     message.data = object.data ?? Buffer.alloc(0);

--- a/integration/const-enum/const-enum.ts
+++ b/integration/const-enum/const-enum.ts
@@ -137,6 +137,10 @@ export const DividerData = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<DividerData>, I>>(base?: I): DividerData {
+    return DividerData.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<DividerData>, I>>(object: I): DividerData {
     const message = createBaseDividerData();
     message.type = object.type ?? DividerData_DividerType.DOUBLE;
@@ -201,6 +205,10 @@ export const DividerData_TypeMapEntry = {
     message.key !== undefined && (obj.key = message.key);
     message.value !== undefined && (obj.value = dividerData_DividerTypeToJSON(message.value));
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<DividerData_TypeMapEntry>, I>>(base?: I): DividerData_TypeMapEntry {
+    return DividerData_TypeMapEntry.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<DividerData_TypeMapEntry>, I>>(object: I): DividerData_TypeMapEntry {

--- a/integration/enums-as-literals-with-string-enums/enums-as-literals-with-string-enums.ts
+++ b/integration/enums-as-literals-with-string-enums/enums-as-literals-with-string-enums.ts
@@ -110,6 +110,10 @@ export const DividerData = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<DividerData>, I>>(base?: I): DividerData {
+    return DividerData.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<DividerData>, I>>(object: I): DividerData {
     const message = createBaseDividerData();
     message.type = object.type ?? DividerData_DividerType.DOUBLE;

--- a/integration/enums-as-literals/enums-as-literals.ts
+++ b/integration/enums-as-literals/enums-as-literals.ts
@@ -88,6 +88,10 @@ export const DividerData = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<DividerData>, I>>(base?: I): DividerData {
+    return DividerData.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<DividerData>, I>>(object: I): DividerData {
     const message = createBaseDividerData();
     message.type = object.type ?? 0;

--- a/integration/fieldmask/fieldmask.ts
+++ b/integration/fieldmask/fieldmask.ts
@@ -48,6 +48,10 @@ export const FieldMaskMessage = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<FieldMaskMessage>, I>>(base?: I): FieldMaskMessage {
+    return FieldMaskMessage.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<FieldMaskMessage>, I>>(object: I): FieldMaskMessage {
     const message = createBaseFieldMaskMessage();
     message.fieldMask = object.fieldMask ?? undefined;

--- a/integration/fieldmask/google/protobuf/field_mask.ts
+++ b/integration/fieldmask/google/protobuf/field_mask.ts
@@ -252,6 +252,10 @@ export const FieldMask = {
     return message.paths.join(",");
   },
 
+  create<I extends Exact<DeepPartial<FieldMask>, I>>(base?: I): FieldMask {
+    return FieldMask.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<FieldMask>, I>>(object: I): FieldMask {
     const message = createBaseFieldMask();
     message.paths = object.paths?.map((e) => e) || [];

--- a/integration/file-suffix/child.pb.ts
+++ b/integration/file-suffix/child.pb.ts
@@ -80,6 +80,10 @@ export const Child = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Child>, I>>(base?: I): Child {
+    return Child.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Child>, I>>(object: I): Child {
     const message = createBaseChild();
     message.name = object.name ?? "";

--- a/integration/file-suffix/google/protobuf/timestamp.pb.ts
+++ b/integration/file-suffix/google/protobuf/timestamp.pb.ts
@@ -161,6 +161,10 @@ export const Timestamp = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Timestamp>, I>>(base?: I): Timestamp {
+    return Timestamp.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Timestamp>, I>>(object: I): Timestamp {
     const message = createBaseTimestamp();
     message.seconds = object.seconds ?? 0;

--- a/integration/file-suffix/parent.pb.ts
+++ b/integration/file-suffix/parent.pb.ts
@@ -69,6 +69,10 @@ export const Parent = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Parent>, I>>(base?: I): Parent {
+    return Parent.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Parent>, I>>(object: I): Parent {
     const message = createBaseParent();
     message.child = (object.child !== undefined && object.child !== null) ? Child.fromPartial(object.child) : undefined;

--- a/integration/generic-metadata/hero.ts
+++ b/integration/generic-metadata/hero.ts
@@ -64,6 +64,10 @@ export const HeroById = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<HeroById>, I>>(base?: I): HeroById {
+    return HeroById.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<HeroById>, I>>(object: I): HeroById {
     const message = createBaseHeroById();
     message.id = object.id ?? 0;
@@ -109,6 +113,10 @@ export const VillainById = {
     const obj: any = {};
     message.id !== undefined && (obj.id = Math.round(message.id));
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<VillainById>, I>>(base?: I): VillainById {
+    return VillainById.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<VillainById>, I>>(object: I): VillainById {
@@ -165,6 +173,10 @@ export const Hero = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Hero>, I>>(base?: I): Hero {
+    return Hero.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Hero>, I>>(object: I): Hero {
     const message = createBaseHero();
     message.id = object.id ?? 0;
@@ -218,6 +230,10 @@ export const Villain = {
     message.id !== undefined && (obj.id = Math.round(message.id));
     message.name !== undefined && (obj.name = message.name);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Villain>, I>>(base?: I): Villain {
+    return Villain.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<Villain>, I>>(object: I): Villain {

--- a/integration/generic-service-definitions-and-services/simple.ts
+++ b/integration/generic-service-definitions-and-services/simple.ts
@@ -47,6 +47,10 @@ export const TestMessage = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<TestMessage>, I>>(base?: I): TestMessage {
+    return TestMessage.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<TestMessage>, I>>(object: I): TestMessage {
     const message = createBaseTestMessage();
     message.value = object.value ?? "";

--- a/integration/generic-service-definitions/simple.ts
+++ b/integration/generic-service-definitions/simple.ts
@@ -47,6 +47,10 @@ export const TestMessage = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<TestMessage>, I>>(base?: I): TestMessage {
+    return TestMessage.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<TestMessage>, I>>(object: I): TestMessage {
     const message = createBaseTestMessage();
     message.value = object.value ?? "";

--- a/integration/global-this/global-this.ts
+++ b/integration/global-this/global-this.ts
@@ -51,6 +51,10 @@ export const Object = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Object>, I>>(base?: I): Object {
+    return Object.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Object>, I>>(object: I): Object {
     const message = createBaseObject();
     message.name = object.name ?? "";
@@ -96,6 +100,10 @@ export const Error = {
     const obj: any = {};
     message.name !== undefined && (obj.name = message.name);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Error>, I>>(base?: I): Error {
+    return Error.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<Error>, I>>(object: I): Error {

--- a/integration/grpc-js-use-date-false/google/protobuf/timestamp.ts
+++ b/integration/grpc-js-use-date-false/google/protobuf/timestamp.ts
@@ -161,6 +161,10 @@ export const Timestamp = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Timestamp>, I>>(base?: I): Timestamp {
+    return Timestamp.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Timestamp>, I>>(object: I): Timestamp {
     const message = createBaseTimestamp();
     message.seconds = object.seconds ?? 0;

--- a/integration/grpc-js-use-date-false/grpc-js-use-date-false.ts
+++ b/integration/grpc-js-use-date-false/grpc-js-use-date-false.ts
@@ -60,6 +60,10 @@ export const TimestampMessage = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<TimestampMessage>, I>>(base?: I): TimestampMessage {
+    return TimestampMessage.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<TimestampMessage>, I>>(object: I): TimestampMessage {
     const message = createBaseTimestampMessage();
     message.timestamp = (object.timestamp !== undefined && object.timestamp !== null)

--- a/integration/grpc-js-use-date-string/google/protobuf/timestamp.ts
+++ b/integration/grpc-js-use-date-string/google/protobuf/timestamp.ts
@@ -161,6 +161,10 @@ export const Timestamp = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Timestamp>, I>>(base?: I): Timestamp {
+    return Timestamp.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Timestamp>, I>>(object: I): Timestamp {
     const message = createBaseTimestamp();
     message.seconds = object.seconds ?? 0;

--- a/integration/grpc-js-use-date-string/grpc-js-use-date-string.ts
+++ b/integration/grpc-js-use-date-string/grpc-js-use-date-string.ts
@@ -60,6 +60,10 @@ export const TimestampMessage = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<TimestampMessage>, I>>(base?: I): TimestampMessage {
+    return TimestampMessage.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<TimestampMessage>, I>>(object: I): TimestampMessage {
     const message = createBaseTimestampMessage();
     message.timestamp = object.timestamp ?? undefined;

--- a/integration/grpc-js-use-date-true/google/protobuf/timestamp.ts
+++ b/integration/grpc-js-use-date-true/google/protobuf/timestamp.ts
@@ -161,6 +161,10 @@ export const Timestamp = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Timestamp>, I>>(base?: I): Timestamp {
+    return Timestamp.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Timestamp>, I>>(object: I): Timestamp {
     const message = createBaseTimestamp();
     message.seconds = object.seconds ?? 0;

--- a/integration/grpc-js-use-date-true/grpc-js-use-date-true.ts
+++ b/integration/grpc-js-use-date-true/grpc-js-use-date-true.ts
@@ -60,6 +60,10 @@ export const TimestampMessage = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<TimestampMessage>, I>>(base?: I): TimestampMessage {
+    return TimestampMessage.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<TimestampMessage>, I>>(object: I): TimestampMessage {
     const message = createBaseTimestampMessage();
     message.timestamp = object.timestamp ?? undefined;

--- a/integration/grpc-js/google/protobuf/empty.ts
+++ b/integration/grpc-js/google/protobuf/empty.ts
@@ -50,6 +50,10 @@ export const Empty = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Empty>, I>>(base?: I): Empty {
+    return Empty.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Empty>, I>>(_: I): Empty {
     const message = createBaseEmpty();
     return message;

--- a/integration/grpc-js/google/protobuf/struct.ts
+++ b/integration/grpc-js/google/protobuf/struct.ts
@@ -157,6 +157,10 @@ export const Struct = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Struct>, I>>(base?: I): Struct {
+    return Struct.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Struct>, I>>(object: I): Struct {
     const message = createBaseStruct();
     message.fields = Object.entries(object.fields ?? {}).reduce<{ [key: string]: any | undefined }>(
@@ -235,6 +239,10 @@ export const Struct_FieldsEntry = {
     message.key !== undefined && (obj.key = message.key);
     message.value !== undefined && (obj.value = message.value);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Struct_FieldsEntry>, I>>(base?: I): Struct_FieldsEntry {
+    return Struct_FieldsEntry.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<Struct_FieldsEntry>, I>>(object: I): Struct_FieldsEntry {
@@ -335,6 +343,10 @@ export const Value = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Value>, I>>(base?: I): Value {
+    return Value.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Value>, I>>(object: I): Value {
     const message = createBaseValue();
     message.nullValue = object.nullValue ?? undefined;
@@ -428,6 +440,10 @@ export const ListValue = {
       obj.values = [];
     }
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<ListValue>, I>>(base?: I): ListValue {
+    return ListValue.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<ListValue>, I>>(object: I): ListValue {

--- a/integration/grpc-js/google/protobuf/timestamp.ts
+++ b/integration/grpc-js/google/protobuf/timestamp.ts
@@ -161,6 +161,10 @@ export const Timestamp = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Timestamp>, I>>(base?: I): Timestamp {
+    return Timestamp.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Timestamp>, I>>(object: I): Timestamp {
     const message = createBaseTimestamp();
     message.seconds = object.seconds ?? 0;

--- a/integration/grpc-js/google/protobuf/wrappers.ts
+++ b/integration/grpc-js/google/protobuf/wrappers.ts
@@ -134,6 +134,10 @@ export const DoubleValue = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<DoubleValue>, I>>(base?: I): DoubleValue {
+    return DoubleValue.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<DoubleValue>, I>>(object: I): DoubleValue {
     const message = createBaseDoubleValue();
     message.value = object.value ?? 0;
@@ -179,6 +183,10 @@ export const FloatValue = {
     const obj: any = {};
     message.value !== undefined && (obj.value = message.value);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<FloatValue>, I>>(base?: I): FloatValue {
+    return FloatValue.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<FloatValue>, I>>(object: I): FloatValue {
@@ -228,6 +236,10 @@ export const Int64Value = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Int64Value>, I>>(base?: I): Int64Value {
+    return Int64Value.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Int64Value>, I>>(object: I): Int64Value {
     const message = createBaseInt64Value();
     message.value = object.value ?? 0;
@@ -273,6 +285,10 @@ export const UInt64Value = {
     const obj: any = {};
     message.value !== undefined && (obj.value = Math.round(message.value));
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<UInt64Value>, I>>(base?: I): UInt64Value {
+    return UInt64Value.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<UInt64Value>, I>>(object: I): UInt64Value {
@@ -322,6 +338,10 @@ export const Int32Value = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Int32Value>, I>>(base?: I): Int32Value {
+    return Int32Value.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Int32Value>, I>>(object: I): Int32Value {
     const message = createBaseInt32Value();
     message.value = object.value ?? 0;
@@ -367,6 +387,10 @@ export const UInt32Value = {
     const obj: any = {};
     message.value !== undefined && (obj.value = Math.round(message.value));
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<UInt32Value>, I>>(base?: I): UInt32Value {
+    return UInt32Value.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<UInt32Value>, I>>(object: I): UInt32Value {
@@ -416,6 +440,10 @@ export const BoolValue = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<BoolValue>, I>>(base?: I): BoolValue {
+    return BoolValue.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<BoolValue>, I>>(object: I): BoolValue {
     const message = createBaseBoolValue();
     message.value = object.value ?? false;
@@ -461,6 +489,10 @@ export const StringValue = {
     const obj: any = {};
     message.value !== undefined && (obj.value = message.value);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<StringValue>, I>>(base?: I): StringValue {
+    return StringValue.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<StringValue>, I>>(object: I): StringValue {
@@ -509,6 +541,10 @@ export const BytesValue = {
     message.value !== undefined &&
       (obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array()));
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<BytesValue>, I>>(base?: I): BytesValue {
+    return BytesValue.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<BytesValue>, I>>(object: I): BytesValue {

--- a/integration/grpc-js/simple.ts
+++ b/integration/grpc-js/simple.ts
@@ -79,6 +79,10 @@ export const TestMessage = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<TestMessage>, I>>(base?: I): TestMessage {
+    return TestMessage.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<TestMessage>, I>>(object: I): TestMessage {
     const message = createBaseTestMessage();
     message.timestamp = object.timestamp ?? undefined;

--- a/integration/grpc-web-go-server/example.ts
+++ b/integration/grpc-web-go-server/example.ts
@@ -143,6 +143,10 @@ export const DashFlash = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<DashFlash>, I>>(base?: I): DashFlash {
+    return DashFlash.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<DashFlash>, I>>(object: I): DashFlash {
     const message = createBaseDashFlash();
     message.msg = object.msg ?? "";
@@ -214,6 +218,10 @@ export const DashUserSettingsState = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<DashUserSettingsState>, I>>(base?: I): DashUserSettingsState {
+    return DashUserSettingsState.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<DashUserSettingsState>, I>>(object: I): DashUserSettingsState {
     const message = createBaseDashUserSettingsState();
     message.email = object.email ?? "";
@@ -273,6 +281,10 @@ export const DashUserSettingsState_URLs = {
     message.connectGoogle !== undefined && (obj.connectGoogle = message.connectGoogle);
     message.connectGithub !== undefined && (obj.connectGithub = message.connectGithub);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<DashUserSettingsState_URLs>, I>>(base?: I): DashUserSettingsState_URLs {
+    return DashUserSettingsState_URLs.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<DashUserSettingsState_URLs>, I>>(object: I): DashUserSettingsState_URLs {
@@ -349,6 +361,10 @@ export const DashCred = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<DashCred>, I>>(base?: I): DashCred {
+    return DashCred.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<DashCred>, I>>(object: I): DashCred {
     const message = createBaseDashCred();
     message.description = object.description ?? "";
@@ -407,6 +423,10 @@ export const DashAPICredsCreateReq = {
     message.description !== undefined && (obj.description = message.description);
     message.metadata !== undefined && (obj.metadata = message.metadata);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<DashAPICredsCreateReq>, I>>(base?: I): DashAPICredsCreateReq {
+    return DashAPICredsCreateReq.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<DashAPICredsCreateReq>, I>>(object: I): DashAPICredsCreateReq {
@@ -483,6 +503,10 @@ export const DashAPICredsUpdateReq = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<DashAPICredsUpdateReq>, I>>(base?: I): DashAPICredsUpdateReq {
+    return DashAPICredsUpdateReq.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<DashAPICredsUpdateReq>, I>>(object: I): DashAPICredsUpdateReq {
     const message = createBaseDashAPICredsUpdateReq();
     message.credSid = object.credSid ?? "";
@@ -543,6 +567,10 @@ export const DashAPICredsDeleteReq = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<DashAPICredsDeleteReq>, I>>(base?: I): DashAPICredsDeleteReq {
+    return DashAPICredsDeleteReq.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<DashAPICredsDeleteReq>, I>>(object: I): DashAPICredsDeleteReq {
     const message = createBaseDashAPICredsDeleteReq();
     message.credSid = object.credSid ?? "";
@@ -582,6 +610,10 @@ export const Empty = {
   toJSON(_: Empty): unknown {
     const obj: any = {};
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Empty>, I>>(base?: I): Empty {
+    return Empty.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<Empty>, I>>(_: I): Empty {

--- a/integration/grpc-web-no-streaming-observable/example.ts
+++ b/integration/grpc-web-no-streaming-observable/example.ts
@@ -121,6 +121,10 @@ export const DashFlash = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<DashFlash>, I>>(base?: I): DashFlash {
+    return DashFlash.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<DashFlash>, I>>(object: I): DashFlash {
     const message = createBaseDashFlash();
     message.msg = object.msg ?? "";
@@ -192,6 +196,10 @@ export const DashUserSettingsState = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<DashUserSettingsState>, I>>(base?: I): DashUserSettingsState {
+    return DashUserSettingsState.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<DashUserSettingsState>, I>>(object: I): DashUserSettingsState {
     const message = createBaseDashUserSettingsState();
     message.email = object.email ?? "";
@@ -253,6 +261,10 @@ export const DashUserSettingsState_URLs = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<DashUserSettingsState_URLs>, I>>(base?: I): DashUserSettingsState_URLs {
+    return DashUserSettingsState_URLs.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<DashUserSettingsState_URLs>, I>>(object: I): DashUserSettingsState_URLs {
     const message = createBaseDashUserSettingsState_URLs();
     message.connectGoogle = object.connectGoogle ?? "";
@@ -292,6 +304,10 @@ export const Empty = {
   toJSON(_: Empty): unknown {
     const obj: any = {};
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Empty>, I>>(base?: I): Empty {
+    return Empty.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<Empty>, I>>(_: I): Empty {

--- a/integration/grpc-web-no-streaming/example.ts
+++ b/integration/grpc-web-no-streaming/example.ts
@@ -119,6 +119,10 @@ export const DashFlash = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<DashFlash>, I>>(base?: I): DashFlash {
+    return DashFlash.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<DashFlash>, I>>(object: I): DashFlash {
     const message = createBaseDashFlash();
     message.msg = object.msg ?? "";
@@ -190,6 +194,10 @@ export const DashUserSettingsState = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<DashUserSettingsState>, I>>(base?: I): DashUserSettingsState {
+    return DashUserSettingsState.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<DashUserSettingsState>, I>>(object: I): DashUserSettingsState {
     const message = createBaseDashUserSettingsState();
     message.email = object.email ?? "";
@@ -251,6 +259,10 @@ export const DashUserSettingsState_URLs = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<DashUserSettingsState_URLs>, I>>(base?: I): DashUserSettingsState_URLs {
+    return DashUserSettingsState_URLs.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<DashUserSettingsState_URLs>, I>>(object: I): DashUserSettingsState_URLs {
     const message = createBaseDashUserSettingsState_URLs();
     message.connectGoogle = object.connectGoogle ?? "";
@@ -290,6 +302,10 @@ export const Empty = {
   toJSON(_: Empty): unknown {
     const obj: any = {};
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Empty>, I>>(base?: I): Empty {
+    return Empty.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<Empty>, I>>(_: I): Empty {

--- a/integration/grpc-web/example.ts
+++ b/integration/grpc-web/example.ts
@@ -145,6 +145,10 @@ export const DashFlash = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<DashFlash>, I>>(base?: I): DashFlash {
+    return DashFlash.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<DashFlash>, I>>(object: I): DashFlash {
     const message = createBaseDashFlash();
     message.msg = object.msg ?? "";
@@ -216,6 +220,10 @@ export const DashUserSettingsState = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<DashUserSettingsState>, I>>(base?: I): DashUserSettingsState {
+    return DashUserSettingsState.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<DashUserSettingsState>, I>>(object: I): DashUserSettingsState {
     const message = createBaseDashUserSettingsState();
     message.email = object.email ?? "";
@@ -275,6 +283,10 @@ export const DashUserSettingsState_URLs = {
     message.connectGoogle !== undefined && (obj.connectGoogle = message.connectGoogle);
     message.connectGithub !== undefined && (obj.connectGithub = message.connectGithub);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<DashUserSettingsState_URLs>, I>>(base?: I): DashUserSettingsState_URLs {
+    return DashUserSettingsState_URLs.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<DashUserSettingsState_URLs>, I>>(object: I): DashUserSettingsState_URLs {
@@ -351,6 +363,10 @@ export const DashCred = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<DashCred>, I>>(base?: I): DashCred {
+    return DashCred.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<DashCred>, I>>(object: I): DashCred {
     const message = createBaseDashCred();
     message.description = object.description ?? "";
@@ -409,6 +425,10 @@ export const DashAPICredsCreateReq = {
     message.description !== undefined && (obj.description = message.description);
     message.metadata !== undefined && (obj.metadata = message.metadata);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<DashAPICredsCreateReq>, I>>(base?: I): DashAPICredsCreateReq {
+    return DashAPICredsCreateReq.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<DashAPICredsCreateReq>, I>>(object: I): DashAPICredsCreateReq {
@@ -485,6 +505,10 @@ export const DashAPICredsUpdateReq = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<DashAPICredsUpdateReq>, I>>(base?: I): DashAPICredsUpdateReq {
+    return DashAPICredsUpdateReq.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<DashAPICredsUpdateReq>, I>>(object: I): DashAPICredsUpdateReq {
     const message = createBaseDashAPICredsUpdateReq();
     message.credSid = object.credSid ?? "";
@@ -545,6 +569,10 @@ export const DashAPICredsDeleteReq = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<DashAPICredsDeleteReq>, I>>(base?: I): DashAPICredsDeleteReq {
+    return DashAPICredsDeleteReq.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<DashAPICredsDeleteReq>, I>>(object: I): DashAPICredsDeleteReq {
     const message = createBaseDashAPICredsDeleteReq();
     message.credSid = object.credSid ?? "";
@@ -584,6 +612,10 @@ export const Empty = {
   toJSON(_: Empty): unknown {
     const obj: any = {};
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Empty>, I>>(base?: I): Empty {
+    return Empty.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<Empty>, I>>(_: I): Empty {

--- a/integration/import-mapping/google/protobuf/timestamp.ts
+++ b/integration/import-mapping/google/protobuf/timestamp.ts
@@ -161,6 +161,10 @@ export const Timestamp = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Timestamp>, I>>(base?: I): Timestamp {
+    return Timestamp.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Timestamp>, I>>(object: I): Timestamp {
     const message = createBaseTimestamp();
     message.seconds = object.seconds ?? 0;

--- a/integration/import-mapping/mapping.ts
+++ b/integration/import-mapping/mapping.ts
@@ -68,6 +68,10 @@ export const WithEmtpy = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<WithEmtpy>, I>>(base?: I): WithEmtpy {
+    return WithEmtpy.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<WithEmtpy>, I>>(object: I): WithEmtpy {
     const message = createBaseWithEmtpy();
     message.empty = (object.empty !== undefined && object.empty !== null) ? Empty.fromPartial(object.empty) : undefined;
@@ -115,6 +119,10 @@ export const WithStruct = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<WithStruct>, I>>(base?: I): WithStruct {
+    return WithStruct.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<WithStruct>, I>>(object: I): WithStruct {
     const message = createBaseWithStruct();
     message.strut = object.strut ?? undefined;
@@ -160,6 +168,10 @@ export const WithTimestamp = {
     const obj: any = {};
     message.timestamp !== undefined && (obj.timestamp = message.timestamp.toISOString());
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<WithTimestamp>, I>>(base?: I): WithTimestamp {
+    return WithTimestamp.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<WithTimestamp>, I>>(object: I): WithTimestamp {
@@ -242,6 +254,10 @@ export const WithAll = {
     message.veryVerySecret !== undefined &&
       (obj.veryVerySecret = message.veryVerySecret ? VeryVerySecret.toJSON(message.veryVerySecret) : undefined);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<WithAll>, I>>(base?: I): WithAll {
+    return WithAll.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<WithAll>, I>>(object: I): WithAll {

--- a/integration/import-suffix/child.pb.ts
+++ b/integration/import-suffix/child.pb.ts
@@ -80,6 +80,10 @@ export const Child = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Child>, I>>(base?: I): Child {
+    return Child.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Child>, I>>(object: I): Child {
     const message = createBaseChild();
     message.name = object.name ?? "";

--- a/integration/import-suffix/google/protobuf/timestamp.pb.ts
+++ b/integration/import-suffix/google/protobuf/timestamp.pb.ts
@@ -161,6 +161,10 @@ export const Timestamp = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Timestamp>, I>>(base?: I): Timestamp {
+    return Timestamp.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Timestamp>, I>>(object: I): Timestamp {
     const message = createBaseTimestamp();
     message.seconds = object.seconds ?? 0;

--- a/integration/import-suffix/parent.pb.ts
+++ b/integration/import-suffix/parent.pb.ts
@@ -69,6 +69,10 @@ export const Parent = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Parent>, I>>(base?: I): Parent {
+    return Parent.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Parent>, I>>(object: I): Parent {
     const message = createBaseParent();
     message.child = (object.child !== undefined && object.child !== null) ? Child.fromPartial(object.child) : undefined;

--- a/integration/lower-case-svc-methods/math.ts
+++ b/integration/lower-case-svc-methods/math.ts
@@ -65,6 +65,10 @@ export const NumPair = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<NumPair>, I>>(base?: I): NumPair {
+    return NumPair.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<NumPair>, I>>(object: I): NumPair {
     const message = createBaseNumPair();
     message.num1 = object.num1 ?? 0;
@@ -111,6 +115,10 @@ export const NumSingle = {
     const obj: any = {};
     message.num !== undefined && (obj.num = message.num);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<NumSingle>, I>>(base?: I): NumSingle {
+    return NumSingle.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<NumSingle>, I>>(object: I): NumSingle {
@@ -171,6 +179,10 @@ export const Numbers = {
       obj.num = [];
     }
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Numbers>, I>>(base?: I): Numbers {
+    return Numbers.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<Numbers>, I>>(object: I): Numbers {

--- a/integration/nice-grpc/google/protobuf/empty.ts
+++ b/integration/nice-grpc/google/protobuf/empty.ts
@@ -50,6 +50,10 @@ export const Empty = {
     return obj;
   },
 
+  create(base?: DeepPartial<Empty>): Empty {
+    return Empty.fromPartial(base ?? {});
+  },
+
   fromPartial(_: DeepPartial<Empty>): Empty {
     const message = createBaseEmpty();
     return message;

--- a/integration/nice-grpc/google/protobuf/struct.ts
+++ b/integration/nice-grpc/google/protobuf/struct.ts
@@ -157,6 +157,10 @@ export const Struct = {
     return obj;
   },
 
+  create(base?: DeepPartial<Struct>): Struct {
+    return Struct.fromPartial(base ?? {});
+  },
+
   fromPartial(object: DeepPartial<Struct>): Struct {
     const message = createBaseStruct();
     message.fields = Object.entries(object.fields ?? {}).reduce<{ [key: string]: any | undefined }>(
@@ -235,6 +239,10 @@ export const Struct_FieldsEntry = {
     message.key !== undefined && (obj.key = message.key);
     message.value !== undefined && (obj.value = message.value);
     return obj;
+  },
+
+  create(base?: DeepPartial<Struct_FieldsEntry>): Struct_FieldsEntry {
+    return Struct_FieldsEntry.fromPartial(base ?? {});
   },
 
   fromPartial(object: DeepPartial<Struct_FieldsEntry>): Struct_FieldsEntry {
@@ -335,6 +343,10 @@ export const Value = {
     return obj;
   },
 
+  create(base?: DeepPartial<Value>): Value {
+    return Value.fromPartial(base ?? {});
+  },
+
   fromPartial(object: DeepPartial<Value>): Value {
     const message = createBaseValue();
     message.nullValue = object.nullValue ?? undefined;
@@ -428,6 +440,10 @@ export const ListValue = {
       obj.values = [];
     }
     return obj;
+  },
+
+  create(base?: DeepPartial<ListValue>): ListValue {
+    return ListValue.fromPartial(base ?? {});
   },
 
   fromPartial(object: DeepPartial<ListValue>): ListValue {

--- a/integration/nice-grpc/google/protobuf/timestamp.ts
+++ b/integration/nice-grpc/google/protobuf/timestamp.ts
@@ -161,6 +161,10 @@ export const Timestamp = {
     return obj;
   },
 
+  create(base?: DeepPartial<Timestamp>): Timestamp {
+    return Timestamp.fromPartial(base ?? {});
+  },
+
   fromPartial(object: DeepPartial<Timestamp>): Timestamp {
     const message = createBaseTimestamp();
     message.seconds = object.seconds ?? 0;

--- a/integration/nice-grpc/google/protobuf/wrappers.ts
+++ b/integration/nice-grpc/google/protobuf/wrappers.ts
@@ -134,6 +134,10 @@ export const DoubleValue = {
     return obj;
   },
 
+  create(base?: DeepPartial<DoubleValue>): DoubleValue {
+    return DoubleValue.fromPartial(base ?? {});
+  },
+
   fromPartial(object: DeepPartial<DoubleValue>): DoubleValue {
     const message = createBaseDoubleValue();
     message.value = object.value ?? 0;
@@ -179,6 +183,10 @@ export const FloatValue = {
     const obj: any = {};
     message.value !== undefined && (obj.value = message.value);
     return obj;
+  },
+
+  create(base?: DeepPartial<FloatValue>): FloatValue {
+    return FloatValue.fromPartial(base ?? {});
   },
 
   fromPartial(object: DeepPartial<FloatValue>): FloatValue {
@@ -228,6 +236,10 @@ export const Int64Value = {
     return obj;
   },
 
+  create(base?: DeepPartial<Int64Value>): Int64Value {
+    return Int64Value.fromPartial(base ?? {});
+  },
+
   fromPartial(object: DeepPartial<Int64Value>): Int64Value {
     const message = createBaseInt64Value();
     message.value = object.value ?? 0;
@@ -273,6 +285,10 @@ export const UInt64Value = {
     const obj: any = {};
     message.value !== undefined && (obj.value = Math.round(message.value));
     return obj;
+  },
+
+  create(base?: DeepPartial<UInt64Value>): UInt64Value {
+    return UInt64Value.fromPartial(base ?? {});
   },
 
   fromPartial(object: DeepPartial<UInt64Value>): UInt64Value {
@@ -322,6 +338,10 @@ export const Int32Value = {
     return obj;
   },
 
+  create(base?: DeepPartial<Int32Value>): Int32Value {
+    return Int32Value.fromPartial(base ?? {});
+  },
+
   fromPartial(object: DeepPartial<Int32Value>): Int32Value {
     const message = createBaseInt32Value();
     message.value = object.value ?? 0;
@@ -367,6 +387,10 @@ export const UInt32Value = {
     const obj: any = {};
     message.value !== undefined && (obj.value = Math.round(message.value));
     return obj;
+  },
+
+  create(base?: DeepPartial<UInt32Value>): UInt32Value {
+    return UInt32Value.fromPartial(base ?? {});
   },
 
   fromPartial(object: DeepPartial<UInt32Value>): UInt32Value {
@@ -416,6 +440,10 @@ export const BoolValue = {
     return obj;
   },
 
+  create(base?: DeepPartial<BoolValue>): BoolValue {
+    return BoolValue.fromPartial(base ?? {});
+  },
+
   fromPartial(object: DeepPartial<BoolValue>): BoolValue {
     const message = createBaseBoolValue();
     message.value = object.value ?? false;
@@ -461,6 +489,10 @@ export const StringValue = {
     const obj: any = {};
     message.value !== undefined && (obj.value = message.value);
     return obj;
+  },
+
+  create(base?: DeepPartial<StringValue>): StringValue {
+    return StringValue.fromPartial(base ?? {});
   },
 
   fromPartial(object: DeepPartial<StringValue>): StringValue {
@@ -509,6 +541,10 @@ export const BytesValue = {
     message.value !== undefined &&
       (obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array()));
     return obj;
+  },
+
+  create(base?: DeepPartial<BytesValue>): BytesValue {
+    return BytesValue.fromPartial(base ?? {});
   },
 
   fromPartial(object: DeepPartial<BytesValue>): BytesValue {

--- a/integration/nice-grpc/simple.ts
+++ b/integration/nice-grpc/simple.ts
@@ -62,6 +62,10 @@ export const TestMessage = {
     return obj;
   },
 
+  create(base?: DeepPartial<TestMessage>): TestMessage {
+    return TestMessage.fromPartial(base ?? {});
+  },
+
   fromPartial(object: DeepPartial<TestMessage>): TestMessage {
     const message = createBaseTestMessage();
     message.timestamp = object.timestamp ?? undefined;

--- a/integration/no-proto-package/no-proto-package.ts
+++ b/integration/no-proto-package/no-proto-package.ts
@@ -52,6 +52,10 @@ export const User = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<User>, I>>(base?: I): User {
+    return User.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<User>, I>>(object: I): User {
     const message = createBaseUser();
     message.name = object.name ?? "";
@@ -90,6 +94,10 @@ export const Empty = {
   toJSON(_: Empty): unknown {
     const obj: any = {};
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Empty>, I>>(base?: I): Empty {
+    return Empty.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<Empty>, I>>(_: I): Empty {

--- a/integration/omit-optionals/simple.ts
+++ b/integration/omit-optionals/simple.ts
@@ -58,6 +58,10 @@ export const TestMessage = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<TestMessage>, I>>(base?: I): TestMessage {
+    return TestMessage.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<TestMessage>, I>>(object: I): TestMessage {
     const message = createBaseTestMessage();
     message.field1 = object.field1 ?? false;

--- a/integration/oneof-properties/oneof.ts
+++ b/integration/oneof-properties/oneof.ts
@@ -213,6 +213,10 @@ export const PleaseChoose = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<PleaseChoose>, I>>(base?: I): PleaseChoose {
+    return PleaseChoose.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<PleaseChoose>, I>>(object: I): PleaseChoose {
     const message = createBasePleaseChoose();
     message.name = object.name ?? "";
@@ -270,6 +274,10 @@ export const PleaseChoose_Submessage = {
     const obj: any = {};
     message.name !== undefined && (obj.name = message.name);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<PleaseChoose_Submessage>, I>>(base?: I): PleaseChoose_Submessage {
+    return PleaseChoose_Submessage.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<PleaseChoose_Submessage>, I>>(object: I): PleaseChoose_Submessage {

--- a/integration/oneof-unions-snake/google/protobuf/struct.ts
+++ b/integration/oneof-unions-snake/google/protobuf/struct.ts
@@ -142,6 +142,10 @@ export const Struct = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Struct>, I>>(base?: I): Struct {
+    return Struct.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Struct>, I>>(object: I): Struct {
     const message = createBaseStruct();
     message.fields = Object.entries(object.fields ?? {}).reduce<{ [key: string]: any | undefined }>(
@@ -220,6 +224,10 @@ export const Struct_FieldsEntry = {
     message.key !== undefined && (obj.key = message.key);
     message.value !== undefined && (obj.value = message.value);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Struct_FieldsEntry>, I>>(base?: I): Struct_FieldsEntry {
+    return Struct_FieldsEntry.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<Struct_FieldsEntry>, I>>(object: I): Struct_FieldsEntry {
@@ -321,6 +329,10 @@ export const Value = {
     message.kind?.$case === "struct_value" && (obj.struct_value = message.kind?.struct_value);
     message.kind?.$case === "list_value" && (obj.list_value = message.kind?.list_value);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Value>, I>>(base?: I): Value {
+    return Value.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<Value>, I>>(object: I): Value {
@@ -447,6 +459,10 @@ export const ListValue = {
       obj.values = [];
     }
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<ListValue>, I>>(base?: I): ListValue {
+    return ListValue.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<ListValue>, I>>(object: I): ListValue {

--- a/integration/oneof-unions-snake/simple.ts
+++ b/integration/oneof-unions-snake/simple.ts
@@ -53,6 +53,10 @@ export const SimpleStruct = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<SimpleStruct>, I>>(base?: I): SimpleStruct {
+    return SimpleStruct.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<SimpleStruct>, I>>(object: I): SimpleStruct {
     const message = createBaseSimpleStruct();
     message.simple_struct = object.simple_struct ?? undefined;

--- a/integration/oneof-unions/google/protobuf/struct.ts
+++ b/integration/oneof-unions/google/protobuf/struct.ts
@@ -142,6 +142,10 @@ export const Struct = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Struct>, I>>(base?: I): Struct {
+    return Struct.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Struct>, I>>(object: I): Struct {
     const message = createBaseStruct();
     message.fields = Object.entries(object.fields ?? {}).reduce<{ [key: string]: any | undefined }>(
@@ -220,6 +224,10 @@ export const Struct_FieldsEntry = {
     message.key !== undefined && (obj.key = message.key);
     message.value !== undefined && (obj.value = message.value);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Struct_FieldsEntry>, I>>(base?: I): Struct_FieldsEntry {
+    return Struct_FieldsEntry.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<Struct_FieldsEntry>, I>>(object: I): Struct_FieldsEntry {
@@ -318,6 +326,10 @@ export const Value = {
     message.kind?.$case === "structValue" && (obj.structValue = message.kind?.structValue);
     message.kind?.$case === "listValue" && (obj.listValue = message.kind?.listValue);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Value>, I>>(base?: I): Value {
+    return Value.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<Value>, I>>(object: I): Value {
@@ -438,6 +450,10 @@ export const ListValue = {
       obj.values = [];
     }
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<ListValue>, I>>(base?: I): ListValue {
+    return ListValue.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<ListValue>, I>>(object: I): ListValue {

--- a/integration/oneof-unions/oneof.ts
+++ b/integration/oneof-unions/oneof.ts
@@ -226,6 +226,10 @@ export const PleaseChoose = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<PleaseChoose>, I>>(base?: I): PleaseChoose {
+    return PleaseChoose.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<PleaseChoose>, I>>(object: I): PleaseChoose {
     const message = createBasePleaseChoose();
     message.name = object.name ?? "";
@@ -315,6 +319,10 @@ export const PleaseChoose_Submessage = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<PleaseChoose_Submessage>, I>>(base?: I): PleaseChoose_Submessage {
+    return PleaseChoose_Submessage.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<PleaseChoose_Submessage>, I>>(object: I): PleaseChoose_Submessage {
     const message = createBasePleaseChoose_Submessage();
     message.name = object.name ?? "";
@@ -370,6 +378,10 @@ export const SimpleButOptional = {
     message.name !== undefined && (obj.name = message.name);
     message.age !== undefined && (obj.age = Math.round(message.age));
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<SimpleButOptional>, I>>(base?: I): SimpleButOptional {
+    return SimpleButOptional.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<SimpleButOptional>, I>>(object: I): SimpleButOptional {

--- a/integration/point/point.ts
+++ b/integration/point/point.ts
@@ -60,6 +60,10 @@ export const Point = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Point>, I>>(base?: I): Point {
+    return Point.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Point>, I>>(object: I): Point {
     const message = createBasePoint();
     message.lat = object.lat ?? 0;
@@ -116,6 +120,10 @@ export const Area = {
     message.nw !== undefined && (obj.nw = message.nw ? Point.toJSON(message.nw) : undefined);
     message.se !== undefined && (obj.se = message.se ? Point.toJSON(message.se) : undefined);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Area>, I>>(base?: I): Area {
+    return Area.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<Area>, I>>(object: I): Area {

--- a/integration/reserved-words/reserved-words.ts
+++ b/integration/reserved-words/reserved-words.ts
@@ -39,6 +39,10 @@ export const Record = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Record>, I>>(base?: I): Record {
+    return Record.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Record>, I>>(_: I): Record {
     const message = createBaseRecord();
     return message;

--- a/integration/return-observable/observable.ts
+++ b/integration/return-observable/observable.ts
@@ -52,6 +52,10 @@ export const ProduceRequest = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<ProduceRequest>, I>>(base?: I): ProduceRequest {
+    return ProduceRequest.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<ProduceRequest>, I>>(object: I): ProduceRequest {
     const message = createBaseProduceRequest();
     message.ingredients = object.ingredients ?? "";
@@ -97,6 +101,10 @@ export const ProduceReply = {
     const obj: any = {};
     message.result !== undefined && (obj.result = message.result);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<ProduceReply>, I>>(base?: I): ProduceReply {
+    return ProduceReply.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<ProduceReply>, I>>(object: I): ProduceReply {

--- a/integration/simple-deprecated-fields/simple.ts
+++ b/integration/simple-deprecated-fields/simple.ts
@@ -107,6 +107,10 @@ export const Simple = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Simple>, I>>(base?: I): Simple {
+    return Simple.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Simple>, I>>(object: I): Simple {
     const message = createBaseSimple();
     message.name = object.name ?? "";
@@ -156,6 +160,10 @@ export const Child = {
     const obj: any = {};
     message.name !== undefined && (obj.name = message.name);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Child>, I>>(base?: I): Child {
+    return Child.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<Child>, I>>(object: I): Child {

--- a/integration/simple-esmodule-interop/simple.ts
+++ b/integration/simple-esmodule-interop/simple.ts
@@ -71,6 +71,10 @@ export const Simple = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Simple>, I>>(base?: I): Simple {
+    return Simple.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Simple>, I>>(object: I): Simple {
     const message = createBaseSimple();
     message.name = object.name ?? "";
@@ -220,6 +224,10 @@ export const Numbers = {
     message.sfixed32 !== undefined && (obj.sfixed32 = Math.round(message.sfixed32));
     message.sfixed64 !== undefined && (obj.sfixed64 = Math.round(message.sfixed64));
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Numbers>, I>>(base?: I): Numbers {
+    return Numbers.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<Numbers>, I>>(object: I): Numbers {

--- a/integration/simple-json-name/google/protobuf/timestamp.ts
+++ b/integration/simple-json-name/google/protobuf/timestamp.ts
@@ -161,6 +161,10 @@ export const Timestamp = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Timestamp>, I>>(base?: I): Timestamp {
+    return Timestamp.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Timestamp>, I>>(object: I): Timestamp {
     const message = createBaseTimestamp();
     message.seconds = object.seconds ?? 0;

--- a/integration/simple-json-name/simple.ts
+++ b/integration/simple-json-name/simple.ts
@@ -126,6 +126,10 @@ export const Simple = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Simple>, I>>(base?: I): Simple {
+    return Simple.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Simple>, I>>(object: I): Simple {
     const message = createBaseSimple();
     message.name = object.name ?? "";

--- a/integration/simple-long-bigint/google/protobuf/timestamp.ts
+++ b/integration/simple-long-bigint/google/protobuf/timestamp.ts
@@ -161,6 +161,10 @@ export const Timestamp = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Timestamp>, I>>(base?: I): Timestamp {
+    return Timestamp.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Timestamp>, I>>(object: I): Timestamp {
     const message = createBaseTimestamp();
     message.seconds = object.seconds ?? BigInt("0");

--- a/integration/simple-long-bigint/google/protobuf/wrappers.ts
+++ b/integration/simple-long-bigint/google/protobuf/wrappers.ts
@@ -134,6 +134,10 @@ export const DoubleValue = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<DoubleValue>, I>>(base?: I): DoubleValue {
+    return DoubleValue.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<DoubleValue>, I>>(object: I): DoubleValue {
     const message = createBaseDoubleValue();
     message.value = object.value ?? 0;
@@ -179,6 +183,10 @@ export const FloatValue = {
     const obj: any = {};
     message.value !== undefined && (obj.value = message.value);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<FloatValue>, I>>(base?: I): FloatValue {
+    return FloatValue.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<FloatValue>, I>>(object: I): FloatValue {
@@ -228,6 +236,10 @@ export const Int64Value = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Int64Value>, I>>(base?: I): Int64Value {
+    return Int64Value.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Int64Value>, I>>(object: I): Int64Value {
     const message = createBaseInt64Value();
     message.value = object.value ?? BigInt("0");
@@ -273,6 +285,10 @@ export const UInt64Value = {
     const obj: any = {};
     message.value !== undefined && (obj.value = message.value.toString());
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<UInt64Value>, I>>(base?: I): UInt64Value {
+    return UInt64Value.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<UInt64Value>, I>>(object: I): UInt64Value {
@@ -322,6 +338,10 @@ export const Int32Value = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Int32Value>, I>>(base?: I): Int32Value {
+    return Int32Value.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Int32Value>, I>>(object: I): Int32Value {
     const message = createBaseInt32Value();
     message.value = object.value ?? 0;
@@ -367,6 +387,10 @@ export const UInt32Value = {
     const obj: any = {};
     message.value !== undefined && (obj.value = Math.round(message.value));
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<UInt32Value>, I>>(base?: I): UInt32Value {
+    return UInt32Value.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<UInt32Value>, I>>(object: I): UInt32Value {
@@ -416,6 +440,10 @@ export const BoolValue = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<BoolValue>, I>>(base?: I): BoolValue {
+    return BoolValue.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<BoolValue>, I>>(object: I): BoolValue {
     const message = createBaseBoolValue();
     message.value = object.value ?? false;
@@ -461,6 +489,10 @@ export const StringValue = {
     const obj: any = {};
     message.value !== undefined && (obj.value = message.value);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<StringValue>, I>>(base?: I): StringValue {
+    return StringValue.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<StringValue>, I>>(object: I): StringValue {
@@ -509,6 +541,10 @@ export const BytesValue = {
     message.value !== undefined &&
       (obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array()));
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<BytesValue>, I>>(base?: I): BytesValue {
+    return BytesValue.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<BytesValue>, I>>(object: I): BytesValue {

--- a/integration/simple-long-bigint/simple.ts
+++ b/integration/simple-long-bigint/simple.ts
@@ -207,6 +207,10 @@ export const Numbers = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Numbers>, I>>(base?: I): Numbers {
+    return Numbers.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Numbers>, I>>(object: I): Numbers {
     const message = createBaseNumbers();
     message.double = object.double ?? 0;

--- a/integration/simple-long-string/google/protobuf/timestamp.ts
+++ b/integration/simple-long-string/google/protobuf/timestamp.ts
@@ -161,6 +161,10 @@ export const Timestamp = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Timestamp>, I>>(base?: I): Timestamp {
+    return Timestamp.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Timestamp>, I>>(object: I): Timestamp {
     const message = createBaseTimestamp();
     message.seconds = object.seconds ?? "0";

--- a/integration/simple-long-string/google/protobuf/wrappers.ts
+++ b/integration/simple-long-string/google/protobuf/wrappers.ts
@@ -134,6 +134,10 @@ export const DoubleValue = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<DoubleValue>, I>>(base?: I): DoubleValue {
+    return DoubleValue.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<DoubleValue>, I>>(object: I): DoubleValue {
     const message = createBaseDoubleValue();
     message.value = object.value ?? 0;
@@ -179,6 +183,10 @@ export const FloatValue = {
     const obj: any = {};
     message.value !== undefined && (obj.value = message.value);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<FloatValue>, I>>(base?: I): FloatValue {
+    return FloatValue.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<FloatValue>, I>>(object: I): FloatValue {
@@ -228,6 +236,10 @@ export const Int64Value = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Int64Value>, I>>(base?: I): Int64Value {
+    return Int64Value.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Int64Value>, I>>(object: I): Int64Value {
     const message = createBaseInt64Value();
     message.value = object.value ?? "0";
@@ -273,6 +285,10 @@ export const UInt64Value = {
     const obj: any = {};
     message.value !== undefined && (obj.value = message.value);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<UInt64Value>, I>>(base?: I): UInt64Value {
+    return UInt64Value.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<UInt64Value>, I>>(object: I): UInt64Value {
@@ -322,6 +338,10 @@ export const Int32Value = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Int32Value>, I>>(base?: I): Int32Value {
+    return Int32Value.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Int32Value>, I>>(object: I): Int32Value {
     const message = createBaseInt32Value();
     message.value = object.value ?? 0;
@@ -367,6 +387,10 @@ export const UInt32Value = {
     const obj: any = {};
     message.value !== undefined && (obj.value = Math.round(message.value));
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<UInt32Value>, I>>(base?: I): UInt32Value {
+    return UInt32Value.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<UInt32Value>, I>>(object: I): UInt32Value {
@@ -416,6 +440,10 @@ export const BoolValue = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<BoolValue>, I>>(base?: I): BoolValue {
+    return BoolValue.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<BoolValue>, I>>(object: I): BoolValue {
     const message = createBaseBoolValue();
     message.value = object.value ?? false;
@@ -461,6 +489,10 @@ export const StringValue = {
     const obj: any = {};
     message.value !== undefined && (obj.value = message.value);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<StringValue>, I>>(base?: I): StringValue {
+    return StringValue.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<StringValue>, I>>(object: I): StringValue {
@@ -509,6 +541,10 @@ export const BytesValue = {
     message.value !== undefined &&
       (obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array()));
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<BytesValue>, I>>(base?: I): BytesValue {
+    return BytesValue.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<BytesValue>, I>>(object: I): BytesValue {

--- a/integration/simple-long-string/simple.ts
+++ b/integration/simple-long-string/simple.ts
@@ -184,6 +184,10 @@ export const Numbers = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Numbers>, I>>(base?: I): Numbers {
+    return Numbers.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Numbers>, I>>(object: I): Numbers {
     const message = createBaseNumbers();
     message.double = object.double ?? 0;

--- a/integration/simple-long/google/protobuf/wrappers.ts
+++ b/integration/simple-long/google/protobuf/wrappers.ts
@@ -134,6 +134,10 @@ export const DoubleValue = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<DoubleValue>, I>>(base?: I): DoubleValue {
+    return DoubleValue.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<DoubleValue>, I>>(object: I): DoubleValue {
     const message = createBaseDoubleValue();
     message.value = object.value ?? 0;
@@ -179,6 +183,10 @@ export const FloatValue = {
     const obj: any = {};
     message.value !== undefined && (obj.value = message.value);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<FloatValue>, I>>(base?: I): FloatValue {
+    return FloatValue.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<FloatValue>, I>>(object: I): FloatValue {
@@ -228,6 +236,10 @@ export const Int64Value = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Int64Value>, I>>(base?: I): Int64Value {
+    return Int64Value.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Int64Value>, I>>(object: I): Int64Value {
     const message = createBaseInt64Value();
     message.value = (object.value !== undefined && object.value !== null) ? Long.fromValue(object.value) : Long.ZERO;
@@ -273,6 +285,10 @@ export const UInt64Value = {
     const obj: any = {};
     message.value !== undefined && (obj.value = (message.value || Long.UZERO).toString());
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<UInt64Value>, I>>(base?: I): UInt64Value {
+    return UInt64Value.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<UInt64Value>, I>>(object: I): UInt64Value {
@@ -322,6 +338,10 @@ export const Int32Value = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Int32Value>, I>>(base?: I): Int32Value {
+    return Int32Value.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Int32Value>, I>>(object: I): Int32Value {
     const message = createBaseInt32Value();
     message.value = object.value ?? 0;
@@ -367,6 +387,10 @@ export const UInt32Value = {
     const obj: any = {};
     message.value !== undefined && (obj.value = Math.round(message.value));
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<UInt32Value>, I>>(base?: I): UInt32Value {
+    return UInt32Value.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<UInt32Value>, I>>(object: I): UInt32Value {
@@ -416,6 +440,10 @@ export const BoolValue = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<BoolValue>, I>>(base?: I): BoolValue {
+    return BoolValue.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<BoolValue>, I>>(object: I): BoolValue {
     const message = createBaseBoolValue();
     message.value = object.value ?? false;
@@ -461,6 +489,10 @@ export const StringValue = {
     const obj: any = {};
     message.value !== undefined && (obj.value = message.value);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<StringValue>, I>>(base?: I): StringValue {
+    return StringValue.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<StringValue>, I>>(object: I): StringValue {
@@ -509,6 +541,10 @@ export const BytesValue = {
     message.value !== undefined &&
       (obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array()));
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<BytesValue>, I>>(base?: I): BytesValue {
+    return BytesValue.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<BytesValue>, I>>(object: I): BytesValue {

--- a/integration/simple-long/simple-test.ts
+++ b/integration/simple-long/simple-test.ts
@@ -1,6 +1,33 @@
 import { SimpleWithMap } from './simple';
 
 describe('simple', () => {
+  it('can use create with an empty value', () => {
+    const s1 = SimpleWithMap.create()
+    expect(s1).toMatchInlineSnapshot(`
+      Object {
+        "intLookup": Object {},
+        "longLookup": Object {},
+        "nameLookup": Object {},
+      }
+    `);
+  });
+
+  it('can use create with a partial value', () => {
+    const s1 = SimpleWithMap.create({
+      intLookup: { 1: 2, 2: 1 },
+    })
+    expect(s1).toMatchInlineSnapshot(`
+      Object {
+        "intLookup": Object {
+          "1": 2,
+          "2": 1,
+        },
+        "longLookup": Object {},
+        "nameLookup": Object {},
+      }
+    `);
+  });
+
   it('can fromPartial maps', () => {
     const s1 = SimpleWithMap.fromPartial({
       intLookup: { 1: 2, 2: 1 },

--- a/integration/simple-long/simple.ts
+++ b/integration/simple-long/simple.ts
@@ -143,6 +143,10 @@ export const SimpleWithWrappers = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<SimpleWithWrappers>, I>>(base?: I): SimpleWithWrappers {
+    return SimpleWithWrappers.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<SimpleWithWrappers>, I>>(object: I): SimpleWithWrappers {
     const message = createBaseSimpleWithWrappers();
     message.name = object.name ?? undefined;
@@ -254,6 +258,10 @@ export const SimpleWithMap = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<SimpleWithMap>, I>>(base?: I): SimpleWithMap {
+    return SimpleWithMap.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<SimpleWithMap>, I>>(object: I): SimpleWithMap {
     const message = createBaseSimpleWithMap();
     message.nameLookup = Object.entries(object.nameLookup ?? {}).reduce<{ [key: string]: string }>(
@@ -334,6 +342,10 @@ export const SimpleWithMap_NameLookupEntry = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<SimpleWithMap_NameLookupEntry>, I>>(base?: I): SimpleWithMap_NameLookupEntry {
+    return SimpleWithMap_NameLookupEntry.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<SimpleWithMap_NameLookupEntry>, I>>(
     object: I,
   ): SimpleWithMap_NameLookupEntry {
@@ -389,6 +401,10 @@ export const SimpleWithMap_IntLookupEntry = {
     message.key !== undefined && (obj.key = Math.round(message.key));
     message.value !== undefined && (obj.value = Math.round(message.value));
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<SimpleWithMap_IntLookupEntry>, I>>(base?: I): SimpleWithMap_IntLookupEntry {
+    return SimpleWithMap_IntLookupEntry.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<SimpleWithMap_IntLookupEntry>, I>>(object: I): SimpleWithMap_IntLookupEntry {
@@ -447,6 +463,10 @@ export const SimpleWithMap_LongLookupEntry = {
     message.key !== undefined && (obj.key = message.key);
     message.value !== undefined && (obj.value = (message.value || Long.ZERO).toString());
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<SimpleWithMap_LongLookupEntry>, I>>(base?: I): SimpleWithMap_LongLookupEntry {
+    return SimpleWithMap_LongLookupEntry.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<SimpleWithMap_LongLookupEntry>, I>>(
@@ -622,6 +642,10 @@ export const Numbers = {
       obj.manyUint64 = [];
     }
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Numbers>, I>>(base?: I): Numbers {
+    return Numbers.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<Numbers>, I>>(object: I): Numbers {

--- a/integration/simple-optionals/google/protobuf/timestamp.ts
+++ b/integration/simple-optionals/google/protobuf/timestamp.ts
@@ -161,6 +161,10 @@ export const Timestamp = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Timestamp>, I>>(base?: I): Timestamp {
+    return Timestamp.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Timestamp>, I>>(object: I): Timestamp {
     const message = createBaseTimestamp();
     message.seconds = object.seconds ?? 0;

--- a/integration/simple-optionals/google/protobuf/wrappers.ts
+++ b/integration/simple-optionals/google/protobuf/wrappers.ts
@@ -134,6 +134,10 @@ export const DoubleValue = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<DoubleValue>, I>>(base?: I): DoubleValue {
+    return DoubleValue.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<DoubleValue>, I>>(object: I): DoubleValue {
     const message = createBaseDoubleValue();
     message.value = object.value ?? 0;
@@ -179,6 +183,10 @@ export const FloatValue = {
     const obj: any = {};
     message.value !== undefined && (obj.value = message.value);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<FloatValue>, I>>(base?: I): FloatValue {
+    return FloatValue.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<FloatValue>, I>>(object: I): FloatValue {
@@ -228,6 +236,10 @@ export const Int64Value = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Int64Value>, I>>(base?: I): Int64Value {
+    return Int64Value.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Int64Value>, I>>(object: I): Int64Value {
     const message = createBaseInt64Value();
     message.value = object.value ?? 0;
@@ -273,6 +285,10 @@ export const UInt64Value = {
     const obj: any = {};
     message.value !== undefined && (obj.value = Math.round(message.value));
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<UInt64Value>, I>>(base?: I): UInt64Value {
+    return UInt64Value.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<UInt64Value>, I>>(object: I): UInt64Value {
@@ -322,6 +338,10 @@ export const Int32Value = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Int32Value>, I>>(base?: I): Int32Value {
+    return Int32Value.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Int32Value>, I>>(object: I): Int32Value {
     const message = createBaseInt32Value();
     message.value = object.value ?? 0;
@@ -367,6 +387,10 @@ export const UInt32Value = {
     const obj: any = {};
     message.value !== undefined && (obj.value = Math.round(message.value));
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<UInt32Value>, I>>(base?: I): UInt32Value {
+    return UInt32Value.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<UInt32Value>, I>>(object: I): UInt32Value {
@@ -416,6 +440,10 @@ export const BoolValue = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<BoolValue>, I>>(base?: I): BoolValue {
+    return BoolValue.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<BoolValue>, I>>(object: I): BoolValue {
     const message = createBaseBoolValue();
     message.value = object.value ?? false;
@@ -461,6 +489,10 @@ export const StringValue = {
     const obj: any = {};
     message.value !== undefined && (obj.value = message.value);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<StringValue>, I>>(base?: I): StringValue {
+    return StringValue.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<StringValue>, I>>(object: I): StringValue {
@@ -509,6 +541,10 @@ export const BytesValue = {
     message.value !== undefined &&
       (obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array()));
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<BytesValue>, I>>(base?: I): BytesValue {
+    return BytesValue.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<BytesValue>, I>>(object: I): BytesValue {

--- a/integration/simple-optionals/import_dir/thing.ts
+++ b/integration/simple-optionals/import_dir/thing.ts
@@ -48,6 +48,10 @@ export const ImportedThing = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<ImportedThing>, I>>(base?: I): ImportedThing {
+    return ImportedThing.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<ImportedThing>, I>>(object: I): ImportedThing {
     const message = createBaseImportedThing();
     message.createdAt = object.createdAt ?? undefined;

--- a/integration/simple-optionals/simple.ts
+++ b/integration/simple-optionals/simple.ts
@@ -399,6 +399,10 @@ export const Simple = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Simple>, I>>(base?: I): Simple {
+    return Simple.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Simple>, I>>(object: I): Simple {
     const message = createBaseSimple();
     message.name = object.name ?? "";
@@ -465,6 +469,10 @@ export const Child = {
     message.name !== undefined && (obj.name = message.name);
     message.type !== undefined && (obj.type = child_TypeToJSON(message.type));
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Child>, I>>(base?: I): Child {
+    return Child.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<Child>, I>>(object: I): Child {
@@ -534,6 +542,10 @@ export const Nested = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Nested>, I>>(base?: I): Nested {
+    return Nested.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Nested>, I>>(object: I): Nested {
     const message = createBaseNested();
     message.name = object.name ?? "";
@@ -596,6 +608,10 @@ export const Nested_InnerMessage = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Nested_InnerMessage>, I>>(base?: I): Nested_InnerMessage {
+    return Nested_InnerMessage.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Nested_InnerMessage>, I>>(object: I): Nested_InnerMessage {
     const message = createBaseNested_InnerMessage();
     message.name = object.name ?? "";
@@ -644,6 +660,10 @@ export const Nested_InnerMessage_DeepMessage = {
     const obj: any = {};
     message.name !== undefined && (obj.name = message.name);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Nested_InnerMessage_DeepMessage>, I>>(base?: I): Nested_InnerMessage_DeepMessage {
+    return Nested_InnerMessage_DeepMessage.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<Nested_InnerMessage_DeepMessage>, I>>(
@@ -703,6 +723,10 @@ export const OneOfMessage = {
     message.first !== undefined && (obj.first = message.first);
     message.last !== undefined && (obj.last = message.last);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<OneOfMessage>, I>>(base?: I): OneOfMessage {
+    return OneOfMessage.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<OneOfMessage>, I>>(object: I): OneOfMessage {
@@ -795,6 +819,10 @@ export const SimpleWithWrappers = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<SimpleWithWrappers>, I>>(base?: I): SimpleWithWrappers {
+    return SimpleWithWrappers.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<SimpleWithWrappers>, I>>(object: I): SimpleWithWrappers {
     const message = createBaseSimpleWithWrappers();
     message.name = object.name ?? undefined;
@@ -844,6 +872,10 @@ export const Entity = {
     const obj: any = {};
     message.id !== undefined && (obj.id = Math.round(message.id));
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Entity>, I>>(base?: I): Entity {
+    return Entity.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<Entity>, I>>(object: I): Entity {
@@ -950,6 +982,10 @@ export const SimpleWithMap = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<SimpleWithMap>, I>>(base?: I): SimpleWithMap {
+    return SimpleWithMap.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<SimpleWithMap>, I>>(object: I): SimpleWithMap {
     const message = createBaseSimpleWithMap();
     message.entitiesById = Object.entries(object.entitiesById ?? {}).reduce<{ [key: number]: Entity }>(
@@ -1033,6 +1069,10 @@ export const SimpleWithMap_EntitiesByIdEntry = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<SimpleWithMap_EntitiesByIdEntry>, I>>(base?: I): SimpleWithMap_EntitiesByIdEntry {
+    return SimpleWithMap_EntitiesByIdEntry.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<SimpleWithMap_EntitiesByIdEntry>, I>>(
     object: I,
   ): SimpleWithMap_EntitiesByIdEntry {
@@ -1092,6 +1132,10 @@ export const SimpleWithMap_NameLookupEntry = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<SimpleWithMap_NameLookupEntry>, I>>(base?: I): SimpleWithMap_NameLookupEntry {
+    return SimpleWithMap_NameLookupEntry.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<SimpleWithMap_NameLookupEntry>, I>>(
     object: I,
   ): SimpleWithMap_NameLookupEntry {
@@ -1147,6 +1191,10 @@ export const SimpleWithMap_IntLookupEntry = {
     message.key !== undefined && (obj.key = Math.round(message.key));
     message.value !== undefined && (obj.value = Math.round(message.value));
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<SimpleWithMap_IntLookupEntry>, I>>(base?: I): SimpleWithMap_IntLookupEntry {
+    return SimpleWithMap_IntLookupEntry.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<SimpleWithMap_IntLookupEntry>, I>>(object: I): SimpleWithMap_IntLookupEntry {
@@ -1210,6 +1258,10 @@ export const SimpleWithSnakeCaseMap = {
       });
     }
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<SimpleWithSnakeCaseMap>, I>>(base?: I): SimpleWithSnakeCaseMap {
+    return SimpleWithSnakeCaseMap.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<SimpleWithSnakeCaseMap>, I>>(object: I): SimpleWithSnakeCaseMap {
@@ -1277,6 +1329,12 @@ export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<SimpleWithSnakeCaseMap_EntitiesByIdEntry>, I>>(
+    base?: I,
+  ): SimpleWithSnakeCaseMap_EntitiesByIdEntry {
+    return SimpleWithSnakeCaseMap_EntitiesByIdEntry.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<SimpleWithSnakeCaseMap_EntitiesByIdEntry>, I>>(
     object: I,
   ): SimpleWithSnakeCaseMap_EntitiesByIdEntry {
@@ -1329,6 +1387,10 @@ export const PingRequest = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<PingRequest>, I>>(base?: I): PingRequest {
+    return PingRequest.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<PingRequest>, I>>(object: I): PingRequest {
     const message = createBasePingRequest();
     message.input = object.input ?? "";
@@ -1374,6 +1436,10 @@ export const PingResponse = {
     const obj: any = {};
     message.output !== undefined && (obj.output = message.output);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<PingResponse>, I>>(base?: I): PingResponse {
+    return PingResponse.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<PingResponse>, I>>(object: I): PingResponse {
@@ -1524,6 +1590,10 @@ export const Numbers = {
     message.sfixed32 !== undefined && (obj.sfixed32 = Math.round(message.sfixed32));
     message.sfixed64 !== undefined && (obj.sfixed64 = Math.round(message.sfixed64));
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Numbers>, I>>(base?: I): Numbers {
+    return Numbers.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<Numbers>, I>>(object: I): Numbers {

--- a/integration/simple-optionals/thing.ts
+++ b/integration/simple-optionals/thing.ts
@@ -48,6 +48,10 @@ export const ImportedThing = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<ImportedThing>, I>>(base?: I): ImportedThing {
+    return ImportedThing.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<ImportedThing>, I>>(object: I): ImportedThing {
     const message = createBaseImportedThing();
     message.createdAt = object.createdAt ?? undefined;

--- a/integration/simple-proto2/simple.ts
+++ b/integration/simple-proto2/simple.ts
@@ -80,6 +80,10 @@ export const Issue56 = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Issue56>, I>>(base?: I): Issue56 {
+    return Issue56.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Issue56>, I>>(object: I): Issue56 {
     const message = createBaseIssue56();
     message.test = object.test ?? 1;

--- a/integration/simple-prototype-defaults/google/protobuf/timestamp.ts
+++ b/integration/simple-prototype-defaults/google/protobuf/timestamp.ts
@@ -161,6 +161,10 @@ export const Timestamp = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Timestamp>, I>>(base?: I): Timestamp {
+    return Timestamp.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Timestamp>, I>>(object: I): Timestamp {
     const message = Object.create(createBaseTimestamp()) as Timestamp;
     message.seconds = object.seconds ?? 0;

--- a/integration/simple-prototype-defaults/google/protobuf/wrappers.ts
+++ b/integration/simple-prototype-defaults/google/protobuf/wrappers.ts
@@ -134,6 +134,10 @@ export const DoubleValue = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<DoubleValue>, I>>(base?: I): DoubleValue {
+    return DoubleValue.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<DoubleValue>, I>>(object: I): DoubleValue {
     const message = Object.create(createBaseDoubleValue()) as DoubleValue;
     message.value = object.value ?? 0;
@@ -179,6 +183,10 @@ export const FloatValue = {
     const obj: any = {};
     message.value !== undefined && (obj.value = message.value);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<FloatValue>, I>>(base?: I): FloatValue {
+    return FloatValue.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<FloatValue>, I>>(object: I): FloatValue {
@@ -228,6 +236,10 @@ export const Int64Value = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Int64Value>, I>>(base?: I): Int64Value {
+    return Int64Value.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Int64Value>, I>>(object: I): Int64Value {
     const message = Object.create(createBaseInt64Value()) as Int64Value;
     message.value = object.value ?? 0;
@@ -273,6 +285,10 @@ export const UInt64Value = {
     const obj: any = {};
     message.value !== undefined && (obj.value = Math.round(message.value));
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<UInt64Value>, I>>(base?: I): UInt64Value {
+    return UInt64Value.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<UInt64Value>, I>>(object: I): UInt64Value {
@@ -322,6 +338,10 @@ export const Int32Value = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Int32Value>, I>>(base?: I): Int32Value {
+    return Int32Value.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Int32Value>, I>>(object: I): Int32Value {
     const message = Object.create(createBaseInt32Value()) as Int32Value;
     message.value = object.value ?? 0;
@@ -367,6 +387,10 @@ export const UInt32Value = {
     const obj: any = {};
     message.value !== undefined && (obj.value = Math.round(message.value));
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<UInt32Value>, I>>(base?: I): UInt32Value {
+    return UInt32Value.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<UInt32Value>, I>>(object: I): UInt32Value {
@@ -416,6 +440,10 @@ export const BoolValue = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<BoolValue>, I>>(base?: I): BoolValue {
+    return BoolValue.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<BoolValue>, I>>(object: I): BoolValue {
     const message = Object.create(createBaseBoolValue()) as BoolValue;
     message.value = object.value ?? false;
@@ -461,6 +489,10 @@ export const StringValue = {
     const obj: any = {};
     message.value !== undefined && (obj.value = message.value);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<StringValue>, I>>(base?: I): StringValue {
+    return StringValue.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<StringValue>, I>>(object: I): StringValue {
@@ -509,6 +541,10 @@ export const BytesValue = {
     message.value !== undefined &&
       (obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array()));
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<BytesValue>, I>>(base?: I): BytesValue {
+    return BytesValue.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<BytesValue>, I>>(object: I): BytesValue {

--- a/integration/simple-prototype-defaults/google/type/date.ts
+++ b/integration/simple-prototype-defaults/google/type/date.ts
@@ -92,6 +92,10 @@ export const DateMessage = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<DateMessage>, I>>(base?: I): DateMessage {
+    return DateMessage.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<DateMessage>, I>>(object: I): DateMessage {
     const message = Object.create(createBaseDateMessage()) as DateMessage;
     message.year = object.year ?? 0;

--- a/integration/simple-prototype-defaults/import_dir/thing.ts
+++ b/integration/simple-prototype-defaults/import_dir/thing.ts
@@ -48,6 +48,10 @@ export const ImportedThing = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<ImportedThing>, I>>(base?: I): ImportedThing {
+    return ImportedThing.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<ImportedThing>, I>>(object: I): ImportedThing {
     const message = Object.create(createBaseImportedThing()) as ImportedThing;
     message.createdAt = object.createdAt ?? undefined;

--- a/integration/simple-prototype-defaults/simple.ts
+++ b/integration/simple-prototype-defaults/simple.ts
@@ -494,6 +494,10 @@ export const Simple = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Simple>, I>>(base?: I): Simple {
+    return Simple.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Simple>, I>>(object: I): Simple {
     const message = Object.create(createBaseSimple()) as Simple;
     message.name = object.name ?? "";
@@ -567,6 +571,10 @@ export const Child = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Child>, I>>(base?: I): Child {
+    return Child.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Child>, I>>(object: I): Child {
     const message = Object.create(createBaseChild()) as Child;
     message.name = object.name ?? "";
@@ -634,6 +642,10 @@ export const Nested = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Nested>, I>>(base?: I): Nested {
+    return Nested.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Nested>, I>>(object: I): Nested {
     const message = Object.create(createBaseNested()) as Nested;
     message.name = object.name ?? "";
@@ -696,6 +708,10 @@ export const Nested_InnerMessage = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Nested_InnerMessage>, I>>(base?: I): Nested_InnerMessage {
+    return Nested_InnerMessage.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Nested_InnerMessage>, I>>(object: I): Nested_InnerMessage {
     const message = Object.create(createBaseNested_InnerMessage()) as Nested_InnerMessage;
     message.name = object.name ?? "";
@@ -744,6 +760,10 @@ export const Nested_InnerMessage_DeepMessage = {
     const obj: any = {};
     message.name !== undefined && (obj.name = message.name);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Nested_InnerMessage_DeepMessage>, I>>(base?: I): Nested_InnerMessage_DeepMessage {
+    return Nested_InnerMessage_DeepMessage.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<Nested_InnerMessage_DeepMessage>, I>>(
@@ -803,6 +823,10 @@ export const OneOfMessage = {
     message.first !== undefined && (obj.first = message.first);
     message.last !== undefined && (obj.last = message.last);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<OneOfMessage>, I>>(base?: I): OneOfMessage {
+    return OneOfMessage.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<OneOfMessage>, I>>(object: I): OneOfMessage {
@@ -903,6 +927,10 @@ export const SimpleWithWrappers = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<SimpleWithWrappers>, I>>(base?: I): SimpleWithWrappers {
+    return SimpleWithWrappers.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<SimpleWithWrappers>, I>>(object: I): SimpleWithWrappers {
     const message = Object.create(createBaseSimpleWithWrappers()) as SimpleWithWrappers;
     message.name = object.name ?? undefined;
@@ -953,6 +981,10 @@ export const Entity = {
     const obj: any = {};
     message.id !== undefined && (obj.id = Math.round(message.id));
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Entity>, I>>(base?: I): Entity {
+    return Entity.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<Entity>, I>>(object: I): Entity {
@@ -1156,6 +1188,10 @@ export const SimpleWithMap = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<SimpleWithMap>, I>>(base?: I): SimpleWithMap {
+    return SimpleWithMap.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<SimpleWithMap>, I>>(object: I): SimpleWithMap {
     const message = Object.create(createBaseSimpleWithMap()) as SimpleWithMap;
     message.entitiesById = Object.entries(object.entitiesById ?? {}).reduce<{ [key: number]: Entity }>(
@@ -1274,6 +1310,10 @@ export const SimpleWithMap_EntitiesByIdEntry = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<SimpleWithMap_EntitiesByIdEntry>, I>>(base?: I): SimpleWithMap_EntitiesByIdEntry {
+    return SimpleWithMap_EntitiesByIdEntry.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<SimpleWithMap_EntitiesByIdEntry>, I>>(
     object: I,
   ): SimpleWithMap_EntitiesByIdEntry {
@@ -1333,6 +1373,10 @@ export const SimpleWithMap_NameLookupEntry = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<SimpleWithMap_NameLookupEntry>, I>>(base?: I): SimpleWithMap_NameLookupEntry {
+    return SimpleWithMap_NameLookupEntry.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<SimpleWithMap_NameLookupEntry>, I>>(
     object: I,
   ): SimpleWithMap_NameLookupEntry {
@@ -1388,6 +1432,10 @@ export const SimpleWithMap_IntLookupEntry = {
     message.key !== undefined && (obj.key = Math.round(message.key));
     message.value !== undefined && (obj.value = Math.round(message.value));
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<SimpleWithMap_IntLookupEntry>, I>>(base?: I): SimpleWithMap_IntLookupEntry {
+    return SimpleWithMap_IntLookupEntry.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<SimpleWithMap_IntLookupEntry>, I>>(object: I): SimpleWithMap_IntLookupEntry {
@@ -1446,6 +1494,12 @@ export const SimpleWithMap_MapOfTimestampsEntry = {
     message.key !== undefined && (obj.key = message.key);
     message.value !== undefined && (obj.value = message.value.toISOString());
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<SimpleWithMap_MapOfTimestampsEntry>, I>>(
+    base?: I,
+  ): SimpleWithMap_MapOfTimestampsEntry {
+    return SimpleWithMap_MapOfTimestampsEntry.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<SimpleWithMap_MapOfTimestampsEntry>, I>>(
@@ -1507,6 +1561,10 @@ export const SimpleWithMap_MapOfBytesEntry = {
     message.value !== undefined &&
       (obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array()));
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<SimpleWithMap_MapOfBytesEntry>, I>>(base?: I): SimpleWithMap_MapOfBytesEntry {
+    return SimpleWithMap_MapOfBytesEntry.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<SimpleWithMap_MapOfBytesEntry>, I>>(
@@ -1571,6 +1629,12 @@ export const SimpleWithMap_MapOfStringValuesEntry = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<SimpleWithMap_MapOfStringValuesEntry>, I>>(
+    base?: I,
+  ): SimpleWithMap_MapOfStringValuesEntry {
+    return SimpleWithMap_MapOfStringValuesEntry.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<SimpleWithMap_MapOfStringValuesEntry>, I>>(
     object: I,
   ): SimpleWithMap_MapOfStringValuesEntry {
@@ -1628,6 +1692,10 @@ export const SimpleWithMap_LongLookupEntry = {
     message.key !== undefined && (obj.key = Math.round(message.key));
     message.value !== undefined && (obj.value = Math.round(message.value));
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<SimpleWithMap_LongLookupEntry>, I>>(base?: I): SimpleWithMap_LongLookupEntry {
+    return SimpleWithMap_LongLookupEntry.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<SimpleWithMap_LongLookupEntry>, I>>(
@@ -1695,6 +1763,10 @@ export const SimpleWithSnakeCaseMap = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<SimpleWithSnakeCaseMap>, I>>(base?: I): SimpleWithSnakeCaseMap {
+    return SimpleWithSnakeCaseMap.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<SimpleWithSnakeCaseMap>, I>>(object: I): SimpleWithSnakeCaseMap {
     const message = Object.create(createBaseSimpleWithSnakeCaseMap()) as SimpleWithSnakeCaseMap;
     message.entitiesById = Object.entries(object.entitiesById ?? {}).reduce<{ [key: number]: Entity }>(
@@ -1760,6 +1832,12 @@ export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
     message.key !== undefined && (obj.key = Math.round(message.key));
     message.value !== undefined && (obj.value = message.value ? Entity.toJSON(message.value) : undefined);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<SimpleWithSnakeCaseMap_EntitiesByIdEntry>, I>>(
+    base?: I,
+  ): SimpleWithSnakeCaseMap_EntitiesByIdEntry {
+    return SimpleWithSnakeCaseMap_EntitiesByIdEntry.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<SimpleWithSnakeCaseMap_EntitiesByIdEntry>, I>>(
@@ -1831,6 +1909,10 @@ export const SimpleWithMapOfEnums = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<SimpleWithMapOfEnums>, I>>(base?: I): SimpleWithMapOfEnums {
+    return SimpleWithMapOfEnums.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<SimpleWithMapOfEnums>, I>>(object: I): SimpleWithMapOfEnums {
     const message = Object.create(createBaseSimpleWithMapOfEnums()) as SimpleWithMapOfEnums;
     message.enumsById = Object.entries(object.enumsById ?? {}).reduce<{ [key: number]: StateEnum }>(
@@ -1898,6 +1980,12 @@ export const SimpleWithMapOfEnums_EnumsByIdEntry = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<SimpleWithMapOfEnums_EnumsByIdEntry>, I>>(
+    base?: I,
+  ): SimpleWithMapOfEnums_EnumsByIdEntry {
+    return SimpleWithMapOfEnums_EnumsByIdEntry.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<SimpleWithMapOfEnums_EnumsByIdEntry>, I>>(
     object: I,
   ): SimpleWithMapOfEnums_EnumsByIdEntry {
@@ -1950,6 +2038,10 @@ export const PingRequest = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<PingRequest>, I>>(base?: I): PingRequest {
+    return PingRequest.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<PingRequest>, I>>(object: I): PingRequest {
     const message = Object.create(createBasePingRequest()) as PingRequest;
     message.input = object.input ?? "";
@@ -1995,6 +2087,10 @@ export const PingResponse = {
     const obj: any = {};
     message.output !== undefined && (obj.output = message.output);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<PingResponse>, I>>(base?: I): PingResponse {
+    return PingResponse.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<PingResponse>, I>>(object: I): PingResponse {
@@ -2147,6 +2243,10 @@ export const Numbers = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Numbers>, I>>(base?: I): Numbers {
+    return Numbers.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Numbers>, I>>(object: I): Numbers {
     const message = Object.create(createBaseNumbers()) as Numbers;
     message.double = object.double ?? 0;
@@ -2265,6 +2365,10 @@ export const SimpleButOptional = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<SimpleButOptional>, I>>(base?: I): SimpleButOptional {
+    return SimpleButOptional.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<SimpleButOptional>, I>>(object: I): SimpleButOptional {
     const message = Object.create(createBaseSimpleButOptional()) as SimpleButOptional;
     message.name = object.name ?? undefined;
@@ -2313,6 +2417,10 @@ export const Empty = {
   toJSON(_: Empty): unknown {
     const obj: any = {};
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Empty>, I>>(base?: I): Empty {
+    return Empty.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<Empty>, I>>(_: I): Empty {

--- a/integration/simple-snake/google/protobuf/struct.ts
+++ b/integration/simple-snake/google/protobuf/struct.ts
@@ -157,6 +157,10 @@ export const Struct = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Struct>, I>>(base?: I): Struct {
+    return Struct.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Struct>, I>>(object: I): Struct {
     const message = createBaseStruct();
     message.fields = Object.entries(object.fields ?? {}).reduce<{ [key: string]: any | undefined }>(
@@ -235,6 +239,10 @@ export const Struct_FieldsEntry = {
     message.key !== undefined && (obj.key = message.key);
     message.value !== undefined && (obj.value = message.value);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Struct_FieldsEntry>, I>>(base?: I): Struct_FieldsEntry {
+    return Struct_FieldsEntry.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<Struct_FieldsEntry>, I>>(object: I): Struct_FieldsEntry {
@@ -335,6 +343,10 @@ export const Value = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Value>, I>>(base?: I): Value {
+    return Value.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Value>, I>>(object: I): Value {
     const message = createBaseValue();
     message.null_value = object.null_value ?? undefined;
@@ -428,6 +440,10 @@ export const ListValue = {
       obj.values = [];
     }
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<ListValue>, I>>(base?: I): ListValue {
+    return ListValue.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<ListValue>, I>>(object: I): ListValue {

--- a/integration/simple-snake/google/protobuf/timestamp.ts
+++ b/integration/simple-snake/google/protobuf/timestamp.ts
@@ -161,6 +161,10 @@ export const Timestamp = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Timestamp>, I>>(base?: I): Timestamp {
+    return Timestamp.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Timestamp>, I>>(object: I): Timestamp {
     const message = createBaseTimestamp();
     message.seconds = object.seconds ?? 0;

--- a/integration/simple-snake/google/protobuf/wrappers.ts
+++ b/integration/simple-snake/google/protobuf/wrappers.ts
@@ -134,6 +134,10 @@ export const DoubleValue = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<DoubleValue>, I>>(base?: I): DoubleValue {
+    return DoubleValue.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<DoubleValue>, I>>(object: I): DoubleValue {
     const message = createBaseDoubleValue();
     message.value = object.value ?? 0;
@@ -179,6 +183,10 @@ export const FloatValue = {
     const obj: any = {};
     message.value !== undefined && (obj.value = message.value);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<FloatValue>, I>>(base?: I): FloatValue {
+    return FloatValue.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<FloatValue>, I>>(object: I): FloatValue {
@@ -228,6 +236,10 @@ export const Int64Value = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Int64Value>, I>>(base?: I): Int64Value {
+    return Int64Value.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Int64Value>, I>>(object: I): Int64Value {
     const message = createBaseInt64Value();
     message.value = object.value ?? 0;
@@ -273,6 +285,10 @@ export const UInt64Value = {
     const obj: any = {};
     message.value !== undefined && (obj.value = Math.round(message.value));
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<UInt64Value>, I>>(base?: I): UInt64Value {
+    return UInt64Value.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<UInt64Value>, I>>(object: I): UInt64Value {
@@ -322,6 +338,10 @@ export const Int32Value = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Int32Value>, I>>(base?: I): Int32Value {
+    return Int32Value.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Int32Value>, I>>(object: I): Int32Value {
     const message = createBaseInt32Value();
     message.value = object.value ?? 0;
@@ -367,6 +387,10 @@ export const UInt32Value = {
     const obj: any = {};
     message.value !== undefined && (obj.value = Math.round(message.value));
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<UInt32Value>, I>>(base?: I): UInt32Value {
+    return UInt32Value.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<UInt32Value>, I>>(object: I): UInt32Value {
@@ -416,6 +440,10 @@ export const BoolValue = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<BoolValue>, I>>(base?: I): BoolValue {
+    return BoolValue.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<BoolValue>, I>>(object: I): BoolValue {
     const message = createBaseBoolValue();
     message.value = object.value ?? false;
@@ -461,6 +489,10 @@ export const StringValue = {
     const obj: any = {};
     message.value !== undefined && (obj.value = message.value);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<StringValue>, I>>(base?: I): StringValue {
+    return StringValue.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<StringValue>, I>>(object: I): StringValue {
@@ -509,6 +541,10 @@ export const BytesValue = {
     message.value !== undefined &&
       (obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array()));
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<BytesValue>, I>>(base?: I): BytesValue {
+    return BytesValue.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<BytesValue>, I>>(object: I): BytesValue {

--- a/integration/simple-snake/import_dir/thing.ts
+++ b/integration/simple-snake/import_dir/thing.ts
@@ -48,6 +48,10 @@ export const ImportedThing = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<ImportedThing>, I>>(base?: I): ImportedThing {
+    return ImportedThing.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<ImportedThing>, I>>(object: I): ImportedThing {
     const message = createBaseImportedThing();
     message.created_at = object.created_at ?? undefined;

--- a/integration/simple-snake/simple.ts
+++ b/integration/simple-snake/simple.ts
@@ -404,6 +404,10 @@ export const Simple = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Simple>, I>>(base?: I): Simple {
+    return Simple.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Simple>, I>>(object: I): Simple {
     const message = createBaseSimple();
     message.name = object.name ?? "";
@@ -470,6 +474,10 @@ export const Child = {
     message.name !== undefined && (obj.name = message.name);
     message.type !== undefined && (obj.type = child_TypeToJSON(message.type));
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Child>, I>>(base?: I): Child {
+    return Child.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<Child>, I>>(object: I): Child {
@@ -539,6 +547,10 @@ export const Nested = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Nested>, I>>(base?: I): Nested {
+    return Nested.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Nested>, I>>(object: I): Nested {
     const message = createBaseNested();
     message.name = object.name ?? "";
@@ -601,6 +613,10 @@ export const Nested_InnerMessage = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Nested_InnerMessage>, I>>(base?: I): Nested_InnerMessage {
+    return Nested_InnerMessage.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Nested_InnerMessage>, I>>(object: I): Nested_InnerMessage {
     const message = createBaseNested_InnerMessage();
     message.name = object.name ?? "";
@@ -649,6 +665,10 @@ export const Nested_InnerMessage_DeepMessage = {
     const obj: any = {};
     message.name !== undefined && (obj.name = message.name);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Nested_InnerMessage_DeepMessage>, I>>(base?: I): Nested_InnerMessage_DeepMessage {
+    return Nested_InnerMessage_DeepMessage.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<Nested_InnerMessage_DeepMessage>, I>>(
@@ -708,6 +728,10 @@ export const OneOfMessage = {
     message.first !== undefined && (obj.first = message.first);
     message.last !== undefined && (obj.last = message.last);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<OneOfMessage>, I>>(base?: I): OneOfMessage {
+    return OneOfMessage.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<OneOfMessage>, I>>(object: I): OneOfMessage {
@@ -800,6 +824,10 @@ export const SimpleWithWrappers = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<SimpleWithWrappers>, I>>(base?: I): SimpleWithWrappers {
+    return SimpleWithWrappers.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<SimpleWithWrappers>, I>>(object: I): SimpleWithWrappers {
     const message = createBaseSimpleWithWrappers();
     message.name = object.name ?? undefined;
@@ -849,6 +877,10 @@ export const Entity = {
     const obj: any = {};
     message.id !== undefined && (obj.id = Math.round(message.id));
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Entity>, I>>(base?: I): Entity {
+    return Entity.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<Entity>, I>>(object: I): Entity {
@@ -955,6 +987,10 @@ export const SimpleWithMap = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<SimpleWithMap>, I>>(base?: I): SimpleWithMap {
+    return SimpleWithMap.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<SimpleWithMap>, I>>(object: I): SimpleWithMap {
     const message = createBaseSimpleWithMap();
     message.entitiesById = Object.entries(object.entitiesById ?? {}).reduce<{ [key: number]: Entity }>(
@@ -1038,6 +1074,10 @@ export const SimpleWithMap_EntitiesByIdEntry = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<SimpleWithMap_EntitiesByIdEntry>, I>>(base?: I): SimpleWithMap_EntitiesByIdEntry {
+    return SimpleWithMap_EntitiesByIdEntry.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<SimpleWithMap_EntitiesByIdEntry>, I>>(
     object: I,
   ): SimpleWithMap_EntitiesByIdEntry {
@@ -1097,6 +1137,10 @@ export const SimpleWithMap_NameLookupEntry = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<SimpleWithMap_NameLookupEntry>, I>>(base?: I): SimpleWithMap_NameLookupEntry {
+    return SimpleWithMap_NameLookupEntry.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<SimpleWithMap_NameLookupEntry>, I>>(
     object: I,
   ): SimpleWithMap_NameLookupEntry {
@@ -1152,6 +1196,10 @@ export const SimpleWithMap_IntLookupEntry = {
     message.key !== undefined && (obj.key = Math.round(message.key));
     message.value !== undefined && (obj.value = Math.round(message.value));
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<SimpleWithMap_IntLookupEntry>, I>>(base?: I): SimpleWithMap_IntLookupEntry {
+    return SimpleWithMap_IntLookupEntry.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<SimpleWithMap_IntLookupEntry>, I>>(object: I): SimpleWithMap_IntLookupEntry {
@@ -1215,6 +1263,10 @@ export const SimpleWithSnakeCaseMap = {
       });
     }
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<SimpleWithSnakeCaseMap>, I>>(base?: I): SimpleWithSnakeCaseMap {
+    return SimpleWithSnakeCaseMap.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<SimpleWithSnakeCaseMap>, I>>(object: I): SimpleWithSnakeCaseMap {
@@ -1282,6 +1334,12 @@ export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<SimpleWithSnakeCaseMap_EntitiesByIdEntry>, I>>(
+    base?: I,
+  ): SimpleWithSnakeCaseMap_EntitiesByIdEntry {
+    return SimpleWithSnakeCaseMap_EntitiesByIdEntry.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<SimpleWithSnakeCaseMap_EntitiesByIdEntry>, I>>(
     object: I,
   ): SimpleWithSnakeCaseMap_EntitiesByIdEntry {
@@ -1334,6 +1392,10 @@ export const PingRequest = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<PingRequest>, I>>(base?: I): PingRequest {
+    return PingRequest.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<PingRequest>, I>>(object: I): PingRequest {
     const message = createBasePingRequest();
     message.input = object.input ?? "";
@@ -1379,6 +1441,10 @@ export const PingResponse = {
     const obj: any = {};
     message.output !== undefined && (obj.output = message.output);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<PingResponse>, I>>(base?: I): PingResponse {
+    return PingResponse.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<PingResponse>, I>>(object: I): PingResponse {
@@ -1531,6 +1597,10 @@ export const Numbers = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Numbers>, I>>(base?: I): Numbers {
+    return Numbers.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Numbers>, I>>(object: I): Numbers {
     const message = createBaseNumbers();
     message.double = object.double ?? 0;
@@ -1587,6 +1657,10 @@ export const SimpleStruct = {
     const obj: any = {};
     message.simple_struct !== undefined && (obj.simple_struct = message.simple_struct);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<SimpleStruct>, I>>(base?: I): SimpleStruct {
+    return SimpleStruct.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<SimpleStruct>, I>>(object: I): SimpleStruct {

--- a/integration/simple-string-enums/google/protobuf/struct.ts
+++ b/integration/simple-string-enums/google/protobuf/struct.ts
@@ -167,6 +167,10 @@ export const Struct = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Struct>, I>>(base?: I): Struct {
+    return Struct.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Struct>, I>>(object: I): Struct {
     const message = createBaseStruct();
     message.fields = Object.entries(object.fields ?? {}).reduce<{ [key: string]: any | undefined }>(
@@ -245,6 +249,10 @@ export const Struct_FieldsEntry = {
     message.key !== undefined && (obj.key = message.key);
     message.value !== undefined && (obj.value = message.value);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Struct_FieldsEntry>, I>>(base?: I): Struct_FieldsEntry {
+    return Struct_FieldsEntry.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<Struct_FieldsEntry>, I>>(object: I): Struct_FieldsEntry {
@@ -345,6 +353,10 @@ export const Value = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Value>, I>>(base?: I): Value {
+    return Value.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Value>, I>>(object: I): Value {
     const message = createBaseValue();
     message.nullValue = object.nullValue ?? undefined;
@@ -438,6 +450,10 @@ export const ListValue = {
       obj.values = [];
     }
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<ListValue>, I>>(base?: I): ListValue {
+    return ListValue.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<ListValue>, I>>(object: I): ListValue {

--- a/integration/simple-string-enums/simple.ts
+++ b/integration/simple-string-enums/simple.ts
@@ -170,6 +170,10 @@ export const Simple = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Simple>, I>>(base?: I): Simple {
+    return Simple.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Simple>, I>>(object: I): Simple {
     const message = createBaseSimple();
     message.name = object.name ?? "";
@@ -237,6 +241,10 @@ export const Simple_StateMapEntry = {
     message.key !== undefined && (obj.key = message.key);
     message.value !== undefined && (obj.value = stateEnumToJSON(message.value));
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Simple_StateMapEntry>, I>>(base?: I): Simple_StateMapEntry {
+    return Simple_StateMapEntry.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<Simple_StateMapEntry>, I>>(object: I): Simple_StateMapEntry {

--- a/integration/simple-unrecognized-enum/google/protobuf/timestamp.ts
+++ b/integration/simple-unrecognized-enum/google/protobuf/timestamp.ts
@@ -161,6 +161,10 @@ export const Timestamp = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Timestamp>, I>>(base?: I): Timestamp {
+    return Timestamp.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Timestamp>, I>>(object: I): Timestamp {
     const message = createBaseTimestamp();
     message.seconds = object.seconds ?? 0;

--- a/integration/simple-unrecognized-enum/google/protobuf/wrappers.ts
+++ b/integration/simple-unrecognized-enum/google/protobuf/wrappers.ts
@@ -134,6 +134,10 @@ export const DoubleValue = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<DoubleValue>, I>>(base?: I): DoubleValue {
+    return DoubleValue.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<DoubleValue>, I>>(object: I): DoubleValue {
     const message = createBaseDoubleValue();
     message.value = object.value ?? 0;
@@ -179,6 +183,10 @@ export const FloatValue = {
     const obj: any = {};
     message.value !== undefined && (obj.value = message.value);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<FloatValue>, I>>(base?: I): FloatValue {
+    return FloatValue.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<FloatValue>, I>>(object: I): FloatValue {
@@ -228,6 +236,10 @@ export const Int64Value = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Int64Value>, I>>(base?: I): Int64Value {
+    return Int64Value.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Int64Value>, I>>(object: I): Int64Value {
     const message = createBaseInt64Value();
     message.value = object.value ?? 0;
@@ -273,6 +285,10 @@ export const UInt64Value = {
     const obj: any = {};
     message.value !== undefined && (obj.value = Math.round(message.value));
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<UInt64Value>, I>>(base?: I): UInt64Value {
+    return UInt64Value.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<UInt64Value>, I>>(object: I): UInt64Value {
@@ -322,6 +338,10 @@ export const Int32Value = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Int32Value>, I>>(base?: I): Int32Value {
+    return Int32Value.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Int32Value>, I>>(object: I): Int32Value {
     const message = createBaseInt32Value();
     message.value = object.value ?? 0;
@@ -367,6 +387,10 @@ export const UInt32Value = {
     const obj: any = {};
     message.value !== undefined && (obj.value = Math.round(message.value));
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<UInt32Value>, I>>(base?: I): UInt32Value {
+    return UInt32Value.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<UInt32Value>, I>>(object: I): UInt32Value {
@@ -416,6 +440,10 @@ export const BoolValue = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<BoolValue>, I>>(base?: I): BoolValue {
+    return BoolValue.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<BoolValue>, I>>(object: I): BoolValue {
     const message = createBaseBoolValue();
     message.value = object.value ?? false;
@@ -461,6 +489,10 @@ export const StringValue = {
     const obj: any = {};
     message.value !== undefined && (obj.value = message.value);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<StringValue>, I>>(base?: I): StringValue {
+    return StringValue.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<StringValue>, I>>(object: I): StringValue {
@@ -509,6 +541,10 @@ export const BytesValue = {
     message.value !== undefined &&
       (obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array()));
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<BytesValue>, I>>(base?: I): BytesValue {
+    return BytesValue.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<BytesValue>, I>>(object: I): BytesValue {

--- a/integration/simple-unrecognized-enum/import_dir/thing.ts
+++ b/integration/simple-unrecognized-enum/import_dir/thing.ts
@@ -48,6 +48,10 @@ export const ImportedThing = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<ImportedThing>, I>>(base?: I): ImportedThing {
+    return ImportedThing.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<ImportedThing>, I>>(object: I): ImportedThing {
     const message = createBaseImportedThing();
     message.createdAt = object.createdAt ?? undefined;

--- a/integration/simple-unrecognized-enum/simple.ts
+++ b/integration/simple-unrecognized-enum/simple.ts
@@ -387,6 +387,10 @@ export const Simple = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Simple>, I>>(base?: I): Simple {
+    return Simple.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Simple>, I>>(object: I): Simple {
     const message = createBaseSimple();
     message.name = object.name ?? "";
@@ -453,6 +457,10 @@ export const Child = {
     message.name !== undefined && (obj.name = message.name);
     message.type !== undefined && (obj.type = child_TypeToJSON(message.type));
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Child>, I>>(base?: I): Child {
+    return Child.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<Child>, I>>(object: I): Child {
@@ -522,6 +530,10 @@ export const Nested = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Nested>, I>>(base?: I): Nested {
+    return Nested.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Nested>, I>>(object: I): Nested {
     const message = createBaseNested();
     message.name = object.name ?? "";
@@ -584,6 +596,10 @@ export const Nested_InnerMessage = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Nested_InnerMessage>, I>>(base?: I): Nested_InnerMessage {
+    return Nested_InnerMessage.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Nested_InnerMessage>, I>>(object: I): Nested_InnerMessage {
     const message = createBaseNested_InnerMessage();
     message.name = object.name ?? "";
@@ -632,6 +648,10 @@ export const Nested_InnerMessage_DeepMessage = {
     const obj: any = {};
     message.name !== undefined && (obj.name = message.name);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Nested_InnerMessage_DeepMessage>, I>>(base?: I): Nested_InnerMessage_DeepMessage {
+    return Nested_InnerMessage_DeepMessage.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<Nested_InnerMessage_DeepMessage>, I>>(
@@ -691,6 +711,10 @@ export const OneOfMessage = {
     message.first !== undefined && (obj.first = message.first);
     message.last !== undefined && (obj.last = message.last);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<OneOfMessage>, I>>(base?: I): OneOfMessage {
+    return OneOfMessage.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<OneOfMessage>, I>>(object: I): OneOfMessage {
@@ -783,6 +807,10 @@ export const SimpleWithWrappers = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<SimpleWithWrappers>, I>>(base?: I): SimpleWithWrappers {
+    return SimpleWithWrappers.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<SimpleWithWrappers>, I>>(object: I): SimpleWithWrappers {
     const message = createBaseSimpleWithWrappers();
     message.name = object.name ?? undefined;
@@ -832,6 +860,10 @@ export const Entity = {
     const obj: any = {};
     message.id !== undefined && (obj.id = Math.round(message.id));
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Entity>, I>>(base?: I): Entity {
+    return Entity.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<Entity>, I>>(object: I): Entity {
@@ -938,6 +970,10 @@ export const SimpleWithMap = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<SimpleWithMap>, I>>(base?: I): SimpleWithMap {
+    return SimpleWithMap.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<SimpleWithMap>, I>>(object: I): SimpleWithMap {
     const message = createBaseSimpleWithMap();
     message.entitiesById = Object.entries(object.entitiesById ?? {}).reduce<{ [key: number]: Entity }>(
@@ -1021,6 +1057,10 @@ export const SimpleWithMap_EntitiesByIdEntry = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<SimpleWithMap_EntitiesByIdEntry>, I>>(base?: I): SimpleWithMap_EntitiesByIdEntry {
+    return SimpleWithMap_EntitiesByIdEntry.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<SimpleWithMap_EntitiesByIdEntry>, I>>(
     object: I,
   ): SimpleWithMap_EntitiesByIdEntry {
@@ -1080,6 +1120,10 @@ export const SimpleWithMap_NameLookupEntry = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<SimpleWithMap_NameLookupEntry>, I>>(base?: I): SimpleWithMap_NameLookupEntry {
+    return SimpleWithMap_NameLookupEntry.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<SimpleWithMap_NameLookupEntry>, I>>(
     object: I,
   ): SimpleWithMap_NameLookupEntry {
@@ -1135,6 +1179,10 @@ export const SimpleWithMap_IntLookupEntry = {
     message.key !== undefined && (obj.key = Math.round(message.key));
     message.value !== undefined && (obj.value = Math.round(message.value));
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<SimpleWithMap_IntLookupEntry>, I>>(base?: I): SimpleWithMap_IntLookupEntry {
+    return SimpleWithMap_IntLookupEntry.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<SimpleWithMap_IntLookupEntry>, I>>(object: I): SimpleWithMap_IntLookupEntry {
@@ -1198,6 +1246,10 @@ export const SimpleWithSnakeCaseMap = {
       });
     }
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<SimpleWithSnakeCaseMap>, I>>(base?: I): SimpleWithSnakeCaseMap {
+    return SimpleWithSnakeCaseMap.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<SimpleWithSnakeCaseMap>, I>>(object: I): SimpleWithSnakeCaseMap {
@@ -1265,6 +1317,12 @@ export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<SimpleWithSnakeCaseMap_EntitiesByIdEntry>, I>>(
+    base?: I,
+  ): SimpleWithSnakeCaseMap_EntitiesByIdEntry {
+    return SimpleWithSnakeCaseMap_EntitiesByIdEntry.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<SimpleWithSnakeCaseMap_EntitiesByIdEntry>, I>>(
     object: I,
   ): SimpleWithSnakeCaseMap_EntitiesByIdEntry {
@@ -1317,6 +1375,10 @@ export const PingRequest = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<PingRequest>, I>>(base?: I): PingRequest {
+    return PingRequest.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<PingRequest>, I>>(object: I): PingRequest {
     const message = createBasePingRequest();
     message.input = object.input ?? "";
@@ -1362,6 +1424,10 @@ export const PingResponse = {
     const obj: any = {};
     message.output !== undefined && (obj.output = message.output);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<PingResponse>, I>>(base?: I): PingResponse {
+    return PingResponse.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<PingResponse>, I>>(object: I): PingResponse {
@@ -1512,6 +1578,10 @@ export const Numbers = {
     message.sfixed32 !== undefined && (obj.sfixed32 = Math.round(message.sfixed32));
     message.sfixed64 !== undefined && (obj.sfixed64 = Math.round(message.sfixed64));
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Numbers>, I>>(base?: I): Numbers {
+    return Numbers.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<Numbers>, I>>(object: I): Numbers {

--- a/integration/simple/google/protobuf/timestamp.ts
+++ b/integration/simple/google/protobuf/timestamp.ts
@@ -161,6 +161,10 @@ export const Timestamp = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Timestamp>, I>>(base?: I): Timestamp {
+    return Timestamp.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Timestamp>, I>>(object: I): Timestamp {
     const message = createBaseTimestamp();
     message.seconds = object.seconds ?? 0;

--- a/integration/simple/google/protobuf/wrappers.ts
+++ b/integration/simple/google/protobuf/wrappers.ts
@@ -134,6 +134,10 @@ export const DoubleValue = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<DoubleValue>, I>>(base?: I): DoubleValue {
+    return DoubleValue.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<DoubleValue>, I>>(object: I): DoubleValue {
     const message = createBaseDoubleValue();
     message.value = object.value ?? 0;
@@ -179,6 +183,10 @@ export const FloatValue = {
     const obj: any = {};
     message.value !== undefined && (obj.value = message.value);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<FloatValue>, I>>(base?: I): FloatValue {
+    return FloatValue.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<FloatValue>, I>>(object: I): FloatValue {
@@ -228,6 +236,10 @@ export const Int64Value = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Int64Value>, I>>(base?: I): Int64Value {
+    return Int64Value.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Int64Value>, I>>(object: I): Int64Value {
     const message = createBaseInt64Value();
     message.value = object.value ?? 0;
@@ -273,6 +285,10 @@ export const UInt64Value = {
     const obj: any = {};
     message.value !== undefined && (obj.value = Math.round(message.value));
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<UInt64Value>, I>>(base?: I): UInt64Value {
+    return UInt64Value.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<UInt64Value>, I>>(object: I): UInt64Value {
@@ -322,6 +338,10 @@ export const Int32Value = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Int32Value>, I>>(base?: I): Int32Value {
+    return Int32Value.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Int32Value>, I>>(object: I): Int32Value {
     const message = createBaseInt32Value();
     message.value = object.value ?? 0;
@@ -367,6 +387,10 @@ export const UInt32Value = {
     const obj: any = {};
     message.value !== undefined && (obj.value = Math.round(message.value));
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<UInt32Value>, I>>(base?: I): UInt32Value {
+    return UInt32Value.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<UInt32Value>, I>>(object: I): UInt32Value {
@@ -416,6 +440,10 @@ export const BoolValue = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<BoolValue>, I>>(base?: I): BoolValue {
+    return BoolValue.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<BoolValue>, I>>(object: I): BoolValue {
     const message = createBaseBoolValue();
     message.value = object.value ?? false;
@@ -461,6 +489,10 @@ export const StringValue = {
     const obj: any = {};
     message.value !== undefined && (obj.value = message.value);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<StringValue>, I>>(base?: I): StringValue {
+    return StringValue.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<StringValue>, I>>(object: I): StringValue {
@@ -509,6 +541,10 @@ export const BytesValue = {
     message.value !== undefined &&
       (obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array()));
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<BytesValue>, I>>(base?: I): BytesValue {
+    return BytesValue.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<BytesValue>, I>>(object: I): BytesValue {

--- a/integration/simple/google/type/date.ts
+++ b/integration/simple/google/type/date.ts
@@ -92,6 +92,10 @@ export const DateMessage = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<DateMessage>, I>>(base?: I): DateMessage {
+    return DateMessage.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<DateMessage>, I>>(object: I): DateMessage {
     const message = createBaseDateMessage();
     message.year = object.year ?? 0;

--- a/integration/simple/import_dir/thing.ts
+++ b/integration/simple/import_dir/thing.ts
@@ -48,6 +48,10 @@ export const ImportedThing = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<ImportedThing>, I>>(base?: I): ImportedThing {
+    return ImportedThing.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<ImportedThing>, I>>(object: I): ImportedThing {
     const message = createBaseImportedThing();
     message.createdAt = object.createdAt ?? undefined;

--- a/integration/simple/simple.ts
+++ b/integration/simple/simple.ts
@@ -504,6 +504,10 @@ export const Simple = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Simple>, I>>(base?: I): Simple {
+    return Simple.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Simple>, I>>(object: I): Simple {
     const message = createBaseSimple();
     message.name = object.name ?? "";
@@ -578,6 +582,10 @@ export const Child = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Child>, I>>(base?: I): Child {
+    return Child.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Child>, I>>(object: I): Child {
     const message = createBaseChild();
     message.name = object.name ?? "";
@@ -645,6 +653,10 @@ export const Nested = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Nested>, I>>(base?: I): Nested {
+    return Nested.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Nested>, I>>(object: I): Nested {
     const message = createBaseNested();
     message.name = object.name ?? "";
@@ -707,6 +719,10 @@ export const Nested_InnerMessage = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Nested_InnerMessage>, I>>(base?: I): Nested_InnerMessage {
+    return Nested_InnerMessage.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Nested_InnerMessage>, I>>(object: I): Nested_InnerMessage {
     const message = createBaseNested_InnerMessage();
     message.name = object.name ?? "";
@@ -755,6 +771,10 @@ export const Nested_InnerMessage_DeepMessage = {
     const obj: any = {};
     message.name !== undefined && (obj.name = message.name);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Nested_InnerMessage_DeepMessage>, I>>(base?: I): Nested_InnerMessage_DeepMessage {
+    return Nested_InnerMessage_DeepMessage.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<Nested_InnerMessage_DeepMessage>, I>>(
@@ -814,6 +834,10 @@ export const OneOfMessage = {
     message.first !== undefined && (obj.first = message.first);
     message.last !== undefined && (obj.last = message.last);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<OneOfMessage>, I>>(base?: I): OneOfMessage {
+    return OneOfMessage.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<OneOfMessage>, I>>(object: I): OneOfMessage {
@@ -914,6 +938,10 @@ export const SimpleWithWrappers = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<SimpleWithWrappers>, I>>(base?: I): SimpleWithWrappers {
+    return SimpleWithWrappers.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<SimpleWithWrappers>, I>>(object: I): SimpleWithWrappers {
     const message = createBaseSimpleWithWrappers();
     message.name = object.name ?? undefined;
@@ -964,6 +992,10 @@ export const Entity = {
     const obj: any = {};
     message.id !== undefined && (obj.id = Math.round(message.id));
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Entity>, I>>(base?: I): Entity {
+    return Entity.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<Entity>, I>>(object: I): Entity {
@@ -1167,6 +1199,10 @@ export const SimpleWithMap = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<SimpleWithMap>, I>>(base?: I): SimpleWithMap {
+    return SimpleWithMap.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<SimpleWithMap>, I>>(object: I): SimpleWithMap {
     const message = createBaseSimpleWithMap();
     message.entitiesById = Object.entries(object.entitiesById ?? {}).reduce<{ [key: number]: Entity }>(
@@ -1285,6 +1321,10 @@ export const SimpleWithMap_EntitiesByIdEntry = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<SimpleWithMap_EntitiesByIdEntry>, I>>(base?: I): SimpleWithMap_EntitiesByIdEntry {
+    return SimpleWithMap_EntitiesByIdEntry.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<SimpleWithMap_EntitiesByIdEntry>, I>>(
     object: I,
   ): SimpleWithMap_EntitiesByIdEntry {
@@ -1344,6 +1384,10 @@ export const SimpleWithMap_NameLookupEntry = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<SimpleWithMap_NameLookupEntry>, I>>(base?: I): SimpleWithMap_NameLookupEntry {
+    return SimpleWithMap_NameLookupEntry.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<SimpleWithMap_NameLookupEntry>, I>>(
     object: I,
   ): SimpleWithMap_NameLookupEntry {
@@ -1399,6 +1443,10 @@ export const SimpleWithMap_IntLookupEntry = {
     message.key !== undefined && (obj.key = Math.round(message.key));
     message.value !== undefined && (obj.value = Math.round(message.value));
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<SimpleWithMap_IntLookupEntry>, I>>(base?: I): SimpleWithMap_IntLookupEntry {
+    return SimpleWithMap_IntLookupEntry.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<SimpleWithMap_IntLookupEntry>, I>>(object: I): SimpleWithMap_IntLookupEntry {
@@ -1457,6 +1505,12 @@ export const SimpleWithMap_MapOfTimestampsEntry = {
     message.key !== undefined && (obj.key = message.key);
     message.value !== undefined && (obj.value = message.value.toISOString());
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<SimpleWithMap_MapOfTimestampsEntry>, I>>(
+    base?: I,
+  ): SimpleWithMap_MapOfTimestampsEntry {
+    return SimpleWithMap_MapOfTimestampsEntry.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<SimpleWithMap_MapOfTimestampsEntry>, I>>(
@@ -1520,6 +1574,10 @@ export const SimpleWithMap_MapOfBytesEntry = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<SimpleWithMap_MapOfBytesEntry>, I>>(base?: I): SimpleWithMap_MapOfBytesEntry {
+    return SimpleWithMap_MapOfBytesEntry.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<SimpleWithMap_MapOfBytesEntry>, I>>(
     object: I,
   ): SimpleWithMap_MapOfBytesEntry {
@@ -1580,6 +1638,12 @@ export const SimpleWithMap_MapOfStringValuesEntry = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<SimpleWithMap_MapOfStringValuesEntry>, I>>(
+    base?: I,
+  ): SimpleWithMap_MapOfStringValuesEntry {
+    return SimpleWithMap_MapOfStringValuesEntry.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<SimpleWithMap_MapOfStringValuesEntry>, I>>(
     object: I,
   ): SimpleWithMap_MapOfStringValuesEntry {
@@ -1635,6 +1699,10 @@ export const SimpleWithMap_LongLookupEntry = {
     message.key !== undefined && (obj.key = Math.round(message.key));
     message.value !== undefined && (obj.value = Math.round(message.value));
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<SimpleWithMap_LongLookupEntry>, I>>(base?: I): SimpleWithMap_LongLookupEntry {
+    return SimpleWithMap_LongLookupEntry.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<SimpleWithMap_LongLookupEntry>, I>>(
@@ -1702,6 +1770,10 @@ export const SimpleWithSnakeCaseMap = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<SimpleWithSnakeCaseMap>, I>>(base?: I): SimpleWithSnakeCaseMap {
+    return SimpleWithSnakeCaseMap.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<SimpleWithSnakeCaseMap>, I>>(object: I): SimpleWithSnakeCaseMap {
     const message = createBaseSimpleWithSnakeCaseMap();
     message.entitiesById = Object.entries(object.entitiesById ?? {}).reduce<{ [key: number]: Entity }>(
@@ -1765,6 +1837,12 @@ export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
     message.key !== undefined && (obj.key = Math.round(message.key));
     message.value !== undefined && (obj.value = message.value ? Entity.toJSON(message.value) : undefined);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<SimpleWithSnakeCaseMap_EntitiesByIdEntry>, I>>(
+    base?: I,
+  ): SimpleWithSnakeCaseMap_EntitiesByIdEntry {
+    return SimpleWithSnakeCaseMap_EntitiesByIdEntry.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<SimpleWithSnakeCaseMap_EntitiesByIdEntry>, I>>(
@@ -1834,6 +1912,10 @@ export const SimpleWithMapOfEnums = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<SimpleWithMapOfEnums>, I>>(base?: I): SimpleWithMapOfEnums {
+    return SimpleWithMapOfEnums.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<SimpleWithMapOfEnums>, I>>(object: I): SimpleWithMapOfEnums {
     const message = createBaseSimpleWithMapOfEnums();
     message.enumsById = Object.entries(object.enumsById ?? {}).reduce<{ [key: number]: StateEnum }>(
@@ -1899,6 +1981,12 @@ export const SimpleWithMapOfEnums_EnumsByIdEntry = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<SimpleWithMapOfEnums_EnumsByIdEntry>, I>>(
+    base?: I,
+  ): SimpleWithMapOfEnums_EnumsByIdEntry {
+    return SimpleWithMapOfEnums_EnumsByIdEntry.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<SimpleWithMapOfEnums_EnumsByIdEntry>, I>>(
     object: I,
   ): SimpleWithMapOfEnums_EnumsByIdEntry {
@@ -1949,6 +2037,10 @@ export const PingRequest = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<PingRequest>, I>>(base?: I): PingRequest {
+    return PingRequest.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<PingRequest>, I>>(object: I): PingRequest {
     const message = createBasePingRequest();
     message.input = object.input ?? "";
@@ -1994,6 +2086,10 @@ export const PingResponse = {
     const obj: any = {};
     message.output !== undefined && (obj.output = message.output);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<PingResponse>, I>>(base?: I): PingResponse {
+    return PingResponse.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<PingResponse>, I>>(object: I): PingResponse {
@@ -2146,6 +2242,10 @@ export const Numbers = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Numbers>, I>>(base?: I): Numbers {
+    return Numbers.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Numbers>, I>>(object: I): Numbers {
     const message = createBaseNumbers();
     message.double = object.double ?? 0;
@@ -2264,6 +2364,10 @@ export const SimpleButOptional = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<SimpleButOptional>, I>>(base?: I): SimpleButOptional {
+    return SimpleButOptional.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<SimpleButOptional>, I>>(object: I): SimpleButOptional {
     const message = createBaseSimpleButOptional();
     message.name = object.name ?? undefined;
@@ -2312,6 +2416,10 @@ export const Empty = {
   toJSON(_: Empty): unknown {
     const obj: any = {};
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Empty>, I>>(base?: I): Empty {
+    return Empty.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<Empty>, I>>(_: I): Empty {

--- a/integration/struct/google/protobuf/struct.ts
+++ b/integration/struct/google/protobuf/struct.ts
@@ -157,6 +157,10 @@ export const Struct = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Struct>, I>>(base?: I): Struct {
+    return Struct.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Struct>, I>>(object: I): Struct {
     const message = createBaseStruct();
     message.fields = Object.entries(object.fields ?? {}).reduce<{ [key: string]: any | undefined }>(
@@ -235,6 +239,10 @@ export const Struct_FieldsEntry = {
     message.key !== undefined && (obj.key = message.key);
     message.value !== undefined && (obj.value = message.value);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Struct_FieldsEntry>, I>>(base?: I): Struct_FieldsEntry {
+    return Struct_FieldsEntry.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<Struct_FieldsEntry>, I>>(object: I): Struct_FieldsEntry {
@@ -335,6 +343,10 @@ export const Value = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Value>, I>>(base?: I): Value {
+    return Value.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Value>, I>>(object: I): Value {
     const message = createBaseValue();
     message.nullValue = object.nullValue ?? undefined;
@@ -428,6 +440,10 @@ export const ListValue = {
       obj.values = [];
     }
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<ListValue>, I>>(base?: I): ListValue {
+    return ListValue.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<ListValue>, I>>(object: I): ListValue {

--- a/integration/struct/struct.ts
+++ b/integration/struct/struct.ts
@@ -48,6 +48,10 @@ export const StructMessage = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<StructMessage>, I>>(base?: I): StructMessage {
+    return StructMessage.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<StructMessage>, I>>(object: I): StructMessage {
     const message = createBaseStructMessage();
     message.value = object.value ?? undefined;

--- a/integration/type-registry/bar/bar.ts
+++ b/integration/type-registry/bar/bar.ts
@@ -52,6 +52,10 @@ export const Bar = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Bar>, I>>(base?: I): Bar {
+    return Bar.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Bar>, I>>(object: I): Bar {
     const message = createBaseBar();
     message.foo = (object.foo !== undefined && object.foo !== null) ? Foo.fromPartial(object.foo) : undefined;

--- a/integration/type-registry/foo.ts
+++ b/integration/type-registry/foo.ts
@@ -63,6 +63,10 @@ export const Foo = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Foo>, I>>(base?: I): Foo {
+    return Foo.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Foo>, I>>(object: I): Foo {
     const message = createBaseFoo();
     message.timestamp = object.timestamp ?? undefined;
@@ -114,6 +118,10 @@ export const Foo2 = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Foo2>, I>>(base?: I): Foo2 {
+    return Foo2.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Foo2>, I>>(object: I): Foo2 {
     const message = createBaseFoo2();
     message.timestamp = object.timestamp ?? undefined;
@@ -163,6 +171,10 @@ export const WithStruct = {
     const obj: any = {};
     message.struct !== undefined && (obj.struct = message.struct);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<WithStruct>, I>>(base?: I): WithStruct {
+    return WithStruct.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<WithStruct>, I>>(object: I): WithStruct {

--- a/integration/type-registry/google/protobuf/struct.ts
+++ b/integration/type-registry/google/protobuf/struct.ts
@@ -168,6 +168,10 @@ export const Struct = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Struct>, I>>(base?: I): Struct {
+    return Struct.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Struct>, I>>(object: I): Struct {
     const message = createBaseStruct();
     message.fields = Object.entries(object.fields ?? {}).reduce<{ [key: string]: any | undefined }>(
@@ -254,6 +258,10 @@ export const Struct_FieldsEntry = {
     message.key !== undefined && (obj.key = message.key);
     message.value !== undefined && (obj.value = message.value);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Struct_FieldsEntry>, I>>(base?: I): Struct_FieldsEntry {
+    return Struct_FieldsEntry.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<Struct_FieldsEntry>, I>>(object: I): Struct_FieldsEntry {
@@ -360,6 +368,10 @@ export const Value = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Value>, I>>(base?: I): Value {
+    return Value.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Value>, I>>(object: I): Value {
     const message = createBaseValue();
     message.nullValue = object.nullValue ?? undefined;
@@ -457,6 +469,10 @@ export const ListValue = {
       obj.values = [];
     }
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<ListValue>, I>>(base?: I): ListValue {
+    return ListValue.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<ListValue>, I>>(object: I): ListValue {

--- a/integration/type-registry/google/protobuf/timestamp.ts
+++ b/integration/type-registry/google/protobuf/timestamp.ts
@@ -166,6 +166,10 @@ export const Timestamp = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Timestamp>, I>>(base?: I): Timestamp {
+    return Timestamp.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Timestamp>, I>>(object: I): Timestamp {
     const message = createBaseTimestamp();
     message.seconds = object.seconds ?? 0;

--- a/integration/types-with-underscores/file.ts
+++ b/integration/types-with-underscores/file.ts
@@ -50,6 +50,10 @@ export const Baz = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Baz>, I>>(base?: I): Baz {
+    return Baz.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Baz>, I>>(object: I): Baz {
     const message = createBaseBaz();
     message.foo = (object.foo !== undefined && object.foo !== null) ? FooBar.fromPartial(object.foo) : undefined;
@@ -88,6 +92,10 @@ export const FooBar = {
   toJSON(_: FooBar): unknown {
     const obj: any = {};
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<FooBar>, I>>(base?: I): FooBar {
+    return FooBar.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<FooBar>, I>>(_: I): FooBar {

--- a/integration/use-date-false/google/protobuf/timestamp.ts
+++ b/integration/use-date-false/google/protobuf/timestamp.ts
@@ -161,6 +161,10 @@ export const Timestamp = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Timestamp>, I>>(base?: I): Timestamp {
+    return Timestamp.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Timestamp>, I>>(object: I): Timestamp {
     const message = createBaseTimestamp();
     message.seconds = object.seconds ?? 0;

--- a/integration/use-date-false/metadata.ts
+++ b/integration/use-date-false/metadata.ts
@@ -48,6 +48,10 @@ export const Metadata = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Metadata>, I>>(base?: I): Metadata {
+    return Metadata.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Metadata>, I>>(object: I): Metadata {
     const message = createBaseMetadata();
     message.lastEdited = (object.lastEdited !== undefined && object.lastEdited !== null)

--- a/integration/use-date-string/google/protobuf/timestamp.ts
+++ b/integration/use-date-string/google/protobuf/timestamp.ts
@@ -161,6 +161,10 @@ export const Timestamp = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Timestamp>, I>>(base?: I): Timestamp {
+    return Timestamp.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Timestamp>, I>>(object: I): Timestamp {
     const message = createBaseTimestamp();
     message.seconds = object.seconds ?? 0;

--- a/integration/use-date-string/use-date-string.ts
+++ b/integration/use-date-string/use-date-string.ts
@@ -110,6 +110,10 @@ export const Todo = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Todo>, I>>(base?: I): Todo {
+    return Todo.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Todo>, I>>(object: I): Todo {
     const message = createBaseTodo();
     message.id = object.id ?? "";
@@ -177,6 +181,10 @@ export const Todo_MapOfTimestampsEntry = {
     message.key !== undefined && (obj.key = message.key);
     message.value !== undefined && (obj.value = message.value);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Todo_MapOfTimestampsEntry>, I>>(base?: I): Todo_MapOfTimestampsEntry {
+    return Todo_MapOfTimestampsEntry.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<Todo_MapOfTimestampsEntry>, I>>(object: I): Todo_MapOfTimestampsEntry {

--- a/integration/use-date-true/google/protobuf/empty.ts
+++ b/integration/use-date-true/google/protobuf/empty.ts
@@ -50,6 +50,10 @@ export const Empty = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Empty>, I>>(base?: I): Empty {
+    return Empty.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Empty>, I>>(_: I): Empty {
     const message = createBaseEmpty();
     return message;

--- a/integration/use-date-true/google/protobuf/timestamp.ts
+++ b/integration/use-date-true/google/protobuf/timestamp.ts
@@ -161,6 +161,10 @@ export const Timestamp = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Timestamp>, I>>(base?: I): Timestamp {
+    return Timestamp.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Timestamp>, I>>(object: I): Timestamp {
     const message = createBaseTimestamp();
     message.seconds = object.seconds ?? 0;

--- a/integration/use-date-true/use-date-true.ts
+++ b/integration/use-date-true/use-date-true.ts
@@ -111,6 +111,10 @@ export const Todo = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Todo>, I>>(base?: I): Todo {
+    return Todo.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Todo>, I>>(object: I): Todo {
     const message = createBaseTodo();
     message.id = object.id ?? "";
@@ -178,6 +182,10 @@ export const Todo_MapOfTimestampsEntry = {
     message.key !== undefined && (obj.key = message.key);
     message.value !== undefined && (obj.value = message.value.toISOString());
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Todo_MapOfTimestampsEntry>, I>>(base?: I): Todo_MapOfTimestampsEntry {
+    return Todo_MapOfTimestampsEntry.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<Todo_MapOfTimestampsEntry>, I>>(object: I): Todo_MapOfTimestampsEntry {

--- a/integration/use-exact-types-false/foo.ts
+++ b/integration/use-exact-types-false/foo.ts
@@ -55,6 +55,10 @@ export const Foo = {
     return obj;
   },
 
+  create(base?: DeepPartial<Foo>): Foo {
+    return Foo.fromPartial(base ?? {});
+  },
+
   fromPartial(object: DeepPartial<Foo>): Foo {
     const message = createBaseFoo();
     message.bar = object.bar ?? "";

--- a/integration/use-map-type/google/protobuf/struct.ts
+++ b/integration/use-map-type/google/protobuf/struct.ts
@@ -157,6 +157,10 @@ export const Struct = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Struct>, I>>(base?: I): Struct {
+    return Struct.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Struct>, I>>(object: I): Struct {
     const message = createBaseStruct();
     message.fields = (() => {
@@ -235,6 +239,10 @@ export const Struct_FieldsEntry = {
     message.key !== undefined && (obj.key = message.key);
     message.value !== undefined && (obj.value = message.value);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Struct_FieldsEntry>, I>>(base?: I): Struct_FieldsEntry {
+    return Struct_FieldsEntry.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<Struct_FieldsEntry>, I>>(object: I): Struct_FieldsEntry {
@@ -335,6 +343,10 @@ export const Value = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Value>, I>>(base?: I): Value {
+    return Value.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Value>, I>>(object: I): Value {
     const message = createBaseValue();
     message.nullValue = object.nullValue ?? undefined;
@@ -428,6 +440,10 @@ export const ListValue = {
       obj.values = [];
     }
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<ListValue>, I>>(base?: I): ListValue {
+    return ListValue.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<ListValue>, I>>(object: I): ListValue {

--- a/integration/use-map-type/google/protobuf/timestamp.ts
+++ b/integration/use-map-type/google/protobuf/timestamp.ts
@@ -161,6 +161,10 @@ export const Timestamp = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Timestamp>, I>>(base?: I): Timestamp {
+    return Timestamp.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Timestamp>, I>>(object: I): Timestamp {
     const message = createBaseTimestamp();
     message.seconds = object.seconds ?? 0;

--- a/integration/use-map-type/use-map-type.ts
+++ b/integration/use-map-type/use-map-type.ts
@@ -84,6 +84,10 @@ export const Entity = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Entity>, I>>(base?: I): Entity {
+    return Entity.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Entity>, I>>(object: I): Entity {
     const message = createBaseEntity();
     message.id = object.id ?? 0;
@@ -245,6 +249,10 @@ export const Maps = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Maps>, I>>(base?: I): Maps {
+    return Maps.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Maps>, I>>(object: I): Maps {
     const message = createBaseMaps();
     message.strToEntity = (() => {
@@ -347,6 +355,10 @@ export const Maps_StrToEntityEntry = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Maps_StrToEntityEntry>, I>>(base?: I): Maps_StrToEntityEntry {
+    return Maps_StrToEntityEntry.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Maps_StrToEntityEntry>, I>>(object: I): Maps_StrToEntityEntry {
     const message = createBaseMaps_StrToEntityEntry();
     message.key = object.key ?? "";
@@ -402,6 +414,10 @@ export const Maps_Int32ToInt32Entry = {
     message.key !== undefined && (obj.key = Math.round(message.key));
     message.value !== undefined && (obj.value = Math.round(message.value));
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Maps_Int32ToInt32Entry>, I>>(base?: I): Maps_Int32ToInt32Entry {
+    return Maps_Int32ToInt32Entry.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<Maps_Int32ToInt32Entry>, I>>(object: I): Maps_Int32ToInt32Entry {
@@ -463,6 +479,10 @@ export const Maps_StringToBytesEntry = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Maps_StringToBytesEntry>, I>>(base?: I): Maps_StringToBytesEntry {
+    return Maps_StringToBytesEntry.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Maps_StringToBytesEntry>, I>>(object: I): Maps_StringToBytesEntry {
     const message = createBaseMaps_StringToBytesEntry();
     message.key = object.key ?? "";
@@ -516,6 +536,10 @@ export const Maps_Int64ToInt64Entry = {
     message.key !== undefined && (obj.key = Math.round(message.key));
     message.value !== undefined && (obj.value = Math.round(message.value));
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Maps_Int64ToInt64Entry>, I>>(base?: I): Maps_Int64ToInt64Entry {
+    return Maps_Int64ToInt64Entry.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<Maps_Int64ToInt64Entry>, I>>(object: I): Maps_Int64ToInt64Entry {
@@ -574,6 +598,10 @@ export const Maps_MapOfTimestampsEntry = {
     message.key !== undefined && (obj.key = message.key);
     message.value !== undefined && (obj.value = message.value.toISOString());
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Maps_MapOfTimestampsEntry>, I>>(base?: I): Maps_MapOfTimestampsEntry {
+    return Maps_MapOfTimestampsEntry.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<Maps_MapOfTimestampsEntry>, I>>(object: I): Maps_MapOfTimestampsEntry {

--- a/integration/use-numeric-enum-json/google/protobuf/struct.ts
+++ b/integration/use-numeric-enum-json/google/protobuf/struct.ts
@@ -157,6 +157,10 @@ export const Struct = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Struct>, I>>(base?: I): Struct {
+    return Struct.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Struct>, I>>(object: I): Struct {
     const message = createBaseStruct();
     message.fields = Object.entries(object.fields ?? {}).reduce<{ [key: string]: any | undefined }>(
@@ -235,6 +239,10 @@ export const Struct_FieldsEntry = {
     message.key !== undefined && (obj.key = message.key);
     message.value !== undefined && (obj.value = message.value);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Struct_FieldsEntry>, I>>(base?: I): Struct_FieldsEntry {
+    return Struct_FieldsEntry.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<Struct_FieldsEntry>, I>>(object: I): Struct_FieldsEntry {
@@ -335,6 +343,10 @@ export const Value = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Value>, I>>(base?: I): Value {
+    return Value.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Value>, I>>(object: I): Value {
     const message = createBaseValue();
     message.nullValue = object.nullValue ?? undefined;
@@ -428,6 +440,10 @@ export const ListValue = {
       obj.values = [];
     }
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<ListValue>, I>>(base?: I): ListValue {
+    return ListValue.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<ListValue>, I>>(object: I): ListValue {

--- a/integration/use-numeric-enum-json/simple.ts
+++ b/integration/use-numeric-enum-json/simple.ts
@@ -156,6 +156,10 @@ export const Simple = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Simple>, I>>(base?: I): Simple {
+    return Simple.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Simple>, I>>(object: I): Simple {
     const message = createBaseSimple();
     message.name = object.name ?? "";
@@ -223,6 +227,10 @@ export const Simple_StateMapEntry = {
     message.key !== undefined && (obj.key = message.key);
     message.value !== undefined && (obj.value = stateEnumToJSON(message.value));
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Simple_StateMapEntry>, I>>(base?: I): Simple_StateMapEntry {
+    return Simple_StateMapEntry.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<Simple_StateMapEntry>, I>>(object: I): Simple_StateMapEntry {

--- a/integration/use-objectid-true-external-import/objectid/objectid.ts
+++ b/integration/use-objectid-true-external-import/objectid/objectid.ts
@@ -47,6 +47,10 @@ export const ObjectId = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<ObjectId>, I>>(base?: I): ObjectId {
+    return ObjectId.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<ObjectId>, I>>(object: I): ObjectId {
     const message = createBaseObjectId();
     message.value = object.value ?? "";

--- a/integration/use-objectid-true-external-import/use-objectid-true.ts
+++ b/integration/use-objectid-true-external-import/use-objectid-true.ts
@@ -109,6 +109,10 @@ export const Todo = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Todo>, I>>(base?: I): Todo {
+    return Todo.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Todo>, I>>(object: I): Todo {
     const message = createBaseTodo();
     message.id = object.id ?? "";
@@ -178,6 +182,10 @@ export const Todo_MapOfOidsEntry = {
     message.key !== undefined && (obj.key = message.key);
     message.value !== undefined && (obj.value = message.value.toString());
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Todo_MapOfOidsEntry>, I>>(base?: I): Todo_MapOfOidsEntry {
+    return Todo_MapOfOidsEntry.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<Todo_MapOfOidsEntry>, I>>(object: I): Todo_MapOfOidsEntry {

--- a/integration/use-optionals-all/test.ts
+++ b/integration/use-optionals-all/test.ts
@@ -403,6 +403,10 @@ export const OptionalsTest = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<OptionalsTest>, I>>(base?: I): OptionalsTest {
+    return OptionalsTest.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<OptionalsTest>, I>>(object: I): OptionalsTest {
     const message = createBaseOptionalsTest();
     message.id = object.id ?? 0;
@@ -488,6 +492,10 @@ export const OptionalsTest_TranslationsEntry = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<OptionalsTest_TranslationsEntry>, I>>(base?: I): OptionalsTest_TranslationsEntry {
+    return OptionalsTest_TranslationsEntry.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<OptionalsTest_TranslationsEntry>, I>>(
     object: I,
   ): OptionalsTest_TranslationsEntry {
@@ -529,6 +537,10 @@ export const Child = {
   toJSON(_: Child): unknown {
     const obj: any = {};
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Child>, I>>(base?: I): Child {
+    return Child.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<Child>, I>>(_: I): Child {

--- a/integration/use-readonly-types/google/protobuf/field_mask.ts
+++ b/integration/use-readonly-types/google/protobuf/field_mask.ts
@@ -252,6 +252,10 @@ export const FieldMask = {
     return message.paths.join(",");
   },
 
+  create<I extends Exact<DeepPartial<FieldMask>, I>>(base?: I): FieldMask {
+    return FieldMask.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<FieldMask>, I>>(object: I): FieldMask {
     const message = createBaseFieldMask() as any;
     message.paths = object.paths?.map((e) => e) || [];

--- a/integration/use-readonly-types/google/protobuf/struct.ts
+++ b/integration/use-readonly-types/google/protobuf/struct.ts
@@ -142,6 +142,10 @@ export const Struct = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Struct>, I>>(base?: I): Struct {
+    return Struct.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Struct>, I>>(object: I): Struct {
     const message = createBaseStruct() as any;
     message.fields = Object.entries(object.fields ?? {}).reduce<{ [key: string]: any | undefined }>(
@@ -220,6 +224,10 @@ export const Struct_FieldsEntry = {
     message.key !== undefined && (obj.key = message.key);
     message.value !== undefined && (obj.value = message.value);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Struct_FieldsEntry>, I>>(base?: I): Struct_FieldsEntry {
+    return Struct_FieldsEntry.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<Struct_FieldsEntry>, I>>(object: I): Struct_FieldsEntry {
@@ -318,6 +326,10 @@ export const Value = {
     message.kind?.$case === "structValue" && (obj.structValue = message.kind?.structValue);
     message.kind?.$case === "listValue" && (obj.listValue = message.kind?.listValue);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Value>, I>>(base?: I): Value {
+    return Value.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<Value>, I>>(object: I): Value {
@@ -438,6 +450,10 @@ export const ListValue = {
       obj.values = [];
     }
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<ListValue>, I>>(base?: I): ListValue {
+    return ListValue.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<ListValue>, I>>(object: I): ListValue {

--- a/integration/use-readonly-types/use-readonly-types.ts
+++ b/integration/use-readonly-types/use-readonly-types.ts
@@ -195,6 +195,10 @@ export const Entity = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Entity>, I>>(base?: I): Entity {
+    return Entity.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Entity>, I>>(object: I): Entity {
     const message = createBaseEntity() as any;
     message.intVal = object.intVal ?? 0;
@@ -265,6 +269,10 @@ export const SubEntity = {
     const obj: any = {};
     message.subVal !== undefined && (obj.subVal = Math.round(message.subVal));
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<SubEntity>, I>>(base?: I): SubEntity {
+    return SubEntity.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<SubEntity>, I>>(object: I): SubEntity {

--- a/integration/value/google/protobuf/struct.ts
+++ b/integration/value/google/protobuf/struct.ts
@@ -157,6 +157,10 @@ export const Struct = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Struct>, I>>(base?: I): Struct {
+    return Struct.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Struct>, I>>(object: I): Struct {
     const message = createBaseStruct();
     message.fields = Object.entries(object.fields ?? {}).reduce<{ [key: string]: any | undefined }>(
@@ -235,6 +239,10 @@ export const Struct_FieldsEntry = {
     message.key !== undefined && (obj.key = message.key);
     message.value !== undefined && (obj.value = message.value);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Struct_FieldsEntry>, I>>(base?: I): Struct_FieldsEntry {
+    return Struct_FieldsEntry.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<Struct_FieldsEntry>, I>>(object: I): Struct_FieldsEntry {
@@ -335,6 +343,10 @@ export const Value = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Value>, I>>(base?: I): Value {
+    return Value.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Value>, I>>(object: I): Value {
     const message = createBaseValue();
     message.nullValue = object.nullValue ?? undefined;
@@ -428,6 +440,10 @@ export const ListValue = {
       obj.values = [];
     }
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<ListValue>, I>>(base?: I): ListValue {
+    return ListValue.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<ListValue>, I>>(object: I): ListValue {

--- a/integration/value/google/protobuf/wrappers.ts
+++ b/integration/value/google/protobuf/wrappers.ts
@@ -134,6 +134,10 @@ export const DoubleValue = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<DoubleValue>, I>>(base?: I): DoubleValue {
+    return DoubleValue.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<DoubleValue>, I>>(object: I): DoubleValue {
     const message = createBaseDoubleValue();
     message.value = object.value ?? 0;
@@ -179,6 +183,10 @@ export const FloatValue = {
     const obj: any = {};
     message.value !== undefined && (obj.value = message.value);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<FloatValue>, I>>(base?: I): FloatValue {
+    return FloatValue.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<FloatValue>, I>>(object: I): FloatValue {
@@ -228,6 +236,10 @@ export const Int64Value = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Int64Value>, I>>(base?: I): Int64Value {
+    return Int64Value.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Int64Value>, I>>(object: I): Int64Value {
     const message = createBaseInt64Value();
     message.value = object.value ?? 0;
@@ -273,6 +285,10 @@ export const UInt64Value = {
     const obj: any = {};
     message.value !== undefined && (obj.value = Math.round(message.value));
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<UInt64Value>, I>>(base?: I): UInt64Value {
+    return UInt64Value.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<UInt64Value>, I>>(object: I): UInt64Value {
@@ -322,6 +338,10 @@ export const Int32Value = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Int32Value>, I>>(base?: I): Int32Value {
+    return Int32Value.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Int32Value>, I>>(object: I): Int32Value {
     const message = createBaseInt32Value();
     message.value = object.value ?? 0;
@@ -367,6 +387,10 @@ export const UInt32Value = {
     const obj: any = {};
     message.value !== undefined && (obj.value = Math.round(message.value));
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<UInt32Value>, I>>(base?: I): UInt32Value {
+    return UInt32Value.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<UInt32Value>, I>>(object: I): UInt32Value {
@@ -416,6 +440,10 @@ export const BoolValue = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<BoolValue>, I>>(base?: I): BoolValue {
+    return BoolValue.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<BoolValue>, I>>(object: I): BoolValue {
     const message = createBaseBoolValue();
     message.value = object.value ?? false;
@@ -461,6 +489,10 @@ export const StringValue = {
     const obj: any = {};
     message.value !== undefined && (obj.value = message.value);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<StringValue>, I>>(base?: I): StringValue {
+    return StringValue.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<StringValue>, I>>(object: I): StringValue {
@@ -509,6 +541,10 @@ export const BytesValue = {
     message.value !== undefined &&
       (obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array()));
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<BytesValue>, I>>(base?: I): BytesValue {
+    return BytesValue.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<BytesValue>, I>>(object: I): BytesValue {

--- a/integration/value/value.ts
+++ b/integration/value/value.ts
@@ -95,6 +95,10 @@ export const ValueMessage = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<ValueMessage>, I>>(base?: I): ValueMessage {
+    return ValueMessage.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<ValueMessage>, I>>(object: I): ValueMessage {
     const message = createBaseValueMessage();
     message.value = object.value ?? undefined;

--- a/integration/vector-tile/vector_tile.ts
+++ b/integration/vector-tile/vector_tile.ts
@@ -123,6 +123,10 @@ export const Tile = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Tile>, I>>(base?: I): Tile {
+    return Tile.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Tile>, I>>(object: I): Tile {
     const message = createBaseTile();
     message.layers = object.layers?.map((e) => Tile_Layer.fromPartial(e)) || [];
@@ -218,6 +222,10 @@ export const Tile_Value = {
     message.sintValue !== undefined && (obj.sintValue = Math.round(message.sintValue));
     message.boolValue !== undefined && (obj.boolValue = message.boolValue);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Tile_Value>, I>>(base?: I): Tile_Value {
+    return Tile_Value.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<Tile_Value>, I>>(object: I): Tile_Value {
@@ -325,6 +333,10 @@ export const Tile_Feature = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Tile_Feature>, I>>(base?: I): Tile_Feature {
+    return Tile_Feature.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Tile_Feature>, I>>(object: I): Tile_Feature {
     const message = createBaseTile_Feature();
     message.id = object.id ?? 0;
@@ -427,6 +439,10 @@ export const Tile_Layer = {
     }
     message.extent !== undefined && (obj.extent = Math.round(message.extent));
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Tile_Layer>, I>>(base?: I): Tile_Layer {
+    return Tile_Layer.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<Tile_Layer>, I>>(object: I): Tile_Layer {

--- a/integration/wrappers-regression/google/protobuf/empty.ts
+++ b/integration/wrappers-regression/google/protobuf/empty.ts
@@ -50,6 +50,10 @@ export const Empty = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Empty>, I>>(base?: I): Empty {
+    return Empty.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Empty>, I>>(_: I): Empty {
     const message = createBaseEmpty();
     return message;

--- a/integration/wrappers-regression/google/protobuf/timestamp.ts
+++ b/integration/wrappers-regression/google/protobuf/timestamp.ts
@@ -161,6 +161,10 @@ export const Timestamp = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Timestamp>, I>>(base?: I): Timestamp {
+    return Timestamp.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Timestamp>, I>>(object: I): Timestamp {
     const message = createBaseTimestamp();
     message.seconds = object.seconds ?? 0;

--- a/integration/wrappers-regression/google/protobuf/wrappers.ts
+++ b/integration/wrappers-regression/google/protobuf/wrappers.ts
@@ -134,6 +134,10 @@ export const DoubleValue = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<DoubleValue>, I>>(base?: I): DoubleValue {
+    return DoubleValue.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<DoubleValue>, I>>(object: I): DoubleValue {
     const message = createBaseDoubleValue();
     message.value = object.value ?? 0;
@@ -179,6 +183,10 @@ export const FloatValue = {
     const obj: any = {};
     message.value !== undefined && (obj.value = message.value);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<FloatValue>, I>>(base?: I): FloatValue {
+    return FloatValue.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<FloatValue>, I>>(object: I): FloatValue {
@@ -228,6 +236,10 @@ export const Int64Value = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Int64Value>, I>>(base?: I): Int64Value {
+    return Int64Value.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Int64Value>, I>>(object: I): Int64Value {
     const message = createBaseInt64Value();
     message.value = object.value ?? 0;
@@ -273,6 +285,10 @@ export const UInt64Value = {
     const obj: any = {};
     message.value !== undefined && (obj.value = Math.round(message.value));
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<UInt64Value>, I>>(base?: I): UInt64Value {
+    return UInt64Value.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<UInt64Value>, I>>(object: I): UInt64Value {
@@ -322,6 +338,10 @@ export const Int32Value = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Int32Value>, I>>(base?: I): Int32Value {
+    return Int32Value.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<Int32Value>, I>>(object: I): Int32Value {
     const message = createBaseInt32Value();
     message.value = object.value ?? 0;
@@ -367,6 +387,10 @@ export const UInt32Value = {
     const obj: any = {};
     message.value !== undefined && (obj.value = Math.round(message.value));
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<UInt32Value>, I>>(base?: I): UInt32Value {
+    return UInt32Value.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<UInt32Value>, I>>(object: I): UInt32Value {
@@ -416,6 +440,10 @@ export const BoolValue = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<BoolValue>, I>>(base?: I): BoolValue {
+    return BoolValue.fromPartial(base ?? {});
+  },
+
   fromPartial<I extends Exact<DeepPartial<BoolValue>, I>>(object: I): BoolValue {
     const message = createBaseBoolValue();
     message.value = object.value ?? false;
@@ -461,6 +489,10 @@ export const StringValue = {
     const obj: any = {};
     message.value !== undefined && (obj.value = message.value);
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<StringValue>, I>>(base?: I): StringValue {
+    return StringValue.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<StringValue>, I>>(object: I): StringValue {
@@ -509,6 +541,10 @@ export const BytesValue = {
     message.value !== undefined &&
       (obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array()));
     return obj;
+  },
+
+  create<I extends Exact<DeepPartial<BytesValue>, I>>(base?: I): BytesValue {
+    return BytesValue.fromPartial(base ?? {});
   },
 
   fromPartial<I extends Exact<DeepPartial<BytesValue>, I>>(object: I): BytesValue {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1599,10 +1599,27 @@ function generateToJson(
 }
 
 function generateFromPartial(ctx: Context, fullName: string, messageDesc: DescriptorProto): Code {
-  const { options, utils, typeMap } = ctx;
+  const { options, utils } = ctx;
   const chunks: Code[] = [];
 
-  // create the basic function declaration
+  // create the create function definition
+  if (ctx.options.useExactTypes) {
+    chunks.push(code`
+      create<I extends ${utils.Exact}<${utils.DeepPartial}<${fullName}>, I>>(base?: I): ${fullName} {
+    `);
+  } else {
+    chunks.push(code`
+      create(base?: ${utils.DeepPartial}<${fullName}>): ${fullName} {
+    `);
+  }
+
+  chunks.push(code`
+    return ${fullName}.fromPartial(base ?? {})
+  `);
+
+  chunks.push(code`},`, code``);
+
+  // create the fromPartial function declaration
   const paramName = messageDesc.field.length > 0 ? "object" : "_";
 
   if (ctx.options.useExactTypes) {


### PR DESCRIPTION
Similar to `fromPartial` except it allows an empty argument:

 - create() -> {object}
 - create({partial object}) -> {object}

Calls fromPartial internally.

Callers of the library can now use create() instead of fromPartial({}) which, while functionally equivalent, is much more readable.

Context: https://github.com/stephenh/ts-proto/pull/727#issuecomment-1374975543