### PR TITLE
docs: `useMongoObjectId` instead of `useObjectId`

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -220,7 +220,7 @@ creating a class and calling the right getters/setters.
 
 - ObjectIds can be mapped as `mongodb.ObjectId`
 
-  (Configurable with the `useObjectId` parameter.)
+  (Configurable with the `useMongoObjectId` parameter.)
 
 # Auto-Batching / N+1 Prevention
 
@@ -410,7 +410,7 @@ Generated code will be placed in the Gradle build directory.
 
 - With `--ts_proto_opt=useDate=false`, fields of type `google.protobuf.Timestamp` will not be mapped to type `Date` in the generated types. See [Timestamp](#timestamp) for more details.
 
-- With `--ts_proto_opt=useObjectId=true`, fields of a type called ObjectId where the message is constructed to have on field called value that is a string will be mapped to type `mongodb.ObjectId` in the generated types. This will require your project to install the mongodb npm package. See [ObjectId](#objectid) for more details.
+- With `--ts_proto_opt=useMongoObjectId=true`, fields of a type called ObjectId where the message is constructed to have on field called value that is a string will be mapped to type `mongodb.ObjectId` in the generated types. This will require your project to install the mongodb npm package. See [ObjectId](#objectid) for more details.
 
 - With `--ts_proto_opt=outputSchema=true`, meta typings will be generated that can later be used in other code generators.
 


### PR DESCRIPTION
Fix a typo in README. 

Related: #467 