### PR TITLE
Fixing generator when both `forceLong=bigint` and `outputTypeRegistry=true` options are used

### DIFF
--- a/integration/simple-long-bigint/google/protobuf/timestamp.ts
+++ b/integration/simple-long-bigint/google/protobuf/timestamp.ts
@@ -173,7 +173,7 @@ export const Timestamp = {
   },
 };
 
-type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | bigint | undefined;
 
 export type DeepPartial<T> = T extends Builtin ? T
   : T extends Array<infer U> ? Array<DeepPartial<U>> : T extends ReadonlyArray<infer U> ? ReadonlyArray<DeepPartial<U>>

--- a/integration/simple-long-bigint/google/protobuf/wrappers.ts
+++ b/integration/simple-long-bigint/google/protobuf/wrappers.ts
@@ -598,7 +598,7 @@ function base64FromBytes(arr: Uint8Array): string {
   }
 }
 
-type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | bigint | undefined;
 
 export type DeepPartial<T> = T extends Builtin ? T
   : T extends Array<infer U> ? Array<DeepPartial<U>> : T extends ReadonlyArray<infer U> ? ReadonlyArray<DeepPartial<U>>

--- a/integration/simple-long-bigint/simple.ts
+++ b/integration/simple-long-bigint/simple.ts
@@ -232,7 +232,7 @@ export const Numbers = {
   },
 };
 
-type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | bigint | undefined;
 
 export type DeepPartial<T> = T extends Builtin ? T
   : T extends Array<infer U> ? Array<DeepPartial<U>> : T extends ReadonlyArray<infer U> ? ReadonlyArray<DeepPartial<U>>

--- a/src/main.ts
+++ b/src/main.ts
@@ -546,7 +546,9 @@ function makeDeepPartial(options: Options, longs: ReturnType<typeof makeLongUtil
 
   const Builtin = conditionalOutput(
     "Builtin",
-    code`type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;`
+    code`type Builtin = Date | Function | Uint8Array | string | number | boolean |${
+      options.forceLong === LongOption.BIGINT ? " bigint |" : ""
+    } undefined;`
   );
 
   // Based on https://github.com/sindresorhus/type-fest/pull/259


### PR DESCRIPTION
Fixing generator when both `forceLong=bigint` and `outputTypeRegistry=true` options are used

Generated `BuiltIn` type was missing `bigint` type.

