### PR TITLE
perf: use array.push to prevent reallocation on every field

### DIFF
--- a/integration/groups/test.ts
+++ b/integration/groups/test.ts
@@ -110,10 +110,14 @@ export const GroupsOptionalTest = {
       }
       const startPos = reader.pos;
       reader.skipType(tag & 7);
-      (message as any)._unknownFields[tag] = [
-        ...((message as any)._unknownFields[tag] || []),
-        reader.buf.slice(startPos, reader.pos),
-      ];
+      const buf = reader.buf.slice(startPos, reader.pos);
+      const list = (message as any)._unknownFields[tag];
+
+      if (list === undefined) {
+        (message as any)._unknownFields[tag] = [buf];
+      } else {
+        list.push(buf);
+      }
     }
     return message;
   },
@@ -207,10 +211,14 @@ export const GroupsOptionalTest_Group = {
       }
       const startPos = reader.pos;
       reader.skipType(tag & 7);
-      (message as any)._unknownFields[tag] = [
-        ...((message as any)._unknownFields[tag] || []),
-        reader.buf.slice(startPos, reader.pos),
-      ];
+      const buf = reader.buf.slice(startPos, reader.pos);
+      const list = (message as any)._unknownFields[tag];
+
+      if (list === undefined) {
+        (message as any)._unknownFields[tag] = [buf];
+      } else {
+        list.push(buf);
+      }
     }
     return message;
   },
@@ -333,10 +341,14 @@ export const GroupsRepeatedTest = {
       }
       const startPos = reader.pos;
       reader.skipType(tag & 7);
-      (message as any)._unknownFields[tag] = [
-        ...((message as any)._unknownFields[tag] || []),
-        reader.buf.slice(startPos, reader.pos),
-      ];
+      const buf = reader.buf.slice(startPos, reader.pos);
+      const list = (message as any)._unknownFields[tag];
+
+      if (list === undefined) {
+        (message as any)._unknownFields[tag] = [buf];
+      } else {
+        list.push(buf);
+      }
     }
     return message;
   },
@@ -443,10 +455,14 @@ export const GroupsRepeatedTest_Group = {
       }
       const startPos = reader.pos;
       reader.skipType(tag & 7);
-      (message as any)._unknownFields[tag] = [
-        ...((message as any)._unknownFields[tag] || []),
-        reader.buf.slice(startPos, reader.pos),
-      ];
+      const buf = reader.buf.slice(startPos, reader.pos);
+      const list = (message as any)._unknownFields[tag];
+
+      if (list === undefined) {
+        (message as any)._unknownFields[tag] = [buf];
+      } else {
+        list.push(buf);
+      }
     }
     return message;
   },
@@ -580,10 +596,14 @@ export const GroupsNestedTest = {
       }
       const startPos = reader.pos;
       reader.skipType(tag & 7);
-      (message as any)._unknownFields[tag] = [
-        ...((message as any)._unknownFields[tag] || []),
-        reader.buf.slice(startPos, reader.pos),
-      ];
+      const buf = reader.buf.slice(startPos, reader.pos);
+      const list = (message as any)._unknownFields[tag];
+
+      if (list === undefined) {
+        (message as any)._unknownFields[tag] = [buf];
+      } else {
+        list.push(buf);
+      }
     }
     return message;
   },
@@ -678,10 +698,14 @@ export const GroupsNestedTest_Group = {
       }
       const startPos = reader.pos;
       reader.skipType(tag & 7);
-      (message as any)._unknownFields[tag] = [
-        ...((message as any)._unknownFields[tag] || []),
-        reader.buf.slice(startPos, reader.pos),
-      ];
+      const buf = reader.buf.slice(startPos, reader.pos);
+      const list = (message as any)._unknownFields[tag];
+
+      if (list === undefined) {
+        (message as any)._unknownFields[tag] = [buf];
+      } else {
+        list.push(buf);
+      }
     }
     return message;
   },
@@ -764,10 +788,14 @@ export const GroupsNestedTest_Group_Nested = {
       }
       const startPos = reader.pos;
       reader.skipType(tag & 7);
-      (message as any)._unknownFields[tag] = [
-        ...((message as any)._unknownFields[tag] || []),
-        reader.buf.slice(startPos, reader.pos),
-      ];
+      const buf = reader.buf.slice(startPos, reader.pos);
+      const list = (message as any)._unknownFields[tag];
+
+      if (list === undefined) {
+        (message as any)._unknownFields[tag] = [buf];
+      } else {
+        list.push(buf);
+      }
     }
     return message;
   },
@@ -850,10 +878,14 @@ export const GroupsNestedTest_Group_Nested_Nested2 = {
       }
       const startPos = reader.pos;
       reader.skipType(tag & 7);
-      (message as any)._unknownFields[tag] = [
-        ...((message as any)._unknownFields[tag] || []),
-        reader.buf.slice(startPos, reader.pos),
-      ];
+      const buf = reader.buf.slice(startPos, reader.pos);
+      const list = (message as any)._unknownFields[tag];
+
+      if (list === undefined) {
+        (message as any)._unknownFields[tag] = [buf];
+      } else {
+        list.push(buf);
+      }
     }
     return message;
   },

--- a/integration/groups/test.ts
+++ b/integration/groups/test.ts
@@ -76,7 +76,7 @@ export const GroupsOptionalTest = {
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): GroupsOptionalTest {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseGroupsOptionalTest();
     (message as any)._unknownFields = {};
@@ -180,7 +180,7 @@ export const GroupsOptionalTest_Group = {
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): GroupsOptionalTest_Group {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseGroupsOptionalTest_Group();
     (message as any)._unknownFields = {};
@@ -281,7 +281,7 @@ export const GroupsRepeatedTest = {
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): GroupsRepeatedTest {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseGroupsRepeatedTest();
     (message as any)._unknownFields = {};
@@ -416,7 +416,7 @@ export const GroupsRepeatedTest_Group = {
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): GroupsRepeatedTest_Group {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseGroupsRepeatedTest_Group();
     (message as any)._unknownFields = {};
@@ -528,7 +528,7 @@ export const GroupsNestedTest = {
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): GroupsNestedTest {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseGroupsNestedTest();
     (message as any)._unknownFields = {};
@@ -658,7 +658,7 @@ export const GroupsNestedTest_Group = {
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): GroupsNestedTest_Group {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseGroupsNestedTest_Group();
     (message as any)._unknownFields = {};
@@ -744,7 +744,7 @@ export const GroupsNestedTest_Group_Nested = {
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): GroupsNestedTest_Group_Nested {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseGroupsNestedTest_Group_Nested();
     (message as any)._unknownFields = {};
@@ -830,7 +830,7 @@ export const GroupsNestedTest_Group_Nested_Nested2 = {
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): GroupsNestedTest_Group_Nested_Nested2 {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseGroupsNestedTest_Group_Nested_Nested2();
     (message as any)._unknownFields = {};

--- a/integration/unknown-fields/google/protobuf/compiler/plugin.ts
+++ b/integration/unknown-fields/google/protobuf/compiler/plugin.ts
@@ -219,10 +219,14 @@ export const Version = {
       }
       const startPos = reader.pos;
       reader.skipType(tag & 7);
-      (message as any)._unknownFields[tag] = [
-        ...((message as any)._unknownFields[tag] || []),
-        reader.buf.slice(startPos, reader.pos),
-      ];
+      const buf = reader.buf.slice(startPos, reader.pos);
+      const list = (message as any)._unknownFields[tag];
+
+      if (list === undefined) {
+        (message as any)._unknownFields[tag] = [buf];
+      } else {
+        list.push(buf);
+      }
     }
     return message;
   },
@@ -305,10 +309,14 @@ export const CodeGeneratorRequest = {
       }
       const startPos = reader.pos;
       reader.skipType(tag & 7);
-      (message as any)._unknownFields[tag] = [
-        ...((message as any)._unknownFields[tag] || []),
-        reader.buf.slice(startPos, reader.pos),
-      ];
+      const buf = reader.buf.slice(startPos, reader.pos);
+      const list = (message as any)._unknownFields[tag];
+
+      if (list === undefined) {
+        (message as any)._unknownFields[tag] = [buf];
+      } else {
+        list.push(buf);
+      }
     }
     return message;
   },
@@ -381,10 +389,14 @@ export const CodeGeneratorResponse = {
       }
       const startPos = reader.pos;
       reader.skipType(tag & 7);
-      (message as any)._unknownFields[tag] = [
-        ...((message as any)._unknownFields[tag] || []),
-        reader.buf.slice(startPos, reader.pos),
-      ];
+      const buf = reader.buf.slice(startPos, reader.pos);
+      const list = (message as any)._unknownFields[tag];
+
+      if (list === undefined) {
+        (message as any)._unknownFields[tag] = [buf];
+      } else {
+        list.push(buf);
+      }
     }
     return message;
   },
@@ -467,10 +479,14 @@ export const CodeGeneratorResponse_File = {
       }
       const startPos = reader.pos;
       reader.skipType(tag & 7);
-      (message as any)._unknownFields[tag] = [
-        ...((message as any)._unknownFields[tag] || []),
-        reader.buf.slice(startPos, reader.pos),
-      ];
+      const buf = reader.buf.slice(startPos, reader.pos);
+      const list = (message as any)._unknownFields[tag];
+
+      if (list === undefined) {
+        (message as any)._unknownFields[tag] = [buf];
+      } else {
+        list.push(buf);
+      }
     }
     return message;
   },

--- a/integration/unknown-fields/google/protobuf/descriptor.ts
+++ b/integration/unknown-fields/google/protobuf/descriptor.ts
@@ -907,10 +907,14 @@ export const FileDescriptorSet = {
       }
       const startPos = reader.pos;
       reader.skipType(tag & 7);
-      (message as any)._unknownFields[tag] = [
-        ...((message as any)._unknownFields[tag] || []),
-        reader.buf.slice(startPos, reader.pos),
-      ];
+      const buf = reader.buf.slice(startPos, reader.pos);
+      const list = (message as any)._unknownFields[tag];
+
+      if (list === undefined) {
+        (message as any)._unknownFields[tag] = [buf];
+      } else {
+        list.push(buf);
+      }
     }
     return message;
   },
@@ -1108,10 +1112,14 @@ export const FileDescriptorProto = {
       }
       const startPos = reader.pos;
       reader.skipType(tag & 7);
-      (message as any)._unknownFields[tag] = [
-        ...((message as any)._unknownFields[tag] || []),
-        reader.buf.slice(startPos, reader.pos),
-      ];
+      const buf = reader.buf.slice(startPos, reader.pos);
+      const list = (message as any)._unknownFields[tag];
+
+      if (list === undefined) {
+        (message as any)._unknownFields[tag] = [buf];
+      } else {
+        list.push(buf);
+      }
     }
     return message;
   },
@@ -1265,10 +1273,14 @@ export const DescriptorProto = {
       }
       const startPos = reader.pos;
       reader.skipType(tag & 7);
-      (message as any)._unknownFields[tag] = [
-        ...((message as any)._unknownFields[tag] || []),
-        reader.buf.slice(startPos, reader.pos),
-      ];
+      const buf = reader.buf.slice(startPos, reader.pos);
+      const list = (message as any)._unknownFields[tag];
+
+      if (list === undefined) {
+        (message as any)._unknownFields[tag] = [buf];
+      } else {
+        list.push(buf);
+      }
     }
     return message;
   },
@@ -1341,10 +1353,14 @@ export const DescriptorProto_ExtensionRange = {
       }
       const startPos = reader.pos;
       reader.skipType(tag & 7);
-      (message as any)._unknownFields[tag] = [
-        ...((message as any)._unknownFields[tag] || []),
-        reader.buf.slice(startPos, reader.pos),
-      ];
+      const buf = reader.buf.slice(startPos, reader.pos);
+      const list = (message as any)._unknownFields[tag];
+
+      if (list === undefined) {
+        (message as any)._unknownFields[tag] = [buf];
+      } else {
+        list.push(buf);
+      }
     }
     return message;
   },
@@ -1407,10 +1423,14 @@ export const DescriptorProto_ReservedRange = {
       }
       const startPos = reader.pos;
       reader.skipType(tag & 7);
-      (message as any)._unknownFields[tag] = [
-        ...((message as any)._unknownFields[tag] || []),
-        reader.buf.slice(startPos, reader.pos),
-      ];
+      const buf = reader.buf.slice(startPos, reader.pos);
+      const list = (message as any)._unknownFields[tag];
+
+      if (list === undefined) {
+        (message as any)._unknownFields[tag] = [buf];
+      } else {
+        list.push(buf);
+      }
     }
     return message;
   },
@@ -1463,10 +1483,14 @@ export const ExtensionRangeOptions = {
       }
       const startPos = reader.pos;
       reader.skipType(tag & 7);
-      (message as any)._unknownFields[tag] = [
-        ...((message as any)._unknownFields[tag] || []),
-        reader.buf.slice(startPos, reader.pos),
-      ];
+      const buf = reader.buf.slice(startPos, reader.pos);
+      const list = (message as any)._unknownFields[tag];
+
+      if (list === undefined) {
+        (message as any)._unknownFields[tag] = [buf];
+      } else {
+        list.push(buf);
+      }
     }
     return message;
   },
@@ -1631,10 +1655,14 @@ export const FieldDescriptorProto = {
       }
       const startPos = reader.pos;
       reader.skipType(tag & 7);
-      (message as any)._unknownFields[tag] = [
-        ...((message as any)._unknownFields[tag] || []),
-        reader.buf.slice(startPos, reader.pos),
-      ];
+      const buf = reader.buf.slice(startPos, reader.pos);
+      const list = (message as any)._unknownFields[tag];
+
+      if (list === undefined) {
+        (message as any)._unknownFields[tag] = [buf];
+      } else {
+        list.push(buf);
+      }
     }
     return message;
   },
@@ -1697,10 +1725,14 @@ export const OneofDescriptorProto = {
       }
       const startPos = reader.pos;
       reader.skipType(tag & 7);
-      (message as any)._unknownFields[tag] = [
-        ...((message as any)._unknownFields[tag] || []),
-        reader.buf.slice(startPos, reader.pos),
-      ];
+      const buf = reader.buf.slice(startPos, reader.pos);
+      const list = (message as any)._unknownFields[tag];
+
+      if (list === undefined) {
+        (message as any)._unknownFields[tag] = [buf];
+      } else {
+        list.push(buf);
+      }
     }
     return message;
   },
@@ -1793,10 +1825,14 @@ export const EnumDescriptorProto = {
       }
       const startPos = reader.pos;
       reader.skipType(tag & 7);
-      (message as any)._unknownFields[tag] = [
-        ...((message as any)._unknownFields[tag] || []),
-        reader.buf.slice(startPos, reader.pos),
-      ];
+      const buf = reader.buf.slice(startPos, reader.pos);
+      const list = (message as any)._unknownFields[tag];
+
+      if (list === undefined) {
+        (message as any)._unknownFields[tag] = [buf];
+      } else {
+        list.push(buf);
+      }
     }
     return message;
   },
@@ -1859,10 +1895,14 @@ export const EnumDescriptorProto_EnumReservedRange = {
       }
       const startPos = reader.pos;
       reader.skipType(tag & 7);
-      (message as any)._unknownFields[tag] = [
-        ...((message as any)._unknownFields[tag] || []),
-        reader.buf.slice(startPos, reader.pos),
-      ];
+      const buf = reader.buf.slice(startPos, reader.pos);
+      const list = (message as any)._unknownFields[tag];
+
+      if (list === undefined) {
+        (message as any)._unknownFields[tag] = [buf];
+      } else {
+        list.push(buf);
+      }
     }
     return message;
   },
@@ -1935,10 +1975,14 @@ export const EnumValueDescriptorProto = {
       }
       const startPos = reader.pos;
       reader.skipType(tag & 7);
-      (message as any)._unknownFields[tag] = [
-        ...((message as any)._unknownFields[tag] || []),
-        reader.buf.slice(startPos, reader.pos),
-      ];
+      const buf = reader.buf.slice(startPos, reader.pos);
+      const list = (message as any)._unknownFields[tag];
+
+      if (list === undefined) {
+        (message as any)._unknownFields[tag] = [buf];
+      } else {
+        list.push(buf);
+      }
     }
     return message;
   },
@@ -2011,10 +2055,14 @@ export const ServiceDescriptorProto = {
       }
       const startPos = reader.pos;
       reader.skipType(tag & 7);
-      (message as any)._unknownFields[tag] = [
-        ...((message as any)._unknownFields[tag] || []),
-        reader.buf.slice(startPos, reader.pos),
-      ];
+      const buf = reader.buf.slice(startPos, reader.pos);
+      const list = (message as any)._unknownFields[tag];
+
+      if (list === undefined) {
+        (message as any)._unknownFields[tag] = [buf];
+      } else {
+        list.push(buf);
+      }
     }
     return message;
   },
@@ -2124,10 +2172,14 @@ export const MethodDescriptorProto = {
       }
       const startPos = reader.pos;
       reader.skipType(tag & 7);
-      (message as any)._unknownFields[tag] = [
-        ...((message as any)._unknownFields[tag] || []),
-        reader.buf.slice(startPos, reader.pos),
-      ];
+      const buf = reader.buf.slice(startPos, reader.pos);
+      const list = (message as any)._unknownFields[tag];
+
+      if (list === undefined) {
+        (message as any)._unknownFields[tag] = [buf];
+      } else {
+        list.push(buf);
+      }
     }
     return message;
   },
@@ -2402,10 +2454,14 @@ export const FileOptions = {
       }
       const startPos = reader.pos;
       reader.skipType(tag & 7);
-      (message as any)._unknownFields[tag] = [
-        ...((message as any)._unknownFields[tag] || []),
-        reader.buf.slice(startPos, reader.pos),
-      ];
+      const buf = reader.buf.slice(startPos, reader.pos);
+      const list = (message as any)._unknownFields[tag];
+
+      if (list === undefined) {
+        (message as any)._unknownFields[tag] = [buf];
+      } else {
+        list.push(buf);
+      }
     }
     return message;
   },
@@ -2504,10 +2560,14 @@ export const MessageOptions = {
       }
       const startPos = reader.pos;
       reader.skipType(tag & 7);
-      (message as any)._unknownFields[tag] = [
-        ...((message as any)._unknownFields[tag] || []),
-        reader.buf.slice(startPos, reader.pos),
-      ];
+      const buf = reader.buf.slice(startPos, reader.pos);
+      const list = (message as any)._unknownFields[tag];
+
+      if (list === undefined) {
+        (message as any)._unknownFields[tag] = [buf];
+      } else {
+        list.push(buf);
+      }
     }
     return message;
   },
@@ -2620,10 +2680,14 @@ export const FieldOptions = {
       }
       const startPos = reader.pos;
       reader.skipType(tag & 7);
-      (message as any)._unknownFields[tag] = [
-        ...((message as any)._unknownFields[tag] || []),
-        reader.buf.slice(startPos, reader.pos),
-      ];
+      const buf = reader.buf.slice(startPos, reader.pos);
+      const list = (message as any)._unknownFields[tag];
+
+      if (list === undefined) {
+        (message as any)._unknownFields[tag] = [buf];
+      } else {
+        list.push(buf);
+      }
     }
     return message;
   },
@@ -2676,10 +2740,14 @@ export const OneofOptions = {
       }
       const startPos = reader.pos;
       reader.skipType(tag & 7);
-      (message as any)._unknownFields[tag] = [
-        ...((message as any)._unknownFields[tag] || []),
-        reader.buf.slice(startPos, reader.pos),
-      ];
+      const buf = reader.buf.slice(startPos, reader.pos);
+      const list = (message as any)._unknownFields[tag];
+
+      if (list === undefined) {
+        (message as any)._unknownFields[tag] = [buf];
+      } else {
+        list.push(buf);
+      }
     }
     return message;
   },
@@ -2752,10 +2820,14 @@ export const EnumOptions = {
       }
       const startPos = reader.pos;
       reader.skipType(tag & 7);
-      (message as any)._unknownFields[tag] = [
-        ...((message as any)._unknownFields[tag] || []),
-        reader.buf.slice(startPos, reader.pos),
-      ];
+      const buf = reader.buf.slice(startPos, reader.pos);
+      const list = (message as any)._unknownFields[tag];
+
+      if (list === undefined) {
+        (message as any)._unknownFields[tag] = [buf];
+      } else {
+        list.push(buf);
+      }
     }
     return message;
   },
@@ -2818,10 +2890,14 @@ export const EnumValueOptions = {
       }
       const startPos = reader.pos;
       reader.skipType(tag & 7);
-      (message as any)._unknownFields[tag] = [
-        ...((message as any)._unknownFields[tag] || []),
-        reader.buf.slice(startPos, reader.pos),
-      ];
+      const buf = reader.buf.slice(startPos, reader.pos);
+      const list = (message as any)._unknownFields[tag];
+
+      if (list === undefined) {
+        (message as any)._unknownFields[tag] = [buf];
+      } else {
+        list.push(buf);
+      }
     }
     return message;
   },
@@ -2884,10 +2960,14 @@ export const ServiceOptions = {
       }
       const startPos = reader.pos;
       reader.skipType(tag & 7);
-      (message as any)._unknownFields[tag] = [
-        ...((message as any)._unknownFields[tag] || []),
-        reader.buf.slice(startPos, reader.pos),
-      ];
+      const buf = reader.buf.slice(startPos, reader.pos);
+      const list = (message as any)._unknownFields[tag];
+
+      if (list === undefined) {
+        (message as any)._unknownFields[tag] = [buf];
+      } else {
+        list.push(buf);
+      }
     }
     return message;
   },
@@ -2960,10 +3040,14 @@ export const MethodOptions = {
       }
       const startPos = reader.pos;
       reader.skipType(tag & 7);
-      (message as any)._unknownFields[tag] = [
-        ...((message as any)._unknownFields[tag] || []),
-        reader.buf.slice(startPos, reader.pos),
-      ];
+      const buf = reader.buf.slice(startPos, reader.pos);
+      const list = (message as any)._unknownFields[tag];
+
+      if (list === undefined) {
+        (message as any)._unknownFields[tag] = [buf];
+      } else {
+        list.push(buf);
+      }
     }
     return message;
   },
@@ -3084,10 +3168,14 @@ export const UninterpretedOption = {
       }
       const startPos = reader.pos;
       reader.skipType(tag & 7);
-      (message as any)._unknownFields[tag] = [
-        ...((message as any)._unknownFields[tag] || []),
-        reader.buf.slice(startPos, reader.pos),
-      ];
+      const buf = reader.buf.slice(startPos, reader.pos);
+      const list = (message as any)._unknownFields[tag];
+
+      if (list === undefined) {
+        (message as any)._unknownFields[tag] = [buf];
+      } else {
+        list.push(buf);
+      }
     }
     return message;
   },
@@ -3150,10 +3238,14 @@ export const UninterpretedOption_NamePart = {
       }
       const startPos = reader.pos;
       reader.skipType(tag & 7);
-      (message as any)._unknownFields[tag] = [
-        ...((message as any)._unknownFields[tag] || []),
-        reader.buf.slice(startPos, reader.pos),
-      ];
+      const buf = reader.buf.slice(startPos, reader.pos);
+      const list = (message as any)._unknownFields[tag];
+
+      if (list === undefined) {
+        (message as any)._unknownFields[tag] = [buf];
+      } else {
+        list.push(buf);
+      }
     }
     return message;
   },
@@ -3206,10 +3298,14 @@ export const SourceCodeInfo = {
       }
       const startPos = reader.pos;
       reader.skipType(tag & 7);
-      (message as any)._unknownFields[tag] = [
-        ...((message as any)._unknownFields[tag] || []),
-        reader.buf.slice(startPos, reader.pos),
-      ];
+      const buf = reader.buf.slice(startPos, reader.pos);
+      const list = (message as any)._unknownFields[tag];
+
+      if (list === undefined) {
+        (message as any)._unknownFields[tag] = [buf];
+      } else {
+        list.push(buf);
+      }
     }
     return message;
   },
@@ -3324,10 +3420,14 @@ export const SourceCodeInfo_Location = {
       }
       const startPos = reader.pos;
       reader.skipType(tag & 7);
-      (message as any)._unknownFields[tag] = [
-        ...((message as any)._unknownFields[tag] || []),
-        reader.buf.slice(startPos, reader.pos),
-      ];
+      const buf = reader.buf.slice(startPos, reader.pos);
+      const list = (message as any)._unknownFields[tag];
+
+      if (list === undefined) {
+        (message as any)._unknownFields[tag] = [buf];
+      } else {
+        list.push(buf);
+      }
     }
     return message;
   },
@@ -3380,10 +3480,14 @@ export const GeneratedCodeInfo = {
       }
       const startPos = reader.pos;
       reader.skipType(tag & 7);
-      (message as any)._unknownFields[tag] = [
-        ...((message as any)._unknownFields[tag] || []),
-        reader.buf.slice(startPos, reader.pos),
-      ];
+      const buf = reader.buf.slice(startPos, reader.pos);
+      const list = (message as any)._unknownFields[tag];
+
+      if (list === undefined) {
+        (message as any)._unknownFields[tag] = [buf];
+      } else {
+        list.push(buf);
+      }
     }
     return message;
   },
@@ -3477,10 +3581,14 @@ export const GeneratedCodeInfo_Annotation = {
       }
       const startPos = reader.pos;
       reader.skipType(tag & 7);
-      (message as any)._unknownFields[tag] = [
-        ...((message as any)._unknownFields[tag] || []),
-        reader.buf.slice(startPos, reader.pos),
-      ];
+      const buf = reader.buf.slice(startPos, reader.pos);
+      const list = (message as any)._unknownFields[tag];
+
+      if (list === undefined) {
+        (message as any)._unknownFields[tag] = [buf];
+      } else {
+        list.push(buf);
+      }
     }
     return message;
   },

--- a/integration/unknown-fields/options.ts
+++ b/integration/unknown-fields/options.ts
@@ -99,10 +99,14 @@ export const MyMessage = {
       }
       const startPos = reader.pos;
       reader.skipType(tag & 7);
-      (message as any)._unknownFields[tag] = [
-        ...((message as any)._unknownFields[tag] || []),
-        reader.buf.slice(startPos, reader.pos),
-      ];
+      const buf = reader.buf.slice(startPos, reader.pos);
+      const list = (message as any)._unknownFields[tag];
+
+      if (list === undefined) {
+        (message as any)._unknownFields[tag] = [buf];
+      } else {
+        list.push(buf);
+      }
     }
     return message;
   },
@@ -145,10 +149,14 @@ export const RequestType = {
       }
       const startPos = reader.pos;
       reader.skipType(tag & 7);
-      (message as any)._unknownFields[tag] = [
-        ...((message as any)._unknownFields[tag] || []),
-        reader.buf.slice(startPos, reader.pos),
-      ];
+      const buf = reader.buf.slice(startPos, reader.pos);
+      const list = (message as any)._unknownFields[tag];
+
+      if (list === undefined) {
+        (message as any)._unknownFields[tag] = [buf];
+      } else {
+        list.push(buf);
+      }
     }
     return message;
   },
@@ -191,10 +199,14 @@ export const ResponseType = {
       }
       const startPos = reader.pos;
       reader.skipType(tag & 7);
-      (message as any)._unknownFields[tag] = [
-        ...((message as any)._unknownFields[tag] || []),
-        reader.buf.slice(startPos, reader.pos),
-      ];
+      const buf = reader.buf.slice(startPos, reader.pos);
+      const list = (message as any)._unknownFields[tag];
+
+      if (list === undefined) {
+        (message as any)._unknownFields[tag] = [buf];
+      } else {
+        list.push(buf);
+      }
     }
     return message;
   },

--- a/integration/unknown-fields/something/something.ts
+++ b/integration/unknown-fields/something/something.ts
@@ -76,10 +76,14 @@ export const Something = {
       }
       const startPos = reader.pos;
       reader.skipType(tag & 7);
-      (message as any)._unknownFields[tag] = [
-        ...((message as any)._unknownFields[tag] || []),
-        reader.buf.slice(startPos, reader.pos),
-      ];
+      const buf = reader.buf.slice(startPos, reader.pos);
+      const list = (message as any)._unknownFields[tag];
+
+      if (list === undefined) {
+        (message as any)._unknownFields[tag] = [buf];
+      } else {
+        list.push(buf);
+      }
     }
     return message;
   },

--- a/src/main.ts
+++ b/src/main.ts
@@ -1108,7 +1108,13 @@ function generateDecode(ctx: Context, fullName: string, messageDesc: DescriptorP
     chunks.push(code`
         const startPos = reader.pos;
         reader.skipType(tag & 7);
-        (message as any)._unknownFields[tag] = [...((message as any)._unknownFields[tag] || []), reader.buf.slice(startPos, reader.pos)];
+        const buf = reader.buf.slice(startPos, reader.pos);
+        const list = (message as any)._unknownFields[tag];
+
+        if(list === undefined)
+          (message as any)._unknownFields[tag] = [buf];
+        else
+          list.push(buf);
     `);
   } else {
     chunks.push(code`


### PR DESCRIPTION
Hopefully this one should merge automatically after the initialize fields PR

For a sample file with 600 repeated unknown fields, it bumps the performance from 528 ops/sec to 11,100 ops/sec (20x)

(Should be my last PR for a while (with maybe the exception of the $type issue, thank you for your time)