### PR TITLE
feat: expose service name as separate exported constant

### DIFF
--- a/integration/async-iterable-services-abort-signal/simple.ts
+++ b/integration/async-iterable-services-abort-signal/simple.ts
@@ -108,11 +108,12 @@ export interface Echoer {
   EchoBidiStream(request: AsyncIterable<EchoMsg>, abortSignal?: AbortSignal): AsyncIterable<EchoMsg>;
 }
 
+export const EchoerServiceName = "simple.Echoer";
 export class EchoerClientImpl implements Echoer {
   private readonly rpc: Rpc;
   private readonly service: string;
   constructor(rpc: Rpc, opts?: { service?: string }) {
-    this.service = opts?.service || "simple.Echoer";
+    this.service = opts?.service || EchoerServiceName;
     this.rpc = rpc;
     this.Echo = this.Echo.bind(this);
     this.EchoServerStream = this.EchoServerStream.bind(this);

--- a/integration/async-iterable-services/simple.ts
+++ b/integration/async-iterable-services/simple.ts
@@ -108,11 +108,12 @@ export interface Echoer {
   EchoBidiStream(request: AsyncIterable<EchoMsg>): AsyncIterable<EchoMsg>;
 }
 
+export const EchoerServiceName = "simple.Echoer";
 export class EchoerClientImpl implements Echoer {
   private readonly rpc: Rpc;
   private readonly service: string;
   constructor(rpc: Rpc, opts?: { service?: string }) {
-    this.service = opts?.service || "simple.Echoer";
+    this.service = opts?.service || EchoerServiceName;
     this.rpc = rpc;
     this.Echo = this.Echo.bind(this);
     this.EchoServerStream = this.EchoServerStream.bind(this);

--- a/integration/avoid-import-conflicts/simple.ts
+++ b/integration/avoid-import-conflicts/simple.ts
@@ -330,11 +330,12 @@ export interface FooService {
   Create(request: FooServiceCreateRequest): Promise<FooServiceCreateResponse>;
 }
 
+export const FooServiceServiceName = "simple.FooService";
 export class FooServiceClientImpl implements FooService {
   private readonly rpc: Rpc;
   private readonly service: string;
   constructor(rpc: Rpc, opts?: { service?: string }) {
-    this.service = opts?.service || "simple.FooService";
+    this.service = opts?.service || FooServiceServiceName;
     this.rpc = rpc;
     this.Create = this.Create.bind(this);
   }

--- a/integration/batching-with-context-esModuleInterop/batching.ts
+++ b/integration/batching-with-context-esModuleInterop/batching.ts
@@ -672,11 +672,12 @@ export interface EntityService<Context extends DataLoaders> {
   WriteMethod(ctx: Context, request: WriteMethodRequest): Promise<WriteMethodResponse>;
 }
 
+export const EntityServiceServiceName = "batching.EntityService";
 export class EntityServiceClientImpl<Context extends DataLoaders> implements EntityService<Context> {
   private readonly rpc: Rpc<Context>;
   private readonly service: string;
   constructor(rpc: Rpc<Context>, opts?: { service?: string }) {
-    this.service = opts?.service || "batching.EntityService";
+    this.service = opts?.service || EntityServiceServiceName;
     this.rpc = rpc;
     this.BatchQuery = this.BatchQuery.bind(this);
     this.BatchMapQuery = this.BatchMapQuery.bind(this);

--- a/integration/batching-with-context/batching.ts
+++ b/integration/batching-with-context/batching.ts
@@ -672,11 +672,12 @@ export interface EntityService<Context extends DataLoaders> {
   WriteMethod(ctx: Context, request: WriteMethodRequest): Promise<WriteMethodResponse>;
 }
 
+export const EntityServiceServiceName = "batching.EntityService";
 export class EntityServiceClientImpl<Context extends DataLoaders> implements EntityService<Context> {
   private readonly rpc: Rpc<Context>;
   private readonly service: string;
   constructor(rpc: Rpc<Context>, opts?: { service?: string }) {
-    this.service = opts?.service || "batching.EntityService";
+    this.service = opts?.service || EntityServiceServiceName;
     this.rpc = rpc;
     this.BatchQuery = this.BatchQuery.bind(this);
     this.BatchMapQuery = this.BatchMapQuery.bind(this);

--- a/integration/batching/batching.ts
+++ b/integration/batching/batching.ts
@@ -668,11 +668,12 @@ export interface EntityService {
   WriteMethod(request: WriteMethodRequest): Promise<WriteMethodResponse>;
 }
 
+export const EntityServiceServiceName = "batching.EntityService";
 export class EntityServiceClientImpl implements EntityService {
   private readonly rpc: Rpc;
   private readonly service: string;
   constructor(rpc: Rpc, opts?: { service?: string }) {
-    this.service = opts?.service || "batching.EntityService";
+    this.service = opts?.service || EntityServiceServiceName;
     this.rpc = rpc;
     this.BatchQuery = this.BatchQuery.bind(this);
     this.BatchMapQuery = this.BatchMapQuery.bind(this);

--- a/integration/generic-metadata/hero.ts
+++ b/integration/generic-metadata/hero.ts
@@ -278,11 +278,12 @@ export interface HeroService {
   FindManyVillain(request: Observable<VillainById>, metadata?: Foo): Observable<Villain>;
 }
 
+export const HeroServiceServiceName = "hero.HeroService";
 export class HeroServiceClientImpl implements HeroService {
   private readonly rpc: Rpc;
   private readonly service: string;
   constructor(rpc: Rpc, opts?: { service?: string }) {
-    this.service = opts?.service || "hero.HeroService";
+    this.service = opts?.service || HeroServiceServiceName;
     this.rpc = rpc;
     this.FindOneHero = this.FindOneHero.bind(this);
     this.FindOneVillain = this.FindOneVillain.bind(this);

--- a/integration/grpc-web-go-server/example.ts
+++ b/integration/grpc-web-go-server/example.ts
@@ -711,11 +711,12 @@ export interface DashState {
   ActiveUserSettingsStream(request: Empty): Observable<DashUserSettingsState>;
 }
 
+export const DashStateServiceName = "rpx.DashState";
 export class DashStateClientImpl implements DashState {
   private readonly rpc: Rpc;
   private readonly service: string;
   constructor(rpc: Rpc, opts?: { service?: string }) {
-    this.service = opts?.service || "rpx.DashState";
+    this.service = opts?.service || DashStateServiceName;
     this.rpc = rpc;
     this.UserSettings = this.UserSettings.bind(this);
     this.ActiveUserSettingsStream = this.ActiveUserSettingsStream.bind(this);
@@ -744,11 +745,12 @@ export interface DashAPICreds {
   Delete(request: DashAPICredsDeleteReq): Promise<DashCred>;
 }
 
+export const DashAPICredsServiceName = "rpx.DashAPICreds";
 export class DashAPICredsClientImpl implements DashAPICreds {
   private readonly rpc: Rpc;
   private readonly service: string;
   constructor(rpc: Rpc, opts?: { service?: string }) {
-    this.service = opts?.service || "rpx.DashAPICreds";
+    this.service = opts?.service || DashAPICredsServiceName;
     this.rpc = rpc;
     this.Create = this.Create.bind(this);
     this.Update = this.Update.bind(this);

--- a/integration/lower-case-svc-methods/math.ts
+++ b/integration/lower-case-svc-methods/math.ts
@@ -221,11 +221,12 @@ export interface MathService<Context extends DataLoaders> {
   getDouble(ctx: Context, nu: number): Promise<number>;
 }
 
+export const MathServiceServiceName = "MathService";
 export class MathServiceClientImpl<Context extends DataLoaders> implements MathService<Context> {
   private readonly rpc: Rpc<Context>;
   private readonly service: string;
   constructor(rpc: Rpc<Context>, opts?: { service?: string }) {
-    this.service = opts?.service || "MathService";
+    this.service = opts?.service || MathServiceServiceName;
     this.rpc = rpc;
     this.add = this.add.bind(this);
     this.absoluteValue = this.absoluteValue.bind(this);

--- a/integration/meta-typings/simple.ts
+++ b/integration/meta-typings/simple.ts
@@ -1584,11 +1584,12 @@ export interface PingService {
   ping(request: PingRequest): Promise<PingResponse>;
 }
 
+export const PingServiceServiceName = "simple.PingService";
 export class PingServiceClientImpl implements PingService {
   private readonly rpc: Rpc;
   private readonly service: string;
   constructor(rpc: Rpc, opts?: { service?: string }) {
-    this.service = opts?.service || "simple.PingService";
+    this.service = opts?.service || PingServiceServiceName;
     this.rpc = rpc;
     this.ping = this.ping.bind(this);
   }

--- a/integration/no-proto-package/no-proto-package.ts
+++ b/integration/no-proto-package/no-proto-package.ts
@@ -116,11 +116,12 @@ export interface UserState {
   GetUsers(request: Empty): Observable<User>;
 }
 
+export const UserStateServiceName = "UserState";
 export class UserStateClientImpl implements UserState {
   private readonly rpc: Rpc;
   private readonly service: string;
   constructor(rpc: Rpc, opts?: { service?: string }) {
-    this.service = opts?.service || "UserState";
+    this.service = opts?.service || UserStateServiceName;
     this.rpc = rpc;
     this.GetUsers = this.GetUsers.bind(this);
   }

--- a/integration/options/options.ts
+++ b/integration/options/options.ts
@@ -147,11 +147,12 @@ export interface MyService {
   MyMethod(request: RequestType): Promise<ResponseType>;
 }
 
+export const MyServiceServiceName = "MyService";
 export class MyServiceClientImpl implements MyService {
   private readonly rpc: Rpc;
   private readonly service: string;
   constructor(rpc: Rpc, opts?: { service?: string }) {
-    this.service = opts?.service || "MyService";
+    this.service = opts?.service || MyServiceServiceName;
     this.rpc = rpc;
     this.MyMethod = this.MyMethod.bind(this);
   }

--- a/integration/simple-optionals/simple.ts
+++ b/integration/simple-optionals/simple.ts
@@ -1849,11 +1849,12 @@ export interface PingService {
   ping(request: PingRequest): Promise<PingResponse>;
 }
 
+export const PingServiceServiceName = "simple.PingService";
 export class PingServiceClientImpl implements PingService {
   private readonly rpc: Rpc;
   private readonly service: string;
   constructor(rpc: Rpc, opts?: { service?: string }) {
-    this.service = opts?.service || "simple.PingService";
+    this.service = opts?.service || PingServiceServiceName;
     this.rpc = rpc;
     this.ping = this.ping.bind(this);
   }

--- a/integration/simple-prototype-defaults/simple.ts
+++ b/integration/simple-prototype-defaults/simple.ts
@@ -2776,11 +2776,12 @@ export interface PingService {
   ping(request: PingRequest): Promise<PingResponse>;
 }
 
+export const PingServiceServiceName = "simple.PingService";
 export class PingServiceClientImpl implements PingService {
   private readonly rpc: Rpc;
   private readonly service: string;
   constructor(rpc: Rpc, opts?: { service?: string }) {
-    this.service = opts?.service || "simple.PingService";
+    this.service = opts?.service || PingServiceServiceName;
     this.rpc = rpc;
     this.ping = this.ping.bind(this);
   }

--- a/integration/simple-snake/simple.ts
+++ b/integration/simple-snake/simple.ts
@@ -1910,11 +1910,12 @@ export interface PingService {
   ping(request: PingRequest): Promise<PingResponse>;
 }
 
+export const PingServiceServiceName = "simple.PingService";
 export class PingServiceClientImpl implements PingService {
   private readonly rpc: Rpc;
   private readonly service: string;
   constructor(rpc: Rpc, opts?: { service?: string }) {
-    this.service = opts?.service || "simple.PingService";
+    this.service = opts?.service || PingServiceServiceName;
     this.rpc = rpc;
     this.ping = this.ping.bind(this);
   }

--- a/integration/simple-unrecognized-enum/simple.ts
+++ b/integration/simple-unrecognized-enum/simple.ts
@@ -1837,11 +1837,12 @@ export interface PingService {
   ping(request: PingRequest): Promise<PingResponse>;
 }
 
+export const PingServiceServiceName = "simple.PingService";
 export class PingServiceClientImpl implements PingService {
   private readonly rpc: Rpc;
   private readonly service: string;
   constructor(rpc: Rpc, opts?: { service?: string }) {
-    this.service = opts?.service || "simple.PingService";
+    this.service = opts?.service || PingServiceServiceName;
     this.rpc = rpc;
     this.ping = this.ping.bind(this);
   }

--- a/integration/simple/simple.ts
+++ b/integration/simple/simple.ts
@@ -2779,11 +2779,12 @@ export interface PingService {
   ping(request: PingRequest): Promise<PingResponse>;
 }
 
+export const PingServiceServiceName = "simple.PingService";
 export class PingServiceClientImpl implements PingService {
   private readonly rpc: Rpc;
   private readonly service: string;
   constructor(rpc: Rpc, opts?: { service?: string }) {
-    this.service = opts?.service || "simple.PingService";
+    this.service = opts?.service || PingServiceServiceName;
     this.rpc = rpc;
     this.ping = this.ping.bind(this);
   }

--- a/integration/unknown-fields/options.ts
+++ b/integration/unknown-fields/options.ts
@@ -219,11 +219,12 @@ export interface MyService {
   MyMethod(request: RequestType): Promise<ResponseType>;
 }
 
+export const MyServiceServiceName = "MyService";
 export class MyServiceClientImpl implements MyService {
   private readonly rpc: Rpc;
   private readonly service: string;
   constructor(rpc: Rpc, opts?: { service?: string }) {
-    this.service = opts?.service || "MyService";
+    this.service = opts?.service || MyServiceServiceName;
     this.rpc = rpc;
     this.MyMethod = this.MyMethod.bind(this);
   }

--- a/integration/use-date-true/use-date-true.ts
+++ b/integration/use-date-true/use-date-true.ts
@@ -230,11 +230,12 @@ export interface Clock {
   Now(request: Empty): Promise<Timestamp>;
 }
 
+export const ClockServiceName = "Clock";
 export class ClockClientImpl implements Clock {
   private readonly rpc: Rpc;
   private readonly service: string;
   constructor(rpc: Rpc, opts?: { service?: string }) {
-    this.service = opts?.service || "Clock";
+    this.service = opts?.service || ClockServiceName;
     this.rpc = rpc;
     this.Now = this.Now.bind(this);
   }

--- a/integration/wrappers-regression/wrappers-regression.ts
+++ b/integration/wrappers-regression/wrappers-regression.ts
@@ -15,11 +15,12 @@ export interface Clock {
   NowBool(request: Empty): Promise<BoolValue>;
 }
 
+export const ClockServiceName = "Clock";
 export class ClockClientImpl implements Clock {
   private readonly rpc: Rpc;
   private readonly service: string;
   constructor(rpc: Rpc, opts?: { service?: string }) {
-    this.service = opts?.service || "Clock";
+    this.service = opts?.service || ClockServiceName;
     this.rpc = rpc;
     this.Now = this.Now.bind(this);
     this.NowString = this.NowString.bind(this);

--- a/src/generate-services.ts
+++ b/src/generate-services.ts
@@ -181,8 +181,15 @@ export function generateServiceClientImpl(
   const { options } = ctx;
   const chunks: Code[] = [];
 
-  // Define the FooServiceImpl class
+  // Determine information about the service.
   const { name } = serviceDesc;
+  const serviceName = maybePrefixPackage(fileDesc, serviceDesc.name);
+
+  // Define the service name constant.
+  const serviceNameConst = `${name}ServiceName`;
+  chunks.push(code`export const ${serviceNameConst} = "${serviceName}";`);
+
+  // Define the FooServiceImpl class
   const i = options.context ? `${name}<Context>` : name;
   const t = options.context ? `<${contextTypeVar}>` : "";
   chunks.push(code`export class ${name}ClientImpl${t} implements ${def(i)} {`);
@@ -192,8 +199,7 @@ export function generateServiceClientImpl(
   chunks.push(code`private readonly rpc: ${rpcType};`);
   chunks.push(code`private readonly service: string;`);
   chunks.push(code`constructor(rpc: ${rpcType}, opts?: {service?: string}) {`);
-  const serviceID = maybePrefixPackage(fileDesc, serviceDesc.name);
-  chunks.push(code`this.service = opts?.service || "${serviceID}";`);
+  chunks.push(code`this.service = opts?.service || ${serviceNameConst};`);
   chunks.push(code`this.rpc = rpc;`);
 
   // Bind each FooService method to the FooServiceImpl class


### PR DESCRIPTION
The service ID (for example, "simple.Echoer") is currently hidden within the constructor of the service implementation.

While it's possible to override the service ID with a constructor parameter, we should also export this ServiceID constant so that it can be used elsewhere.