### PR TITLE
docs: update README with protobufPackage note

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -340,7 +340,7 @@ Generated code will be placed in the Gradle build directory.
 
   (See [this issue](https://github.com/stephenh/ts-proto/issues/120#issuecomment-678375833) and [this issue](https://github.com/stephenh/ts-proto/issues/397#issuecomment-977259118) for discussions on `useOptional`.)
 
-- With `--ts_proto_opt=exportCommonSymbols=false`, utility types like `DeepPartial` won't be `export`d.
+- With `--ts_proto_opt=exportCommonSymbols=false`, utility types like `DeepPartial` and `protobufPackage` won't be `export`d.
 
   This should make it possible to use create barrel imports of the generated output, i.e. `import * from ./foo` and `import * from ./bar`.
 


### PR DESCRIPTION
I suggest adding the note that `protobufPackage` is also skipped in the export when using the `exportCommonSymbols=false`  flag. I spent a bit too long looking for this information, and found it in some old PR or issue discussion.

This should make it easier for users to find this information, as they can just search the page for `protobufPackage`.