### PR TITLE
feat: implementation of useAbortSignal option for grpc-web

### DIFF
--- a/integration/grpc-web-no-streaming-observable/example.ts
+++ b/integration/grpc-web-no-streaming-observable/example.ts
@@ -323,8 +323,8 @@ export const Empty = {
 export interface DashState {
   UserSettings(
     request: DeepPartial<Empty>,
-    abortSignal?: AbortSignal,
     metadata?: grpc.Metadata,
+    abortSignal?: AbortSignal,
   ): Observable<DashUserSettingsState>;
 }
 
@@ -338,8 +338,8 @@ export class DashStateClientImpl implements DashState {
 
   UserSettings(
     request: DeepPartial<Empty>,
-    abortSignal: AbortSignal | undefined,
     metadata?: grpc.Metadata,
+    abortSignal?: AbortSignal,
   ): Observable<DashUserSettingsState> {
     return this.rpc.unary(DashStateUserSettingsDesc, Empty.fromPartial(request), abortSignal, metadata);
   }
@@ -381,8 +381,8 @@ interface Rpc {
   unary<T extends UnaryMethodDefinitionish>(
     methodDesc: T,
     request: any,
-    abortSignal: AbortSignal | undefined,
     metadata: grpc.Metadata | undefined,
+    abortSignal?: AbortSignal,
   ): Observable<any>;
 }
 
@@ -413,8 +413,8 @@ export class GrpcWebImpl {
   unary<T extends UnaryMethodDefinitionish>(
     methodDesc: T,
     _request: any,
-    abortSignal: AbortSignal | undefined,
     metadata: grpc.Metadata | undefined,
+    abortSignal?: AbortSignal,
   ): Observable<any> {
     const request = { ..._request, ...methodDesc.requestType };
     const maybeCombinedMetadata = metadata && this.options.metadata

--- a/integration/grpc-web-no-streaming-observable/parameters.txt
+++ b/integration/grpc-web-no-streaming-observable/parameters.txt
@@ -1,1 +1,1 @@
-outputClientImpl=grpc-web,returnObservable=true
+outputClientImpl=grpc-web,returnObservable=true,useAbortSignal=true

--- a/integration/grpc-web/example.ts
+++ b/integration/grpc-web/example.ts
@@ -918,7 +918,11 @@ export class GrpcWebImpl {
             }
           },
         });
-        observer.add(() => client.close());
+        observer.add(() => {
+          if (!observer.closed) {
+            return client.close();
+          }
+        });
       });
       upStream();
     }).pipe(share());

--- a/integration/grpc-web/parameters.txt
+++ b/integration/grpc-web/parameters.txt
@@ -1,1 +1,1 @@
-outputClientImpl=grpc-web, useAbortSignal=true
+outputClientImpl=grpc-web

--- a/integration/grpc-web/parameters.txt
+++ b/integration/grpc-web/parameters.txt
@@ -1,1 +1,1 @@
-outputClientImpl=grpc-web
+outputClientImpl=grpc-web, useAbortSignal=true

--- a/src/generate-grpc-web.ts
+++ b/src/generate-grpc-web.ts
@@ -58,8 +58,8 @@ function generateRpcMethod(ctx: Context, serviceDesc: ServiceDescriptorProto, me
     return code`
     ${methodDesc.formattedName}(
       request: ${inputType},
-      ${useAbortSignal ? "abortSignal: AbortSignal | undefined," : ""}
       metadata?: grpc.Metadata,
+      ${useAbortSignal ? "abortSignal?: AbortSignal," : ""}
     ): ${returns} {
       throw new Error('ts-proto does not yet support client streaming!');
     }
@@ -70,8 +70,8 @@ function generateRpcMethod(ctx: Context, serviceDesc: ServiceDescriptorProto, me
   return code`
     ${methodDesc.formattedName}(
       request: ${inputType},
-      ${useAbortSignal ? "abortSignal: AbortSignal | undefined," : ""}
       metadata?: grpc.Metadata,
+      ${useAbortSignal ? "abortSignal?: AbortSignal," : ""}
     ): ${returns} {
       return this.rpc.${method}(
         ${methodDescName(serviceDesc, methodDesc)},
@@ -180,8 +180,8 @@ function generateGrpcWebRpcType(ctx: Context, returnObservable: boolean, hasStre
     unary<T extends UnaryMethodDefinitionish>(
       methodDesc: T,
       request: any,
-      ${useAbortSignal ? "abortSignal: AbortSignal | undefined," : ""}
       metadata: grpc.Metadata | undefined,
+      ${useAbortSignal ? "abortSignal?: AbortSignal," : ""}
     ): ${wrapper}<any>;
   `);
 
@@ -190,8 +190,8 @@ function generateGrpcWebRpcType(ctx: Context, returnObservable: boolean, hasStre
       invoke<T extends UnaryMethodDefinitionish>(
         methodDesc: T,
         request: any,
-        ${useAbortSignal ? "abortSignal: AbortSignal | undefined," : ""}
         metadata: grpc.Metadata | undefined,
+        ${useAbortSignal ? "abortSignal?: AbortSignal," : ""}
       ): ${observableType(ctx)}<any>;
     `);
   }
@@ -256,8 +256,8 @@ function createPromiseUnaryMethod(ctx: Context): Code {
     unary<T extends UnaryMethodDefinitionish>(
       methodDesc: T,
       _request: any,
-      ${useAbortSignal ? "abortSignal: AbortSignal | undefined," : ""}
-      metadata: grpc.Metadata | undefined
+      metadata: grpc.Metadata | undefined,
+      ${useAbortSignal ? "abortSignal?: AbortSignal," : ""}
     ): Promise<any> {
       const request = { ..._request, ...methodDesc.requestType };
       const maybeCombinedMetadata =
@@ -303,8 +303,8 @@ function createObservableUnaryMethod(ctx: Context): Code {
     unary<T extends UnaryMethodDefinitionish>(
       methodDesc: T,
       _request: any,
-      ${useAbortSignal ? "abortSignal: AbortSignal | undefined," : ""}
-      metadata: grpc.Metadata | undefined
+      metadata: grpc.Metadata | undefined,
+      ${useAbortSignal ? "abortSignal?: AbortSignal," : ""}
     ): ${observableType(ctx)}<any> {
       const request = { ..._request, ...methodDesc.requestType };
       const maybeCombinedMetadata =
@@ -354,8 +354,8 @@ function createInvokeMethod(ctx: Context) {
     invoke<T extends UnaryMethodDefinitionish>(
       methodDesc: T,
       _request: any,
-      ${useAbortSignal ? "abortSignal: AbortSignal | undefined," : ""}
-      metadata: grpc.Metadata | undefined
+      metadata: grpc.Metadata | undefined,
+      ${useAbortSignal ? "abortSignal?: AbortSignal," : ""}
     ): ${observableType(ctx)}<any> {
       const upStreamCodes = this.options.upStreamRetryCodes || [];
       const DEFAULT_TIMEOUT_TIME: number = 3_000;

--- a/src/generate-grpc-web.ts
+++ b/src/generate-grpc-web.ts
@@ -271,13 +271,17 @@ function createPromiseUnaryMethod(ctx: Context): Code {
           },
         });
 
-        ${useAbortSignal ? `
+        ${
+          useAbortSignal
+            ? `
         const abortHandler = () => {
           client.close();
           reject(new Error("Aborted"));
         }
   
-        if (abortSignal) abortSignal.addEventListener("abort", abortHandler);` : ""}
+        if (abortSignal) abortSignal.addEventListener("abort", abortHandler);`
+            : ""
+        }
       });
     }
   `;
@@ -318,12 +322,16 @@ function createObservableUnaryMethod(ctx: Context): Code {
         });
 
 
-      ${useAbortSignal ? `
+      ${
+        useAbortSignal
+          ? `
         const abortHandler = () => {
           observer.error("Aborted");
           client.close();
         };
-        if (abortSignal) abortSignal.addEventListener("abort", abortHandler);` : ""}
+        if (abortSignal) abortSignal.addEventListener("abort", abortHandler);`
+          : ""
+      }
       });
 
       }).pipe(${take}(1));
@@ -334,7 +342,7 @@ function createObservableUnaryMethod(ctx: Context): Code {
 function createInvokeMethod(ctx: Context) {
   const { options } = ctx;
   const { useAbortSignal } = options;
-  
+
   return code`
     invoke<T extends UnaryMethodDefinitionish>(
       methodDesc: T,
@@ -375,12 +383,16 @@ function createInvokeMethod(ctx: Context) {
             if (!observer.closed) return client.close()
           });
 
-          ${useAbortSignal ? `
+          ${
+            useAbortSignal
+              ? `
           const abortHandler = () => {
             observer.error("Aborted");
             client.close();
           };
-          if (abortSignal) abortSignal.addEventListener("abort", abortHandler);` : ""}
+          if (abortSignal) abortSignal.addEventListener("abort", abortHandler);`
+              : ""
+          }
         });
         upStream();
       }).pipe(${share}());

--- a/src/generate-grpc-web.ts
+++ b/src/generate-grpc-web.ts
@@ -332,7 +332,6 @@ function createObservableUnaryMethod(ctx: Context): Code {
         if (abortSignal) abortSignal.addEventListener("abort", abortHandler);`
           : ""
       }
-      });
 
       }).pipe(${take}(1));
     } 

--- a/src/generate-services.ts
+++ b/src/generate-services.ts
@@ -62,9 +62,6 @@ export function generateService(
     const partialInput = options.outputClientImpl === "grpc-web";
     const inputType = requestType(ctx, methodDesc, partialInput);
     params.push(code`request: ${inputType}`);
-    if (options.useAbortSignal) {
-      params.push(code`abortSignal?: AbortSignal`);
-    }
 
     // Use metadata as last argument for interface only configuration
     if (options.outputClientImpl === "grpc-web") {
@@ -77,6 +74,9 @@ export function generateService(
     } else if (options.metadataType) {
       const Metadata = imp(options.metadataType);
       params.push(code`metadata?: ${Metadata}`);
+    }
+    if (options.useAbortSignal) {
+      params.push(code`abortSignal?: AbortSignal`);
     }
     if (options.addNestjsRestParameter) {
       params.push(code`...rest: any`);


### PR DESCRIPTION
https://github.com/stephenh/ts-proto/pull/731 introduces the `useAbortSignal` option but it's currently not implemented for grpc-web.

This PR add useAbortSignal for grpc-web, fully working with unary/invoke 