### PR TITLE
Add const-only variant to to outputTypeAnnotations option

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -414,7 +414,7 @@ Generated code will be placed in the Gradle build directory.
 
 - With `--ts_proto_opt=outputSchema=true`, meta typings will be generated that can later be used in other code generators.
 
-- With `--ts_proto_opt=outputTypeAnnotations=true`, each message will be given a `$type` field containing its fully-qualified name.
+- With `--ts_proto_opt=outputTypeAnnotations=true`, each message will be given a `$type` field containing its fully-qualified name. You can use `--ts_proto_opt=outputTypeAnnotations=const-only` to omit it from the `interface` declaration.
 
 - With `--ts_proto_opt=outputTypeRegistry=true`, the type registry will be generated that can be used to resolve message types by fully-qualified name. Also, each message will be given a `$type` field containing its fully-qualified name.
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -602,7 +602,10 @@ function makeDeepPartial(options: Options, longs: ReturnType<typeof makeLongUtil
   );
 
   // Based on https://github.com/sindresorhus/type-fest/pull/259
-  const maybeExcludeType = options.outputTypeAnnotations || options.outputTypeRegistry ? `| '$type'` : "";
+  const maybeExcludeType =
+    (options.outputTypeAnnotations || options.outputTypeRegistry) && options.outputTypeAnnotations !== "const-only"
+      ? `| '$type'`
+      : "";
   const Exact = conditionalOutput(
     "Exact",
     code`
@@ -616,7 +619,9 @@ function makeDeepPartial(options: Options, longs: ReturnType<typeof makeLongUtil
 
   // Based on the type from ts-essentials
   const keys =
-    options.outputTypeAnnotations || options.outputTypeRegistry ? code`Exclude<keyof T, '$type'>` : code`keyof T`;
+    (options.outputTypeAnnotations || options.outputTypeRegistry) && options.outputTypeAnnotations !== "const-only"
+      ? code`Exclude<keyof T, '$type'>`
+      : code`keyof T`;
   const DeepPartial = conditionalOutput(
     "DeepPartial",
     code`
@@ -696,7 +701,9 @@ function makeTimestampMethods(options: Options, longs: ReturnType<typeof makeLon
   }
 
   const maybeTypeField =
-    options.outputTypeAnnotations || options.outputTypeRegistry ? `$type: 'google.protobuf.Timestamp',` : "";
+    (options.outputTypeAnnotations || options.outputTypeRegistry) && options.outputTypeAnnotations !== "const-only"
+      ? `$type: 'google.protobuf.Timestamp',`
+      : "";
 
   const toTimestamp = conditionalOutput(
     "toTimestamp",
@@ -851,7 +858,7 @@ function generateInterfaceDeclaration(
   // interface name should be defined to avoid import collisions
   chunks.push(code`export interface ${def(fullName)} {`);
 
-  if (ctx.options.outputTypeAnnotations || ctx.options.outputTypeRegistry) {
+  if ((options.outputTypeAnnotations || options.outputTypeRegistry) && options.outputTypeAnnotations !== "const-only") {
     chunks.push(code`$type: '${fullTypeName}',`);
   }
 
@@ -971,7 +978,7 @@ function generateBaseInstanceFactory(
     fields.push(code`${name}: ${val}`);
   }
 
-  if (ctx.options.outputTypeAnnotations || ctx.options.outputTypeRegistry) {
+  if ((options.outputTypeAnnotations || options.outputTypeRegistry) && options.outputTypeAnnotations !== "const-only") {
     fields.unshift(code`$type: '${fullTypeName}'`);
   }
 
@@ -1246,7 +1253,9 @@ function getEncodeWriteSnippet(ctx: Context, field: FieldDescriptorProto): (plac
     return (place) => code`${type}.encode(${utils.toTimestamp}(${place}), writer.uint32(${tag}).fork()).ldelim()`;
   } else if (isValueType(ctx, field)) {
     const maybeTypeField =
-      options.outputTypeAnnotations || options.outputTypeRegistry ? `$type: '${field.typeName.slice(1)}',` : "";
+      (options.outputTypeAnnotations || options.outputTypeRegistry) && options.outputTypeAnnotations !== "const-only"
+        ? `$type: '${field.typeName.slice(1)}',`
+        : "";
 
     const type = basicTypeName(ctx, field, { keepValueType: true });
     const wrappedValue = (place: string): Code => {
@@ -1309,7 +1318,10 @@ function generateEncode(ctx: Context, fullName: string, messageDesc: DescriptorP
       if (isMapType(ctx, messageDesc, field)) {
         const valueType = (typeMap.get(field.typeName)![2] as DescriptorProto).field[1];
         const maybeTypeField =
-          options.outputTypeAnnotations || options.outputTypeRegistry ? `$type: '${field.typeName.slice(1)}',` : "";
+          (options.outputTypeAnnotations || options.outputTypeRegistry) &&
+          options.outputTypeAnnotations !== "const-only"
+            ? `$type: '${field.typeName.slice(1)}',`
+            : "";
         const entryWriteSnippet = isValueType(ctx, valueType)
           ? code`
               if (value !== undefined) {
@@ -1561,7 +1573,10 @@ function generateExtension(ctx: Context, message: DescriptorProto | undefined, e
         return (place) => code`${type}.encode(${utils.toTimestamp}(${place}), writer.fork()).ldelim()`;
       } else if (isValueType(ctx, field)) {
         const maybeTypeField =
-          options.outputTypeAnnotations || options.outputTypeRegistry ? `$type: '${field.typeName.slice(1)}',` : "";
+          (options.outputTypeAnnotations || options.outputTypeRegistry) &&
+          options.outputTypeAnnotations !== "const-only"
+            ? `$type: '${field.typeName.slice(1)}',`
+            : "";
 
         const type = basicTypeName(ctx, field, { keepValueType: true });
         const wrappedValue = (place: string): Code => {
@@ -1706,7 +1721,7 @@ function generateFromJson(ctx: Context, fullName: string, fullTypeName: string, 
       return {
   `);
 
-  if (ctx.options.outputTypeAnnotations || ctx.options.outputTypeRegistry) {
+  if ((options.outputTypeAnnotations || options.outputTypeRegistry) && options.outputTypeAnnotations !== "const-only") {
     chunks.push(code`$type: ${fullName}.$type,`);
   }
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -48,7 +48,7 @@ export type Options = {
   outputEncodeMethods: true | false | "encode-only" | "decode-only" | "encode-no-creation";
   outputJsonMethods: boolean;
   outputPartialMethods: boolean;
-  outputTypeAnnotations: boolean;
+  outputTypeAnnotations: boolean | "const-only";
   outputTypeRegistry: boolean;
   stringEnums: boolean;
   constEnums: boolean;


### PR DESCRIPTION
Hi, I want to write a generic function like such:

```
function Encode<D>(desc: {$type: string, encode(value: D): Writer}, value: D)
```

So I need to have type annotations emitted but also still have the interfaces generated without the `$type` field. In this PR I'm adding a const-only variant to `outputTypeAnnotations` that does this.