### PR TITLE
Only return Observavle types for NestJS if the option is switched on

### DIFF
--- a/src/generate-nestjs.ts
+++ b/src/generate-nestjs.ts
@@ -55,13 +55,13 @@ export function generateNestjsServiceController(
     let returns: Code;
     if (isEmptyType(methodDesc.outputType)) {
       returns = code`void`;
-    } else if (options.returnObservable || methodDesc.serverStreaming) {
+    } else if (methodDesc.serverStreaming) {
       returns = code`${responseObservable(ctx, methodDesc)}`;
     } else {
       // generate nestjs union type
       returns = code`
         ${responsePromise(ctx, methodDesc)}
-        | ${responseObservable(ctx, methodDesc)}
+        ${options.returnObservable ? "\n| " + responseObservable(ctx, methodDesc) : ''}
         | ${responseType(ctx, methodDesc)}
       `;
     }


### PR DESCRIPTION
We're using `--ts_proto_opt=nestjs=true` and wanted to remove `Observable`'s being returned, so we tried `--ts_proto_opt=returnObservable=false` but it had no effect.

This PR fixes that issue so it does behave as expected. If it is incorrect, then I suggest you update the documentation to make it clear that `returnObservable` has no effect when `nestjs=true`. Thanks.