### PR TITLE
refactor: use the AbortSignal reason for rejection

### DIFF
--- a/integration/grpc-web-no-streaming-observable/example.ts
+++ b/integration/grpc-web-no-streaming-observable/example.ts
@@ -470,12 +470,11 @@ export class GrpcWebImpl {
         },
       });
 
-      const abortHandler = () => {
-        observer.error("Aborted");
-        client.close();
-      };
       if (abortSignal) {
-        abortSignal.addEventListener("abort", abortHandler);
+        abortSignal.addEventListener("abort", () => {
+          observer.error(abortSignal.reason);
+          client.close();
+        });
       }
     }).pipe(take(1));
   }

--- a/src/generate-grpc-web.ts
+++ b/src/generate-grpc-web.ts
@@ -244,12 +244,10 @@ function createPromiseUnaryMethod(ctx: Context): Code {
 
   const maybeAbortSignal = useAbortSignal
     ? `
-      const abortHandler = () => {
+      if (abortSignal) abortSignal.addEventListener("abort", () => {
         client.close();
-        reject(new Error("Aborted"));
-      }
-
-      if (abortSignal) abortSignal.addEventListener("abort", abortHandler);`
+        reject(abortSignal.reason);
+      });`
     : "";
 
   return code`
@@ -293,11 +291,10 @@ function createObservableUnaryMethod(ctx: Context): Code {
 
   const maybeAbortSignal = useAbortSignal
     ? `
-      const abortHandler = () => {
-        observer.error("Aborted");
+      if (abortSignal) abortSignal.addEventListener("abort", () => {
+        observer.error(abortSignal.reason);
         client.close();
-      };
-      if (abortSignal) abortSignal.addEventListener("abort", abortHandler);`
+      });`
     : "";
   return code`
     unary<T extends UnaryMethodDefinitionish>(
@@ -343,11 +340,10 @@ function createInvokeMethod(ctx: Context) {
 
   const maybeAbortSignal = useAbortSignal
     ? `
-      const abortHandler = () => {
-        observer.error("Aborted");
+      if (abortSignal) abortSignal.addEventListener("abort", () => {
+        observer.error(abortSignal.reason);
         client.close();
-      };
-      if (abortSignal) abortSignal.addEventListener("abort", abortHandler);`
+      });`
     : "";
 
   return code`


### PR DESCRIPTION
The AbortSignal [has a 'reason' property](http://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/reason) that can be used to pass through an exception. We should pass that on