### PR TITLE
feat: support "lib: es6"

### DIFF
--- a/integration/bytes-as-base64/message.ts
+++ b/integration/bytes-as-base64/message.ts
@@ -7,18 +7,18 @@ export interface Message {
 }
 
 function createBaseMessage(): Message {
-  return { data: new Uint8Array() };
+  return { data: new Uint8Array(0) };
 }
 
 export const Message = {
   fromJSON(object: any): Message {
-    return { data: isSet(object.data) ? bytesFromBase64(object.data) : new Uint8Array() };
+    return { data: isSet(object.data) ? bytesFromBase64(object.data) : new Uint8Array(0) };
   },
 
   toJSON(message: Message): unknown {
     const obj: any = {};
     message.data !== undefined &&
-      (obj.data = base64FromBytes(message.data !== undefined ? message.data : new Uint8Array()));
+      (obj.data = base64FromBytes(message.data !== undefined ? message.data : new Uint8Array(0)));
     return obj;
   },
 
@@ -28,7 +28,7 @@ export const Message = {
 
   fromPartial<I extends Exact<DeepPartial<Message>, I>>(object: I): Message {
     const message = createBaseMessage();
-    message.data = object.data ?? new Uint8Array();
+    message.data = object.data ?? new Uint8Array(0);
     return message;
   },
 };

--- a/integration/grpc-js/google/protobuf/wrappers.ts
+++ b/integration/grpc-js/google/protobuf/wrappers.ts
@@ -543,7 +543,7 @@ export const StringValue = {
 };
 
 function createBaseBytesValue(): BytesValue {
-  return { value: new Uint8Array() };
+  return { value: new Uint8Array(0) };
 }
 
 export const BytesValue = {
@@ -578,13 +578,13 @@ export const BytesValue = {
   },
 
   fromJSON(object: any): BytesValue {
-    return { value: isSet(object.value) ? bytesFromBase64(object.value) : new Uint8Array() };
+    return { value: isSet(object.value) ? bytesFromBase64(object.value) : new Uint8Array(0) };
   },
 
   toJSON(message: BytesValue): unknown {
     const obj: any = {};
     message.value !== undefined &&
-      (obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array()));
+      (obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array(0)));
     return obj;
   },
 
@@ -594,7 +594,7 @@ export const BytesValue = {
 
   fromPartial<I extends Exact<DeepPartial<BytesValue>, I>>(object: I): BytesValue {
     const message = createBaseBytesValue();
-    message.value = object.value ?? new Uint8Array();
+    message.value = object.value ?? new Uint8Array(0);
     return message;
   },
 };

--- a/integration/grpc-js/simple.ts
+++ b/integration/grpc-js/simple.ts
@@ -166,10 +166,10 @@ export const TestService = {
     requestStream: false,
     responseStream: false,
     requestSerialize: (value: Uint8Array | undefined) =>
-      Buffer.from(BytesValue.encode({ value: value ?? new Uint8Array() }).finish()),
+      Buffer.from(BytesValue.encode({ value: value ?? new Uint8Array(0) }).finish()),
     requestDeserialize: (value: Buffer) => BytesValue.decode(value).value,
     responseSerialize: (value: Uint8Array | undefined) =>
-      Buffer.from(BytesValue.encode({ value: value ?? new Uint8Array() }).finish()),
+      Buffer.from(BytesValue.encode({ value: value ?? new Uint8Array(0) }).finish()),
     responseDeserialize: (value: Buffer) => BytesValue.decode(value).value,
   },
   unaryFloatValue: {

--- a/integration/meta-typings/google/protobuf/wrappers.ts
+++ b/integration/meta-typings/google/protobuf/wrappers.ts
@@ -384,7 +384,7 @@ export const StringValue = {
 };
 
 function createBaseBytesValue(): BytesValue {
-  return { value: new Uint8Array() };
+  return { value: new Uint8Array(0) };
 }
 
 export const BytesValue = {

--- a/integration/meta-typings/simple.ts
+++ b/integration/meta-typings/simple.ts
@@ -206,7 +206,7 @@ function createBaseSimple(): Simple {
     thing: undefined,
     blobs: [],
     birthday: undefined,
-    blob: new Uint8Array(),
+    blob: new Uint8Array(0),
   };
 }
 
@@ -1004,7 +1004,7 @@ export const SimpleWithMap_MapOfTimestampsEntry = {
 };
 
 function createBaseSimpleWithMap_MapOfBytesEntry(): SimpleWithMap_MapOfBytesEntry {
-  return { key: "", value: new Uint8Array() };
+  return { key: "", value: new Uint8Array(0) };
 }
 
 export const SimpleWithMap_MapOfBytesEntry = {

--- a/integration/nice-grpc/google/protobuf/wrappers.ts
+++ b/integration/nice-grpc/google/protobuf/wrappers.ts
@@ -543,7 +543,7 @@ export const StringValue = {
 };
 
 function createBaseBytesValue(): BytesValue {
-  return { value: new Uint8Array() };
+  return { value: new Uint8Array(0) };
 }
 
 export const BytesValue = {
@@ -578,13 +578,13 @@ export const BytesValue = {
   },
 
   fromJSON(object: any): BytesValue {
-    return { value: isSet(object.value) ? bytesFromBase64(object.value) : new Uint8Array() };
+    return { value: isSet(object.value) ? bytesFromBase64(object.value) : new Uint8Array(0) };
   },
 
   toJSON(message: BytesValue): unknown {
     const obj: any = {};
     message.value !== undefined &&
-      (obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array()));
+      (obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array(0)));
     return obj;
   },
 
@@ -594,7 +594,7 @@ export const BytesValue = {
 
   fromPartial(object: DeepPartial<BytesValue>): BytesValue {
     const message = createBaseBytesValue();
-    message.value = object.value ?? new Uint8Array();
+    message.value = object.value ?? new Uint8Array(0);
     return message;
   },
 };

--- a/integration/oneof-unions/oneof-unions-test.ts
+++ b/integration/oneof-unions/oneof-unions-test.ts
@@ -42,7 +42,7 @@ describe('oneof=unions', () => {
       age: 37,
       choice: { $case: 'aBool', aBool: true },
       eitherOr: { $case: 'or', or: 'perhaps not' },
-      signature: new Uint8Array(),
+      signature: new Uint8Array(0),
       value: 'Debbie'
     });
   });
@@ -72,7 +72,7 @@ describe('oneof=unions', () => {
     expect(empty).toEqual({
       name: '',
       age: 0,
-      signature: new Uint8Array(),
+      signature: new Uint8Array(0),
     });
 
     let partial = PleaseChoose.fromPartial({
@@ -107,7 +107,7 @@ describe('oneof=unions', () => {
 
   it('fromJSON', () => {
     let empty = PleaseChoose.fromJSON({});
-    expect(empty).toEqual({ age: 0, name: '', signature: new Uint8Array() });
+    expect(empty).toEqual({ age: 0, name: '', signature: new Uint8Array(0) });
 
     let debbie: PleaseChoose = {
       name: 'Debbie',

--- a/integration/oneof-unions/oneof.ts
+++ b/integration/oneof-unions/oneof.ts
@@ -72,7 +72,7 @@ export interface SimpleButOptional {
 }
 
 function createBasePleaseChoose(): PleaseChoose {
-  return { name: "", choice: undefined, age: 0, eitherOr: undefined, signature: new Uint8Array(), value: undefined };
+  return { name: "", choice: undefined, age: 0, eitherOr: undefined, signature: new Uint8Array(0), value: undefined };
 }
 
 export const PleaseChoose = {
@@ -254,7 +254,7 @@ export const PleaseChoose = {
         : isSet(object.thirdOption)
         ? { $case: "thirdOption", thirdOption: String(object.thirdOption) }
         : undefined,
-      signature: isSet(object.signature) ? bytesFromBase64(object.signature) : new Uint8Array(),
+      signature: isSet(object.signature) ? bytesFromBase64(object.signature) : new Uint8Array(0),
       value: isSet(object?.value) ? object.value : undefined,
     };
   },
@@ -278,7 +278,7 @@ export const PleaseChoose = {
     message.eitherOr?.$case === "or" && (obj.or = message.eitherOr?.or);
     message.eitherOr?.$case === "thirdOption" && (obj.thirdOption = message.eitherOr?.thirdOption);
     message.signature !== undefined &&
-      (obj.signature = base64FromBytes(message.signature !== undefined ? message.signature : new Uint8Array()));
+      (obj.signature = base64FromBytes(message.signature !== undefined ? message.signature : new Uint8Array(0)));
     message.value !== undefined && (obj.value = message.value);
     return obj;
   },
@@ -330,7 +330,7 @@ export const PleaseChoose = {
     ) {
       message.eitherOr = { $case: "thirdOption", thirdOption: object.eitherOr.thirdOption };
     }
-    message.signature = object.signature ?? new Uint8Array();
+    message.signature = object.signature ?? new Uint8Array(0);
     message.value = object.value ?? undefined;
     return message;
   },

--- a/integration/options/google/protobuf/descriptor.ts
+++ b/integration/options/google/protobuf/descriptor.ts
@@ -2559,7 +2559,7 @@ function createBaseUninterpretedOption(): UninterpretedOption {
     positiveIntValue: 0,
     negativeIntValue: 0,
     doubleValue: 0,
-    stringValue: new Uint8Array(),
+    stringValue: new Uint8Array(0),
     aggregateValue: "",
   };
 }

--- a/integration/output-decode-only/google/protobuf/wrappers.ts
+++ b/integration/output-decode-only/google/protobuf/wrappers.ts
@@ -327,7 +327,7 @@ export const StringValue = {
 };
 
 function createBaseBytesValue(): BytesValue {
-  return { value: new Uint8Array() };
+  return { value: new Uint8Array(0) };
 }
 
 export const BytesValue = {

--- a/integration/output-encode-only/google/protobuf/wrappers.ts
+++ b/integration/output-encode-only/google/protobuf/wrappers.ts
@@ -198,7 +198,7 @@ export const StringValue = {
 };
 
 function createBaseBytesValue(): BytesValue {
-  return { value: new Uint8Array() };
+  return { value: new Uint8Array(0) };
 }
 
 export const BytesValue = {

--- a/integration/simple-long-bigint/google/protobuf/wrappers.ts
+++ b/integration/simple-long-bigint/google/protobuf/wrappers.ts
@@ -543,7 +543,7 @@ export const StringValue = {
 };
 
 function createBaseBytesValue(): BytesValue {
-  return { value: new Uint8Array() };
+  return { value: new Uint8Array(0) };
 }
 
 export const BytesValue = {
@@ -578,13 +578,13 @@ export const BytesValue = {
   },
 
   fromJSON(object: any): BytesValue {
-    return { value: isSet(object.value) ? bytesFromBase64(object.value) : new Uint8Array() };
+    return { value: isSet(object.value) ? bytesFromBase64(object.value) : new Uint8Array(0) };
   },
 
   toJSON(message: BytesValue): unknown {
     const obj: any = {};
     message.value !== undefined &&
-      (obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array()));
+      (obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array(0)));
     return obj;
   },
 
@@ -594,7 +594,7 @@ export const BytesValue = {
 
   fromPartial<I extends Exact<DeepPartial<BytesValue>, I>>(object: I): BytesValue {
     const message = createBaseBytesValue();
-    message.value = object.value ?? new Uint8Array();
+    message.value = object.value ?? new Uint8Array(0);
     return message;
   },
 };

--- a/integration/simple-long-string/google/protobuf/wrappers.ts
+++ b/integration/simple-long-string/google/protobuf/wrappers.ts
@@ -543,7 +543,7 @@ export const StringValue = {
 };
 
 function createBaseBytesValue(): BytesValue {
-  return { value: new Uint8Array() };
+  return { value: new Uint8Array(0) };
 }
 
 export const BytesValue = {
@@ -578,13 +578,13 @@ export const BytesValue = {
   },
 
   fromJSON(object: any): BytesValue {
-    return { value: isSet(object.value) ? bytesFromBase64(object.value) : new Uint8Array() };
+    return { value: isSet(object.value) ? bytesFromBase64(object.value) : new Uint8Array(0) };
   },
 
   toJSON(message: BytesValue): unknown {
     const obj: any = {};
     message.value !== undefined &&
-      (obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array()));
+      (obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array(0)));
     return obj;
   },
 
@@ -594,7 +594,7 @@ export const BytesValue = {
 
   fromPartial<I extends Exact<DeepPartial<BytesValue>, I>>(object: I): BytesValue {
     const message = createBaseBytesValue();
-    message.value = object.value ?? new Uint8Array();
+    message.value = object.value ?? new Uint8Array(0);
     return message;
   },
 };

--- a/integration/simple-long/google/protobuf/wrappers.ts
+++ b/integration/simple-long/google/protobuf/wrappers.ts
@@ -543,7 +543,7 @@ export const StringValue = {
 };
 
 function createBaseBytesValue(): BytesValue {
-  return { value: new Uint8Array() };
+  return { value: new Uint8Array(0) };
 }
 
 export const BytesValue = {
@@ -578,13 +578,13 @@ export const BytesValue = {
   },
 
   fromJSON(object: any): BytesValue {
-    return { value: isSet(object.value) ? bytesFromBase64(object.value) : new Uint8Array() };
+    return { value: isSet(object.value) ? bytesFromBase64(object.value) : new Uint8Array(0) };
   },
 
   toJSON(message: BytesValue): unknown {
     const obj: any = {};
     message.value !== undefined &&
-      (obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array()));
+      (obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array(0)));
     return obj;
   },
 
@@ -594,7 +594,7 @@ export const BytesValue = {
 
   fromPartial<I extends Exact<DeepPartial<BytesValue>, I>>(object: I): BytesValue {
     const message = createBaseBytesValue();
-    message.value = object.value ?? new Uint8Array();
+    message.value = object.value ?? new Uint8Array(0);
     return message;
   },
 };

--- a/integration/simple-optionals/google/protobuf/wrappers.ts
+++ b/integration/simple-optionals/google/protobuf/wrappers.ts
@@ -543,7 +543,7 @@ export const StringValue = {
 };
 
 function createBaseBytesValue(): BytesValue {
-  return { value: new Uint8Array() };
+  return { value: new Uint8Array(0) };
 }
 
 export const BytesValue = {
@@ -578,13 +578,13 @@ export const BytesValue = {
   },
 
   fromJSON(object: any): BytesValue {
-    return { value: isSet(object.value) ? bytesFromBase64(object.value) : new Uint8Array() };
+    return { value: isSet(object.value) ? bytesFromBase64(object.value) : new Uint8Array(0) };
   },
 
   toJSON(message: BytesValue): unknown {
     const obj: any = {};
     message.value !== undefined &&
-      (obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array()));
+      (obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array(0)));
     return obj;
   },
 
@@ -594,7 +594,7 @@ export const BytesValue = {
 
   fromPartial<I extends Exact<DeepPartial<BytesValue>, I>>(object: I): BytesValue {
     const message = createBaseBytesValue();
-    message.value = object.value ?? new Uint8Array();
+    message.value = object.value ?? new Uint8Array(0);
     return message;
   },
 };

--- a/integration/simple-prototype-defaults/google/protobuf/wrappers.ts
+++ b/integration/simple-prototype-defaults/google/protobuf/wrappers.ts
@@ -543,7 +543,7 @@ export const StringValue = {
 };
 
 function createBaseBytesValue(): BytesValue {
-  return { value: new Uint8Array() };
+  return { value: new Uint8Array(0) };
 }
 
 export const BytesValue = {
@@ -578,13 +578,13 @@ export const BytesValue = {
   },
 
   fromJSON(object: any): BytesValue {
-    return { value: isSet(object.value) ? bytesFromBase64(object.value) : new Uint8Array() };
+    return { value: isSet(object.value) ? bytesFromBase64(object.value) : new Uint8Array(0) };
   },
 
   toJSON(message: BytesValue): unknown {
     const obj: any = {};
     message.value !== undefined &&
-      (obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array()));
+      (obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array(0)));
     return obj;
   },
 
@@ -594,7 +594,7 @@ export const BytesValue = {
 
   fromPartial<I extends Exact<DeepPartial<BytesValue>, I>>(object: I): BytesValue {
     const message = Object.create(createBaseBytesValue()) as BytesValue;
-    message.value = object.value ?? new Uint8Array();
+    message.value = object.value ?? new Uint8Array(0);
     return message;
   },
 };

--- a/integration/simple-prototype-defaults/simple.ts
+++ b/integration/simple-prototype-defaults/simple.ts
@@ -314,7 +314,7 @@ function createBaseSimple(): Simple {
     thing: undefined,
     blobs: [],
     birthday: undefined,
-    blob: new Uint8Array(),
+    blob: new Uint8Array(0),
   };
 }
 
@@ -509,7 +509,7 @@ export const Simple = {
       thing: isSet(object.thing) ? ImportedThing.fromJSON(object.thing) : undefined,
       blobs: Array.isArray(object?.blobs) ? object.blobs.map((e: any) => bytesFromBase64(e)) : [],
       birthday: isSet(object.birthday) ? DateMessage.fromJSON(object.birthday) : undefined,
-      blob: isSet(object.blob) ? bytesFromBase64(object.blob) : new Uint8Array(),
+      blob: isSet(object.blob) ? bytesFromBase64(object.blob) : new Uint8Array(0),
     };
   },
 
@@ -542,14 +542,14 @@ export const Simple = {
     }
     message.thing !== undefined && (obj.thing = message.thing ? ImportedThing.toJSON(message.thing) : undefined);
     if (message.blobs) {
-      obj.blobs = message.blobs.map((e) => base64FromBytes(e !== undefined ? e : new Uint8Array()));
+      obj.blobs = message.blobs.map((e) => base64FromBytes(e !== undefined ? e : new Uint8Array(0)));
     } else {
       obj.blobs = [];
     }
     message.birthday !== undefined &&
       (obj.birthday = message.birthday ? DateMessage.toJSON(message.birthday) : undefined);
     message.blob !== undefined &&
-      (obj.blob = base64FromBytes(message.blob !== undefined ? message.blob : new Uint8Array()));
+      (obj.blob = base64FromBytes(message.blob !== undefined ? message.blob : new Uint8Array(0)));
     return obj;
   },
 
@@ -575,7 +575,7 @@ export const Simple = {
     message.birthday = (object.birthday !== undefined && object.birthday !== null)
       ? DateMessage.fromPartial(object.birthday)
       : undefined;
-    message.blob = object.blob ?? new Uint8Array();
+    message.blob = object.blob ?? new Uint8Array(0);
     return message;
   },
 };
@@ -1712,7 +1712,7 @@ export const SimpleWithMap_MapOfTimestampsEntry = {
 };
 
 function createBaseSimpleWithMap_MapOfBytesEntry(): SimpleWithMap_MapOfBytesEntry {
-  return { key: "", value: new Uint8Array() };
+  return { key: "", value: new Uint8Array(0) };
 }
 
 export const SimpleWithMap_MapOfBytesEntry = {
@@ -1759,7 +1759,7 @@ export const SimpleWithMap_MapOfBytesEntry = {
   fromJSON(object: any): SimpleWithMap_MapOfBytesEntry {
     return {
       key: isSet(object.key) ? String(object.key) : "",
-      value: isSet(object.value) ? bytesFromBase64(object.value) : new Uint8Array(),
+      value: isSet(object.value) ? bytesFromBase64(object.value) : new Uint8Array(0),
     };
   },
 
@@ -1767,7 +1767,7 @@ export const SimpleWithMap_MapOfBytesEntry = {
     const obj: any = {};
     message.key !== undefined && (obj.key = message.key);
     message.value !== undefined &&
-      (obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array()));
+      (obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array(0)));
     return obj;
   },
 
@@ -1780,7 +1780,7 @@ export const SimpleWithMap_MapOfBytesEntry = {
   ): SimpleWithMap_MapOfBytesEntry {
     const message = Object.create(createBaseSimpleWithMap_MapOfBytesEntry()) as SimpleWithMap_MapOfBytesEntry;
     message.key = object.key ?? "";
-    message.value = object.value ?? new Uint8Array();
+    message.value = object.value ?? new Uint8Array(0);
     return message;
   },
 };

--- a/integration/simple-snake/google/protobuf/wrappers.ts
+++ b/integration/simple-snake/google/protobuf/wrappers.ts
@@ -543,7 +543,7 @@ export const StringValue = {
 };
 
 function createBaseBytesValue(): BytesValue {
-  return { value: new Uint8Array() };
+  return { value: new Uint8Array(0) };
 }
 
 export const BytesValue = {
@@ -578,13 +578,13 @@ export const BytesValue = {
   },
 
   fromJSON(object: any): BytesValue {
-    return { value: isSet(object.value) ? bytesFromBase64(object.value) : new Uint8Array() };
+    return { value: isSet(object.value) ? bytesFromBase64(object.value) : new Uint8Array(0) };
   },
 
   toJSON(message: BytesValue): unknown {
     const obj: any = {};
     message.value !== undefined &&
-      (obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array()));
+      (obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array(0)));
     return obj;
   },
 
@@ -594,7 +594,7 @@ export const BytesValue = {
 
   fromPartial<I extends Exact<DeepPartial<BytesValue>, I>>(object: I): BytesValue {
     const message = createBaseBytesValue();
-    message.value = object.value ?? new Uint8Array();
+    message.value = object.value ?? new Uint8Array(0);
     return message;
   },
 };

--- a/integration/simple-unrecognized-enum/google/protobuf/wrappers.ts
+++ b/integration/simple-unrecognized-enum/google/protobuf/wrappers.ts
@@ -543,7 +543,7 @@ export const StringValue = {
 };
 
 function createBaseBytesValue(): BytesValue {
-  return { value: new Uint8Array() };
+  return { value: new Uint8Array(0) };
 }
 
 export const BytesValue = {
@@ -578,13 +578,13 @@ export const BytesValue = {
   },
 
   fromJSON(object: any): BytesValue {
-    return { value: isSet(object.value) ? bytesFromBase64(object.value) : new Uint8Array() };
+    return { value: isSet(object.value) ? bytesFromBase64(object.value) : new Uint8Array(0) };
   },
 
   toJSON(message: BytesValue): unknown {
     const obj: any = {};
     message.value !== undefined &&
-      (obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array()));
+      (obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array(0)));
     return obj;
   },
 
@@ -594,7 +594,7 @@ export const BytesValue = {
 
   fromPartial<I extends Exact<DeepPartial<BytesValue>, I>>(object: I): BytesValue {
     const message = createBaseBytesValue();
-    message.value = object.value ?? new Uint8Array();
+    message.value = object.value ?? new Uint8Array(0);
     return message;
   },
 };

--- a/integration/simple/google/protobuf/wrappers.ts
+++ b/integration/simple/google/protobuf/wrappers.ts
@@ -543,7 +543,7 @@ export const StringValue = {
 };
 
 function createBaseBytesValue(): BytesValue {
-  return { value: new Uint8Array() };
+  return { value: new Uint8Array(0) };
 }
 
 export const BytesValue = {
@@ -578,13 +578,13 @@ export const BytesValue = {
   },
 
   fromJSON(object: any): BytesValue {
-    return { value: isSet(object.value) ? bytesFromBase64(object.value) : new Uint8Array() };
+    return { value: isSet(object.value) ? bytesFromBase64(object.value) : new Uint8Array(0) };
   },
 
   toJSON(message: BytesValue): unknown {
     const obj: any = {};
     message.value !== undefined &&
-      (obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array()));
+      (obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array(0)));
     return obj;
   },
 
@@ -594,7 +594,7 @@ export const BytesValue = {
 
   fromPartial<I extends Exact<DeepPartial<BytesValue>, I>>(object: I): BytesValue {
     const message = createBaseBytesValue();
-    message.value = object.value ?? new Uint8Array();
+    message.value = object.value ?? new Uint8Array(0);
     return message;
   },
 };

--- a/integration/simple/simple-json-test.ts
+++ b/integration/simple/simple-json-test.ts
@@ -29,7 +29,7 @@ describe("simple json", () => {
       ...s1,
       birthday: undefined,
       blobs: [],
-      blob: new Uint8Array(),
+      blob: new Uint8Array(0),
       createdAt: undefined,
       thing: undefined,
     });
@@ -308,7 +308,7 @@ describe("simple json", () => {
       createdAt: new Date(1_000),
       thing: undefined,
       blobs: [],
-      blob: new Uint8Array(),
+      blob: new Uint8Array(0),
       birthday: undefined,
       enabled: true,
     };

--- a/integration/simple/simple-test.ts
+++ b/integration/simple/simple-test.ts
@@ -43,7 +43,7 @@ describe("simple", () => {
       createdAt: jan1,
       thing: undefined,
       blobs: [],
-      blob: new Uint8Array(),
+      blob: new Uint8Array(0),
       birthday: undefined,
       enabled: true,
     };
@@ -74,7 +74,7 @@ describe("simple", () => {
     const s2 = Simple.decode(Reader.create(PbSimple.encode(PbSimple.fromObject(s1)).finish()));
     expect(s2).toEqual({
       ...s1,
-      blob: new Uint8Array(),
+      blob: new Uint8Array(0),
     });
   });
 
@@ -94,7 +94,7 @@ describe("simple", () => {
       createdAt: jan1,
       thing: undefined,
       blobs: [],
-      blob: new Uint8Array(),
+      blob: new Uint8Array(0),
       birthday: undefined,
       enabled: true,
     };
@@ -211,7 +211,7 @@ describe("simple", () => {
       createdAt: jan1,
       thing: undefined,
       blobs: [],
-      blob: new Uint8Array(),
+      blob: new Uint8Array(0),
       birthday: undefined,
       enabled: true,
     };

--- a/integration/simple/simple.ts
+++ b/integration/simple/simple.ts
@@ -315,7 +315,7 @@ function createBaseSimple(): Simple {
     thing: undefined,
     blobs: [],
     birthday: undefined,
-    blob: new Uint8Array(),
+    blob: new Uint8Array(0),
     enabled: false,
   };
 }
@@ -521,7 +521,7 @@ export const Simple = {
       thing: isSet(object.thing) ? ImportedThing.fromJSON(object.thing) : undefined,
       blobs: Array.isArray(object?.blobs) ? object.blobs.map((e: any) => bytesFromBase64(e)) : [],
       birthday: isSet(object.birthday) ? DateMessage.fromJSON(object.birthday) : undefined,
-      blob: isSet(object.blob) ? bytesFromBase64(object.blob) : new Uint8Array(),
+      blob: isSet(object.blob) ? bytesFromBase64(object.blob) : new Uint8Array(0),
       enabled: isSet(object.enabled) ? Boolean(object.enabled) : false,
     };
   },
@@ -555,14 +555,14 @@ export const Simple = {
     }
     message.thing !== undefined && (obj.thing = message.thing ? ImportedThing.toJSON(message.thing) : undefined);
     if (message.blobs) {
-      obj.blobs = message.blobs.map((e) => base64FromBytes(e !== undefined ? e : new Uint8Array()));
+      obj.blobs = message.blobs.map((e) => base64FromBytes(e !== undefined ? e : new Uint8Array(0)));
     } else {
       obj.blobs = [];
     }
     message.birthday !== undefined &&
       (obj.birthday = message.birthday ? DateMessage.toJSON(message.birthday) : undefined);
     message.blob !== undefined &&
-      (obj.blob = base64FromBytes(message.blob !== undefined ? message.blob : new Uint8Array()));
+      (obj.blob = base64FromBytes(message.blob !== undefined ? message.blob : new Uint8Array(0)));
     message.enabled !== undefined && (obj.enabled = message.enabled);
     return obj;
   },
@@ -589,7 +589,7 @@ export const Simple = {
     message.birthday = (object.birthday !== undefined && object.birthday !== null)
       ? DateMessage.fromPartial(object.birthday)
       : undefined;
-    message.blob = object.blob ?? new Uint8Array();
+    message.blob = object.blob ?? new Uint8Array(0);
     message.enabled = object.enabled ?? false;
     return message;
   },
@@ -1727,7 +1727,7 @@ export const SimpleWithMap_MapOfTimestampsEntry = {
 };
 
 function createBaseSimpleWithMap_MapOfBytesEntry(): SimpleWithMap_MapOfBytesEntry {
-  return { key: "", value: new Uint8Array() };
+  return { key: "", value: new Uint8Array(0) };
 }
 
 export const SimpleWithMap_MapOfBytesEntry = {
@@ -1774,7 +1774,7 @@ export const SimpleWithMap_MapOfBytesEntry = {
   fromJSON(object: any): SimpleWithMap_MapOfBytesEntry {
     return {
       key: isSet(object.key) ? String(object.key) : "",
-      value: isSet(object.value) ? bytesFromBase64(object.value) : new Uint8Array(),
+      value: isSet(object.value) ? bytesFromBase64(object.value) : new Uint8Array(0),
     };
   },
 
@@ -1782,7 +1782,7 @@ export const SimpleWithMap_MapOfBytesEntry = {
     const obj: any = {};
     message.key !== undefined && (obj.key = message.key);
     message.value !== undefined &&
-      (obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array()));
+      (obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array(0)));
     return obj;
   },
 
@@ -1795,7 +1795,7 @@ export const SimpleWithMap_MapOfBytesEntry = {
   ): SimpleWithMap_MapOfBytesEntry {
     const message = createBaseSimpleWithMap_MapOfBytesEntry();
     message.key = object.key ?? "";
-    message.value = object.value ?? new Uint8Array();
+    message.value = object.value ?? new Uint8Array(0);
     return message;
   },
 };

--- a/integration/unknown-fields/google/protobuf/descriptor.ts
+++ b/integration/unknown-fields/google/protobuf/descriptor.ts
@@ -3104,7 +3104,7 @@ function createBaseUninterpretedOption(): UninterpretedOption {
     positiveIntValue: 0,
     negativeIntValue: 0,
     doubleValue: 0,
-    stringValue: new Uint8Array(),
+    stringValue: new Uint8Array(0),
     aggregateValue: "",
     _unknownFields: {},
   };

--- a/integration/use-map-type/use-map-type.ts
+++ b/integration/use-map-type/use-map-type.ts
@@ -477,7 +477,7 @@ export const Maps_Int32ToInt32Entry = {
 };
 
 function createBaseMaps_StringToBytesEntry(): Maps_StringToBytesEntry {
-  return { key: "", value: new Uint8Array() };
+  return { key: "", value: new Uint8Array(0) };
 }
 
 export const Maps_StringToBytesEntry = {
@@ -524,7 +524,7 @@ export const Maps_StringToBytesEntry = {
   fromJSON(object: any): Maps_StringToBytesEntry {
     return {
       key: isSet(object.key) ? String(object.key) : "",
-      value: isSet(object.value) ? bytesFromBase64(object.value) : new Uint8Array(),
+      value: isSet(object.value) ? bytesFromBase64(object.value) : new Uint8Array(0),
     };
   },
 
@@ -532,7 +532,7 @@ export const Maps_StringToBytesEntry = {
     const obj: any = {};
     message.key !== undefined && (obj.key = message.key);
     message.value !== undefined &&
-      (obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array()));
+      (obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array(0)));
     return obj;
   },
 
@@ -543,7 +543,7 @@ export const Maps_StringToBytesEntry = {
   fromPartial<I extends Exact<DeepPartial<Maps_StringToBytesEntry>, I>>(object: I): Maps_StringToBytesEntry {
     const message = createBaseMaps_StringToBytesEntry();
     message.key = object.key ?? "";
-    message.value = object.value ?? new Uint8Array();
+    message.value = object.value ?? new Uint8Array(0);
     return message;
   },
 };

--- a/integration/use-optionals-all/test.ts
+++ b/integration/use-optionals-all/test.ts
@@ -84,7 +84,7 @@ function createBaseOptionalsTest(): OptionalsTest {
     long: 0,
     truth: false,
     description: "",
-    data: new Uint8Array(),
+    data: new Uint8Array(0),
     repId: [],
     repChild: [],
     repState: [],
@@ -417,7 +417,7 @@ export const OptionalsTest = {
       long: isSet(object.long) ? Number(object.long) : 0,
       truth: isSet(object.truth) ? Boolean(object.truth) : false,
       description: isSet(object.description) ? String(object.description) : "",
-      data: isSet(object.data) ? bytesFromBase64(object.data) : new Uint8Array(),
+      data: isSet(object.data) ? bytesFromBase64(object.data) : new Uint8Array(0),
       repId: Array.isArray(object?.repId) ? object.repId.map((e: any) => Number(e)) : [],
       repChild: Array.isArray(object?.repChild) ? object.repChild.map((e: any) => Child.fromJSON(e)) : [],
       repState: Array.isArray(object?.repState) ? object.repState.map((e: any) => stateEnumFromJSON(e)) : [],
@@ -450,7 +450,7 @@ export const OptionalsTest = {
     message.truth !== undefined && (obj.truth = message.truth);
     message.description !== undefined && (obj.description = message.description);
     message.data !== undefined &&
-      (obj.data = base64FromBytes(message.data !== undefined ? message.data : new Uint8Array()));
+      (obj.data = base64FromBytes(message.data !== undefined ? message.data : new Uint8Array(0)));
     if (message.repId) {
       obj.repId = message.repId.map((e) => Math.round(e));
     } else {
@@ -482,7 +482,7 @@ export const OptionalsTest = {
       obj.repDescription = [];
     }
     if (message.repData) {
-      obj.repData = message.repData.map((e) => base64FromBytes(e !== undefined ? e : new Uint8Array()));
+      obj.repData = message.repData.map((e) => base64FromBytes(e !== undefined ? e : new Uint8Array(0)));
     } else {
       obj.repData = [];
     }
@@ -516,7 +516,7 @@ export const OptionalsTest = {
     message.long = object.long ?? 0;
     message.truth = object.truth ?? false;
     message.description = object.description ?? "";
-    message.data = object.data ?? new Uint8Array();
+    message.data = object.data ?? new Uint8Array(0);
     message.repId = object.repId?.map((e) => e) || [];
     message.repChild = object.repChild?.map((e) => Child.fromPartial(e)) || [];
     message.repState = object.repState?.map((e) => e) || [];

--- a/integration/use-optionals-no-undefined/test.ts
+++ b/integration/use-optionals-no-undefined/test.ts
@@ -465,7 +465,7 @@ export const OptionalsTest = {
     message.truth !== undefined && (obj.truth = message.truth);
     message.description !== undefined && (obj.description = message.description);
     message.data !== undefined &&
-      (obj.data = base64FromBytes(message.data !== undefined ? message.data : new Uint8Array()));
+      (obj.data = base64FromBytes(message.data !== undefined ? message.data : new Uint8Array(0)));
     if (message.repId) {
       obj.repId = message.repId.map((e) => Math.round(e));
     } else {
@@ -497,7 +497,7 @@ export const OptionalsTest = {
       obj.repDescription = [];
     }
     if (message.repData) {
-      obj.repData = message.repData.map((e) => base64FromBytes(e !== undefined ? e : new Uint8Array()));
+      obj.repData = message.repData.map((e) => base64FromBytes(e !== undefined ? e : new Uint8Array(0)));
     } else {
       obj.repData = [];
     }

--- a/integration/value/google/protobuf/wrappers.ts
+++ b/integration/value/google/protobuf/wrappers.ts
@@ -543,7 +543,7 @@ export const StringValue = {
 };
 
 function createBaseBytesValue(): BytesValue {
-  return { value: new Uint8Array() };
+  return { value: new Uint8Array(0) };
 }
 
 export const BytesValue = {
@@ -578,13 +578,13 @@ export const BytesValue = {
   },
 
   fromJSON(object: any): BytesValue {
-    return { value: isSet(object.value) ? bytesFromBase64(object.value) : new Uint8Array() };
+    return { value: isSet(object.value) ? bytesFromBase64(object.value) : new Uint8Array(0) };
   },
 
   toJSON(message: BytesValue): unknown {
     const obj: any = {};
     message.value !== undefined &&
-      (obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array()));
+      (obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array(0)));
     return obj;
   },
 
@@ -594,7 +594,7 @@ export const BytesValue = {
 
   fromPartial<I extends Exact<DeepPartial<BytesValue>, I>>(object: I): BytesValue {
     const message = createBaseBytesValue();
-    message.value = object.value ?? new Uint8Array();
+    message.value = object.value ?? new Uint8Array(0);
     return message;
   },
 };

--- a/integration/wrappers-regression/google/protobuf/wrappers.ts
+++ b/integration/wrappers-regression/google/protobuf/wrappers.ts
@@ -543,7 +543,7 @@ export const StringValue = {
 };
 
 function createBaseBytesValue(): BytesValue {
-  return { value: new Uint8Array() };
+  return { value: new Uint8Array(0) };
 }
 
 export const BytesValue = {
@@ -578,13 +578,13 @@ export const BytesValue = {
   },
 
   fromJSON(object: any): BytesValue {
-    return { value: isSet(object.value) ? bytesFromBase64(object.value) : new Uint8Array() };
+    return { value: isSet(object.value) ? bytesFromBase64(object.value) : new Uint8Array(0) };
   },
 
   toJSON(message: BytesValue): unknown {
     const obj: any = {};
     message.value !== undefined &&
-      (obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array()));
+      (obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array(0)));
     return obj;
   },
 
@@ -594,7 +594,7 @@ export const BytesValue = {
 
   fromPartial<I extends Exact<DeepPartial<BytesValue>, I>>(object: I): BytesValue {
     const message = createBaseBytesValue();
-    message.value = object.value ?? new Uint8Array();
+    message.value = object.value ?? new Uint8Array(0);
     return message;
   },
 };

--- a/protos/google/protobuf/descriptor.ts
+++ b/protos/google/protobuf/descriptor.ts
@@ -4804,7 +4804,7 @@ function createBaseUninterpretedOption(): UninterpretedOption {
     positiveIntValue: 0,
     negativeIntValue: 0,
     doubleValue: 0,
-    stringValue: new Uint8Array(),
+    stringValue: new Uint8Array(0),
     aggregateValue: "",
   };
 }
@@ -4935,7 +4935,7 @@ export const UninterpretedOption = {
       positiveIntValue: isSet(object.positiveIntValue) ? Number(object.positiveIntValue) : 0,
       negativeIntValue: isSet(object.negativeIntValue) ? Number(object.negativeIntValue) : 0,
       doubleValue: isSet(object.doubleValue) ? Number(object.doubleValue) : 0,
-      stringValue: isSet(object.stringValue) ? bytesFromBase64(object.stringValue) : new Uint8Array(),
+      stringValue: isSet(object.stringValue) ? bytesFromBase64(object.stringValue) : new Uint8Array(0),
       aggregateValue: isSet(object.aggregateValue) ? String(object.aggregateValue) : "",
     };
   },
@@ -4952,7 +4952,7 @@ export const UninterpretedOption = {
     message.negativeIntValue !== undefined && (obj.negativeIntValue = Math.round(message.negativeIntValue));
     message.doubleValue !== undefined && (obj.doubleValue = message.doubleValue);
     message.stringValue !== undefined &&
-      (obj.stringValue = base64FromBytes(message.stringValue !== undefined ? message.stringValue : new Uint8Array()));
+      (obj.stringValue = base64FromBytes(message.stringValue !== undefined ? message.stringValue : new Uint8Array(0)));
     message.aggregateValue !== undefined && (obj.aggregateValue = message.aggregateValue);
     return obj;
   },
@@ -4968,7 +4968,7 @@ export const UninterpretedOption = {
     message.positiveIntValue = object.positiveIntValue ?? 0;
     message.negativeIntValue = object.negativeIntValue ?? 0;
     message.doubleValue = object.doubleValue ?? 0;
-    message.stringValue = object.stringValue ?? new Uint8Array();
+    message.stringValue = object.stringValue ?? new Uint8Array(0);
     message.aggregateValue = object.aggregateValue ?? "";
     return message;
   },

--- a/src/encode.ts
+++ b/src/encode.ts
@@ -50,7 +50,7 @@ export function generateEncoder(ctx: Context, typeName: string): Code {
     case "BoolValue":
       return code`${TypeValue}.encode({value: value ?? false}).finish()`;
     case "BytesValue":
-      return code`${TypeValue}.encode({value: value ?? new Uint8Array()}).finish()`;
+      return code`${TypeValue}.encode({value: value ?? new Uint8Array(0)}).finish()`;
   }
 
   throw new Error(`unknown wrapper type: ${name}`);

--- a/src/types.ts
+++ b/src/types.ts
@@ -231,7 +231,7 @@ export function defaultValue(ctx: Context, field: FieldDescriptorProto): any {
       if (options.env === EnvOption.NODE) {
         return "Buffer.alloc(0)";
       } else {
-        return "new Uint8Array()";
+        return "new Uint8Array(0)";
       }
     case FieldDescriptorProto_Type.TYPE_MESSAGE:
     case FieldDescriptorProto_Type.TYPE_GROUP:


### PR DESCRIPTION
es2017 doesn't require array length argument. But 2015 and below needs it https://github.com/microsoft/TypeScript/blob/2a37eb2e471e01e510849f0dc108b3699ab869db/src/lib/es2015.iterable.d.ts#L268

any way according documentation zero – is default initializer https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array

So if you have `lib` param in tsconfig below `es2017`, you've got a problem with typechecking.
I just replaced every empty call to `(0)`. It must work on any es lib configuration.