### PR TITLE
feat: Normalize `toJSON` output by omitting fields set to their default values

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -728,25 +728,14 @@ Foo.fromJSON({ bar: "" }); // => { bar: '' }
 Foo.fromJSON({ bar: "baz" }); // => { bar: 'baz' }
 ```
 
-When writing JSON, `ts-proto` currently does **not** normalize message when converting to JSON, other than omitting unset fields, but it may do so in the future.
+When writing JSON, `ts-proto` normalizes messages by omitting unset fields and fields set to their default values.
 
 ```typescript
-// Current ts-proto behavior
-Foo.toJSON({}); // => { }
-Foo.toJSON({ bar: undefined }); // => { }
-Foo.toJSON({ bar: "" }); // => { bar: '' } - note: this is the default value, but it's not omitted
-Foo.toJSON({ bar: "baz" }); // => { bar: 'baz' }
-```
-
-```typescript
-// Possible future behavior, where ts-proto would normalize message
 Foo.toJSON({}); // => { }
 Foo.toJSON({ bar: undefined }); // => { }
 Foo.toJSON({ bar: "" }); // => { } - note: omitting the default value, as expected
 Foo.toJSON({ bar: "baz" }); // => { bar: 'baz' }
 ```
-
-- Please open an issue if you need this behavior.
 
 # Well-Known Types
 

--- a/integration/angular/simple-message.ts
+++ b/integration/angular/simple-message.ts
@@ -48,7 +48,9 @@ export const SimpleMessage = {
 
   toJSON(message: SimpleMessage): unknown {
     const obj: any = {};
-    message.numberField !== undefined && (obj.numberField = Math.round(message.numberField));
+    if (message.numberField !== 0) {
+      obj.numberField = Math.round(message.numberField);
+    }
     return obj;
   },
 

--- a/integration/async-iterable-services-abort-signal/simple.ts
+++ b/integration/async-iterable-services-abort-signal/simple.ts
@@ -81,7 +81,9 @@ export const EchoMsg = {
 
   toJSON(message: EchoMsg): unknown {
     const obj: any = {};
-    message.body !== undefined && (obj.body = message.body);
+    if (message.body !== "") {
+      obj.body = message.body;
+    }
     return obj;
   },
 

--- a/integration/async-iterable-services/simple.ts
+++ b/integration/async-iterable-services/simple.ts
@@ -81,7 +81,9 @@ export const EchoMsg = {
 
   toJSON(message: EchoMsg): unknown {
     const obj: any = {};
-    message.body !== undefined && (obj.body = message.body);
+    if (message.body !== "") {
+      obj.body = message.body;
+    }
     return obj;
   },
 

--- a/integration/avoid-import-conflicts/simple.ts
+++ b/integration/avoid-import-conflicts/simple.ts
@@ -127,7 +127,7 @@ export const Simple = {
       obj.name = message.name;
     }
     if (message.otherSimple !== undefined) {
-      obj.otherSimple = message.otherSimple ? Simple3.toJSON(message.otherSimple) : undefined;
+      obj.otherSimple = Simple3.toJSON(message.otherSimple);
     }
     return obj;
   },

--- a/integration/avoid-import-conflicts/simple.ts
+++ b/integration/avoid-import-conflicts/simple.ts
@@ -123,9 +123,12 @@ export const Simple = {
 
   toJSON(message: Simple): unknown {
     const obj: any = {};
-    message.name !== undefined && (obj.name = message.name);
-    message.otherSimple !== undefined &&
-      (obj.otherSimple = message.otherSimple ? Simple3.toJSON(message.otherSimple) : undefined);
+    if (message.name !== "") {
+      obj.name = message.name;
+    }
+    if (message.otherSimple !== undefined) {
+      obj.otherSimple = message.otherSimple ? Simple3.toJSON(message.otherSimple) : undefined;
+    }
     return obj;
   },
 
@@ -197,8 +200,12 @@ export const SimpleEnums = {
 
   toJSON(message: SimpleEnums): unknown {
     const obj: any = {};
-    message.localEnum !== undefined && (obj.localEnum = simpleEnumToJSON(message.localEnum));
-    message.importEnum !== undefined && (obj.importEnum = simpleEnumToJSON5(message.importEnum));
+    if (message.localEnum !== 0) {
+      obj.localEnum = simpleEnumToJSON(message.localEnum);
+    }
+    if (message.importEnum !== 0) {
+      obj.importEnum = simpleEnumToJSON5(message.importEnum);
+    }
     return obj;
   },
 
@@ -255,7 +262,9 @@ export const FooServiceCreateRequest = {
 
   toJSON(message: FooServiceCreateRequest): unknown {
     const obj: any = {};
-    message.kind !== undefined && (obj.kind = fooServiceToJSON(message.kind));
+    if (message.kind !== 0) {
+      obj.kind = fooServiceToJSON(message.kind);
+    }
     return obj;
   },
 
@@ -311,7 +320,9 @@ export const FooServiceCreateResponse = {
 
   toJSON(message: FooServiceCreateResponse): unknown {
     const obj: any = {};
-    message.kind !== undefined && (obj.kind = fooServiceToJSON(message.kind));
+    if (message.kind !== 0) {
+      obj.kind = fooServiceToJSON(message.kind);
+    }
     return obj;
   },
 

--- a/integration/avoid-import-conflicts/simple2.ts
+++ b/integration/avoid-import-conflicts/simple2.ts
@@ -137,8 +137,12 @@ export const Simple = {
 
   toJSON(message: Simple): unknown {
     const obj: any = {};
-    message.name !== undefined && (obj.name = message.name);
-    message.age !== undefined && (obj.age = Math.round(message.age));
+    if (message.name !== "") {
+      obj.name = message.name;
+    }
+    if (message.age !== 0) {
+      obj.age = Math.round(message.age);
+    }
     return obj;
   },
 

--- a/integration/barrel-imports/bar.ts
+++ b/integration/barrel-imports/bar.ts
@@ -57,8 +57,12 @@ export const Bar = {
 
   toJSON(message: Bar): unknown {
     const obj: any = {};
-    message.name !== undefined && (obj.name = message.name);
-    message.age !== undefined && (obj.age = Math.round(message.age));
+    if (message.name !== "") {
+      obj.name = message.name;
+    }
+    if (message.age !== 0) {
+      obj.age = Math.round(message.age);
+    }
     return obj;
   },
 

--- a/integration/barrel-imports/foo.ts
+++ b/integration/barrel-imports/foo.ts
@@ -61,8 +61,12 @@ export const Foo = {
 
   toJSON(message: Foo): unknown {
     const obj: any = {};
-    message.name !== undefined && (obj.name = message.name);
-    message.bar !== undefined && (obj.bar = message.bar ? Bar.toJSON(message.bar) : undefined);
+    if (message.name !== "") {
+      obj.name = message.name;
+    }
+    if (message.bar !== undefined) {
+      obj.bar = message.bar ? Bar.toJSON(message.bar) : undefined;
+    }
     return obj;
   },
 

--- a/integration/barrel-imports/foo.ts
+++ b/integration/barrel-imports/foo.ts
@@ -65,7 +65,7 @@ export const Foo = {
       obj.name = message.name;
     }
     if (message.bar !== undefined) {
-      obj.bar = message.bar ? Bar.toJSON(message.bar) : undefined;
+      obj.bar = Bar.toJSON(message.bar);
     }
     return obj;
   },

--- a/integration/batching-with-context-esModuleInterop/batching.ts
+++ b/integration/batching-with-context-esModuleInterop/batching.ts
@@ -88,7 +88,7 @@ export const BatchQueryRequest = {
   toJSON(message: BatchQueryRequest): unknown {
     const obj: any = {};
     if (message.ids?.length) {
-      obj.ids = message.ids.map((e) => e);
+      obj.ids = message.ids;
     }
     return obj;
   },
@@ -204,7 +204,7 @@ export const BatchMapQueryRequest = {
   toJSON(message: BatchMapQueryRequest): unknown {
     const obj: any = {};
     if (message.ids?.length) {
-      obj.ids = message.ids.map((e) => e);
+      obj.ids = message.ids;
     }
     return obj;
   },

--- a/integration/batching-with-context-esModuleInterop/batching.ts
+++ b/integration/batching-with-context-esModuleInterop/batching.ts
@@ -146,7 +146,7 @@ export const BatchQueryResponse = {
   toJSON(message: BatchQueryResponse): unknown {
     const obj: any = {};
     if (message.entities?.length) {
-      obj.entities = message.entities.map((e) => e ? Entity.toJSON(e) : undefined);
+      obj.entities = message.entities.map((e) => Entity.toJSON(e));
     }
     return obj;
   },
@@ -357,7 +357,7 @@ export const BatchMapQueryResponse_EntitiesEntry = {
       obj.key = message.key;
     }
     if (message.value !== undefined) {
-      obj.value = message.value ? Entity.toJSON(message.value) : undefined;
+      obj.value = Entity.toJSON(message.value);
     }
     return obj;
   },
@@ -480,7 +480,7 @@ export const GetOnlyMethodResponse = {
   toJSON(message: GetOnlyMethodResponse): unknown {
     const obj: any = {};
     if (message.entity !== undefined) {
-      obj.entity = message.entity ? Entity.toJSON(message.entity) : undefined;
+      obj.entity = Entity.toJSON(message.entity);
     }
     return obj;
   },

--- a/integration/batching-with-context-esModuleInterop/batching.ts
+++ b/integration/batching-with-context-esModuleInterop/batching.ts
@@ -87,10 +87,8 @@ export const BatchQueryRequest = {
 
   toJSON(message: BatchQueryRequest): unknown {
     const obj: any = {};
-    if (message.ids) {
+    if (message.ids?.length) {
       obj.ids = message.ids.map((e) => e);
-    } else {
-      obj.ids = [];
     }
     return obj;
   },
@@ -147,10 +145,8 @@ export const BatchQueryResponse = {
 
   toJSON(message: BatchQueryResponse): unknown {
     const obj: any = {};
-    if (message.entities) {
+    if (message.entities?.length) {
       obj.entities = message.entities.map((e) => e ? Entity.toJSON(e) : undefined);
-    } else {
-      obj.entities = [];
     }
     return obj;
   },
@@ -207,10 +203,8 @@ export const BatchMapQueryRequest = {
 
   toJSON(message: BatchMapQueryRequest): unknown {
     const obj: any = {};
-    if (message.ids) {
+    if (message.ids?.length) {
       obj.ids = message.ids.map((e) => e);
-    } else {
-      obj.ids = [];
     }
     return obj;
   },
@@ -277,11 +271,14 @@ export const BatchMapQueryResponse = {
 
   toJSON(message: BatchMapQueryResponse): unknown {
     const obj: any = {};
-    obj.entities = {};
     if (message.entities) {
-      Object.entries(message.entities).forEach(([k, v]) => {
-        obj.entities[k] = Entity.toJSON(v);
-      });
+      const entries = Object.entries(message.entities);
+      if (entries.length > 0) {
+        obj.entities = {};
+        entries.forEach(([k, v]) => {
+          obj.entities[k] = Entity.toJSON(v);
+        });
+      }
     }
     return obj;
   },
@@ -356,8 +353,12 @@ export const BatchMapQueryResponse_EntitiesEntry = {
 
   toJSON(message: BatchMapQueryResponse_EntitiesEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = message.key);
-    message.value !== undefined && (obj.value = message.value ? Entity.toJSON(message.value) : undefined);
+    if (message.key !== "") {
+      obj.key = message.key;
+    }
+    if (message.value !== undefined) {
+      obj.value = message.value ? Entity.toJSON(message.value) : undefined;
+    }
     return obj;
   },
 
@@ -420,7 +421,9 @@ export const GetOnlyMethodRequest = {
 
   toJSON(message: GetOnlyMethodRequest): unknown {
     const obj: any = {};
-    message.id !== undefined && (obj.id = message.id);
+    if (message.id !== "") {
+      obj.id = message.id;
+    }
     return obj;
   },
 
@@ -476,7 +479,9 @@ export const GetOnlyMethodResponse = {
 
   toJSON(message: GetOnlyMethodResponse): unknown {
     const obj: any = {};
-    message.entity !== undefined && (obj.entity = message.entity ? Entity.toJSON(message.entity) : undefined);
+    if (message.entity !== undefined) {
+      obj.entity = message.entity ? Entity.toJSON(message.entity) : undefined;
+    }
     return obj;
   },
 
@@ -534,7 +539,9 @@ export const WriteMethodRequest = {
 
   toJSON(message: WriteMethodRequest): unknown {
     const obj: any = {};
-    message.id !== undefined && (obj.id = message.id);
+    if (message.id !== "") {
+      obj.id = message.id;
+    }
     return obj;
   },
 
@@ -644,8 +651,12 @@ export const Entity = {
 
   toJSON(message: Entity): unknown {
     const obj: any = {};
-    message.id !== undefined && (obj.id = message.id);
-    message.name !== undefined && (obj.name = message.name);
+    if (message.id !== "") {
+      obj.id = message.id;
+    }
+    if (message.name !== "") {
+      obj.name = message.name;
+    }
     return obj;
   },
 

--- a/integration/batching-with-context/batching.ts
+++ b/integration/batching-with-context/batching.ts
@@ -88,7 +88,7 @@ export const BatchQueryRequest = {
   toJSON(message: BatchQueryRequest): unknown {
     const obj: any = {};
     if (message.ids?.length) {
-      obj.ids = message.ids.map((e) => e);
+      obj.ids = message.ids;
     }
     return obj;
   },
@@ -204,7 +204,7 @@ export const BatchMapQueryRequest = {
   toJSON(message: BatchMapQueryRequest): unknown {
     const obj: any = {};
     if (message.ids?.length) {
-      obj.ids = message.ids.map((e) => e);
+      obj.ids = message.ids;
     }
     return obj;
   },

--- a/integration/batching-with-context/batching.ts
+++ b/integration/batching-with-context/batching.ts
@@ -146,7 +146,7 @@ export const BatchQueryResponse = {
   toJSON(message: BatchQueryResponse): unknown {
     const obj: any = {};
     if (message.entities?.length) {
-      obj.entities = message.entities.map((e) => e ? Entity.toJSON(e) : undefined);
+      obj.entities = message.entities.map((e) => Entity.toJSON(e));
     }
     return obj;
   },
@@ -357,7 +357,7 @@ export const BatchMapQueryResponse_EntitiesEntry = {
       obj.key = message.key;
     }
     if (message.value !== undefined) {
-      obj.value = message.value ? Entity.toJSON(message.value) : undefined;
+      obj.value = Entity.toJSON(message.value);
     }
     return obj;
   },
@@ -480,7 +480,7 @@ export const GetOnlyMethodResponse = {
   toJSON(message: GetOnlyMethodResponse): unknown {
     const obj: any = {};
     if (message.entity !== undefined) {
-      obj.entity = message.entity ? Entity.toJSON(message.entity) : undefined;
+      obj.entity = Entity.toJSON(message.entity);
     }
     return obj;
   },

--- a/integration/batching-with-context/batching.ts
+++ b/integration/batching-with-context/batching.ts
@@ -87,10 +87,8 @@ export const BatchQueryRequest = {
 
   toJSON(message: BatchQueryRequest): unknown {
     const obj: any = {};
-    if (message.ids) {
+    if (message.ids?.length) {
       obj.ids = message.ids.map((e) => e);
-    } else {
-      obj.ids = [];
     }
     return obj;
   },
@@ -147,10 +145,8 @@ export const BatchQueryResponse = {
 
   toJSON(message: BatchQueryResponse): unknown {
     const obj: any = {};
-    if (message.entities) {
+    if (message.entities?.length) {
       obj.entities = message.entities.map((e) => e ? Entity.toJSON(e) : undefined);
-    } else {
-      obj.entities = [];
     }
     return obj;
   },
@@ -207,10 +203,8 @@ export const BatchMapQueryRequest = {
 
   toJSON(message: BatchMapQueryRequest): unknown {
     const obj: any = {};
-    if (message.ids) {
+    if (message.ids?.length) {
       obj.ids = message.ids.map((e) => e);
-    } else {
-      obj.ids = [];
     }
     return obj;
   },
@@ -277,11 +271,14 @@ export const BatchMapQueryResponse = {
 
   toJSON(message: BatchMapQueryResponse): unknown {
     const obj: any = {};
-    obj.entities = {};
     if (message.entities) {
-      Object.entries(message.entities).forEach(([k, v]) => {
-        obj.entities[k] = Entity.toJSON(v);
-      });
+      const entries = Object.entries(message.entities);
+      if (entries.length > 0) {
+        obj.entities = {};
+        entries.forEach(([k, v]) => {
+          obj.entities[k] = Entity.toJSON(v);
+        });
+      }
     }
     return obj;
   },
@@ -356,8 +353,12 @@ export const BatchMapQueryResponse_EntitiesEntry = {
 
   toJSON(message: BatchMapQueryResponse_EntitiesEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = message.key);
-    message.value !== undefined && (obj.value = message.value ? Entity.toJSON(message.value) : undefined);
+    if (message.key !== "") {
+      obj.key = message.key;
+    }
+    if (message.value !== undefined) {
+      obj.value = message.value ? Entity.toJSON(message.value) : undefined;
+    }
     return obj;
   },
 
@@ -420,7 +421,9 @@ export const GetOnlyMethodRequest = {
 
   toJSON(message: GetOnlyMethodRequest): unknown {
     const obj: any = {};
-    message.id !== undefined && (obj.id = message.id);
+    if (message.id !== "") {
+      obj.id = message.id;
+    }
     return obj;
   },
 
@@ -476,7 +479,9 @@ export const GetOnlyMethodResponse = {
 
   toJSON(message: GetOnlyMethodResponse): unknown {
     const obj: any = {};
-    message.entity !== undefined && (obj.entity = message.entity ? Entity.toJSON(message.entity) : undefined);
+    if (message.entity !== undefined) {
+      obj.entity = message.entity ? Entity.toJSON(message.entity) : undefined;
+    }
     return obj;
   },
 
@@ -534,7 +539,9 @@ export const WriteMethodRequest = {
 
   toJSON(message: WriteMethodRequest): unknown {
     const obj: any = {};
-    message.id !== undefined && (obj.id = message.id);
+    if (message.id !== "") {
+      obj.id = message.id;
+    }
     return obj;
   },
 
@@ -644,8 +651,12 @@ export const Entity = {
 
   toJSON(message: Entity): unknown {
     const obj: any = {};
-    message.id !== undefined && (obj.id = message.id);
-    message.name !== undefined && (obj.name = message.name);
+    if (message.id !== "") {
+      obj.id = message.id;
+    }
+    if (message.name !== "") {
+      obj.name = message.name;
+    }
     return obj;
   },
 

--- a/integration/batching/batching.ts
+++ b/integration/batching/batching.ts
@@ -86,7 +86,7 @@ export const BatchQueryRequest = {
   toJSON(message: BatchQueryRequest): unknown {
     const obj: any = {};
     if (message.ids?.length) {
-      obj.ids = message.ids.map((e) => e);
+      obj.ids = message.ids;
     }
     return obj;
   },
@@ -202,7 +202,7 @@ export const BatchMapQueryRequest = {
   toJSON(message: BatchMapQueryRequest): unknown {
     const obj: any = {};
     if (message.ids?.length) {
-      obj.ids = message.ids.map((e) => e);
+      obj.ids = message.ids;
     }
     return obj;
   },

--- a/integration/batching/batching.ts
+++ b/integration/batching/batching.ts
@@ -144,7 +144,7 @@ export const BatchQueryResponse = {
   toJSON(message: BatchQueryResponse): unknown {
     const obj: any = {};
     if (message.entities?.length) {
-      obj.entities = message.entities.map((e) => e ? Entity.toJSON(e) : undefined);
+      obj.entities = message.entities.map((e) => Entity.toJSON(e));
     }
     return obj;
   },
@@ -355,7 +355,7 @@ export const BatchMapQueryResponse_EntitiesEntry = {
       obj.key = message.key;
     }
     if (message.value !== undefined) {
-      obj.value = message.value ? Entity.toJSON(message.value) : undefined;
+      obj.value = Entity.toJSON(message.value);
     }
     return obj;
   },
@@ -478,7 +478,7 @@ export const GetOnlyMethodResponse = {
   toJSON(message: GetOnlyMethodResponse): unknown {
     const obj: any = {};
     if (message.entity !== undefined) {
-      obj.entity = message.entity ? Entity.toJSON(message.entity) : undefined;
+      obj.entity = Entity.toJSON(message.entity);
     }
     return obj;
   },

--- a/integration/batching/batching.ts
+++ b/integration/batching/batching.ts
@@ -85,10 +85,8 @@ export const BatchQueryRequest = {
 
   toJSON(message: BatchQueryRequest): unknown {
     const obj: any = {};
-    if (message.ids) {
+    if (message.ids?.length) {
       obj.ids = message.ids.map((e) => e);
-    } else {
-      obj.ids = [];
     }
     return obj;
   },
@@ -145,10 +143,8 @@ export const BatchQueryResponse = {
 
   toJSON(message: BatchQueryResponse): unknown {
     const obj: any = {};
-    if (message.entities) {
+    if (message.entities?.length) {
       obj.entities = message.entities.map((e) => e ? Entity.toJSON(e) : undefined);
-    } else {
-      obj.entities = [];
     }
     return obj;
   },
@@ -205,10 +201,8 @@ export const BatchMapQueryRequest = {
 
   toJSON(message: BatchMapQueryRequest): unknown {
     const obj: any = {};
-    if (message.ids) {
+    if (message.ids?.length) {
       obj.ids = message.ids.map((e) => e);
-    } else {
-      obj.ids = [];
     }
     return obj;
   },
@@ -275,11 +269,14 @@ export const BatchMapQueryResponse = {
 
   toJSON(message: BatchMapQueryResponse): unknown {
     const obj: any = {};
-    obj.entities = {};
     if (message.entities) {
-      Object.entries(message.entities).forEach(([k, v]) => {
-        obj.entities[k] = Entity.toJSON(v);
-      });
+      const entries = Object.entries(message.entities);
+      if (entries.length > 0) {
+        obj.entities = {};
+        entries.forEach(([k, v]) => {
+          obj.entities[k] = Entity.toJSON(v);
+        });
+      }
     }
     return obj;
   },
@@ -354,8 +351,12 @@ export const BatchMapQueryResponse_EntitiesEntry = {
 
   toJSON(message: BatchMapQueryResponse_EntitiesEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = message.key);
-    message.value !== undefined && (obj.value = message.value ? Entity.toJSON(message.value) : undefined);
+    if (message.key !== "") {
+      obj.key = message.key;
+    }
+    if (message.value !== undefined) {
+      obj.value = message.value ? Entity.toJSON(message.value) : undefined;
+    }
     return obj;
   },
 
@@ -418,7 +419,9 @@ export const GetOnlyMethodRequest = {
 
   toJSON(message: GetOnlyMethodRequest): unknown {
     const obj: any = {};
-    message.id !== undefined && (obj.id = message.id);
+    if (message.id !== "") {
+      obj.id = message.id;
+    }
     return obj;
   },
 
@@ -474,7 +477,9 @@ export const GetOnlyMethodResponse = {
 
   toJSON(message: GetOnlyMethodResponse): unknown {
     const obj: any = {};
-    message.entity !== undefined && (obj.entity = message.entity ? Entity.toJSON(message.entity) : undefined);
+    if (message.entity !== undefined) {
+      obj.entity = message.entity ? Entity.toJSON(message.entity) : undefined;
+    }
     return obj;
   },
 
@@ -532,7 +537,9 @@ export const WriteMethodRequest = {
 
   toJSON(message: WriteMethodRequest): unknown {
     const obj: any = {};
-    message.id !== undefined && (obj.id = message.id);
+    if (message.id !== "") {
+      obj.id = message.id;
+    }
     return obj;
   },
 
@@ -642,8 +649,12 @@ export const Entity = {
 
   toJSON(message: Entity): unknown {
     const obj: any = {};
-    message.id !== undefined && (obj.id = message.id);
-    message.name !== undefined && (obj.name = message.name);
+    if (message.id !== "") {
+      obj.id = message.id;
+    }
+    if (message.name !== "") {
+      obj.name = message.name;
+    }
     return obj;
   },
 

--- a/integration/bytes-as-base64/message.ts
+++ b/integration/bytes-as-base64/message.ts
@@ -17,8 +17,9 @@ export const Message = {
 
   toJSON(message: Message): unknown {
     const obj: any = {};
-    message.data !== undefined &&
-      (obj.data = base64FromBytes(message.data !== undefined ? message.data : new Uint8Array(0)));
+    if (message.data.length !== 0) {
+      obj.data = base64FromBytes(message.data !== undefined ? message.data : new Uint8Array(0));
+    }
     return obj;
   },
 

--- a/integration/bytes-as-base64/message.ts
+++ b/integration/bytes-as-base64/message.ts
@@ -18,7 +18,7 @@ export const Message = {
   toJSON(message: Message): unknown {
     const obj: any = {};
     if (message.data.length !== 0) {
-      obj.data = base64FromBytes(message.data !== undefined ? message.data : new Uint8Array(0));
+      obj.data = base64FromBytes(message.data);
     }
     return obj;
   },

--- a/integration/bytes-node/google/protobuf/wrappers.ts
+++ b/integration/bytes-node/google/protobuf/wrappers.ts
@@ -135,7 +135,9 @@ export const DoubleValue = {
 
   toJSON(message: DoubleValue): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = message.value);
+    if (message.value !== 0) {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -191,7 +193,9 @@ export const FloatValue = {
 
   toJSON(message: FloatValue): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = message.value);
+    if (message.value !== 0) {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -247,7 +251,9 @@ export const Int64Value = {
 
   toJSON(message: Int64Value): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = Math.round(message.value));
+    if (message.value !== 0) {
+      obj.value = Math.round(message.value);
+    }
     return obj;
   },
 
@@ -303,7 +309,9 @@ export const UInt64Value = {
 
   toJSON(message: UInt64Value): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = Math.round(message.value));
+    if (message.value !== 0) {
+      obj.value = Math.round(message.value);
+    }
     return obj;
   },
 
@@ -359,7 +367,9 @@ export const Int32Value = {
 
   toJSON(message: Int32Value): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = Math.round(message.value));
+    if (message.value !== 0) {
+      obj.value = Math.round(message.value);
+    }
     return obj;
   },
 
@@ -415,7 +425,9 @@ export const UInt32Value = {
 
   toJSON(message: UInt32Value): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = Math.round(message.value));
+    if (message.value !== 0) {
+      obj.value = Math.round(message.value);
+    }
     return obj;
   },
 
@@ -471,7 +483,9 @@ export const BoolValue = {
 
   toJSON(message: BoolValue): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = message.value);
+    if (message.value === true) {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -527,7 +541,9 @@ export const StringValue = {
 
   toJSON(message: StringValue): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = message.value);
+    if (message.value !== "") {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -583,8 +599,9 @@ export const BytesValue = {
 
   toJSON(message: BytesValue): unknown {
     const obj: any = {};
-    message.value !== undefined &&
-      (obj.value = base64FromBytes(message.value !== undefined ? message.value : Buffer.alloc(0)));
+    if (message.value.length !== 0) {
+      obj.value = base64FromBytes(message.value !== undefined ? message.value : Buffer.alloc(0));
+    }
     return obj;
   },
 

--- a/integration/bytes-node/google/protobuf/wrappers.ts
+++ b/integration/bytes-node/google/protobuf/wrappers.ts
@@ -600,7 +600,7 @@ export const BytesValue = {
   toJSON(message: BytesValue): unknown {
     const obj: any = {};
     if (message.value.length !== 0) {
-      obj.value = base64FromBytes(message.value !== undefined ? message.value : Buffer.alloc(0));
+      obj.value = base64FromBytes(message.value);
     }
     return obj;
   },

--- a/integration/bytes-node/point.ts
+++ b/integration/bytes-node/point.ts
@@ -63,9 +63,12 @@ export const Point = {
 
   toJSON(message: Point): unknown {
     const obj: any = {};
-    message.data !== undefined &&
-      (obj.data = base64FromBytes(message.data !== undefined ? message.data : Buffer.alloc(0)));
-    message.dataWrapped !== undefined && (obj.dataWrapped = message.dataWrapped);
+    if (message.data.length !== 0) {
+      obj.data = base64FromBytes(message.data !== undefined ? message.data : Buffer.alloc(0));
+    }
+    if (message.dataWrapped !== undefined) {
+      obj.dataWrapped = message.dataWrapped;
+    }
     return obj;
   },
 

--- a/integration/bytes-node/point.ts
+++ b/integration/bytes-node/point.ts
@@ -64,7 +64,7 @@ export const Point = {
   toJSON(message: Point): unknown {
     const obj: any = {};
     if (message.data.length !== 0) {
-      obj.data = base64FromBytes(message.data !== undefined ? message.data : Buffer.alloc(0));
+      obj.data = base64FromBytes(message.data);
     }
     if (message.dataWrapped !== undefined) {
       obj.dataWrapped = message.dataWrapped;

--- a/integration/const-enum/const-enum.ts
+++ b/integration/const-enum/const-enum.ts
@@ -136,12 +136,17 @@ export const DividerData = {
 
   toJSON(message: DividerData): unknown {
     const obj: any = {};
-    message.type !== undefined && (obj.type = dividerData_DividerTypeToJSON(message.type));
-    obj.typeMap = {};
+    if (message.type !== DividerData_DividerType.DOUBLE) {
+      obj.type = dividerData_DividerTypeToJSON(message.type);
+    }
     if (message.typeMap) {
-      Object.entries(message.typeMap).forEach(([k, v]) => {
-        obj.typeMap[k] = dividerData_DividerTypeToJSON(v);
-      });
+      const entries = Object.entries(message.typeMap);
+      if (entries.length > 0) {
+        obj.typeMap = {};
+        entries.forEach(([k, v]) => {
+          obj.typeMap[k] = dividerData_DividerTypeToJSON(v);
+        });
+      }
     }
     return obj;
   },
@@ -220,8 +225,12 @@ export const DividerData_TypeMapEntry = {
 
   toJSON(message: DividerData_TypeMapEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = message.key);
-    message.value !== undefined && (obj.value = dividerData_DividerTypeToJSON(message.value));
+    if (message.key !== "") {
+      obj.key = message.key;
+    }
+    if (message.value !== DividerData_DividerType.DOUBLE) {
+      obj.value = dividerData_DividerTypeToJSON(message.value);
+    }
     return obj;
   },
 

--- a/integration/enums-as-literals-with-string-enums/enums-as-literals-with-string-enums.ts
+++ b/integration/enums-as-literals-with-string-enums/enums-as-literals-with-string-enums.ts
@@ -111,7 +111,9 @@ export const DividerData = {
 
   toJSON(message: DividerData): unknown {
     const obj: any = {};
-    message.type !== undefined && (obj.type = dividerData_DividerTypeToJSON(message.type));
+    if (message.type !== DividerData_DividerType.DOUBLE) {
+      obj.type = dividerData_DividerTypeToJSON(message.type);
+    }
     return obj;
   },
 

--- a/integration/enums-as-literals/enums-as-literals.ts
+++ b/integration/enums-as-literals/enums-as-literals.ts
@@ -89,7 +89,9 @@ export const DividerData = {
 
   toJSON(message: DividerData): unknown {
     const obj: any = {};
-    message.type !== undefined && (obj.type = dividerData_DividerTypeToJSON(message.type));
+    if (message.type !== 0) {
+      obj.type = dividerData_DividerTypeToJSON(message.type);
+    }
     return obj;
   },
 

--- a/integration/extensions/test.ts
+++ b/integration/extensions/test.ts
@@ -179,7 +179,9 @@ export const Extendable = {
 
   toJSON(message: Extendable): unknown {
     const obj: any = {};
-    message.field !== undefined && (obj.field = message.field);
+    if (message.field !== undefined && message.field !== "") {
+      obj.field = message.field;
+    }
     return obj;
   },
 
@@ -287,7 +289,9 @@ export const Nested = {
 
   toJSON(message: Nested): unknown {
     const obj: any = {};
-    message.field !== undefined && (obj.field = message.field);
+    if (message.field !== undefined && message.field !== "") {
+      obj.field = message.field;
+    }
     return obj;
   },
 
@@ -383,8 +387,12 @@ export const Group = {
 
   toJSON(message: Group): unknown {
     const obj: any = {};
-    message.name !== undefined && (obj.name = message.name);
-    message.value !== undefined && (obj.value = message.value);
+    if (message.name !== undefined && message.name !== "") {
+      obj.name = message.name;
+    }
+    if (message.value !== undefined && message.value !== "") {
+      obj.value = message.value;
+    }
     return obj;
   },
 

--- a/integration/fieldmask/fieldmask.ts
+++ b/integration/fieldmask/fieldmask.ts
@@ -49,7 +49,9 @@ export const FieldMaskMessage = {
 
   toJSON(message: FieldMaskMessage): unknown {
     const obj: any = {};
-    message.fieldMask !== undefined && (obj.fieldMask = FieldMask.toJSON(FieldMask.wrap(message.fieldMask)));
+    if (message.fieldMask !== undefined) {
+      obj.fieldMask = FieldMask.toJSON(FieldMask.wrap(message.fieldMask));
+    }
     return obj;
   },
 

--- a/integration/file-suffix/child.pb.ts
+++ b/integration/file-suffix/child.pb.ts
@@ -81,7 +81,9 @@ export const Child = {
 
   toJSON(message: Child): unknown {
     const obj: any = {};
-    message.name !== undefined && (obj.name = message.name);
+    if (message.name !== "") {
+      obj.name = message.name;
+    }
     return obj;
   },
 

--- a/integration/file-suffix/google/protobuf/timestamp.pb.ts
+++ b/integration/file-suffix/google/protobuf/timestamp.pb.ts
@@ -165,8 +165,12 @@ export const Timestamp = {
 
   toJSON(message: Timestamp): unknown {
     const obj: any = {};
-    message.seconds !== undefined && (obj.seconds = Math.round(message.seconds));
-    message.nanos !== undefined && (obj.nanos = Math.round(message.nanos));
+    if (message.seconds !== 0) {
+      obj.seconds = Math.round(message.seconds);
+    }
+    if (message.nanos !== 0) {
+      obj.nanos = Math.round(message.nanos);
+    }
     return obj;
   },
 

--- a/integration/file-suffix/parent.pb.ts
+++ b/integration/file-suffix/parent.pb.ts
@@ -77,7 +77,7 @@ export const Parent = {
   toJSON(message: Parent): unknown {
     const obj: any = {};
     if (message.child !== undefined) {
-      obj.child = message.child ? Child.toJSON(message.child) : undefined;
+      obj.child = Child.toJSON(message.child);
     }
     if (message.childEnum !== 0) {
       obj.childEnum = childEnumToJSON(message.childEnum);

--- a/integration/file-suffix/parent.pb.ts
+++ b/integration/file-suffix/parent.pb.ts
@@ -76,9 +76,15 @@ export const Parent = {
 
   toJSON(message: Parent): unknown {
     const obj: any = {};
-    message.child !== undefined && (obj.child = message.child ? Child.toJSON(message.child) : undefined);
-    message.childEnum !== undefined && (obj.childEnum = childEnumToJSON(message.childEnum));
-    message.createdAt !== undefined && (obj.createdAt = message.createdAt.toISOString());
+    if (message.child !== undefined) {
+      obj.child = message.child ? Child.toJSON(message.child) : undefined;
+    }
+    if (message.childEnum !== 0) {
+      obj.childEnum = childEnumToJSON(message.childEnum);
+    }
+    if (message.createdAt !== undefined) {
+      obj.createdAt = message.createdAt.toISOString();
+    }
     return obj;
   },
 

--- a/integration/from-partial-no-initialize/test.ts
+++ b/integration/from-partial-no-initialize/test.ts
@@ -252,10 +252,10 @@ export const TPartial = {
       }
     }
     if (message.message !== undefined) {
-      obj.message = message.message ? TPartialMessage.toJSON(message.message) : undefined;
+      obj.message = TPartialMessage.toJSON(message.message);
     }
     if (message.repeatedMessage?.length) {
-      obj.repeatedMessage = message.repeatedMessage.map((e) => e ? TPartialMessage.toJSON(e) : undefined);
+      obj.repeatedMessage = message.repeatedMessage.map((e) => TPartialMessage.toJSON(e));
     }
     if (message.repeatedString?.length) {
       obj.repeatedString = message.repeatedString;

--- a/integration/from-partial-no-initialize/test.ts
+++ b/integration/from-partial-no-initialize/test.ts
@@ -258,7 +258,7 @@ export const TPartial = {
       obj.repeatedMessage = message.repeatedMessage.map((e) => e ? TPartialMessage.toJSON(e) : undefined);
     }
     if (message.repeatedString?.length) {
-      obj.repeatedString = message.repeatedString.map((e) => e);
+      obj.repeatedString = message.repeatedString;
     }
     if (message.repeatedNumber?.length) {
       obj.repeatedNumber = message.repeatedNumber.map((e) => Math.round(e));

--- a/integration/from-partial-no-initialize/test.ts
+++ b/integration/from-partial-no-initialize/test.ts
@@ -63,7 +63,9 @@ export const TPartialMessage = {
 
   toJSON(message: TPartialMessage): unknown {
     const obj: any = {};
-    message.field !== undefined && (obj.field = message.field);
+    if (message.field !== undefined && message.field !== "") {
+      obj.field = message.field;
+    }
     return obj;
   },
 
@@ -234,30 +236,32 @@ export const TPartial = {
 
   toJSON(message: TPartial): unknown {
     const obj: any = {};
-    message.number !== undefined && (obj.number = Math.round(message.number));
-    message.string !== undefined && (obj.string = message.string);
-    obj.map = {};
+    if (message.number !== undefined && message.number !== 0) {
+      obj.number = Math.round(message.number);
+    }
+    if (message.string !== undefined && message.string !== "") {
+      obj.string = message.string;
+    }
     if (message.map) {
-      Object.entries(message.map).forEach(([k, v]) => {
-        obj.map[k] = v;
-      });
+      const entries = Object.entries(message.map);
+      if (entries.length > 0) {
+        obj.map = {};
+        entries.forEach(([k, v]) => {
+          obj.map[k] = v;
+        });
+      }
     }
-    message.message !== undefined &&
-      (obj.message = message.message ? TPartialMessage.toJSON(message.message) : undefined);
-    if (message.repeatedMessage) {
+    if (message.message !== undefined) {
+      obj.message = message.message ? TPartialMessage.toJSON(message.message) : undefined;
+    }
+    if (message.repeatedMessage?.length) {
       obj.repeatedMessage = message.repeatedMessage.map((e) => e ? TPartialMessage.toJSON(e) : undefined);
-    } else {
-      obj.repeatedMessage = [];
     }
-    if (message.repeatedString) {
+    if (message.repeatedString?.length) {
       obj.repeatedString = message.repeatedString.map((e) => e);
-    } else {
-      obj.repeatedString = [];
     }
-    if (message.repeatedNumber) {
+    if (message.repeatedNumber?.length) {
       obj.repeatedNumber = message.repeatedNumber.map((e) => Math.round(e));
-    } else {
-      obj.repeatedNumber = [];
     }
     return obj;
   },
@@ -339,8 +343,12 @@ export const TPartial_MapEntry = {
 
   toJSON(message: TPartial_MapEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = message.key);
-    message.value !== undefined && (obj.value = message.value);
+    if (message.key !== "") {
+      obj.key = message.key;
+    }
+    if (message.value !== "") {
+      obj.value = message.value;
+    }
     return obj;
   },
 

--- a/integration/generic-metadata/hero.ts
+++ b/integration/generic-metadata/hero.ts
@@ -65,7 +65,9 @@ export const HeroById = {
 
   toJSON(message: HeroById): unknown {
     const obj: any = {};
-    message.id !== undefined && (obj.id = Math.round(message.id));
+    if (message.id !== 0) {
+      obj.id = Math.round(message.id);
+    }
     return obj;
   },
 
@@ -121,7 +123,9 @@ export const VillainById = {
 
   toJSON(message: VillainById): unknown {
     const obj: any = {};
-    message.id !== undefined && (obj.id = Math.round(message.id));
+    if (message.id !== 0) {
+      obj.id = Math.round(message.id);
+    }
     return obj;
   },
 
@@ -187,8 +191,12 @@ export const Hero = {
 
   toJSON(message: Hero): unknown {
     const obj: any = {};
-    message.id !== undefined && (obj.id = Math.round(message.id));
-    message.name !== undefined && (obj.name = message.name);
+    if (message.id !== 0) {
+      obj.id = Math.round(message.id);
+    }
+    if (message.name !== "") {
+      obj.name = message.name;
+    }
     return obj;
   },
 
@@ -255,8 +263,12 @@ export const Villain = {
 
   toJSON(message: Villain): unknown {
     const obj: any = {};
-    message.id !== undefined && (obj.id = Math.round(message.id));
-    message.name !== undefined && (obj.name = message.name);
+    if (message.id !== 0) {
+      obj.id = Math.round(message.id);
+    }
+    if (message.name !== "") {
+      obj.name = message.name;
+    }
     return obj;
   },
 

--- a/integration/generic-service-definitions-and-services/simple.ts
+++ b/integration/generic-service-definitions-and-services/simple.ts
@@ -48,7 +48,9 @@ export const TestMessage = {
 
   toJSON(message: TestMessage): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = message.value);
+    if (message.value !== "") {
+      obj.value = message.value;
+    }
     return obj;
   },
 

--- a/integration/generic-service-definitions/simple.ts
+++ b/integration/generic-service-definitions/simple.ts
@@ -48,7 +48,9 @@ export const TestMessage = {
 
   toJSON(message: TestMessage): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = message.value);
+    if (message.value !== "") {
+      obj.value = message.value;
+    }
     return obj;
   },
 

--- a/integration/global-this/global-this.ts
+++ b/integration/global-this/global-this.ts
@@ -52,7 +52,9 @@ export const Object = {
 
   toJSON(message: Object): unknown {
     const obj: any = {};
-    message.name !== undefined && (obj.name = message.name);
+    if (message.name !== "") {
+      obj.name = message.name;
+    }
     return obj;
   },
 
@@ -108,7 +110,9 @@ export const Error = {
 
   toJSON(message: Error): unknown {
     const obj: any = {};
-    message.name !== undefined && (obj.name = message.name);
+    if (message.name !== "") {
+      obj.name = message.name;
+    }
     return obj;
   },
 

--- a/integration/groups/test.ts
+++ b/integration/groups/test.ts
@@ -143,10 +143,15 @@ export const GroupsOptionalTest = {
 
   toJSON(message: GroupsOptionalTest): unknown {
     const obj: any = {};
-    message.int1 !== undefined && (obj.int1 = Math.round(message.int1));
-    message.group !== undefined &&
-      (obj.group = message.group ? GroupsOptionalTest_Group.toJSON(message.group) : undefined);
-    message.int3 !== undefined && (obj.int3 = Math.round(message.int3));
+    if (message.int1 !== undefined && message.int1 !== 0) {
+      obj.int1 = Math.round(message.int1);
+    }
+    if (message.group !== undefined) {
+      obj.group = message.group ? GroupsOptionalTest_Group.toJSON(message.group) : undefined;
+    }
+    if (message.int3 !== undefined && message.int3 !== 0) {
+      obj.int3 = Math.round(message.int3);
+    }
     return obj;
   },
 
@@ -246,8 +251,12 @@ export const GroupsOptionalTest_Group = {
 
   toJSON(message: GroupsOptionalTest_Group): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = message.key);
-    message.value !== undefined && (obj.value = message.value);
+    if (message.key !== undefined && message.key !== "") {
+      obj.key = message.key;
+    }
+    if (message.value !== undefined && message.value !== "") {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -402,20 +411,14 @@ export const GroupsRepeatedTest = {
 
   toJSON(message: GroupsRepeatedTest): unknown {
     const obj: any = {};
-    if (message.int1) {
+    if (message.int1?.length) {
       obj.int1 = message.int1.map((e) => Math.round(e));
-    } else {
-      obj.int1 = [];
     }
-    if (message.group) {
+    if (message.group?.length) {
       obj.group = message.group.map((e) => e ? GroupsRepeatedTest_Group.toJSON(e) : undefined);
-    } else {
-      obj.group = [];
     }
-    if (message.int3) {
+    if (message.int3?.length) {
       obj.int3 = message.int3.map((e) => Math.round(e));
-    } else {
-      obj.int3 = [];
     }
     return obj;
   },
@@ -524,15 +527,11 @@ export const GroupsRepeatedTest_Group = {
 
   toJSON(message: GroupsRepeatedTest_Group): unknown {
     const obj: any = {};
-    if (message.key) {
+    if (message.key?.length) {
       obj.key = message.key.map((e) => e);
-    } else {
-      obj.key = [];
     }
-    if (message.value) {
+    if (message.value?.length) {
       obj.value = message.value.map((e) => e);
-    } else {
-      obj.value = [];
     }
     return obj;
   },
@@ -688,20 +687,14 @@ export const GroupsNestedTest = {
 
   toJSON(message: GroupsNestedTest): unknown {
     const obj: any = {};
-    if (message.int1) {
+    if (message.int1?.length) {
       obj.int1 = message.int1.map((e) => Math.round(e));
-    } else {
-      obj.int1 = [];
     }
-    if (message.group) {
+    if (message.group?.length) {
       obj.group = message.group.map((e) => e ? GroupsNestedTest_Group.toJSON(e) : undefined);
-    } else {
-      obj.group = [];
     }
-    if (message.int3) {
+    if (message.int3?.length) {
       obj.int3 = message.int3.map((e) => Math.round(e));
-    } else {
-      obj.int3 = [];
     }
     return obj;
   },
@@ -796,10 +789,8 @@ export const GroupsNestedTest_Group = {
 
   toJSON(message: GroupsNestedTest_Group): unknown {
     const obj: any = {};
-    if (message.nested) {
+    if (message.nested?.length) {
       obj.nested = message.nested.map((e) => e ? GroupsNestedTest_Group_Nested.toJSON(e) : undefined);
-    } else {
-      obj.nested = [];
     }
     return obj;
   },
@@ -892,10 +883,8 @@ export const GroupsNestedTest_Group_Nested = {
 
   toJSON(message: GroupsNestedTest_Group_Nested): unknown {
     const obj: any = {};
-    if (message.nested2) {
+    if (message.nested2?.length) {
       obj.nested2 = message.nested2.map((e) => e ? GroupsNestedTest_Group_Nested_Nested2.toJSON(e) : undefined);
-    } else {
-      obj.nested2 = [];
     }
     return obj;
   },
@@ -981,7 +970,9 @@ export const GroupsNestedTest_Group_Nested_Nested2 = {
 
   toJSON(message: GroupsNestedTest_Group_Nested_Nested2): unknown {
     const obj: any = {};
-    message.string1 !== undefined && (obj.string1 = message.string1);
+    if (message.string1 !== undefined && message.string1 !== "") {
+      obj.string1 = message.string1;
+    }
     return obj;
   },
 

--- a/integration/groups/test.ts
+++ b/integration/groups/test.ts
@@ -528,10 +528,10 @@ export const GroupsRepeatedTest_Group = {
   toJSON(message: GroupsRepeatedTest_Group): unknown {
     const obj: any = {};
     if (message.key?.length) {
-      obj.key = message.key.map((e) => e);
+      obj.key = message.key;
     }
     if (message.value?.length) {
-      obj.value = message.value.map((e) => e);
+      obj.value = message.value;
     }
     return obj;
   },

--- a/integration/groups/test.ts
+++ b/integration/groups/test.ts
@@ -147,7 +147,7 @@ export const GroupsOptionalTest = {
       obj.int1 = Math.round(message.int1);
     }
     if (message.group !== undefined) {
-      obj.group = message.group ? GroupsOptionalTest_Group.toJSON(message.group) : undefined;
+      obj.group = GroupsOptionalTest_Group.toJSON(message.group);
     }
     if (message.int3 !== undefined && message.int3 !== 0) {
       obj.int3 = Math.round(message.int3);
@@ -415,7 +415,7 @@ export const GroupsRepeatedTest = {
       obj.int1 = message.int1.map((e) => Math.round(e));
     }
     if (message.group?.length) {
-      obj.group = message.group.map((e) => e ? GroupsRepeatedTest_Group.toJSON(e) : undefined);
+      obj.group = message.group.map((e) => GroupsRepeatedTest_Group.toJSON(e));
     }
     if (message.int3?.length) {
       obj.int3 = message.int3.map((e) => Math.round(e));
@@ -691,7 +691,7 @@ export const GroupsNestedTest = {
       obj.int1 = message.int1.map((e) => Math.round(e));
     }
     if (message.group?.length) {
-      obj.group = message.group.map((e) => e ? GroupsNestedTest_Group.toJSON(e) : undefined);
+      obj.group = message.group.map((e) => GroupsNestedTest_Group.toJSON(e));
     }
     if (message.int3?.length) {
       obj.int3 = message.int3.map((e) => Math.round(e));
@@ -790,7 +790,7 @@ export const GroupsNestedTest_Group = {
   toJSON(message: GroupsNestedTest_Group): unknown {
     const obj: any = {};
     if (message.nested?.length) {
-      obj.nested = message.nested.map((e) => e ? GroupsNestedTest_Group_Nested.toJSON(e) : undefined);
+      obj.nested = message.nested.map((e) => GroupsNestedTest_Group_Nested.toJSON(e));
     }
     return obj;
   },
@@ -884,7 +884,7 @@ export const GroupsNestedTest_Group_Nested = {
   toJSON(message: GroupsNestedTest_Group_Nested): unknown {
     const obj: any = {};
     if (message.nested2?.length) {
-      obj.nested2 = message.nested2.map((e) => e ? GroupsNestedTest_Group_Nested_Nested2.toJSON(e) : undefined);
+      obj.nested2 = message.nested2.map((e) => GroupsNestedTest_Group_Nested_Nested2.toJSON(e));
     }
     return obj;
   },

--- a/integration/grpc-js-use-date-false/google/protobuf/timestamp.ts
+++ b/integration/grpc-js-use-date-false/google/protobuf/timestamp.ts
@@ -165,8 +165,12 @@ export const Timestamp = {
 
   toJSON(message: Timestamp): unknown {
     const obj: any = {};
-    message.seconds !== undefined && (obj.seconds = Math.round(message.seconds));
-    message.nanos !== undefined && (obj.nanos = Math.round(message.nanos));
+    if (message.seconds !== 0) {
+      obj.seconds = Math.round(message.seconds);
+    }
+    if (message.nanos !== 0) {
+      obj.nanos = Math.round(message.nanos);
+    }
     return obj;
   },
 

--- a/integration/grpc-js-use-date-false/grpc-js-use-date-false.ts
+++ b/integration/grpc-js-use-date-false/grpc-js-use-date-false.ts
@@ -61,7 +61,9 @@ export const TimestampMessage = {
 
   toJSON(message: TimestampMessage): unknown {
     const obj: any = {};
-    message.timestamp !== undefined && (obj.timestamp = fromTimestamp(message.timestamp).toISOString());
+    if (message.timestamp !== undefined) {
+      obj.timestamp = fromTimestamp(message.timestamp).toISOString();
+    }
     return obj;
   },
 

--- a/integration/grpc-js-use-date-string/google/protobuf/timestamp.ts
+++ b/integration/grpc-js-use-date-string/google/protobuf/timestamp.ts
@@ -165,8 +165,12 @@ export const Timestamp = {
 
   toJSON(message: Timestamp): unknown {
     const obj: any = {};
-    message.seconds !== undefined && (obj.seconds = Math.round(message.seconds));
-    message.nanos !== undefined && (obj.nanos = Math.round(message.nanos));
+    if (message.seconds !== 0) {
+      obj.seconds = Math.round(message.seconds);
+    }
+    if (message.nanos !== 0) {
+      obj.nanos = Math.round(message.nanos);
+    }
     return obj;
   },
 

--- a/integration/grpc-js-use-date-string/grpc-js-use-date-string.ts
+++ b/integration/grpc-js-use-date-string/grpc-js-use-date-string.ts
@@ -61,7 +61,9 @@ export const TimestampMessage = {
 
   toJSON(message: TimestampMessage): unknown {
     const obj: any = {};
-    message.timestamp !== undefined && (obj.timestamp = message.timestamp);
+    if (message.timestamp !== undefined) {
+      obj.timestamp = message.timestamp;
+    }
     return obj;
   },
 

--- a/integration/grpc-js-use-date-true/google/protobuf/timestamp.ts
+++ b/integration/grpc-js-use-date-true/google/protobuf/timestamp.ts
@@ -165,8 +165,12 @@ export const Timestamp = {
 
   toJSON(message: Timestamp): unknown {
     const obj: any = {};
-    message.seconds !== undefined && (obj.seconds = Math.round(message.seconds));
-    message.nanos !== undefined && (obj.nanos = Math.round(message.nanos));
+    if (message.seconds !== 0) {
+      obj.seconds = Math.round(message.seconds);
+    }
+    if (message.nanos !== 0) {
+      obj.nanos = Math.round(message.nanos);
+    }
     return obj;
   },
 

--- a/integration/grpc-js-use-date-true/grpc-js-use-date-true.ts
+++ b/integration/grpc-js-use-date-true/grpc-js-use-date-true.ts
@@ -61,7 +61,9 @@ export const TimestampMessage = {
 
   toJSON(message: TimestampMessage): unknown {
     const obj: any = {};
-    message.timestamp !== undefined && (obj.timestamp = message.timestamp.toISOString());
+    if (message.timestamp !== undefined) {
+      obj.timestamp = message.timestamp.toISOString();
+    }
     return obj;
   },
 

--- a/integration/grpc-js/google/protobuf/struct.ts
+++ b/integration/grpc-js/google/protobuf/struct.ts
@@ -382,7 +382,7 @@ export const Value = {
   toJSON(message: Value): unknown {
     const obj: any = {};
     if (message.nullValue !== undefined) {
-      obj.nullValue = message.nullValue !== undefined ? nullValueToJSON(message.nullValue) : undefined;
+      obj.nullValue = nullValueToJSON(message.nullValue);
     }
     if (message.numberValue !== undefined) {
       obj.numberValue = message.numberValue;

--- a/integration/grpc-js/google/protobuf/struct.ts
+++ b/integration/grpc-js/google/protobuf/struct.ts
@@ -497,7 +497,7 @@ export const ListValue = {
   toJSON(message: ListValue): unknown {
     const obj: any = {};
     if (message.values?.length) {
-      obj.values = message.values.map((e) => e);
+      obj.values = message.values;
     }
     return obj;
   },

--- a/integration/grpc-js/google/protobuf/struct.ts
+++ b/integration/grpc-js/google/protobuf/struct.ts
@@ -153,11 +153,14 @@ export const Struct = {
 
   toJSON(message: Struct): unknown {
     const obj: any = {};
-    obj.fields = {};
     if (message.fields) {
-      Object.entries(message.fields).forEach(([k, v]) => {
-        obj.fields[k] = v;
-      });
+      const entries = Object.entries(message.fields);
+      if (entries.length > 0) {
+        obj.fields = {};
+        entries.forEach(([k, v]) => {
+          obj.fields[k] = v;
+        });
+      }
     }
     return obj;
   },
@@ -252,8 +255,12 @@ export const Struct_FieldsEntry = {
 
   toJSON(message: Struct_FieldsEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = message.key);
-    message.value !== undefined && (obj.value = message.value);
+    if (message.key !== "") {
+      obj.key = message.key;
+    }
+    if (message.value !== undefined) {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -374,13 +381,24 @@ export const Value = {
 
   toJSON(message: Value): unknown {
     const obj: any = {};
-    message.nullValue !== undefined &&
-      (obj.nullValue = message.nullValue !== undefined ? nullValueToJSON(message.nullValue) : undefined);
-    message.numberValue !== undefined && (obj.numberValue = message.numberValue);
-    message.stringValue !== undefined && (obj.stringValue = message.stringValue);
-    message.boolValue !== undefined && (obj.boolValue = message.boolValue);
-    message.structValue !== undefined && (obj.structValue = message.structValue);
-    message.listValue !== undefined && (obj.listValue = message.listValue);
+    if (message.nullValue !== undefined) {
+      obj.nullValue = message.nullValue !== undefined ? nullValueToJSON(message.nullValue) : undefined;
+    }
+    if (message.numberValue !== undefined) {
+      obj.numberValue = message.numberValue;
+    }
+    if (message.stringValue !== undefined) {
+      obj.stringValue = message.stringValue;
+    }
+    if (message.boolValue !== undefined) {
+      obj.boolValue = message.boolValue;
+    }
+    if (message.structValue !== undefined) {
+      obj.structValue = message.structValue;
+    }
+    if (message.listValue !== undefined) {
+      obj.listValue = message.listValue;
+    }
     return obj;
   },
 
@@ -478,10 +496,8 @@ export const ListValue = {
 
   toJSON(message: ListValue): unknown {
     const obj: any = {};
-    if (message.values) {
+    if (message.values?.length) {
       obj.values = message.values.map((e) => e);
-    } else {
-      obj.values = [];
     }
     return obj;
   },

--- a/integration/grpc-js/google/protobuf/timestamp.ts
+++ b/integration/grpc-js/google/protobuf/timestamp.ts
@@ -165,8 +165,12 @@ export const Timestamp = {
 
   toJSON(message: Timestamp): unknown {
     const obj: any = {};
-    message.seconds !== undefined && (obj.seconds = Math.round(message.seconds));
-    message.nanos !== undefined && (obj.nanos = Math.round(message.nanos));
+    if (message.seconds !== 0) {
+      obj.seconds = Math.round(message.seconds);
+    }
+    if (message.nanos !== 0) {
+      obj.nanos = Math.round(message.nanos);
+    }
     return obj;
   },
 

--- a/integration/grpc-js/google/protobuf/wrappers.ts
+++ b/integration/grpc-js/google/protobuf/wrappers.ts
@@ -135,7 +135,9 @@ export const DoubleValue = {
 
   toJSON(message: DoubleValue): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = message.value);
+    if (message.value !== 0) {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -191,7 +193,9 @@ export const FloatValue = {
 
   toJSON(message: FloatValue): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = message.value);
+    if (message.value !== 0) {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -247,7 +251,9 @@ export const Int64Value = {
 
   toJSON(message: Int64Value): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = Math.round(message.value));
+    if (message.value !== 0) {
+      obj.value = Math.round(message.value);
+    }
     return obj;
   },
 
@@ -303,7 +309,9 @@ export const UInt64Value = {
 
   toJSON(message: UInt64Value): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = Math.round(message.value));
+    if (message.value !== 0) {
+      obj.value = Math.round(message.value);
+    }
     return obj;
   },
 
@@ -359,7 +367,9 @@ export const Int32Value = {
 
   toJSON(message: Int32Value): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = Math.round(message.value));
+    if (message.value !== 0) {
+      obj.value = Math.round(message.value);
+    }
     return obj;
   },
 
@@ -415,7 +425,9 @@ export const UInt32Value = {
 
   toJSON(message: UInt32Value): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = Math.round(message.value));
+    if (message.value !== 0) {
+      obj.value = Math.round(message.value);
+    }
     return obj;
   },
 
@@ -471,7 +483,9 @@ export const BoolValue = {
 
   toJSON(message: BoolValue): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = message.value);
+    if (message.value === true) {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -527,7 +541,9 @@ export const StringValue = {
 
   toJSON(message: StringValue): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = message.value);
+    if (message.value !== "") {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -583,8 +599,9 @@ export const BytesValue = {
 
   toJSON(message: BytesValue): unknown {
     const obj: any = {};
-    message.value !== undefined &&
-      (obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array(0)));
+    if (message.value.length !== 0) {
+      obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array(0));
+    }
     return obj;
   },
 

--- a/integration/grpc-js/google/protobuf/wrappers.ts
+++ b/integration/grpc-js/google/protobuf/wrappers.ts
@@ -600,7 +600,7 @@ export const BytesValue = {
   toJSON(message: BytesValue): unknown {
     const obj: any = {};
     if (message.value.length !== 0) {
-      obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array(0));
+      obj.value = base64FromBytes(message.value);
     }
     return obj;
   },

--- a/integration/grpc-js/simple.ts
+++ b/integration/grpc-js/simple.ts
@@ -80,7 +80,9 @@ export const TestMessage = {
 
   toJSON(message: TestMessage): unknown {
     const obj: any = {};
-    message.timestamp !== undefined && (obj.timestamp = message.timestamp.toISOString());
+    if (message.timestamp !== undefined) {
+      obj.timestamp = message.timestamp.toISOString();
+    }
     return obj;
   },
 

--- a/integration/grpc-web-abort-signal/example.ts
+++ b/integration/grpc-web-abort-signal/example.ts
@@ -239,10 +239,10 @@ export const DashUserSettingsState = {
       obj.email = message.email;
     }
     if (message.urls !== undefined) {
-      obj.urls = message.urls ? DashUserSettingsState_URLs.toJSON(message.urls) : undefined;
+      obj.urls = DashUserSettingsState_URLs.toJSON(message.urls);
     }
     if (message.flashes?.length) {
-      obj.flashes = message.flashes.map((e) => e ? DashFlash.toJSON(e) : undefined);
+      obj.flashes = message.flashes.map((e) => DashFlash.toJSON(e));
     }
     return obj;
   },

--- a/integration/grpc-web-abort-signal/example.ts
+++ b/integration/grpc-web-abort-signal/example.ts
@@ -149,8 +149,12 @@ export const DashFlash = {
 
   toJSON(message: DashFlash): unknown {
     const obj: any = {};
-    message.msg !== undefined && (obj.msg = message.msg);
-    message.type !== undefined && (obj.type = dashFlash_TypeToJSON(message.type));
+    if (message.msg !== "") {
+      obj.msg = message.msg;
+    }
+    if (message.type !== 0) {
+      obj.type = dashFlash_TypeToJSON(message.type);
+    }
     return obj;
   },
 
@@ -231,13 +235,14 @@ export const DashUserSettingsState = {
 
   toJSON(message: DashUserSettingsState): unknown {
     const obj: any = {};
-    message.email !== undefined && (obj.email = message.email);
-    message.urls !== undefined &&
-      (obj.urls = message.urls ? DashUserSettingsState_URLs.toJSON(message.urls) : undefined);
-    if (message.flashes) {
+    if (message.email !== "") {
+      obj.email = message.email;
+    }
+    if (message.urls !== undefined) {
+      obj.urls = message.urls ? DashUserSettingsState_URLs.toJSON(message.urls) : undefined;
+    }
+    if (message.flashes?.length) {
       obj.flashes = message.flashes.map((e) => e ? DashFlash.toJSON(e) : undefined);
-    } else {
-      obj.flashes = [];
     }
     return obj;
   },
@@ -311,8 +316,12 @@ export const DashUserSettingsState_URLs = {
 
   toJSON(message: DashUserSettingsState_URLs): unknown {
     const obj: any = {};
-    message.connectGoogle !== undefined && (obj.connectGoogle = message.connectGoogle);
-    message.connectGithub !== undefined && (obj.connectGithub = message.connectGithub);
+    if (message.connectGoogle !== "") {
+      obj.connectGoogle = message.connectGoogle;
+    }
+    if (message.connectGithub !== "") {
+      obj.connectGithub = message.connectGithub;
+    }
     return obj;
   },
 
@@ -404,10 +413,18 @@ export const DashCred = {
 
   toJSON(message: DashCred): unknown {
     const obj: any = {};
-    message.description !== undefined && (obj.description = message.description);
-    message.metadata !== undefined && (obj.metadata = message.metadata);
-    message.token !== undefined && (obj.token = message.token);
-    message.id !== undefined && (obj.id = message.id);
+    if (message.description !== "") {
+      obj.description = message.description;
+    }
+    if (message.metadata !== "") {
+      obj.metadata = message.metadata;
+    }
+    if (message.token !== "") {
+      obj.token = message.token;
+    }
+    if (message.id !== "") {
+      obj.id = message.id;
+    }
     return obj;
   },
 
@@ -479,8 +496,12 @@ export const DashAPICredsCreateReq = {
 
   toJSON(message: DashAPICredsCreateReq): unknown {
     const obj: any = {};
-    message.description !== undefined && (obj.description = message.description);
-    message.metadata !== undefined && (obj.metadata = message.metadata);
+    if (message.description !== "") {
+      obj.description = message.description;
+    }
+    if (message.metadata !== "") {
+      obj.metadata = message.metadata;
+    }
     return obj;
   },
 
@@ -572,10 +593,18 @@ export const DashAPICredsUpdateReq = {
 
   toJSON(message: DashAPICredsUpdateReq): unknown {
     const obj: any = {};
-    message.credSid !== undefined && (obj.credSid = message.credSid);
-    message.description !== undefined && (obj.description = message.description);
-    message.metadata !== undefined && (obj.metadata = message.metadata);
-    message.id !== undefined && (obj.id = message.id);
+    if (message.credSid !== "") {
+      obj.credSid = message.credSid;
+    }
+    if (message.description !== "") {
+      obj.description = message.description;
+    }
+    if (message.metadata !== "") {
+      obj.metadata = message.metadata;
+    }
+    if (message.id !== "") {
+      obj.id = message.id;
+    }
     return obj;
   },
 
@@ -647,8 +676,12 @@ export const DashAPICredsDeleteReq = {
 
   toJSON(message: DashAPICredsDeleteReq): unknown {
     const obj: any = {};
-    message.credSid !== undefined && (obj.credSid = message.credSid);
-    message.id !== undefined && (obj.id = message.id);
+    if (message.credSid !== "") {
+      obj.credSid = message.credSid;
+    }
+    if (message.id !== "") {
+      obj.id = message.id;
+    }
     return obj;
   },
 

--- a/integration/grpc-web-go-server/example.ts
+++ b/integration/grpc-web-go-server/example.ts
@@ -147,8 +147,12 @@ export const DashFlash = {
 
   toJSON(message: DashFlash): unknown {
     const obj: any = {};
-    message.msg !== undefined && (obj.msg = message.msg);
-    message.type !== undefined && (obj.type = dashFlash_TypeToJSON(message.type));
+    if (message.msg !== "") {
+      obj.msg = message.msg;
+    }
+    if (message.type !== 0) {
+      obj.type = dashFlash_TypeToJSON(message.type);
+    }
     return obj;
   },
 
@@ -229,13 +233,14 @@ export const DashUserSettingsState = {
 
   toJSON(message: DashUserSettingsState): unknown {
     const obj: any = {};
-    message.email !== undefined && (obj.email = message.email);
-    message.urls !== undefined &&
-      (obj.urls = message.urls ? DashUserSettingsState_URLs.toJSON(message.urls) : undefined);
-    if (message.flashes) {
+    if (message.email !== "") {
+      obj.email = message.email;
+    }
+    if (message.urls !== undefined) {
+      obj.urls = message.urls ? DashUserSettingsState_URLs.toJSON(message.urls) : undefined;
+    }
+    if (message.flashes?.length) {
       obj.flashes = message.flashes.map((e) => e ? DashFlash.toJSON(e) : undefined);
-    } else {
-      obj.flashes = [];
     }
     return obj;
   },
@@ -309,8 +314,12 @@ export const DashUserSettingsState_URLs = {
 
   toJSON(message: DashUserSettingsState_URLs): unknown {
     const obj: any = {};
-    message.connectGoogle !== undefined && (obj.connectGoogle = message.connectGoogle);
-    message.connectGithub !== undefined && (obj.connectGithub = message.connectGithub);
+    if (message.connectGoogle !== "") {
+      obj.connectGoogle = message.connectGoogle;
+    }
+    if (message.connectGithub !== "") {
+      obj.connectGithub = message.connectGithub;
+    }
     return obj;
   },
 
@@ -402,10 +411,18 @@ export const DashCred = {
 
   toJSON(message: DashCred): unknown {
     const obj: any = {};
-    message.description !== undefined && (obj.description = message.description);
-    message.metadata !== undefined && (obj.metadata = message.metadata);
-    message.token !== undefined && (obj.token = message.token);
-    message.id !== undefined && (obj.id = message.id);
+    if (message.description !== "") {
+      obj.description = message.description;
+    }
+    if (message.metadata !== "") {
+      obj.metadata = message.metadata;
+    }
+    if (message.token !== "") {
+      obj.token = message.token;
+    }
+    if (message.id !== "") {
+      obj.id = message.id;
+    }
     return obj;
   },
 
@@ -477,8 +494,12 @@ export const DashAPICredsCreateReq = {
 
   toJSON(message: DashAPICredsCreateReq): unknown {
     const obj: any = {};
-    message.description !== undefined && (obj.description = message.description);
-    message.metadata !== undefined && (obj.metadata = message.metadata);
+    if (message.description !== "") {
+      obj.description = message.description;
+    }
+    if (message.metadata !== "") {
+      obj.metadata = message.metadata;
+    }
     return obj;
   },
 
@@ -570,10 +591,18 @@ export const DashAPICredsUpdateReq = {
 
   toJSON(message: DashAPICredsUpdateReq): unknown {
     const obj: any = {};
-    message.credSid !== undefined && (obj.credSid = message.credSid);
-    message.description !== undefined && (obj.description = message.description);
-    message.metadata !== undefined && (obj.metadata = message.metadata);
-    message.id !== undefined && (obj.id = message.id);
+    if (message.credSid !== "") {
+      obj.credSid = message.credSid;
+    }
+    if (message.description !== "") {
+      obj.description = message.description;
+    }
+    if (message.metadata !== "") {
+      obj.metadata = message.metadata;
+    }
+    if (message.id !== "") {
+      obj.id = message.id;
+    }
     return obj;
   },
 
@@ -645,8 +674,12 @@ export const DashAPICredsDeleteReq = {
 
   toJSON(message: DashAPICredsDeleteReq): unknown {
     const obj: any = {};
-    message.credSid !== undefined && (obj.credSid = message.credSid);
-    message.id !== undefined && (obj.id = message.id);
+    if (message.credSid !== "") {
+      obj.credSid = message.credSid;
+    }
+    if (message.id !== "") {
+      obj.id = message.id;
+    }
     return obj;
   },
 

--- a/integration/grpc-web-go-server/example.ts
+++ b/integration/grpc-web-go-server/example.ts
@@ -237,10 +237,10 @@ export const DashUserSettingsState = {
       obj.email = message.email;
     }
     if (message.urls !== undefined) {
-      obj.urls = message.urls ? DashUserSettingsState_URLs.toJSON(message.urls) : undefined;
+      obj.urls = DashUserSettingsState_URLs.toJSON(message.urls);
     }
     if (message.flashes?.length) {
-      obj.flashes = message.flashes.map((e) => e ? DashFlash.toJSON(e) : undefined);
+      obj.flashes = message.flashes.map((e) => DashFlash.toJSON(e));
     }
     return obj;
   },

--- a/integration/grpc-web-no-streaming-observable/example.ts
+++ b/integration/grpc-web-no-streaming-observable/example.ts
@@ -215,10 +215,10 @@ export const DashUserSettingsState = {
       obj.email = message.email;
     }
     if (message.urls !== undefined) {
-      obj.urls = message.urls ? DashUserSettingsState_URLs.toJSON(message.urls) : undefined;
+      obj.urls = DashUserSettingsState_URLs.toJSON(message.urls);
     }
     if (message.flashes?.length) {
-      obj.flashes = message.flashes.map((e) => e ? DashFlash.toJSON(e) : undefined);
+      obj.flashes = message.flashes.map((e) => DashFlash.toJSON(e));
     }
     return obj;
   },

--- a/integration/grpc-web-no-streaming-observable/example.ts
+++ b/integration/grpc-web-no-streaming-observable/example.ts
@@ -125,8 +125,12 @@ export const DashFlash = {
 
   toJSON(message: DashFlash): unknown {
     const obj: any = {};
-    message.msg !== undefined && (obj.msg = message.msg);
-    message.type !== undefined && (obj.type = dashFlash_TypeToJSON(message.type));
+    if (message.msg !== "") {
+      obj.msg = message.msg;
+    }
+    if (message.type !== 0) {
+      obj.type = dashFlash_TypeToJSON(message.type);
+    }
     return obj;
   },
 
@@ -207,13 +211,14 @@ export const DashUserSettingsState = {
 
   toJSON(message: DashUserSettingsState): unknown {
     const obj: any = {};
-    message.email !== undefined && (obj.email = message.email);
-    message.urls !== undefined &&
-      (obj.urls = message.urls ? DashUserSettingsState_URLs.toJSON(message.urls) : undefined);
-    if (message.flashes) {
+    if (message.email !== "") {
+      obj.email = message.email;
+    }
+    if (message.urls !== undefined) {
+      obj.urls = message.urls ? DashUserSettingsState_URLs.toJSON(message.urls) : undefined;
+    }
+    if (message.flashes?.length) {
       obj.flashes = message.flashes.map((e) => e ? DashFlash.toJSON(e) : undefined);
-    } else {
-      obj.flashes = [];
     }
     return obj;
   },
@@ -287,8 +292,12 @@ export const DashUserSettingsState_URLs = {
 
   toJSON(message: DashUserSettingsState_URLs): unknown {
     const obj: any = {};
-    message.connectGoogle !== undefined && (obj.connectGoogle = message.connectGoogle);
-    message.connectGithub !== undefined && (obj.connectGithub = message.connectGithub);
+    if (message.connectGoogle !== "") {
+      obj.connectGoogle = message.connectGoogle;
+    }
+    if (message.connectGithub !== "") {
+      obj.connectGithub = message.connectGithub;
+    }
     return obj;
   },
 

--- a/integration/grpc-web-no-streaming/example.ts
+++ b/integration/grpc-web-no-streaming/example.ts
@@ -213,10 +213,10 @@ export const DashUserSettingsState = {
       obj.email = message.email;
     }
     if (message.urls !== undefined) {
-      obj.urls = message.urls ? DashUserSettingsState_URLs.toJSON(message.urls) : undefined;
+      obj.urls = DashUserSettingsState_URLs.toJSON(message.urls);
     }
     if (message.flashes?.length) {
-      obj.flashes = message.flashes.map((e) => e ? DashFlash.toJSON(e) : undefined);
+      obj.flashes = message.flashes.map((e) => DashFlash.toJSON(e));
     }
     return obj;
   },

--- a/integration/grpc-web-no-streaming/example.ts
+++ b/integration/grpc-web-no-streaming/example.ts
@@ -123,8 +123,12 @@ export const DashFlash = {
 
   toJSON(message: DashFlash): unknown {
     const obj: any = {};
-    message.msg !== undefined && (obj.msg = message.msg);
-    message.type !== undefined && (obj.type = dashFlash_TypeToJSON(message.type));
+    if (message.msg !== "") {
+      obj.msg = message.msg;
+    }
+    if (message.type !== 0) {
+      obj.type = dashFlash_TypeToJSON(message.type);
+    }
     return obj;
   },
 
@@ -205,13 +209,14 @@ export const DashUserSettingsState = {
 
   toJSON(message: DashUserSettingsState): unknown {
     const obj: any = {};
-    message.email !== undefined && (obj.email = message.email);
-    message.urls !== undefined &&
-      (obj.urls = message.urls ? DashUserSettingsState_URLs.toJSON(message.urls) : undefined);
-    if (message.flashes) {
+    if (message.email !== "") {
+      obj.email = message.email;
+    }
+    if (message.urls !== undefined) {
+      obj.urls = message.urls ? DashUserSettingsState_URLs.toJSON(message.urls) : undefined;
+    }
+    if (message.flashes?.length) {
       obj.flashes = message.flashes.map((e) => e ? DashFlash.toJSON(e) : undefined);
-    } else {
-      obj.flashes = [];
     }
     return obj;
   },
@@ -285,8 +290,12 @@ export const DashUserSettingsState_URLs = {
 
   toJSON(message: DashUserSettingsState_URLs): unknown {
     const obj: any = {};
-    message.connectGoogle !== undefined && (obj.connectGoogle = message.connectGoogle);
-    message.connectGithub !== undefined && (obj.connectGithub = message.connectGithub);
+    if (message.connectGoogle !== "") {
+      obj.connectGoogle = message.connectGoogle;
+    }
+    if (message.connectGithub !== "") {
+      obj.connectGithub = message.connectGithub;
+    }
     return obj;
   },
 

--- a/integration/grpc-web/example.ts
+++ b/integration/grpc-web/example.ts
@@ -239,10 +239,10 @@ export const DashUserSettingsState = {
       obj.email = message.email;
     }
     if (message.urls !== undefined) {
-      obj.urls = message.urls ? DashUserSettingsState_URLs.toJSON(message.urls) : undefined;
+      obj.urls = DashUserSettingsState_URLs.toJSON(message.urls);
     }
     if (message.flashes?.length) {
-      obj.flashes = message.flashes.map((e) => e ? DashFlash.toJSON(e) : undefined);
+      obj.flashes = message.flashes.map((e) => DashFlash.toJSON(e));
     }
     return obj;
   },

--- a/integration/grpc-web/example.ts
+++ b/integration/grpc-web/example.ts
@@ -149,8 +149,12 @@ export const DashFlash = {
 
   toJSON(message: DashFlash): unknown {
     const obj: any = {};
-    message.msg !== undefined && (obj.msg = message.msg);
-    message.type !== undefined && (obj.type = dashFlash_TypeToJSON(message.type));
+    if (message.msg !== "") {
+      obj.msg = message.msg;
+    }
+    if (message.type !== 0) {
+      obj.type = dashFlash_TypeToJSON(message.type);
+    }
     return obj;
   },
 
@@ -231,13 +235,14 @@ export const DashUserSettingsState = {
 
   toJSON(message: DashUserSettingsState): unknown {
     const obj: any = {};
-    message.email !== undefined && (obj.email = message.email);
-    message.urls !== undefined &&
-      (obj.urls = message.urls ? DashUserSettingsState_URLs.toJSON(message.urls) : undefined);
-    if (message.flashes) {
+    if (message.email !== "") {
+      obj.email = message.email;
+    }
+    if (message.urls !== undefined) {
+      obj.urls = message.urls ? DashUserSettingsState_URLs.toJSON(message.urls) : undefined;
+    }
+    if (message.flashes?.length) {
       obj.flashes = message.flashes.map((e) => e ? DashFlash.toJSON(e) : undefined);
-    } else {
-      obj.flashes = [];
     }
     return obj;
   },
@@ -311,8 +316,12 @@ export const DashUserSettingsState_URLs = {
 
   toJSON(message: DashUserSettingsState_URLs): unknown {
     const obj: any = {};
-    message.connectGoogle !== undefined && (obj.connectGoogle = message.connectGoogle);
-    message.connectGithub !== undefined && (obj.connectGithub = message.connectGithub);
+    if (message.connectGoogle !== "") {
+      obj.connectGoogle = message.connectGoogle;
+    }
+    if (message.connectGithub !== "") {
+      obj.connectGithub = message.connectGithub;
+    }
     return obj;
   },
 
@@ -404,10 +413,18 @@ export const DashCred = {
 
   toJSON(message: DashCred): unknown {
     const obj: any = {};
-    message.description !== undefined && (obj.description = message.description);
-    message.metadata !== undefined && (obj.metadata = message.metadata);
-    message.token !== undefined && (obj.token = message.token);
-    message.id !== undefined && (obj.id = message.id);
+    if (message.description !== "") {
+      obj.description = message.description;
+    }
+    if (message.metadata !== "") {
+      obj.metadata = message.metadata;
+    }
+    if (message.token !== "") {
+      obj.token = message.token;
+    }
+    if (message.id !== "") {
+      obj.id = message.id;
+    }
     return obj;
   },
 
@@ -479,8 +496,12 @@ export const DashAPICredsCreateReq = {
 
   toJSON(message: DashAPICredsCreateReq): unknown {
     const obj: any = {};
-    message.description !== undefined && (obj.description = message.description);
-    message.metadata !== undefined && (obj.metadata = message.metadata);
+    if (message.description !== "") {
+      obj.description = message.description;
+    }
+    if (message.metadata !== "") {
+      obj.metadata = message.metadata;
+    }
     return obj;
   },
 
@@ -572,10 +593,18 @@ export const DashAPICredsUpdateReq = {
 
   toJSON(message: DashAPICredsUpdateReq): unknown {
     const obj: any = {};
-    message.credSid !== undefined && (obj.credSid = message.credSid);
-    message.description !== undefined && (obj.description = message.description);
-    message.metadata !== undefined && (obj.metadata = message.metadata);
-    message.id !== undefined && (obj.id = message.id);
+    if (message.credSid !== "") {
+      obj.credSid = message.credSid;
+    }
+    if (message.description !== "") {
+      obj.description = message.description;
+    }
+    if (message.metadata !== "") {
+      obj.metadata = message.metadata;
+    }
+    if (message.id !== "") {
+      obj.id = message.id;
+    }
     return obj;
   },
 
@@ -647,8 +676,12 @@ export const DashAPICredsDeleteReq = {
 
   toJSON(message: DashAPICredsDeleteReq): unknown {
     const obj: any = {};
-    message.credSid !== undefined && (obj.credSid = message.credSid);
-    message.id !== undefined && (obj.id = message.id);
+    if (message.credSid !== "") {
+      obj.credSid = message.credSid;
+    }
+    if (message.id !== "") {
+      obj.id = message.id;
+    }
     return obj;
   },
 

--- a/integration/import-mapping/google/protobuf/timestamp.ts
+++ b/integration/import-mapping/google/protobuf/timestamp.ts
@@ -165,8 +165,12 @@ export const Timestamp = {
 
   toJSON(message: Timestamp): unknown {
     const obj: any = {};
-    message.seconds !== undefined && (obj.seconds = Math.round(message.seconds));
-    message.nanos !== undefined && (obj.nanos = Math.round(message.nanos));
+    if (message.seconds !== 0) {
+      obj.seconds = Math.round(message.seconds);
+    }
+    if (message.nanos !== 0) {
+      obj.nanos = Math.round(message.nanos);
+    }
     return obj;
   },
 

--- a/integration/import-mapping/mapping.ts
+++ b/integration/import-mapping/mapping.ts
@@ -70,7 +70,7 @@ export const WithEmtpy = {
   toJSON(message: WithEmtpy): unknown {
     const obj: any = {};
     if (message.empty !== undefined) {
-      obj.empty = message.empty ? Empty.toJSON(message.empty) : undefined;
+      obj.empty = Empty.toJSON(message.empty);
     }
     return obj;
   },
@@ -290,7 +290,7 @@ export const WithAll = {
   toJSON(message: WithAll): unknown {
     const obj: any = {};
     if (message.empty !== undefined) {
-      obj.empty = message.empty ? Empty.toJSON(message.empty) : undefined;
+      obj.empty = Empty.toJSON(message.empty);
     }
     if (message.strut !== undefined) {
       obj.strut = message.strut;
@@ -299,10 +299,10 @@ export const WithAll = {
       obj.timestamp = message.timestamp.toISOString();
     }
     if (message.duration !== undefined) {
-      obj.duration = message.duration ? Duration.toJSON(message.duration) : undefined;
+      obj.duration = Duration.toJSON(message.duration);
     }
     if (message.veryVerySecret !== undefined) {
-      obj.veryVerySecret = message.veryVerySecret ? VeryVerySecret.toJSON(message.veryVerySecret) : undefined;
+      obj.veryVerySecret = VeryVerySecret.toJSON(message.veryVerySecret);
     }
     return obj;
   },

--- a/integration/import-mapping/mapping.ts
+++ b/integration/import-mapping/mapping.ts
@@ -69,7 +69,9 @@ export const WithEmtpy = {
 
   toJSON(message: WithEmtpy): unknown {
     const obj: any = {};
-    message.empty !== undefined && (obj.empty = message.empty ? Empty.toJSON(message.empty) : undefined);
+    if (message.empty !== undefined) {
+      obj.empty = message.empty ? Empty.toJSON(message.empty) : undefined;
+    }
     return obj;
   },
 
@@ -125,7 +127,9 @@ export const WithStruct = {
 
   toJSON(message: WithStruct): unknown {
     const obj: any = {};
-    message.strut !== undefined && (obj.strut = message.strut);
+    if (message.strut !== undefined) {
+      obj.strut = message.strut;
+    }
     return obj;
   },
 
@@ -181,7 +185,9 @@ export const WithTimestamp = {
 
   toJSON(message: WithTimestamp): unknown {
     const obj: any = {};
-    message.timestamp !== undefined && (obj.timestamp = message.timestamp.toISOString());
+    if (message.timestamp !== undefined) {
+      obj.timestamp = message.timestamp.toISOString();
+    }
     return obj;
   },
 
@@ -283,12 +289,21 @@ export const WithAll = {
 
   toJSON(message: WithAll): unknown {
     const obj: any = {};
-    message.empty !== undefined && (obj.empty = message.empty ? Empty.toJSON(message.empty) : undefined);
-    message.strut !== undefined && (obj.strut = message.strut);
-    message.timestamp !== undefined && (obj.timestamp = message.timestamp.toISOString());
-    message.duration !== undefined && (obj.duration = message.duration ? Duration.toJSON(message.duration) : undefined);
-    message.veryVerySecret !== undefined &&
-      (obj.veryVerySecret = message.veryVerySecret ? VeryVerySecret.toJSON(message.veryVerySecret) : undefined);
+    if (message.empty !== undefined) {
+      obj.empty = message.empty ? Empty.toJSON(message.empty) : undefined;
+    }
+    if (message.strut !== undefined) {
+      obj.strut = message.strut;
+    }
+    if (message.timestamp !== undefined) {
+      obj.timestamp = message.timestamp.toISOString();
+    }
+    if (message.duration !== undefined) {
+      obj.duration = message.duration ? Duration.toJSON(message.duration) : undefined;
+    }
+    if (message.veryVerySecret !== undefined) {
+      obj.veryVerySecret = message.veryVerySecret ? VeryVerySecret.toJSON(message.veryVerySecret) : undefined;
+    }
     return obj;
   },
 

--- a/integration/import-suffix/child.pb.ts
+++ b/integration/import-suffix/child.pb.ts
@@ -81,7 +81,9 @@ export const Child = {
 
   toJSON(message: Child): unknown {
     const obj: any = {};
-    message.name !== undefined && (obj.name = message.name);
+    if (message.name !== "") {
+      obj.name = message.name;
+    }
     return obj;
   },
 

--- a/integration/import-suffix/google/protobuf/timestamp.pb.ts
+++ b/integration/import-suffix/google/protobuf/timestamp.pb.ts
@@ -165,8 +165,12 @@ export const Timestamp = {
 
   toJSON(message: Timestamp): unknown {
     const obj: any = {};
-    message.seconds !== undefined && (obj.seconds = Math.round(message.seconds));
-    message.nanos !== undefined && (obj.nanos = Math.round(message.nanos));
+    if (message.seconds !== 0) {
+      obj.seconds = Math.round(message.seconds);
+    }
+    if (message.nanos !== 0) {
+      obj.nanos = Math.round(message.nanos);
+    }
     return obj;
   },
 

--- a/integration/import-suffix/parent.pb.ts
+++ b/integration/import-suffix/parent.pb.ts
@@ -77,7 +77,7 @@ export const Parent = {
   toJSON(message: Parent): unknown {
     const obj: any = {};
     if (message.child !== undefined) {
-      obj.child = message.child ? Child.toJSON(message.child) : undefined;
+      obj.child = Child.toJSON(message.child);
     }
     if (message.childEnum !== 0) {
       obj.childEnum = childEnumToJSON(message.childEnum);

--- a/integration/import-suffix/parent.pb.ts
+++ b/integration/import-suffix/parent.pb.ts
@@ -76,9 +76,15 @@ export const Parent = {
 
   toJSON(message: Parent): unknown {
     const obj: any = {};
-    message.child !== undefined && (obj.child = message.child ? Child.toJSON(message.child) : undefined);
-    message.childEnum !== undefined && (obj.childEnum = childEnumToJSON(message.childEnum));
-    message.createdAt !== undefined && (obj.createdAt = message.createdAt.toISOString());
+    if (message.child !== undefined) {
+      obj.child = message.child ? Child.toJSON(message.child) : undefined;
+    }
+    if (message.childEnum !== 0) {
+      obj.childEnum = childEnumToJSON(message.childEnum);
+    }
+    if (message.createdAt !== undefined) {
+      obj.createdAt = message.createdAt.toISOString();
+    }
     return obj;
   },
 

--- a/integration/lower-case-svc-methods/math.ts
+++ b/integration/lower-case-svc-methods/math.ts
@@ -69,8 +69,12 @@ export const NumPair = {
 
   toJSON(message: NumPair): unknown {
     const obj: any = {};
-    message.num1 !== undefined && (obj.num1 = message.num1);
-    message.num2 !== undefined && (obj.num2 = message.num2);
+    if (message.num1 !== 0) {
+      obj.num1 = message.num1;
+    }
+    if (message.num2 !== 0) {
+      obj.num2 = message.num2;
+    }
     return obj;
   },
 
@@ -127,7 +131,9 @@ export const NumSingle = {
 
   toJSON(message: NumSingle): unknown {
     const obj: any = {};
-    message.num !== undefined && (obj.num = message.num);
+    if (message.num !== 0) {
+      obj.num = message.num;
+    }
     return obj;
   },
 
@@ -195,10 +201,8 @@ export const Numbers = {
 
   toJSON(message: Numbers): unknown {
     const obj: any = {};
-    if (message.num) {
+    if (message.num?.length) {
       obj.num = message.num.map((e) => e);
-    } else {
-      obj.num = [];
     }
     return obj;
   },

--- a/integration/lower-case-svc-methods/math.ts
+++ b/integration/lower-case-svc-methods/math.ts
@@ -202,7 +202,7 @@ export const Numbers = {
   toJSON(message: Numbers): unknown {
     const obj: any = {};
     if (message.num?.length) {
-      obj.num = message.num.map((e) => e);
+      obj.num = message.num;
     }
     return obj;
   },

--- a/integration/map-bigint-optional/test.ts
+++ b/integration/map-bigint-optional/test.ts
@@ -96,8 +96,8 @@ export const MapBigInt = {
 
   toJSON(message: MapBigInt): unknown {
     const obj: any = {};
-    obj.map = {};
-    if (message.map) {
+    if (message.map?.size) {
+      obj.map = {};
       message.map.forEach((v, k) => {
         obj.map[k.toString()] = v.toString();
       });
@@ -205,8 +205,12 @@ export const MapBigInt_MapEntry = {
 
   toJSON(message: MapBigInt_MapEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = message.key.toString());
-    message.value !== undefined && (obj.value = message.value.toString());
+    if (message.key !== BigInt("0")) {
+      obj.key = message.key.toString();
+    }
+    if (message.value !== BigInt("0")) {
+      obj.value = message.value.toString();
+    }
     return obj;
   },
 

--- a/integration/map-long-optional/test.ts
+++ b/integration/map-long-optional/test.ts
@@ -96,8 +96,8 @@ export const MapBigInt = {
 
   toJSON(message: MapBigInt): unknown {
     const obj: any = {};
-    obj.map = {};
-    if (message.map) {
+    if (message.map?.size) {
+      obj.map = {};
       message.map.forEach((v, k) => {
         obj.map[longToNumber(k)] = v.toString();
       });
@@ -205,8 +205,12 @@ export const MapBigInt_MapEntry = {
 
   toJSON(message: MapBigInt_MapEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = (message.key || Long.UZERO).toString());
-    message.value !== undefined && (obj.value = (message.value || Long.ZERO).toString());
+    if (!message.key.isZero()) {
+      obj.key = (message.key || Long.UZERO).toString();
+    }
+    if (!message.value.isZero()) {
+      obj.value = (message.value || Long.ZERO).toString();
+    }
     return obj;
   },
 

--- a/integration/map-longstring-optional/test.ts
+++ b/integration/map-longstring-optional/test.ts
@@ -96,8 +96,8 @@ export const MapBigInt = {
 
   toJSON(message: MapBigInt): unknown {
     const obj: any = {};
-    obj.map = {};
-    if (message.map) {
+    if (message.map?.size) {
+      obj.map = {};
       message.map.forEach((v, k) => {
         obj.map[k] = v;
       });
@@ -205,8 +205,12 @@ export const MapBigInt_MapEntry = {
 
   toJSON(message: MapBigInt_MapEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = message.key);
-    message.value !== undefined && (obj.value = message.value);
+    if (message.key !== "0") {
+      obj.key = message.key;
+    }
+    if (message.value !== "0") {
+      obj.value = message.value;
+    }
     return obj;
   },
 

--- a/integration/nice-grpc/google/protobuf/struct.ts
+++ b/integration/nice-grpc/google/protobuf/struct.ts
@@ -382,7 +382,7 @@ export const Value = {
   toJSON(message: Value): unknown {
     const obj: any = {};
     if (message.nullValue !== undefined) {
-      obj.nullValue = message.nullValue !== undefined ? nullValueToJSON(message.nullValue) : undefined;
+      obj.nullValue = nullValueToJSON(message.nullValue);
     }
     if (message.numberValue !== undefined) {
       obj.numberValue = message.numberValue;

--- a/integration/nice-grpc/google/protobuf/struct.ts
+++ b/integration/nice-grpc/google/protobuf/struct.ts
@@ -497,7 +497,7 @@ export const ListValue = {
   toJSON(message: ListValue): unknown {
     const obj: any = {};
     if (message.values?.length) {
-      obj.values = message.values.map((e) => e);
+      obj.values = message.values;
     }
     return obj;
   },

--- a/integration/nice-grpc/google/protobuf/struct.ts
+++ b/integration/nice-grpc/google/protobuf/struct.ts
@@ -153,11 +153,14 @@ export const Struct = {
 
   toJSON(message: Struct): unknown {
     const obj: any = {};
-    obj.fields = {};
     if (message.fields) {
-      Object.entries(message.fields).forEach(([k, v]) => {
-        obj.fields[k] = v;
-      });
+      const entries = Object.entries(message.fields);
+      if (entries.length > 0) {
+        obj.fields = {};
+        entries.forEach(([k, v]) => {
+          obj.fields[k] = v;
+        });
+      }
     }
     return obj;
   },
@@ -252,8 +255,12 @@ export const Struct_FieldsEntry = {
 
   toJSON(message: Struct_FieldsEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = message.key);
-    message.value !== undefined && (obj.value = message.value);
+    if (message.key !== "") {
+      obj.key = message.key;
+    }
+    if (message.value !== undefined) {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -374,13 +381,24 @@ export const Value = {
 
   toJSON(message: Value): unknown {
     const obj: any = {};
-    message.nullValue !== undefined &&
-      (obj.nullValue = message.nullValue !== undefined ? nullValueToJSON(message.nullValue) : undefined);
-    message.numberValue !== undefined && (obj.numberValue = message.numberValue);
-    message.stringValue !== undefined && (obj.stringValue = message.stringValue);
-    message.boolValue !== undefined && (obj.boolValue = message.boolValue);
-    message.structValue !== undefined && (obj.structValue = message.structValue);
-    message.listValue !== undefined && (obj.listValue = message.listValue);
+    if (message.nullValue !== undefined) {
+      obj.nullValue = message.nullValue !== undefined ? nullValueToJSON(message.nullValue) : undefined;
+    }
+    if (message.numberValue !== undefined) {
+      obj.numberValue = message.numberValue;
+    }
+    if (message.stringValue !== undefined) {
+      obj.stringValue = message.stringValue;
+    }
+    if (message.boolValue !== undefined) {
+      obj.boolValue = message.boolValue;
+    }
+    if (message.structValue !== undefined) {
+      obj.structValue = message.structValue;
+    }
+    if (message.listValue !== undefined) {
+      obj.listValue = message.listValue;
+    }
     return obj;
   },
 
@@ -478,10 +496,8 @@ export const ListValue = {
 
   toJSON(message: ListValue): unknown {
     const obj: any = {};
-    if (message.values) {
+    if (message.values?.length) {
       obj.values = message.values.map((e) => e);
-    } else {
-      obj.values = [];
     }
     return obj;
   },

--- a/integration/nice-grpc/google/protobuf/timestamp.ts
+++ b/integration/nice-grpc/google/protobuf/timestamp.ts
@@ -165,8 +165,12 @@ export const Timestamp = {
 
   toJSON(message: Timestamp): unknown {
     const obj: any = {};
-    message.seconds !== undefined && (obj.seconds = Math.round(message.seconds));
-    message.nanos !== undefined && (obj.nanos = Math.round(message.nanos));
+    if (message.seconds !== 0) {
+      obj.seconds = Math.round(message.seconds);
+    }
+    if (message.nanos !== 0) {
+      obj.nanos = Math.round(message.nanos);
+    }
     return obj;
   },
 

--- a/integration/nice-grpc/google/protobuf/wrappers.ts
+++ b/integration/nice-grpc/google/protobuf/wrappers.ts
@@ -135,7 +135,9 @@ export const DoubleValue = {
 
   toJSON(message: DoubleValue): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = message.value);
+    if (message.value !== 0) {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -191,7 +193,9 @@ export const FloatValue = {
 
   toJSON(message: FloatValue): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = message.value);
+    if (message.value !== 0) {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -247,7 +251,9 @@ export const Int64Value = {
 
   toJSON(message: Int64Value): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = Math.round(message.value));
+    if (message.value !== 0) {
+      obj.value = Math.round(message.value);
+    }
     return obj;
   },
 
@@ -303,7 +309,9 @@ export const UInt64Value = {
 
   toJSON(message: UInt64Value): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = Math.round(message.value));
+    if (message.value !== 0) {
+      obj.value = Math.round(message.value);
+    }
     return obj;
   },
 
@@ -359,7 +367,9 @@ export const Int32Value = {
 
   toJSON(message: Int32Value): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = Math.round(message.value));
+    if (message.value !== 0) {
+      obj.value = Math.round(message.value);
+    }
     return obj;
   },
 
@@ -415,7 +425,9 @@ export const UInt32Value = {
 
   toJSON(message: UInt32Value): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = Math.round(message.value));
+    if (message.value !== 0) {
+      obj.value = Math.round(message.value);
+    }
     return obj;
   },
 
@@ -471,7 +483,9 @@ export const BoolValue = {
 
   toJSON(message: BoolValue): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = message.value);
+    if (message.value === true) {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -527,7 +541,9 @@ export const StringValue = {
 
   toJSON(message: StringValue): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = message.value);
+    if (message.value !== "") {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -583,8 +599,9 @@ export const BytesValue = {
 
   toJSON(message: BytesValue): unknown {
     const obj: any = {};
-    message.value !== undefined &&
-      (obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array(0)));
+    if (message.value.length !== 0) {
+      obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array(0));
+    }
     return obj;
   },
 

--- a/integration/nice-grpc/google/protobuf/wrappers.ts
+++ b/integration/nice-grpc/google/protobuf/wrappers.ts
@@ -600,7 +600,7 @@ export const BytesValue = {
   toJSON(message: BytesValue): unknown {
     const obj: any = {};
     if (message.value.length !== 0) {
-      obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array(0));
+      obj.value = base64FromBytes(message.value);
     }
     return obj;
   },

--- a/integration/nice-grpc/simple.ts
+++ b/integration/nice-grpc/simple.ts
@@ -63,7 +63,9 @@ export const TestMessage = {
 
   toJSON(message: TestMessage): unknown {
     const obj: any = {};
-    message.timestamp !== undefined && (obj.timestamp = message.timestamp.toISOString());
+    if (message.timestamp !== undefined) {
+      obj.timestamp = message.timestamp.toISOString();
+    }
     return obj;
   },
 

--- a/integration/no-proto-package/no-proto-package.ts
+++ b/integration/no-proto-package/no-proto-package.ts
@@ -53,7 +53,9 @@ export const User = {
 
   toJSON(message: User): unknown {
     const obj: any = {};
-    message.name !== undefined && (obj.name = message.name);
+    if (message.name !== "") {
+      obj.name = message.name;
+    }
     return obj;
   },
 

--- a/integration/omit-optionals/simple.ts
+++ b/integration/omit-optionals/simple.ts
@@ -62,8 +62,12 @@ export const TestMessage = {
 
   toJSON(message: TestMessage): unknown {
     const obj: any = {};
-    message.field1 !== undefined && (obj.field1 = message.field1);
-    message.field2 !== undefined && (obj.field2 = message.field2);
+    if (message.field1 === true) {
+      obj.field1 = message.field1;
+    }
+    if (message.field2 !== undefined) {
+      obj.field2 = message.field2;
+    }
     return obj;
   },
 

--- a/integration/oneof-properties/oneof.ts
+++ b/integration/oneof-properties/oneof.ts
@@ -251,16 +251,16 @@ export const PleaseChoose = {
       obj.aString = message.aString;
     }
     if (message.aMessage !== undefined) {
-      obj.aMessage = message.aMessage ? PleaseChoose_Submessage.toJSON(message.aMessage) : undefined;
+      obj.aMessage = PleaseChoose_Submessage.toJSON(message.aMessage);
     }
     if (message.aBool !== undefined) {
       obj.aBool = message.aBool;
     }
     if (message.bunchaBytes !== undefined) {
-      obj.bunchaBytes = message.bunchaBytes !== undefined ? base64FromBytes(message.bunchaBytes) : undefined;
+      obj.bunchaBytes = base64FromBytes(message.bunchaBytes);
     }
     if (message.anEnum !== undefined) {
-      obj.anEnum = message.anEnum !== undefined ? pleaseChoose_StateEnumToJSON(message.anEnum) : undefined;
+      obj.anEnum = pleaseChoose_StateEnumToJSON(message.anEnum);
     }
     if (message.age !== 0) {
       obj.age = Math.round(message.age);

--- a/integration/oneof-properties/oneof.ts
+++ b/integration/oneof-properties/oneof.ts
@@ -241,20 +241,39 @@ export const PleaseChoose = {
 
   toJSON(message: PleaseChoose): unknown {
     const obj: any = {};
-    message.name !== undefined && (obj.name = message.name);
-    message.aNumber !== undefined && (obj.aNumber = message.aNumber);
-    message.aString !== undefined && (obj.aString = message.aString);
-    message.aMessage !== undefined &&
-      (obj.aMessage = message.aMessage ? PleaseChoose_Submessage.toJSON(message.aMessage) : undefined);
-    message.aBool !== undefined && (obj.aBool = message.aBool);
-    message.bunchaBytes !== undefined &&
-      (obj.bunchaBytes = message.bunchaBytes !== undefined ? base64FromBytes(message.bunchaBytes) : undefined);
-    message.anEnum !== undefined &&
-      (obj.anEnum = message.anEnum !== undefined ? pleaseChoose_StateEnumToJSON(message.anEnum) : undefined);
-    message.age !== undefined && (obj.age = Math.round(message.age));
-    message.either !== undefined && (obj.either = message.either);
-    message.or !== undefined && (obj.or = message.or);
-    message.thirdOption !== undefined && (obj.thirdOption = message.thirdOption);
+    if (message.name !== "") {
+      obj.name = message.name;
+    }
+    if (message.aNumber !== undefined) {
+      obj.aNumber = message.aNumber;
+    }
+    if (message.aString !== undefined) {
+      obj.aString = message.aString;
+    }
+    if (message.aMessage !== undefined) {
+      obj.aMessage = message.aMessage ? PleaseChoose_Submessage.toJSON(message.aMessage) : undefined;
+    }
+    if (message.aBool !== undefined) {
+      obj.aBool = message.aBool;
+    }
+    if (message.bunchaBytes !== undefined) {
+      obj.bunchaBytes = message.bunchaBytes !== undefined ? base64FromBytes(message.bunchaBytes) : undefined;
+    }
+    if (message.anEnum !== undefined) {
+      obj.anEnum = message.anEnum !== undefined ? pleaseChoose_StateEnumToJSON(message.anEnum) : undefined;
+    }
+    if (message.age !== 0) {
+      obj.age = Math.round(message.age);
+    }
+    if (message.either !== undefined) {
+      obj.either = message.either;
+    }
+    if (message.or !== undefined) {
+      obj.or = message.or;
+    }
+    if (message.thirdOption !== undefined) {
+      obj.thirdOption = message.thirdOption;
+    }
     return obj;
   },
 
@@ -322,7 +341,9 @@ export const PleaseChoose_Submessage = {
 
   toJSON(message: PleaseChoose_Submessage): unknown {
     const obj: any = {};
-    message.name !== undefined && (obj.name = message.name);
+    if (message.name !== "") {
+      obj.name = message.name;
+    }
     return obj;
   },
 

--- a/integration/oneof-unions-snake/google/protobuf/struct.ts
+++ b/integration/oneof-unions-snake/google/protobuf/struct.ts
@@ -139,11 +139,14 @@ export const Struct = {
 
   toJSON(message: Struct): unknown {
     const obj: any = {};
-    obj.fields = {};
     if (message.fields) {
-      Object.entries(message.fields).forEach(([k, v]) => {
-        obj.fields[k] = v;
-      });
+      const entries = Object.entries(message.fields);
+      if (entries.length > 0) {
+        obj.fields = {};
+        entries.forEach(([k, v]) => {
+          obj.fields[k] = v;
+        });
+      }
     }
     return obj;
   },
@@ -238,8 +241,12 @@ export const Struct_FieldsEntry = {
 
   toJSON(message: Struct_FieldsEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = message.key);
-    message.value !== undefined && (obj.value = message.value);
+    if (message.key !== "") {
+      obj.key = message.key;
+    }
+    if (message.value !== undefined) {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -365,13 +372,24 @@ export const Value = {
 
   toJSON(message: Value): unknown {
     const obj: any = {};
-    message.kind?.$case === "null_value" &&
-      (obj.null_value = message.kind?.null_value !== undefined ? nullValueToJSON(message.kind?.null_value) : undefined);
-    message.kind?.$case === "number_value" && (obj.number_value = message.kind?.number_value);
-    message.kind?.$case === "string_value" && (obj.string_value = message.kind?.string_value);
-    message.kind?.$case === "bool_value" && (obj.bool_value = message.kind?.bool_value);
-    message.kind?.$case === "struct_value" && (obj.struct_value = message.kind?.struct_value);
-    message.kind?.$case === "list_value" && (obj.list_value = message.kind?.list_value);
+    if (message.kind?.$case === "null_value") {
+      obj.null_value = message.kind?.null_value !== undefined ? nullValueToJSON(message.kind?.null_value) : undefined;
+    }
+    if (message.kind?.$case === "number_value") {
+      obj.number_value = message.kind?.number_value;
+    }
+    if (message.kind?.$case === "string_value") {
+      obj.string_value = message.kind?.string_value;
+    }
+    if (message.kind?.$case === "bool_value") {
+      obj.bool_value = message.kind?.bool_value;
+    }
+    if (message.kind?.$case === "struct_value") {
+      obj.struct_value = message.kind?.struct_value;
+    }
+    if (message.kind?.$case === "list_value") {
+      obj.list_value = message.kind?.list_value;
+    }
     return obj;
   },
 
@@ -500,10 +518,8 @@ export const ListValue = {
 
   toJSON(message: ListValue): unknown {
     const obj: any = {};
-    if (message.values) {
+    if (message.values?.length) {
       obj.values = message.values.map((e) => e);
-    } else {
-      obj.values = [];
     }
     return obj;
   },

--- a/integration/oneof-unions-snake/google/protobuf/struct.ts
+++ b/integration/oneof-unions-snake/google/protobuf/struct.ts
@@ -519,7 +519,7 @@ export const ListValue = {
   toJSON(message: ListValue): unknown {
     const obj: any = {};
     if (message.values?.length) {
-      obj.values = message.values.map((e) => e);
+      obj.values = message.values;
     }
     return obj;
   },

--- a/integration/oneof-unions-snake/google/protobuf/struct.ts
+++ b/integration/oneof-unions-snake/google/protobuf/struct.ts
@@ -373,22 +373,22 @@ export const Value = {
   toJSON(message: Value): unknown {
     const obj: any = {};
     if (message.kind?.$case === "null_value") {
-      obj.null_value = message.kind?.null_value !== undefined ? nullValueToJSON(message.kind?.null_value) : undefined;
+      obj.null_value = nullValueToJSON(message.kind.null_value);
     }
     if (message.kind?.$case === "number_value") {
-      obj.number_value = message.kind?.number_value;
+      obj.number_value = message.kind.number_value;
     }
     if (message.kind?.$case === "string_value") {
-      obj.string_value = message.kind?.string_value;
+      obj.string_value = message.kind.string_value;
     }
     if (message.kind?.$case === "bool_value") {
-      obj.bool_value = message.kind?.bool_value;
+      obj.bool_value = message.kind.bool_value;
     }
     if (message.kind?.$case === "struct_value") {
-      obj.struct_value = message.kind?.struct_value;
+      obj.struct_value = message.kind.struct_value;
     }
     if (message.kind?.$case === "list_value") {
-      obj.list_value = message.kind?.list_value;
+      obj.list_value = message.kind.list_value;
     }
     return obj;
   },

--- a/integration/oneof-unions-snake/simple.ts
+++ b/integration/oneof-unions-snake/simple.ts
@@ -54,7 +54,9 @@ export const SimpleStruct = {
 
   toJSON(message: SimpleStruct): unknown {
     const obj: any = {};
-    message.simple_struct !== undefined && (obj.simple_struct = message.simple_struct);
+    if (message.simple_struct !== undefined) {
+      obj.simple_struct = message.simple_struct;
+    }
     return obj;
   },
 

--- a/integration/oneof-unions/google/protobuf/struct.ts
+++ b/integration/oneof-unions/google/protobuf/struct.ts
@@ -139,11 +139,14 @@ export const Struct = {
 
   toJSON(message: Struct): unknown {
     const obj: any = {};
-    obj.fields = {};
     if (message.fields) {
-      Object.entries(message.fields).forEach(([k, v]) => {
-        obj.fields[k] = v;
-      });
+      const entries = Object.entries(message.fields);
+      if (entries.length > 0) {
+        obj.fields = {};
+        entries.forEach(([k, v]) => {
+          obj.fields[k] = v;
+        });
+      }
     }
     return obj;
   },
@@ -238,8 +241,12 @@ export const Struct_FieldsEntry = {
 
   toJSON(message: Struct_FieldsEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = message.key);
-    message.value !== undefined && (obj.value = message.value);
+    if (message.key !== "") {
+      obj.key = message.key;
+    }
+    if (message.value !== undefined) {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -362,13 +369,24 @@ export const Value = {
 
   toJSON(message: Value): unknown {
     const obj: any = {};
-    message.kind?.$case === "nullValue" &&
-      (obj.nullValue = message.kind?.nullValue !== undefined ? nullValueToJSON(message.kind?.nullValue) : undefined);
-    message.kind?.$case === "numberValue" && (obj.numberValue = message.kind?.numberValue);
-    message.kind?.$case === "stringValue" && (obj.stringValue = message.kind?.stringValue);
-    message.kind?.$case === "boolValue" && (obj.boolValue = message.kind?.boolValue);
-    message.kind?.$case === "structValue" && (obj.structValue = message.kind?.structValue);
-    message.kind?.$case === "listValue" && (obj.listValue = message.kind?.listValue);
+    if (message.kind?.$case === "nullValue") {
+      obj.nullValue = message.kind?.nullValue !== undefined ? nullValueToJSON(message.kind?.nullValue) : undefined;
+    }
+    if (message.kind?.$case === "numberValue") {
+      obj.numberValue = message.kind?.numberValue;
+    }
+    if (message.kind?.$case === "stringValue") {
+      obj.stringValue = message.kind?.stringValue;
+    }
+    if (message.kind?.$case === "boolValue") {
+      obj.boolValue = message.kind?.boolValue;
+    }
+    if (message.kind?.$case === "structValue") {
+      obj.structValue = message.kind?.structValue;
+    }
+    if (message.kind?.$case === "listValue") {
+      obj.listValue = message.kind?.listValue;
+    }
     return obj;
   },
 
@@ -491,10 +509,8 @@ export const ListValue = {
 
   toJSON(message: ListValue): unknown {
     const obj: any = {};
-    if (message.values) {
+    if (message.values?.length) {
       obj.values = message.values.map((e) => e);
-    } else {
-      obj.values = [];
     }
     return obj;
   },

--- a/integration/oneof-unions/google/protobuf/struct.ts
+++ b/integration/oneof-unions/google/protobuf/struct.ts
@@ -370,22 +370,22 @@ export const Value = {
   toJSON(message: Value): unknown {
     const obj: any = {};
     if (message.kind?.$case === "nullValue") {
-      obj.nullValue = message.kind?.nullValue !== undefined ? nullValueToJSON(message.kind?.nullValue) : undefined;
+      obj.nullValue = nullValueToJSON(message.kind.nullValue);
     }
     if (message.kind?.$case === "numberValue") {
-      obj.numberValue = message.kind?.numberValue;
+      obj.numberValue = message.kind.numberValue;
     }
     if (message.kind?.$case === "stringValue") {
-      obj.stringValue = message.kind?.stringValue;
+      obj.stringValue = message.kind.stringValue;
     }
     if (message.kind?.$case === "boolValue") {
-      obj.boolValue = message.kind?.boolValue;
+      obj.boolValue = message.kind.boolValue;
     }
     if (message.kind?.$case === "structValue") {
-      obj.structValue = message.kind?.structValue;
+      obj.structValue = message.kind.structValue;
     }
     if (message.kind?.$case === "listValue") {
-      obj.listValue = message.kind?.listValue;
+      obj.listValue = message.kind.listValue;
     }
     return obj;
   },

--- a/integration/oneof-unions/google/protobuf/struct.ts
+++ b/integration/oneof-unions/google/protobuf/struct.ts
@@ -510,7 +510,7 @@ export const ListValue = {
   toJSON(message: ListValue): unknown {
     const obj: any = {};
     if (message.values?.length) {
-      obj.values = message.values.map((e) => e);
+      obj.values = message.values;
     }
     return obj;
   },

--- a/integration/oneof-unions/oneof.ts
+++ b/integration/oneof-unions/oneof.ts
@@ -262,25 +262,49 @@ export const PleaseChoose = {
 
   toJSON(message: PleaseChoose): unknown {
     const obj: any = {};
-    message.name !== undefined && (obj.name = message.name);
-    message.choice?.$case === "aNumber" && (obj.aNumber = message.choice?.aNumber);
-    message.choice?.$case === "aString" && (obj.aString = message.choice?.aString);
-    message.choice?.$case === "aMessage" &&
-      (obj.aMessage = message.choice?.aMessage ? PleaseChoose_Submessage.toJSON(message.choice?.aMessage) : undefined);
-    message.choice?.$case === "aBool" && (obj.aBool = message.choice?.aBool);
-    message.choice?.$case === "bunchaBytes" && (obj.bunchaBytes = message.choice?.bunchaBytes !== undefined
-      ? base64FromBytes(message.choice?.bunchaBytes)
-      : undefined);
-    message.choice?.$case === "anEnum" && (obj.anEnum = message.choice?.anEnum !== undefined
-      ? pleaseChoose_StateEnumToJSON(message.choice?.anEnum)
-      : undefined);
-    message.age !== undefined && (obj.age = Math.round(message.age));
-    message.eitherOr?.$case === "either" && (obj.either = message.eitherOr?.either);
-    message.eitherOr?.$case === "or" && (obj.or = message.eitherOr?.or);
-    message.eitherOr?.$case === "thirdOption" && (obj.thirdOption = message.eitherOr?.thirdOption);
-    message.signature !== undefined &&
-      (obj.signature = base64FromBytes(message.signature !== undefined ? message.signature : new Uint8Array(0)));
-    message.value !== undefined && (obj.value = message.value);
+    if (message.name !== "") {
+      obj.name = message.name;
+    }
+    if (message.choice?.$case === "aNumber") {
+      obj.aNumber = message.choice?.aNumber;
+    }
+    if (message.choice?.$case === "aString") {
+      obj.aString = message.choice?.aString;
+    }
+    if (message.choice?.$case === "aMessage") {
+      obj.aMessage = message.choice?.aMessage ? PleaseChoose_Submessage.toJSON(message.choice?.aMessage) : undefined;
+    }
+    if (message.choice?.$case === "aBool") {
+      obj.aBool = message.choice?.aBool;
+    }
+    if (message.choice?.$case === "bunchaBytes") {
+      obj.bunchaBytes = message.choice?.bunchaBytes !== undefined
+        ? base64FromBytes(message.choice?.bunchaBytes)
+        : undefined;
+    }
+    if (message.choice?.$case === "anEnum") {
+      obj.anEnum = message.choice?.anEnum !== undefined
+        ? pleaseChoose_StateEnumToJSON(message.choice?.anEnum)
+        : undefined;
+    }
+    if (message.age !== 0) {
+      obj.age = Math.round(message.age);
+    }
+    if (message.eitherOr?.$case === "either") {
+      obj.either = message.eitherOr?.either;
+    }
+    if (message.eitherOr?.$case === "or") {
+      obj.or = message.eitherOr?.or;
+    }
+    if (message.eitherOr?.$case === "thirdOption") {
+      obj.thirdOption = message.eitherOr?.thirdOption;
+    }
+    if (message.signature.length !== 0) {
+      obj.signature = base64FromBytes(message.signature !== undefined ? message.signature : new Uint8Array(0));
+    }
+    if (message.value !== undefined) {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -378,7 +402,9 @@ export const PleaseChoose_Submessage = {
 
   toJSON(message: PleaseChoose_Submessage): unknown {
     const obj: any = {};
-    message.name !== undefined && (obj.name = message.name);
+    if (message.name !== "") {
+      obj.name = message.name;
+    }
     return obj;
   },
 
@@ -447,8 +473,12 @@ export const SimpleButOptional = {
 
   toJSON(message: SimpleButOptional): unknown {
     const obj: any = {};
-    message.name !== undefined && (obj.name = message.name);
-    message.age !== undefined && (obj.age = Math.round(message.age));
+    if (message.name !== undefined) {
+      obj.name = message.name;
+    }
+    if (message.age !== undefined) {
+      obj.age = Math.round(message.age);
+    }
     return obj;
   },
 

--- a/integration/oneof-unions/oneof.ts
+++ b/integration/oneof-unions/oneof.ts
@@ -266,41 +266,37 @@ export const PleaseChoose = {
       obj.name = message.name;
     }
     if (message.choice?.$case === "aNumber") {
-      obj.aNumber = message.choice?.aNumber;
+      obj.aNumber = message.choice.aNumber;
     }
     if (message.choice?.$case === "aString") {
-      obj.aString = message.choice?.aString;
+      obj.aString = message.choice.aString;
     }
     if (message.choice?.$case === "aMessage") {
-      obj.aMessage = message.choice?.aMessage ? PleaseChoose_Submessage.toJSON(message.choice?.aMessage) : undefined;
+      obj.aMessage = PleaseChoose_Submessage.toJSON(message.choice.aMessage);
     }
     if (message.choice?.$case === "aBool") {
-      obj.aBool = message.choice?.aBool;
+      obj.aBool = message.choice.aBool;
     }
     if (message.choice?.$case === "bunchaBytes") {
-      obj.bunchaBytes = message.choice?.bunchaBytes !== undefined
-        ? base64FromBytes(message.choice?.bunchaBytes)
-        : undefined;
+      obj.bunchaBytes = base64FromBytes(message.choice.bunchaBytes);
     }
     if (message.choice?.$case === "anEnum") {
-      obj.anEnum = message.choice?.anEnum !== undefined
-        ? pleaseChoose_StateEnumToJSON(message.choice?.anEnum)
-        : undefined;
+      obj.anEnum = pleaseChoose_StateEnumToJSON(message.choice.anEnum);
     }
     if (message.age !== 0) {
       obj.age = Math.round(message.age);
     }
     if (message.eitherOr?.$case === "either") {
-      obj.either = message.eitherOr?.either;
+      obj.either = message.eitherOr.either;
     }
     if (message.eitherOr?.$case === "or") {
-      obj.or = message.eitherOr?.or;
+      obj.or = message.eitherOr.or;
     }
     if (message.eitherOr?.$case === "thirdOption") {
-      obj.thirdOption = message.eitherOr?.thirdOption;
+      obj.thirdOption = message.eitherOr.thirdOption;
     }
     if (message.signature.length !== 0) {
-      obj.signature = base64FromBytes(message.signature !== undefined ? message.signature : new Uint8Array(0));
+      obj.signature = base64FromBytes(message.signature);
     }
     if (message.value !== undefined) {
       obj.value = message.value;

--- a/integration/output-index/a.ts
+++ b/integration/output-index/a.ts
@@ -46,7 +46,9 @@ export const A = {
 
   toJSON(message: A): unknown {
     const obj: any = {};
-    message.a !== undefined && (obj.a = message.a);
+    if (message.a !== "") {
+      obj.a = message.a;
+    }
     return obj;
   },
 

--- a/integration/point/point.ts
+++ b/integration/point/point.ts
@@ -64,8 +64,12 @@ export const Point = {
 
   toJSON(message: Point): unknown {
     const obj: any = {};
-    message.lat !== undefined && (obj.lat = message.lat);
-    message.lng !== undefined && (obj.lng = message.lng);
+    if (message.lat !== 0) {
+      obj.lat = message.lat;
+    }
+    if (message.lng !== 0) {
+      obj.lng = message.lng;
+    }
     return obj;
   },
 
@@ -135,8 +139,12 @@ export const Area = {
 
   toJSON(message: Area): unknown {
     const obj: any = {};
-    message.nw !== undefined && (obj.nw = message.nw ? Point.toJSON(message.nw) : undefined);
-    message.se !== undefined && (obj.se = message.se ? Point.toJSON(message.se) : undefined);
+    if (message.nw !== undefined) {
+      obj.nw = message.nw ? Point.toJSON(message.nw) : undefined;
+    }
+    if (message.se !== undefined) {
+      obj.se = message.se ? Point.toJSON(message.se) : undefined;
+    }
     return obj;
   },
 

--- a/integration/point/point.ts
+++ b/integration/point/point.ts
@@ -140,10 +140,10 @@ export const Area = {
   toJSON(message: Area): unknown {
     const obj: any = {};
     if (message.nw !== undefined) {
-      obj.nw = message.nw ? Point.toJSON(message.nw) : undefined;
+      obj.nw = Point.toJSON(message.nw);
     }
     if (message.se !== undefined) {
-      obj.se = message.se ? Point.toJSON(message.se) : undefined;
+      obj.se = Point.toJSON(message.se);
     }
     return obj;
   },

--- a/integration/return-observable/observable.ts
+++ b/integration/return-observable/observable.ts
@@ -53,7 +53,9 @@ export const ProduceRequest = {
 
   toJSON(message: ProduceRequest): unknown {
     const obj: any = {};
-    message.ingredients !== undefined && (obj.ingredients = message.ingredients);
+    if (message.ingredients !== "") {
+      obj.ingredients = message.ingredients;
+    }
     return obj;
   },
 
@@ -109,7 +111,9 @@ export const ProduceReply = {
 
   toJSON(message: ProduceReply): unknown {
     const obj: any = {};
-    message.result !== undefined && (obj.result = message.result);
+    if (message.result !== "") {
+      obj.result = message.result;
+    }
     return obj;
   },
 

--- a/integration/simple-deprecated-fields/simple.ts
+++ b/integration/simple-deprecated-fields/simple.ts
@@ -127,7 +127,7 @@ export const Simple = {
       obj.age = Math.round(message.age);
     }
     if (message.child !== undefined) {
-      obj.child = message.child ? Child.toJSON(message.child) : undefined;
+      obj.child = Child.toJSON(message.child);
     }
     if (message.testField !== "") {
       obj.testField = message.testField;

--- a/integration/simple-deprecated-fields/simple.ts
+++ b/integration/simple-deprecated-fields/simple.ts
@@ -120,11 +120,21 @@ export const Simple = {
 
   toJSON(message: Simple): unknown {
     const obj: any = {};
-    message.name !== undefined && (obj.name = message.name);
-    message.age !== undefined && (obj.age = Math.round(message.age));
-    message.child !== undefined && (obj.child = message.child ? Child.toJSON(message.child) : undefined);
-    message.testField !== undefined && (obj.testField = message.testField);
-    message.testNotDeprecated !== undefined && (obj.testNotDeprecated = message.testNotDeprecated);
+    if (message.name !== "") {
+      obj.name = message.name;
+    }
+    if (message.age !== 0) {
+      obj.age = Math.round(message.age);
+    }
+    if (message.child !== undefined) {
+      obj.child = message.child ? Child.toJSON(message.child) : undefined;
+    }
+    if (message.testField !== "") {
+      obj.testField = message.testField;
+    }
+    if (message.testNotDeprecated !== "") {
+      obj.testNotDeprecated = message.testNotDeprecated;
+    }
     return obj;
   },
 
@@ -184,7 +194,9 @@ export const Child = {
 
   toJSON(message: Child): unknown {
     const obj: any = {};
-    message.name !== undefined && (obj.name = message.name);
+    if (message.name !== "") {
+      obj.name = message.name;
+    }
     return obj;
   },
 

--- a/integration/simple-esmodule-interop/simple.ts
+++ b/integration/simple-esmodule-interop/simple.ts
@@ -75,8 +75,12 @@ export const Simple = {
 
   toJSON(message: Simple): unknown {
     const obj: any = {};
-    message.name !== undefined && (obj.name = message.name);
-    message.age !== undefined && (obj.age = Math.round(message.age));
+    if (message.name !== "") {
+      obj.name = message.name;
+    }
+    if (message.age !== 0) {
+      obj.age = Math.round(message.age);
+    }
     return obj;
   },
 
@@ -269,18 +273,42 @@ export const Numbers = {
 
   toJSON(message: Numbers): unknown {
     const obj: any = {};
-    message.double !== undefined && (obj.double = message.double);
-    message.float !== undefined && (obj.float = message.float);
-    message.int32 !== undefined && (obj.int32 = Math.round(message.int32));
-    message.int64 !== undefined && (obj.int64 = Math.round(message.int64));
-    message.uint32 !== undefined && (obj.uint32 = Math.round(message.uint32));
-    message.uint64 !== undefined && (obj.uint64 = Math.round(message.uint64));
-    message.sint32 !== undefined && (obj.sint32 = Math.round(message.sint32));
-    message.sint64 !== undefined && (obj.sint64 = Math.round(message.sint64));
-    message.fixed32 !== undefined && (obj.fixed32 = Math.round(message.fixed32));
-    message.fixed64 !== undefined && (obj.fixed64 = Math.round(message.fixed64));
-    message.sfixed32 !== undefined && (obj.sfixed32 = Math.round(message.sfixed32));
-    message.sfixed64 !== undefined && (obj.sfixed64 = Math.round(message.sfixed64));
+    if (message.double !== 0) {
+      obj.double = message.double;
+    }
+    if (message.float !== 0) {
+      obj.float = message.float;
+    }
+    if (message.int32 !== 0) {
+      obj.int32 = Math.round(message.int32);
+    }
+    if (message.int64 !== 0) {
+      obj.int64 = Math.round(message.int64);
+    }
+    if (message.uint32 !== 0) {
+      obj.uint32 = Math.round(message.uint32);
+    }
+    if (message.uint64 !== 0) {
+      obj.uint64 = Math.round(message.uint64);
+    }
+    if (message.sint32 !== 0) {
+      obj.sint32 = Math.round(message.sint32);
+    }
+    if (message.sint64 !== 0) {
+      obj.sint64 = Math.round(message.sint64);
+    }
+    if (message.fixed32 !== 0) {
+      obj.fixed32 = Math.round(message.fixed32);
+    }
+    if (message.fixed64 !== 0) {
+      obj.fixed64 = Math.round(message.fixed64);
+    }
+    if (message.sfixed32 !== 0) {
+      obj.sfixed32 = Math.round(message.sfixed32);
+    }
+    if (message.sfixed64 !== 0) {
+      obj.sfixed64 = Math.round(message.sfixed64);
+    }
     return obj;
   },
 

--- a/integration/simple-json-name/google/protobuf/timestamp.ts
+++ b/integration/simple-json-name/google/protobuf/timestamp.ts
@@ -165,8 +165,12 @@ export const Timestamp = {
 
   toJSON(message: Timestamp): unknown {
     const obj: any = {};
-    message.seconds !== undefined && (obj.seconds = Math.round(message.seconds));
-    message.nanos !== undefined && (obj.nanos = Math.round(message.nanos));
+    if (message.seconds !== 0) {
+      obj.seconds = Math.round(message.seconds);
+    }
+    if (message.nanos !== 0) {
+      obj.nanos = Math.round(message.nanos);
+    }
     return obj;
   },
 

--- a/integration/simple-json-name/simple.ts
+++ b/integration/simple-json-name/simple.ts
@@ -166,7 +166,7 @@ export const Simple = {
       obj.dollar$ = message.dollarEnd;
     }
     if (message.hyphenList?.length) {
-      obj["hyphen-list"] = message.hyphenList.map((e) => e);
+      obj["hyphen-list"] = message.hyphenList;
     }
     return obj;
   },

--- a/integration/simple-json-name/simple.ts
+++ b/integration/simple-json-name/simple.ts
@@ -144,17 +144,29 @@ export const Simple = {
 
   toJSON(message: Simple): unknown {
     const obj: any = {};
-    message.name !== undefined && (obj.other_name = message.name);
-    message.age !== undefined && (obj.other_age = Math.round(message.age));
-    message.createdAt !== undefined && (obj.createdAt = message.createdAt.toISOString());
-    message.hyphen !== undefined && (obj["hyphened-name"] = message.hyphen);
-    message.spaces !== undefined && (obj["name with spaces"] = message.spaces);
-    message.dollarStart !== undefined && (obj.$dollar = message.dollarStart);
-    message.dollarEnd !== undefined && (obj.dollar$ = message.dollarEnd);
-    if (message.hyphenList) {
+    if (message.name !== "") {
+      obj.other_name = message.name;
+    }
+    if (message.age !== undefined) {
+      obj.other_age = Math.round(message.age);
+    }
+    if (message.createdAt !== undefined) {
+      obj.createdAt = message.createdAt.toISOString();
+    }
+    if (message.hyphen !== "") {
+      obj["hyphened-name"] = message.hyphen;
+    }
+    if (message.spaces !== "") {
+      obj["name with spaces"] = message.spaces;
+    }
+    if (message.dollarStart !== "") {
+      obj.$dollar = message.dollarStart;
+    }
+    if (message.dollarEnd !== "") {
+      obj.dollar$ = message.dollarEnd;
+    }
+    if (message.hyphenList?.length) {
       obj["hyphen-list"] = message.hyphenList.map((e) => e);
-    } else {
-      obj["hyphen-list"] = [];
     }
     return obj;
   },

--- a/integration/simple-long-bigint/google/protobuf/timestamp.ts
+++ b/integration/simple-long-bigint/google/protobuf/timestamp.ts
@@ -165,8 +165,12 @@ export const Timestamp = {
 
   toJSON(message: Timestamp): unknown {
     const obj: any = {};
-    message.seconds !== undefined && (obj.seconds = message.seconds.toString());
-    message.nanos !== undefined && (obj.nanos = Math.round(message.nanos));
+    if (message.seconds !== BigInt("0")) {
+      obj.seconds = message.seconds.toString();
+    }
+    if (message.nanos !== 0) {
+      obj.nanos = Math.round(message.nanos);
+    }
     return obj;
   },
 

--- a/integration/simple-long-bigint/google/protobuf/wrappers.ts
+++ b/integration/simple-long-bigint/google/protobuf/wrappers.ts
@@ -135,7 +135,9 @@ export const DoubleValue = {
 
   toJSON(message: DoubleValue): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = message.value);
+    if (message.value !== 0) {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -191,7 +193,9 @@ export const FloatValue = {
 
   toJSON(message: FloatValue): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = message.value);
+    if (message.value !== 0) {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -247,7 +251,9 @@ export const Int64Value = {
 
   toJSON(message: Int64Value): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = message.value.toString());
+    if (message.value !== BigInt("0")) {
+      obj.value = message.value.toString();
+    }
     return obj;
   },
 
@@ -303,7 +309,9 @@ export const UInt64Value = {
 
   toJSON(message: UInt64Value): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = message.value.toString());
+    if (message.value !== BigInt("0")) {
+      obj.value = message.value.toString();
+    }
     return obj;
   },
 
@@ -359,7 +367,9 @@ export const Int32Value = {
 
   toJSON(message: Int32Value): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = Math.round(message.value));
+    if (message.value !== 0) {
+      obj.value = Math.round(message.value);
+    }
     return obj;
   },
 
@@ -415,7 +425,9 @@ export const UInt32Value = {
 
   toJSON(message: UInt32Value): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = Math.round(message.value));
+    if (message.value !== 0) {
+      obj.value = Math.round(message.value);
+    }
     return obj;
   },
 
@@ -471,7 +483,9 @@ export const BoolValue = {
 
   toJSON(message: BoolValue): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = message.value);
+    if (message.value === true) {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -527,7 +541,9 @@ export const StringValue = {
 
   toJSON(message: StringValue): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = message.value);
+    if (message.value !== "") {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -583,8 +599,9 @@ export const BytesValue = {
 
   toJSON(message: BytesValue): unknown {
     const obj: any = {};
-    message.value !== undefined &&
-      (obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array(0)));
+    if (message.value.length !== 0) {
+      obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array(0));
+    }
     return obj;
   },
 

--- a/integration/simple-long-bigint/google/protobuf/wrappers.ts
+++ b/integration/simple-long-bigint/google/protobuf/wrappers.ts
@@ -600,7 +600,7 @@ export const BytesValue = {
   toJSON(message: BytesValue): unknown {
     const obj: any = {};
     if (message.value.length !== 0) {
-      obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array(0));
+      obj.value = base64FromBytes(message.value);
     }
     return obj;
   },

--- a/integration/simple-long-bigint/simple.ts
+++ b/integration/simple-long-bigint/simple.ts
@@ -249,24 +249,50 @@ export const Numbers = {
 
   toJSON(message: Numbers): unknown {
     const obj: any = {};
-    message.double !== undefined && (obj.double = message.double);
-    message.float !== undefined && (obj.float = message.float);
-    message.int32 !== undefined && (obj.int32 = Math.round(message.int32));
-    message.int64 !== undefined && (obj.int64 = message.int64.toString());
-    message.uint32 !== undefined && (obj.uint32 = Math.round(message.uint32));
-    message.uint64 !== undefined && (obj.uint64 = message.uint64.toString());
-    message.sint32 !== undefined && (obj.sint32 = Math.round(message.sint32));
-    message.sint64 !== undefined && (obj.sint64 = message.sint64.toString());
-    message.fixed32 !== undefined && (obj.fixed32 = Math.round(message.fixed32));
-    message.fixed64 !== undefined && (obj.fixed64 = message.fixed64.toString());
-    message.sfixed32 !== undefined && (obj.sfixed32 = Math.round(message.sfixed32));
-    message.sfixed64 !== undefined && (obj.sfixed64 = message.sfixed64.toString());
-    message.guint64 !== undefined && (obj.guint64 = message.guint64);
-    message.timestamp !== undefined && (obj.timestamp = message.timestamp.toISOString());
-    if (message.uint64s) {
+    if (message.double !== 0) {
+      obj.double = message.double;
+    }
+    if (message.float !== 0) {
+      obj.float = message.float;
+    }
+    if (message.int32 !== 0) {
+      obj.int32 = Math.round(message.int32);
+    }
+    if (message.int64 !== BigInt("0")) {
+      obj.int64 = message.int64.toString();
+    }
+    if (message.uint32 !== 0) {
+      obj.uint32 = Math.round(message.uint32);
+    }
+    if (message.uint64 !== BigInt("0")) {
+      obj.uint64 = message.uint64.toString();
+    }
+    if (message.sint32 !== 0) {
+      obj.sint32 = Math.round(message.sint32);
+    }
+    if (message.sint64 !== BigInt("0")) {
+      obj.sint64 = message.sint64.toString();
+    }
+    if (message.fixed32 !== 0) {
+      obj.fixed32 = Math.round(message.fixed32);
+    }
+    if (message.fixed64 !== BigInt("0")) {
+      obj.fixed64 = message.fixed64.toString();
+    }
+    if (message.sfixed32 !== 0) {
+      obj.sfixed32 = Math.round(message.sfixed32);
+    }
+    if (message.sfixed64 !== BigInt("0")) {
+      obj.sfixed64 = message.sfixed64.toString();
+    }
+    if (message.guint64 !== undefined) {
+      obj.guint64 = message.guint64;
+    }
+    if (message.timestamp !== undefined) {
+      obj.timestamp = message.timestamp.toISOString();
+    }
+    if (message.uint64s?.length) {
       obj.uint64s = message.uint64s.map((e) => e.toString());
-    } else {
-      obj.uint64s = [];
     }
     return obj;
   },

--- a/integration/simple-long-string/google/protobuf/timestamp.ts
+++ b/integration/simple-long-string/google/protobuf/timestamp.ts
@@ -165,8 +165,12 @@ export const Timestamp = {
 
   toJSON(message: Timestamp): unknown {
     const obj: any = {};
-    message.seconds !== undefined && (obj.seconds = message.seconds);
-    message.nanos !== undefined && (obj.nanos = Math.round(message.nanos));
+    if (message.seconds !== "0") {
+      obj.seconds = message.seconds;
+    }
+    if (message.nanos !== 0) {
+      obj.nanos = Math.round(message.nanos);
+    }
     return obj;
   },
 

--- a/integration/simple-long-string/google/protobuf/wrappers.ts
+++ b/integration/simple-long-string/google/protobuf/wrappers.ts
@@ -135,7 +135,9 @@ export const DoubleValue = {
 
   toJSON(message: DoubleValue): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = message.value);
+    if (message.value !== 0) {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -191,7 +193,9 @@ export const FloatValue = {
 
   toJSON(message: FloatValue): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = message.value);
+    if (message.value !== 0) {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -247,7 +251,9 @@ export const Int64Value = {
 
   toJSON(message: Int64Value): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = message.value);
+    if (message.value !== "0") {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -303,7 +309,9 @@ export const UInt64Value = {
 
   toJSON(message: UInt64Value): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = message.value);
+    if (message.value !== "0") {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -359,7 +367,9 @@ export const Int32Value = {
 
   toJSON(message: Int32Value): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = Math.round(message.value));
+    if (message.value !== 0) {
+      obj.value = Math.round(message.value);
+    }
     return obj;
   },
 
@@ -415,7 +425,9 @@ export const UInt32Value = {
 
   toJSON(message: UInt32Value): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = Math.round(message.value));
+    if (message.value !== 0) {
+      obj.value = Math.round(message.value);
+    }
     return obj;
   },
 
@@ -471,7 +483,9 @@ export const BoolValue = {
 
   toJSON(message: BoolValue): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = message.value);
+    if (message.value === true) {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -527,7 +541,9 @@ export const StringValue = {
 
   toJSON(message: StringValue): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = message.value);
+    if (message.value !== "") {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -583,8 +599,9 @@ export const BytesValue = {
 
   toJSON(message: BytesValue): unknown {
     const obj: any = {};
-    message.value !== undefined &&
-      (obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array(0)));
+    if (message.value.length !== 0) {
+      obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array(0));
+    }
     return obj;
   },
 

--- a/integration/simple-long-string/google/protobuf/wrappers.ts
+++ b/integration/simple-long-string/google/protobuf/wrappers.ts
@@ -600,7 +600,7 @@ export const BytesValue = {
   toJSON(message: BytesValue): unknown {
     const obj: any = {};
     if (message.value.length !== 0) {
-      obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array(0));
+      obj.value = base64FromBytes(message.value);
     }
     return obj;
   },

--- a/integration/simple-long-string/simple.ts
+++ b/integration/simple-long-string/simple.ts
@@ -224,20 +224,48 @@ export const Numbers = {
 
   toJSON(message: Numbers): unknown {
     const obj: any = {};
-    message.double !== undefined && (obj.double = message.double);
-    message.float !== undefined && (obj.float = message.float);
-    message.int32 !== undefined && (obj.int32 = Math.round(message.int32));
-    message.int64 !== undefined && (obj.int64 = message.int64);
-    message.uint32 !== undefined && (obj.uint32 = Math.round(message.uint32));
-    message.uint64 !== undefined && (obj.uint64 = message.uint64);
-    message.sint32 !== undefined && (obj.sint32 = Math.round(message.sint32));
-    message.sint64 !== undefined && (obj.sint64 = message.sint64);
-    message.fixed32 !== undefined && (obj.fixed32 = Math.round(message.fixed32));
-    message.fixed64 !== undefined && (obj.fixed64 = message.fixed64);
-    message.sfixed32 !== undefined && (obj.sfixed32 = Math.round(message.sfixed32));
-    message.sfixed64 !== undefined && (obj.sfixed64 = message.sfixed64);
-    message.guint64 !== undefined && (obj.guint64 = message.guint64);
-    message.timestamp !== undefined && (obj.timestamp = message.timestamp.toISOString());
+    if (message.double !== 0) {
+      obj.double = message.double;
+    }
+    if (message.float !== 0) {
+      obj.float = message.float;
+    }
+    if (message.int32 !== 0) {
+      obj.int32 = Math.round(message.int32);
+    }
+    if (message.int64 !== "0") {
+      obj.int64 = message.int64;
+    }
+    if (message.uint32 !== 0) {
+      obj.uint32 = Math.round(message.uint32);
+    }
+    if (message.uint64 !== "0") {
+      obj.uint64 = message.uint64;
+    }
+    if (message.sint32 !== 0) {
+      obj.sint32 = Math.round(message.sint32);
+    }
+    if (message.sint64 !== "0") {
+      obj.sint64 = message.sint64;
+    }
+    if (message.fixed32 !== 0) {
+      obj.fixed32 = Math.round(message.fixed32);
+    }
+    if (message.fixed64 !== "0") {
+      obj.fixed64 = message.fixed64;
+    }
+    if (message.sfixed32 !== 0) {
+      obj.sfixed32 = Math.round(message.sfixed32);
+    }
+    if (message.sfixed64 !== "0") {
+      obj.sfixed64 = message.sfixed64;
+    }
+    if (message.guint64 !== undefined) {
+      obj.guint64 = message.guint64;
+    }
+    if (message.timestamp !== undefined) {
+      obj.timestamp = message.timestamp.toISOString();
+    }
     return obj;
   },
 

--- a/integration/simple-long/google/protobuf/wrappers.ts
+++ b/integration/simple-long/google/protobuf/wrappers.ts
@@ -135,7 +135,9 @@ export const DoubleValue = {
 
   toJSON(message: DoubleValue): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = message.value);
+    if (message.value !== 0) {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -191,7 +193,9 @@ export const FloatValue = {
 
   toJSON(message: FloatValue): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = message.value);
+    if (message.value !== 0) {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -247,7 +251,9 @@ export const Int64Value = {
 
   toJSON(message: Int64Value): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = (message.value || Long.ZERO).toString());
+    if (!message.value.isZero()) {
+      obj.value = (message.value || Long.ZERO).toString();
+    }
     return obj;
   },
 
@@ -303,7 +309,9 @@ export const UInt64Value = {
 
   toJSON(message: UInt64Value): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = (message.value || Long.UZERO).toString());
+    if (!message.value.isZero()) {
+      obj.value = (message.value || Long.UZERO).toString();
+    }
     return obj;
   },
 
@@ -359,7 +367,9 @@ export const Int32Value = {
 
   toJSON(message: Int32Value): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = Math.round(message.value));
+    if (message.value !== 0) {
+      obj.value = Math.round(message.value);
+    }
     return obj;
   },
 
@@ -415,7 +425,9 @@ export const UInt32Value = {
 
   toJSON(message: UInt32Value): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = Math.round(message.value));
+    if (message.value !== 0) {
+      obj.value = Math.round(message.value);
+    }
     return obj;
   },
 
@@ -471,7 +483,9 @@ export const BoolValue = {
 
   toJSON(message: BoolValue): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = message.value);
+    if (message.value === true) {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -527,7 +541,9 @@ export const StringValue = {
 
   toJSON(message: StringValue): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = message.value);
+    if (message.value !== "") {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -583,8 +599,9 @@ export const BytesValue = {
 
   toJSON(message: BytesValue): unknown {
     const obj: any = {};
-    message.value !== undefined &&
-      (obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array(0)));
+    if (message.value.length !== 0) {
+      obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array(0));
+    }
     return obj;
   },
 

--- a/integration/simple-long/google/protobuf/wrappers.ts
+++ b/integration/simple-long/google/protobuf/wrappers.ts
@@ -600,7 +600,7 @@ export const BytesValue = {
   toJSON(message: BytesValue): unknown {
     const obj: any = {};
     if (message.value.length !== 0) {
-      obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array(0));
+      obj.value = base64FromBytes(message.value);
     }
     return obj;
   },

--- a/integration/simple-long/simple-test.ts
+++ b/integration/simple-long/simple-test.ts
@@ -73,7 +73,6 @@ describe("simple", () => {
           "1": "2",
           "2": "1",
         },
-        "nameLookup": {},
       }
     `);
 

--- a/integration/simple-long/simple.ts
+++ b/integration/simple-long/simple.ts
@@ -164,10 +164,10 @@ export const SimpleWithWrappers = {
       obj.bananas = message.bananas;
     }
     if (message.coins?.length) {
-      obj.coins = message.coins.map((e) => e);
+      obj.coins = message.coins;
     }
     if (message.snacks?.length) {
-      obj.snacks = message.snacks.map((e) => e);
+      obj.snacks = message.snacks;
     }
     return obj;
   },

--- a/integration/simple-long/simple.ts
+++ b/integration/simple-long/simple.ts
@@ -151,19 +151,23 @@ export const SimpleWithWrappers = {
 
   toJSON(message: SimpleWithWrappers): unknown {
     const obj: any = {};
-    message.name !== undefined && (obj.name = message.name);
-    message.age !== undefined && (obj.age = message.age);
-    message.enabled !== undefined && (obj.enabled = message.enabled);
-    message.bananas !== undefined && (obj.bananas = message.bananas);
-    if (message.coins) {
-      obj.coins = message.coins.map((e) => e);
-    } else {
-      obj.coins = [];
+    if (message.name !== undefined) {
+      obj.name = message.name;
     }
-    if (message.snacks) {
+    if (message.age !== undefined) {
+      obj.age = message.age;
+    }
+    if (message.enabled !== undefined) {
+      obj.enabled = message.enabled;
+    }
+    if (message.bananas !== undefined) {
+      obj.bananas = message.bananas;
+    }
+    if (message.coins?.length) {
+      obj.coins = message.coins.map((e) => e);
+    }
+    if (message.snacks?.length) {
       obj.snacks = message.snacks.map((e) => e);
-    } else {
-      obj.snacks = [];
     }
     return obj;
   },
@@ -275,23 +279,32 @@ export const SimpleWithMap = {
 
   toJSON(message: SimpleWithMap): unknown {
     const obj: any = {};
-    obj.nameLookup = {};
     if (message.nameLookup) {
-      Object.entries(message.nameLookup).forEach(([k, v]) => {
-        obj.nameLookup[k] = v;
-      });
+      const entries = Object.entries(message.nameLookup);
+      if (entries.length > 0) {
+        obj.nameLookup = {};
+        entries.forEach(([k, v]) => {
+          obj.nameLookup[k] = v;
+        });
+      }
     }
-    obj.intLookup = {};
     if (message.intLookup) {
-      Object.entries(message.intLookup).forEach(([k, v]) => {
-        obj.intLookup[k] = Math.round(v);
-      });
+      const entries = Object.entries(message.intLookup);
+      if (entries.length > 0) {
+        obj.intLookup = {};
+        entries.forEach(([k, v]) => {
+          obj.intLookup[k] = Math.round(v);
+        });
+      }
     }
-    obj.longLookup = {};
     if (message.longLookup) {
-      Object.entries(message.longLookup).forEach(([k, v]) => {
-        obj.longLookup[k] = v.toString();
-      });
+      const entries = Object.entries(message.longLookup);
+      if (entries.length > 0) {
+        obj.longLookup = {};
+        entries.forEach(([k, v]) => {
+          obj.longLookup[k] = v.toString();
+        });
+      }
     }
     return obj;
   },
@@ -384,8 +397,12 @@ export const SimpleWithMap_NameLookupEntry = {
 
   toJSON(message: SimpleWithMap_NameLookupEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = message.key);
-    message.value !== undefined && (obj.value = message.value);
+    if (message.key !== "") {
+      obj.key = message.key;
+    }
+    if (message.value !== "") {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -454,8 +471,12 @@ export const SimpleWithMap_IntLookupEntry = {
 
   toJSON(message: SimpleWithMap_IntLookupEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = Math.round(message.key));
-    message.value !== undefined && (obj.value = Math.round(message.value));
+    if (message.key !== 0) {
+      obj.key = Math.round(message.key);
+    }
+    if (message.value !== 0) {
+      obj.value = Math.round(message.value);
+    }
     return obj;
   },
 
@@ -525,8 +546,12 @@ export const SimpleWithMap_LongLookupEntry = {
 
   toJSON(message: SimpleWithMap_LongLookupEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = message.key);
-    message.value !== undefined && (obj.value = (message.value || Long.ZERO).toString());
+    if (message.key !== "") {
+      obj.key = message.key;
+    }
+    if (!message.value.isZero()) {
+      obj.value = (message.value || Long.ZERO).toString();
+    }
     return obj;
   },
 
@@ -745,22 +770,44 @@ export const Numbers = {
 
   toJSON(message: Numbers): unknown {
     const obj: any = {};
-    message.double !== undefined && (obj.double = message.double);
-    message.float !== undefined && (obj.float = message.float);
-    message.int32 !== undefined && (obj.int32 = Math.round(message.int32));
-    message.int64 !== undefined && (obj.int64 = (message.int64 || Long.ZERO).toString());
-    message.uint32 !== undefined && (obj.uint32 = Math.round(message.uint32));
-    message.uint64 !== undefined && (obj.uint64 = (message.uint64 || Long.UZERO).toString());
-    message.sint32 !== undefined && (obj.sint32 = Math.round(message.sint32));
-    message.sint64 !== undefined && (obj.sint64 = (message.sint64 || Long.ZERO).toString());
-    message.fixed32 !== undefined && (obj.fixed32 = Math.round(message.fixed32));
-    message.fixed64 !== undefined && (obj.fixed64 = (message.fixed64 || Long.UZERO).toString());
-    message.sfixed32 !== undefined && (obj.sfixed32 = Math.round(message.sfixed32));
-    message.sfixed64 !== undefined && (obj.sfixed64 = (message.sfixed64 || Long.ZERO).toString());
-    if (message.manyUint64) {
+    if (message.double !== 0) {
+      obj.double = message.double;
+    }
+    if (message.float !== 0) {
+      obj.float = message.float;
+    }
+    if (message.int32 !== 0) {
+      obj.int32 = Math.round(message.int32);
+    }
+    if (!message.int64.isZero()) {
+      obj.int64 = (message.int64 || Long.ZERO).toString();
+    }
+    if (message.uint32 !== 0) {
+      obj.uint32 = Math.round(message.uint32);
+    }
+    if (!message.uint64.isZero()) {
+      obj.uint64 = (message.uint64 || Long.UZERO).toString();
+    }
+    if (message.sint32 !== 0) {
+      obj.sint32 = Math.round(message.sint32);
+    }
+    if (!message.sint64.isZero()) {
+      obj.sint64 = (message.sint64 || Long.ZERO).toString();
+    }
+    if (message.fixed32 !== 0) {
+      obj.fixed32 = Math.round(message.fixed32);
+    }
+    if (!message.fixed64.isZero()) {
+      obj.fixed64 = (message.fixed64 || Long.UZERO).toString();
+    }
+    if (message.sfixed32 !== 0) {
+      obj.sfixed32 = Math.round(message.sfixed32);
+    }
+    if (!message.sfixed64.isZero()) {
+      obj.sfixed64 = (message.sfixed64 || Long.ZERO).toString();
+    }
+    if (message.manyUint64?.length) {
       obj.manyUint64 = message.manyUint64.map((e) => (e || Long.UZERO).toString());
-    } else {
-      obj.manyUint64 = [];
     }
     return obj;
   },

--- a/integration/simple-optionals/google/protobuf/timestamp.ts
+++ b/integration/simple-optionals/google/protobuf/timestamp.ts
@@ -165,8 +165,12 @@ export const Timestamp = {
 
   toJSON(message: Timestamp): unknown {
     const obj: any = {};
-    message.seconds !== undefined && (obj.seconds = Math.round(message.seconds));
-    message.nanos !== undefined && (obj.nanos = Math.round(message.nanos));
+    if (message.seconds !== 0) {
+      obj.seconds = Math.round(message.seconds);
+    }
+    if (message.nanos !== 0) {
+      obj.nanos = Math.round(message.nanos);
+    }
     return obj;
   },
 

--- a/integration/simple-optionals/google/protobuf/wrappers.ts
+++ b/integration/simple-optionals/google/protobuf/wrappers.ts
@@ -135,7 +135,9 @@ export const DoubleValue = {
 
   toJSON(message: DoubleValue): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = message.value);
+    if (message.value !== 0) {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -191,7 +193,9 @@ export const FloatValue = {
 
   toJSON(message: FloatValue): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = message.value);
+    if (message.value !== 0) {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -247,7 +251,9 @@ export const Int64Value = {
 
   toJSON(message: Int64Value): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = Math.round(message.value));
+    if (message.value !== 0) {
+      obj.value = Math.round(message.value);
+    }
     return obj;
   },
 
@@ -303,7 +309,9 @@ export const UInt64Value = {
 
   toJSON(message: UInt64Value): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = Math.round(message.value));
+    if (message.value !== 0) {
+      obj.value = Math.round(message.value);
+    }
     return obj;
   },
 
@@ -359,7 +367,9 @@ export const Int32Value = {
 
   toJSON(message: Int32Value): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = Math.round(message.value));
+    if (message.value !== 0) {
+      obj.value = Math.round(message.value);
+    }
     return obj;
   },
 
@@ -415,7 +425,9 @@ export const UInt32Value = {
 
   toJSON(message: UInt32Value): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = Math.round(message.value));
+    if (message.value !== 0) {
+      obj.value = Math.round(message.value);
+    }
     return obj;
   },
 
@@ -471,7 +483,9 @@ export const BoolValue = {
 
   toJSON(message: BoolValue): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = message.value);
+    if (message.value === true) {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -527,7 +541,9 @@ export const StringValue = {
 
   toJSON(message: StringValue): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = message.value);
+    if (message.value !== "") {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -583,8 +599,9 @@ export const BytesValue = {
 
   toJSON(message: BytesValue): unknown {
     const obj: any = {};
-    message.value !== undefined &&
-      (obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array(0)));
+    if (message.value.length !== 0) {
+      obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array(0));
+    }
     return obj;
   },
 

--- a/integration/simple-optionals/google/protobuf/wrappers.ts
+++ b/integration/simple-optionals/google/protobuf/wrappers.ts
@@ -600,7 +600,7 @@ export const BytesValue = {
   toJSON(message: BytesValue): unknown {
     const obj: any = {};
     if (message.value.length !== 0) {
-      obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array(0));
+      obj.value = base64FromBytes(message.value);
     }
     return obj;
   },

--- a/integration/simple-optionals/import_dir/thing.ts
+++ b/integration/simple-optionals/import_dir/thing.ts
@@ -49,7 +49,9 @@ export const ImportedThing = {
 
   toJSON(message: ImportedThing): unknown {
     const obj: any = {};
-    message.createdAt !== undefined && (obj.createdAt = message.createdAt.toISOString());
+    if (message.createdAt !== undefined) {
+      obj.createdAt = message.createdAt.toISOString();
+    }
     return obj;
   },
 

--- a/integration/simple-optionals/simple.ts
+++ b/integration/simple-optionals/simple.ts
@@ -439,7 +439,7 @@ export const Simple = {
       obj.coins = message.coins.map((e) => Math.round(e));
     }
     if (message.snacks?.length) {
-      obj.snacks = message.snacks.map((e) => e);
+      obj.snacks = message.snacks;
     }
     if (message.oldStates?.length) {
       obj.oldStates = message.oldStates.map((e) => stateEnumToJSON(e));
@@ -948,10 +948,10 @@ export const SimpleWithWrappers = {
       obj.enabled = message.enabled;
     }
     if (message.coins?.length) {
-      obj.coins = message.coins.map((e) => e);
+      obj.coins = message.coins;
     }
     if (message.snacks?.length) {
-      obj.snacks = message.snacks.map((e) => e);
+      obj.snacks = message.snacks;
     }
     return obj;
   },

--- a/integration/simple-optionals/simple.ts
+++ b/integration/simple-optionals/simple.ts
@@ -417,32 +417,36 @@ export const Simple = {
 
   toJSON(message: Simple): unknown {
     const obj: any = {};
-    message.name !== undefined && (obj.name = message.name);
-    message.age !== undefined && (obj.age = Math.round(message.age));
-    message.createdAt !== undefined && (obj.createdAt = message.createdAt.toISOString());
-    message.child !== undefined && (obj.child = message.child ? Child.toJSON(message.child) : undefined);
-    message.state !== undefined && (obj.state = stateEnumToJSON(message.state));
-    if (message.grandChildren) {
+    if (message.name !== "") {
+      obj.name = message.name;
+    }
+    if (message.age !== 0) {
+      obj.age = Math.round(message.age);
+    }
+    if (message.createdAt !== undefined) {
+      obj.createdAt = message.createdAt.toISOString();
+    }
+    if (message.child !== undefined) {
+      obj.child = message.child ? Child.toJSON(message.child) : undefined;
+    }
+    if (message.state !== 0) {
+      obj.state = stateEnumToJSON(message.state);
+    }
+    if (message.grandChildren?.length) {
       obj.grandChildren = message.grandChildren.map((e) => e ? Child.toJSON(e) : undefined);
-    } else {
-      obj.grandChildren = [];
     }
-    if (message.coins) {
+    if (message.coins?.length) {
       obj.coins = message.coins.map((e) => Math.round(e));
-    } else {
-      obj.coins = [];
     }
-    if (message.snacks) {
+    if (message.snacks?.length) {
       obj.snacks = message.snacks.map((e) => e);
-    } else {
-      obj.snacks = [];
     }
-    if (message.oldStates) {
+    if (message.oldStates?.length) {
       obj.oldStates = message.oldStates.map((e) => stateEnumToJSON(e));
-    } else {
-      obj.oldStates = [];
     }
-    message.thing !== undefined && (obj.thing = message.thing ? ImportedThing.toJSON(message.thing) : undefined);
+    if (message.thing !== undefined) {
+      obj.thing = message.thing ? ImportedThing.toJSON(message.thing) : undefined;
+    }
     return obj;
   },
 
@@ -522,8 +526,12 @@ export const Child = {
 
   toJSON(message: Child): unknown {
     const obj: any = {};
-    message.name !== undefined && (obj.name = message.name);
-    message.type !== undefined && (obj.type = child_TypeToJSON(message.type));
+    if (message.name !== "") {
+      obj.name = message.name;
+    }
+    if (message.type !== 0) {
+      obj.type = child_TypeToJSON(message.type);
+    }
     return obj;
   },
 
@@ -604,10 +612,15 @@ export const Nested = {
 
   toJSON(message: Nested): unknown {
     const obj: any = {};
-    message.name !== undefined && (obj.name = message.name);
-    message.message !== undefined &&
-      (obj.message = message.message ? Nested_InnerMessage.toJSON(message.message) : undefined);
-    message.state !== undefined && (obj.state = nested_InnerEnumToJSON(message.state));
+    if (message.name !== "") {
+      obj.name = message.name;
+    }
+    if (message.message !== undefined) {
+      obj.message = message.message ? Nested_InnerMessage.toJSON(message.message) : undefined;
+    }
+    if (message.state !== 0) {
+      obj.state = nested_InnerEnumToJSON(message.state);
+    }
     return obj;
   },
 
@@ -680,9 +693,12 @@ export const Nested_InnerMessage = {
 
   toJSON(message: Nested_InnerMessage): unknown {
     const obj: any = {};
-    message.name !== undefined && (obj.name = message.name);
-    message.deep !== undefined &&
-      (obj.deep = message.deep ? Nested_InnerMessage_DeepMessage.toJSON(message.deep) : undefined);
+    if (message.name !== "") {
+      obj.name = message.name;
+    }
+    if (message.deep !== undefined) {
+      obj.deep = message.deep ? Nested_InnerMessage_DeepMessage.toJSON(message.deep) : undefined;
+    }
     return obj;
   },
 
@@ -741,7 +757,9 @@ export const Nested_InnerMessage_DeepMessage = {
 
   toJSON(message: Nested_InnerMessage_DeepMessage): unknown {
     const obj: any = {};
-    message.name !== undefined && (obj.name = message.name);
+    if (message.name !== "") {
+      obj.name = message.name;
+    }
     return obj;
   },
 
@@ -812,8 +830,12 @@ export const OneOfMessage = {
 
   toJSON(message: OneOfMessage): unknown {
     const obj: any = {};
-    message.first !== undefined && (obj.first = message.first);
-    message.last !== undefined && (obj.last = message.last);
+    if (message.first !== undefined) {
+      obj.first = message.first;
+    }
+    if (message.last !== undefined) {
+      obj.last = message.last;
+    }
     return obj;
   },
 
@@ -916,18 +938,20 @@ export const SimpleWithWrappers = {
 
   toJSON(message: SimpleWithWrappers): unknown {
     const obj: any = {};
-    message.name !== undefined && (obj.name = message.name);
-    message.age !== undefined && (obj.age = message.age);
-    message.enabled !== undefined && (obj.enabled = message.enabled);
-    if (message.coins) {
-      obj.coins = message.coins.map((e) => e);
-    } else {
-      obj.coins = [];
+    if (message.name !== undefined) {
+      obj.name = message.name;
     }
-    if (message.snacks) {
+    if (message.age !== undefined) {
+      obj.age = message.age;
+    }
+    if (message.enabled !== undefined) {
+      obj.enabled = message.enabled;
+    }
+    if (message.coins?.length) {
+      obj.coins = message.coins.map((e) => e);
+    }
+    if (message.snacks?.length) {
       obj.snacks = message.snacks.map((e) => e);
-    } else {
-      obj.snacks = [];
     }
     return obj;
   },
@@ -988,7 +1012,9 @@ export const Entity = {
 
   toJSON(message: Entity): unknown {
     const obj: any = {};
-    message.id !== undefined && (obj.id = Math.round(message.id));
+    if (message.id !== 0) {
+      obj.id = Math.round(message.id);
+    }
     return obj;
   },
 
@@ -1092,23 +1118,32 @@ export const SimpleWithMap = {
 
   toJSON(message: SimpleWithMap): unknown {
     const obj: any = {};
-    obj.entitiesById = {};
     if (message.entitiesById) {
-      Object.entries(message.entitiesById).forEach(([k, v]) => {
-        obj.entitiesById[k] = Entity.toJSON(v);
-      });
+      const entries = Object.entries(message.entitiesById);
+      if (entries.length > 0) {
+        obj.entitiesById = {};
+        entries.forEach(([k, v]) => {
+          obj.entitiesById[k] = Entity.toJSON(v);
+        });
+      }
     }
-    obj.nameLookup = {};
     if (message.nameLookup) {
-      Object.entries(message.nameLookup).forEach(([k, v]) => {
-        obj.nameLookup[k] = v;
-      });
+      const entries = Object.entries(message.nameLookup);
+      if (entries.length > 0) {
+        obj.nameLookup = {};
+        entries.forEach(([k, v]) => {
+          obj.nameLookup[k] = v;
+        });
+      }
     }
-    obj.intLookup = {};
     if (message.intLookup) {
-      Object.entries(message.intLookup).forEach(([k, v]) => {
-        obj.intLookup[k] = Math.round(v);
-      });
+      const entries = Object.entries(message.intLookup);
+      if (entries.length > 0) {
+        obj.intLookup = {};
+        entries.forEach(([k, v]) => {
+          obj.intLookup[k] = Math.round(v);
+        });
+      }
     }
     return obj;
   },
@@ -1204,8 +1239,12 @@ export const SimpleWithMap_EntitiesByIdEntry = {
 
   toJSON(message: SimpleWithMap_EntitiesByIdEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = Math.round(message.key));
-    message.value !== undefined && (obj.value = message.value ? Entity.toJSON(message.value) : undefined);
+    if (message.key !== 0) {
+      obj.key = Math.round(message.key);
+    }
+    if (message.value !== undefined) {
+      obj.value = message.value ? Entity.toJSON(message.value) : undefined;
+    }
     return obj;
   },
 
@@ -1276,8 +1315,12 @@ export const SimpleWithMap_NameLookupEntry = {
 
   toJSON(message: SimpleWithMap_NameLookupEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = message.key);
-    message.value !== undefined && (obj.value = message.value);
+    if (message.key !== "") {
+      obj.key = message.key;
+    }
+    if (message.value !== "") {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -1346,8 +1389,12 @@ export const SimpleWithMap_IntLookupEntry = {
 
   toJSON(message: SimpleWithMap_IntLookupEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = Math.round(message.key));
-    message.value !== undefined && (obj.value = Math.round(message.value));
+    if (message.key !== 0) {
+      obj.key = Math.round(message.key);
+    }
+    if (message.value !== 0) {
+      obj.value = Math.round(message.value);
+    }
     return obj;
   },
 
@@ -1414,11 +1461,14 @@ export const SimpleWithSnakeCaseMap = {
 
   toJSON(message: SimpleWithSnakeCaseMap): unknown {
     const obj: any = {};
-    obj.entitiesById = {};
     if (message.entitiesById) {
-      Object.entries(message.entitiesById).forEach(([k, v]) => {
-        obj.entitiesById[k] = Entity.toJSON(v);
-      });
+      const entries = Object.entries(message.entitiesById);
+      if (entries.length > 0) {
+        obj.entitiesById = {};
+        entries.forEach(([k, v]) => {
+          obj.entitiesById[k] = Entity.toJSON(v);
+        });
+      }
     }
     return obj;
   },
@@ -1496,8 +1546,12 @@ export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
 
   toJSON(message: SimpleWithSnakeCaseMap_EntitiesByIdEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = Math.round(message.key));
-    message.value !== undefined && (obj.value = message.value ? Entity.toJSON(message.value) : undefined);
+    if (message.key !== 0) {
+      obj.key = Math.round(message.key);
+    }
+    if (message.value !== undefined) {
+      obj.value = message.value ? Entity.toJSON(message.value) : undefined;
+    }
     return obj;
   },
 
@@ -1560,7 +1614,9 @@ export const PingRequest = {
 
   toJSON(message: PingRequest): unknown {
     const obj: any = {};
-    message.input !== undefined && (obj.input = message.input);
+    if (message.input !== "") {
+      obj.input = message.input;
+    }
     return obj;
   },
 
@@ -1616,7 +1672,9 @@ export const PingResponse = {
 
   toJSON(message: PingResponse): unknown {
     const obj: any = {};
-    message.output !== undefined && (obj.output = message.output);
+    if (message.output !== "") {
+      obj.output = message.output;
+    }
     return obj;
   },
 
@@ -1808,18 +1866,42 @@ export const Numbers = {
 
   toJSON(message: Numbers): unknown {
     const obj: any = {};
-    message.double !== undefined && (obj.double = message.double);
-    message.float !== undefined && (obj.float = message.float);
-    message.int32 !== undefined && (obj.int32 = Math.round(message.int32));
-    message.int64 !== undefined && (obj.int64 = Math.round(message.int64));
-    message.uint32 !== undefined && (obj.uint32 = Math.round(message.uint32));
-    message.uint64 !== undefined && (obj.uint64 = Math.round(message.uint64));
-    message.sint32 !== undefined && (obj.sint32 = Math.round(message.sint32));
-    message.sint64 !== undefined && (obj.sint64 = Math.round(message.sint64));
-    message.fixed32 !== undefined && (obj.fixed32 = Math.round(message.fixed32));
-    message.fixed64 !== undefined && (obj.fixed64 = Math.round(message.fixed64));
-    message.sfixed32 !== undefined && (obj.sfixed32 = Math.round(message.sfixed32));
-    message.sfixed64 !== undefined && (obj.sfixed64 = Math.round(message.sfixed64));
+    if (message.double !== 0) {
+      obj.double = message.double;
+    }
+    if (message.float !== 0) {
+      obj.float = message.float;
+    }
+    if (message.int32 !== 0) {
+      obj.int32 = Math.round(message.int32);
+    }
+    if (message.int64 !== 0) {
+      obj.int64 = Math.round(message.int64);
+    }
+    if (message.uint32 !== 0) {
+      obj.uint32 = Math.round(message.uint32);
+    }
+    if (message.uint64 !== 0) {
+      obj.uint64 = Math.round(message.uint64);
+    }
+    if (message.sint32 !== 0) {
+      obj.sint32 = Math.round(message.sint32);
+    }
+    if (message.sint64 !== 0) {
+      obj.sint64 = Math.round(message.sint64);
+    }
+    if (message.fixed32 !== 0) {
+      obj.fixed32 = Math.round(message.fixed32);
+    }
+    if (message.fixed64 !== 0) {
+      obj.fixed64 = Math.round(message.fixed64);
+    }
+    if (message.sfixed32 !== 0) {
+      obj.sfixed32 = Math.round(message.sfixed32);
+    }
+    if (message.sfixed64 !== 0) {
+      obj.sfixed64 = Math.round(message.sfixed64);
+    }
     return obj;
   },
 

--- a/integration/simple-optionals/simple.ts
+++ b/integration/simple-optionals/simple.ts
@@ -427,13 +427,13 @@ export const Simple = {
       obj.createdAt = message.createdAt.toISOString();
     }
     if (message.child !== undefined) {
-      obj.child = message.child ? Child.toJSON(message.child) : undefined;
+      obj.child = Child.toJSON(message.child);
     }
     if (message.state !== 0) {
       obj.state = stateEnumToJSON(message.state);
     }
     if (message.grandChildren?.length) {
-      obj.grandChildren = message.grandChildren.map((e) => e ? Child.toJSON(e) : undefined);
+      obj.grandChildren = message.grandChildren.map((e) => Child.toJSON(e));
     }
     if (message.coins?.length) {
       obj.coins = message.coins.map((e) => Math.round(e));
@@ -445,7 +445,7 @@ export const Simple = {
       obj.oldStates = message.oldStates.map((e) => stateEnumToJSON(e));
     }
     if (message.thing !== undefined) {
-      obj.thing = message.thing ? ImportedThing.toJSON(message.thing) : undefined;
+      obj.thing = ImportedThing.toJSON(message.thing);
     }
     return obj;
   },
@@ -616,7 +616,7 @@ export const Nested = {
       obj.name = message.name;
     }
     if (message.message !== undefined) {
-      obj.message = message.message ? Nested_InnerMessage.toJSON(message.message) : undefined;
+      obj.message = Nested_InnerMessage.toJSON(message.message);
     }
     if (message.state !== 0) {
       obj.state = nested_InnerEnumToJSON(message.state);
@@ -697,7 +697,7 @@ export const Nested_InnerMessage = {
       obj.name = message.name;
     }
     if (message.deep !== undefined) {
-      obj.deep = message.deep ? Nested_InnerMessage_DeepMessage.toJSON(message.deep) : undefined;
+      obj.deep = Nested_InnerMessage_DeepMessage.toJSON(message.deep);
     }
     return obj;
   },
@@ -1243,7 +1243,7 @@ export const SimpleWithMap_EntitiesByIdEntry = {
       obj.key = Math.round(message.key);
     }
     if (message.value !== undefined) {
-      obj.value = message.value ? Entity.toJSON(message.value) : undefined;
+      obj.value = Entity.toJSON(message.value);
     }
     return obj;
   },
@@ -1550,7 +1550,7 @@ export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
       obj.key = Math.round(message.key);
     }
     if (message.value !== undefined) {
-      obj.value = message.value ? Entity.toJSON(message.value) : undefined;
+      obj.value = Entity.toJSON(message.value);
     }
     return obj;
   },

--- a/integration/simple-optionals/thing.ts
+++ b/integration/simple-optionals/thing.ts
@@ -49,7 +49,9 @@ export const ImportedThing = {
 
   toJSON(message: ImportedThing): unknown {
     const obj: any = {};
-    message.createdAt !== undefined && (obj.createdAt = message.createdAt.toISOString());
+    if (message.createdAt !== undefined) {
+      obj.createdAt = message.createdAt.toISOString();
+    }
     return obj;
   },
 

--- a/integration/simple-proto2/simple.ts
+++ b/integration/simple-proto2/simple.ts
@@ -81,7 +81,9 @@ export const Issue56 = {
 
   toJSON(message: Issue56): unknown {
     const obj: any = {};
-    message.test !== undefined && (obj.test = enumWithoutZeroToJSON(message.test));
+    if (message.test !== 1) {
+      obj.test = enumWithoutZeroToJSON(message.test);
+    }
     return obj;
   },
 

--- a/integration/simple-prototype-defaults/google/protobuf/timestamp.ts
+++ b/integration/simple-prototype-defaults/google/protobuf/timestamp.ts
@@ -165,8 +165,12 @@ export const Timestamp = {
 
   toJSON(message: Timestamp): unknown {
     const obj: any = {};
-    message.seconds !== undefined && (obj.seconds = Math.round(message.seconds));
-    message.nanos !== undefined && (obj.nanos = Math.round(message.nanos));
+    if (message.seconds !== 0) {
+      obj.seconds = Math.round(message.seconds);
+    }
+    if (message.nanos !== 0) {
+      obj.nanos = Math.round(message.nanos);
+    }
     return obj;
   },
 

--- a/integration/simple-prototype-defaults/google/protobuf/wrappers.ts
+++ b/integration/simple-prototype-defaults/google/protobuf/wrappers.ts
@@ -135,7 +135,9 @@ export const DoubleValue = {
 
   toJSON(message: DoubleValue): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = message.value);
+    if (message.value !== 0) {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -191,7 +193,9 @@ export const FloatValue = {
 
   toJSON(message: FloatValue): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = message.value);
+    if (message.value !== 0) {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -247,7 +251,9 @@ export const Int64Value = {
 
   toJSON(message: Int64Value): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = Math.round(message.value));
+    if (message.value !== 0) {
+      obj.value = Math.round(message.value);
+    }
     return obj;
   },
 
@@ -303,7 +309,9 @@ export const UInt64Value = {
 
   toJSON(message: UInt64Value): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = Math.round(message.value));
+    if (message.value !== 0) {
+      obj.value = Math.round(message.value);
+    }
     return obj;
   },
 
@@ -359,7 +367,9 @@ export const Int32Value = {
 
   toJSON(message: Int32Value): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = Math.round(message.value));
+    if (message.value !== 0) {
+      obj.value = Math.round(message.value);
+    }
     return obj;
   },
 
@@ -415,7 +425,9 @@ export const UInt32Value = {
 
   toJSON(message: UInt32Value): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = Math.round(message.value));
+    if (message.value !== 0) {
+      obj.value = Math.round(message.value);
+    }
     return obj;
   },
 
@@ -471,7 +483,9 @@ export const BoolValue = {
 
   toJSON(message: BoolValue): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = message.value);
+    if (message.value === true) {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -527,7 +541,9 @@ export const StringValue = {
 
   toJSON(message: StringValue): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = message.value);
+    if (message.value !== "") {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -583,8 +599,9 @@ export const BytesValue = {
 
   toJSON(message: BytesValue): unknown {
     const obj: any = {};
-    message.value !== undefined &&
-      (obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array(0)));
+    if (message.value.length !== 0) {
+      obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array(0));
+    }
     return obj;
   },
 

--- a/integration/simple-prototype-defaults/google/protobuf/wrappers.ts
+++ b/integration/simple-prototype-defaults/google/protobuf/wrappers.ts
@@ -600,7 +600,7 @@ export const BytesValue = {
   toJSON(message: BytesValue): unknown {
     const obj: any = {};
     if (message.value.length !== 0) {
-      obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array(0));
+      obj.value = base64FromBytes(message.value);
     }
     return obj;
   },

--- a/integration/simple-prototype-defaults/google/type/date.ts
+++ b/integration/simple-prototype-defaults/google/type/date.ts
@@ -99,9 +99,15 @@ export const DateMessage = {
 
   toJSON(message: DateMessage): unknown {
     const obj: any = {};
-    message.year !== undefined && (obj.year = Math.round(message.year));
-    message.month !== undefined && (obj.month = Math.round(message.month));
-    message.day !== undefined && (obj.day = Math.round(message.day));
+    if (message.year !== 0) {
+      obj.year = Math.round(message.year);
+    }
+    if (message.month !== 0) {
+      obj.month = Math.round(message.month);
+    }
+    if (message.day !== 0) {
+      obj.day = Math.round(message.day);
+    }
     return obj;
   },
 

--- a/integration/simple-prototype-defaults/import_dir/thing.ts
+++ b/integration/simple-prototype-defaults/import_dir/thing.ts
@@ -49,7 +49,9 @@ export const ImportedThing = {
 
   toJSON(message: ImportedThing): unknown {
     const obj: any = {};
-    message.createdAt !== undefined && (obj.createdAt = message.createdAt.toISOString());
+    if (message.createdAt !== undefined) {
+      obj.createdAt = message.createdAt.toISOString();
+    }
     return obj;
   },
 

--- a/integration/simple-prototype-defaults/simple.ts
+++ b/integration/simple-prototype-defaults/simple.ts
@@ -515,41 +515,45 @@ export const Simple = {
 
   toJSON(message: Simple): unknown {
     const obj: any = {};
-    message.name !== undefined && (obj.name = message.name);
-    message.age !== undefined && (obj.age = Math.round(message.age));
-    message.createdAt !== undefined && (obj.createdAt = message.createdAt.toISOString());
-    message.child !== undefined && (obj.child = message.child ? Child.toJSON(message.child) : undefined);
-    message.state !== undefined && (obj.state = stateEnumToJSON(message.state));
-    if (message.grandChildren) {
+    if (message.name !== "") {
+      obj.name = message.name;
+    }
+    if (message.age !== 0) {
+      obj.age = Math.round(message.age);
+    }
+    if (message.createdAt !== undefined) {
+      obj.createdAt = message.createdAt.toISOString();
+    }
+    if (message.child !== undefined) {
+      obj.child = message.child ? Child.toJSON(message.child) : undefined;
+    }
+    if (message.state !== 0) {
+      obj.state = stateEnumToJSON(message.state);
+    }
+    if (message.grandChildren?.length) {
       obj.grandChildren = message.grandChildren.map((e) => e ? Child.toJSON(e) : undefined);
-    } else {
-      obj.grandChildren = [];
     }
-    if (message.coins) {
+    if (message.coins?.length) {
       obj.coins = message.coins.map((e) => Math.round(e));
-    } else {
-      obj.coins = [];
     }
-    if (message.snacks) {
+    if (message.snacks?.length) {
       obj.snacks = message.snacks.map((e) => e);
-    } else {
-      obj.snacks = [];
     }
-    if (message.oldStates) {
+    if (message.oldStates?.length) {
       obj.oldStates = message.oldStates.map((e) => stateEnumToJSON(e));
-    } else {
-      obj.oldStates = [];
     }
-    message.thing !== undefined && (obj.thing = message.thing ? ImportedThing.toJSON(message.thing) : undefined);
-    if (message.blobs) {
+    if (message.thing !== undefined) {
+      obj.thing = message.thing ? ImportedThing.toJSON(message.thing) : undefined;
+    }
+    if (message.blobs?.length) {
       obj.blobs = message.blobs.map((e) => base64FromBytes(e !== undefined ? e : new Uint8Array(0)));
-    } else {
-      obj.blobs = [];
     }
-    message.birthday !== undefined &&
-      (obj.birthday = message.birthday ? DateMessage.toJSON(message.birthday) : undefined);
-    message.blob !== undefined &&
-      (obj.blob = base64FromBytes(message.blob !== undefined ? message.blob : new Uint8Array(0)));
+    if (message.birthday !== undefined) {
+      obj.birthday = message.birthday ? DateMessage.toJSON(message.birthday) : undefined;
+    }
+    if (message.blob.length !== 0) {
+      obj.blob = base64FromBytes(message.blob !== undefined ? message.blob : new Uint8Array(0));
+    }
     return obj;
   },
 
@@ -634,8 +638,12 @@ export const Child = {
 
   toJSON(message: Child): unknown {
     const obj: any = {};
-    message.name !== undefined && (obj.name = message.name);
-    message.type !== undefined && (obj.type = child_TypeToJSON(message.type));
+    if (message.name !== "") {
+      obj.name = message.name;
+    }
+    if (message.type !== 0) {
+      obj.type = child_TypeToJSON(message.type);
+    }
     return obj;
   },
 
@@ -716,10 +724,15 @@ export const Nested = {
 
   toJSON(message: Nested): unknown {
     const obj: any = {};
-    message.name !== undefined && (obj.name = message.name);
-    message.message !== undefined &&
-      (obj.message = message.message ? Nested_InnerMessage.toJSON(message.message) : undefined);
-    message.state !== undefined && (obj.state = nested_InnerEnumToJSON(message.state));
+    if (message.name !== "") {
+      obj.name = message.name;
+    }
+    if (message.message !== undefined) {
+      obj.message = message.message ? Nested_InnerMessage.toJSON(message.message) : undefined;
+    }
+    if (message.state !== 0) {
+      obj.state = nested_InnerEnumToJSON(message.state);
+    }
     return obj;
   },
 
@@ -792,9 +805,12 @@ export const Nested_InnerMessage = {
 
   toJSON(message: Nested_InnerMessage): unknown {
     const obj: any = {};
-    message.name !== undefined && (obj.name = message.name);
-    message.deep !== undefined &&
-      (obj.deep = message.deep ? Nested_InnerMessage_DeepMessage.toJSON(message.deep) : undefined);
+    if (message.name !== "") {
+      obj.name = message.name;
+    }
+    if (message.deep !== undefined) {
+      obj.deep = message.deep ? Nested_InnerMessage_DeepMessage.toJSON(message.deep) : undefined;
+    }
     return obj;
   },
 
@@ -853,7 +869,9 @@ export const Nested_InnerMessage_DeepMessage = {
 
   toJSON(message: Nested_InnerMessage_DeepMessage): unknown {
     const obj: any = {};
-    message.name !== undefined && (obj.name = message.name);
+    if (message.name !== "") {
+      obj.name = message.name;
+    }
     return obj;
   },
 
@@ -924,8 +942,12 @@ export const OneOfMessage = {
 
   toJSON(message: OneOfMessage): unknown {
     const obj: any = {};
-    message.first !== undefined && (obj.first = message.first);
-    message.last !== undefined && (obj.last = message.last);
+    if (message.first !== undefined) {
+      obj.first = message.first;
+    }
+    if (message.last !== undefined) {
+      obj.last = message.last;
+    }
     return obj;
   },
 
@@ -1039,20 +1061,24 @@ export const SimpleWithWrappers = {
 
   toJSON(message: SimpleWithWrappers): unknown {
     const obj: any = {};
-    message.name !== undefined && (obj.name = message.name);
-    message.age !== undefined && (obj.age = message.age);
-    message.enabled !== undefined && (obj.enabled = message.enabled);
-    if (message.coins) {
+    if (message.name !== undefined) {
+      obj.name = message.name;
+    }
+    if (message.age !== undefined) {
+      obj.age = message.age;
+    }
+    if (message.enabled !== undefined) {
+      obj.enabled = message.enabled;
+    }
+    if (message.coins?.length) {
       obj.coins = message.coins.map((e) => e);
-    } else {
-      obj.coins = [];
     }
-    if (message.snacks) {
+    if (message.snacks?.length) {
       obj.snacks = message.snacks.map((e) => e);
-    } else {
-      obj.snacks = [];
     }
-    message.id !== undefined && (obj.id = message.id);
+    if (message.id !== undefined) {
+      obj.id = message.id;
+    }
     return obj;
   },
 
@@ -1113,7 +1139,9 @@ export const Entity = {
 
   toJSON(message: Entity): unknown {
     const obj: any = {};
-    message.id !== undefined && (obj.id = Math.round(message.id));
+    if (message.id !== 0) {
+      obj.id = Math.round(message.id);
+    }
     return obj;
   },
 
@@ -1306,47 +1334,68 @@ export const SimpleWithMap = {
 
   toJSON(message: SimpleWithMap): unknown {
     const obj: any = {};
-    obj.entitiesById = {};
     if (message.entitiesById) {
-      Object.entries(message.entitiesById).forEach(([k, v]) => {
-        obj.entitiesById[k] = Entity.toJSON(v);
-      });
+      const entries = Object.entries(message.entitiesById);
+      if (entries.length > 0) {
+        obj.entitiesById = {};
+        entries.forEach(([k, v]) => {
+          obj.entitiesById[k] = Entity.toJSON(v);
+        });
+      }
     }
-    obj.nameLookup = {};
     if (message.nameLookup) {
-      Object.entries(message.nameLookup).forEach(([k, v]) => {
-        obj.nameLookup[k] = v;
-      });
+      const entries = Object.entries(message.nameLookup);
+      if (entries.length > 0) {
+        obj.nameLookup = {};
+        entries.forEach(([k, v]) => {
+          obj.nameLookup[k] = v;
+        });
+      }
     }
-    obj.intLookup = {};
     if (message.intLookup) {
-      Object.entries(message.intLookup).forEach(([k, v]) => {
-        obj.intLookup[k] = Math.round(v);
-      });
+      const entries = Object.entries(message.intLookup);
+      if (entries.length > 0) {
+        obj.intLookup = {};
+        entries.forEach(([k, v]) => {
+          obj.intLookup[k] = Math.round(v);
+        });
+      }
     }
-    obj.mapOfTimestamps = {};
     if (message.mapOfTimestamps) {
-      Object.entries(message.mapOfTimestamps).forEach(([k, v]) => {
-        obj.mapOfTimestamps[k] = v.toISOString();
-      });
+      const entries = Object.entries(message.mapOfTimestamps);
+      if (entries.length > 0) {
+        obj.mapOfTimestamps = {};
+        entries.forEach(([k, v]) => {
+          obj.mapOfTimestamps[k] = v.toISOString();
+        });
+      }
     }
-    obj.mapOfBytes = {};
     if (message.mapOfBytes) {
-      Object.entries(message.mapOfBytes).forEach(([k, v]) => {
-        obj.mapOfBytes[k] = base64FromBytes(v);
-      });
+      const entries = Object.entries(message.mapOfBytes);
+      if (entries.length > 0) {
+        obj.mapOfBytes = {};
+        entries.forEach(([k, v]) => {
+          obj.mapOfBytes[k] = base64FromBytes(v);
+        });
+      }
     }
-    obj.mapOfStringValues = {};
     if (message.mapOfStringValues) {
-      Object.entries(message.mapOfStringValues).forEach(([k, v]) => {
-        obj.mapOfStringValues[k] = v;
-      });
+      const entries = Object.entries(message.mapOfStringValues);
+      if (entries.length > 0) {
+        obj.mapOfStringValues = {};
+        entries.forEach(([k, v]) => {
+          obj.mapOfStringValues[k] = v;
+        });
+      }
     }
-    obj.longLookup = {};
     if (message.longLookup) {
-      Object.entries(message.longLookup).forEach(([k, v]) => {
-        obj.longLookup[k] = Math.round(v);
-      });
+      const entries = Object.entries(message.longLookup);
+      if (entries.length > 0) {
+        obj.longLookup = {};
+        entries.forEach(([k, v]) => {
+          obj.longLookup[k] = Math.round(v);
+        });
+      }
     }
     return obj;
   },
@@ -1477,8 +1526,12 @@ export const SimpleWithMap_EntitiesByIdEntry = {
 
   toJSON(message: SimpleWithMap_EntitiesByIdEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = Math.round(message.key));
-    message.value !== undefined && (obj.value = message.value ? Entity.toJSON(message.value) : undefined);
+    if (message.key !== 0) {
+      obj.key = Math.round(message.key);
+    }
+    if (message.value !== undefined) {
+      obj.value = message.value ? Entity.toJSON(message.value) : undefined;
+    }
     return obj;
   },
 
@@ -1549,8 +1602,12 @@ export const SimpleWithMap_NameLookupEntry = {
 
   toJSON(message: SimpleWithMap_NameLookupEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = message.key);
-    message.value !== undefined && (obj.value = message.value);
+    if (message.key !== "") {
+      obj.key = message.key;
+    }
+    if (message.value !== "") {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -1619,8 +1676,12 @@ export const SimpleWithMap_IntLookupEntry = {
 
   toJSON(message: SimpleWithMap_IntLookupEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = Math.round(message.key));
-    message.value !== undefined && (obj.value = Math.round(message.value));
+    if (message.key !== 0) {
+      obj.key = Math.round(message.key);
+    }
+    if (message.value !== 0) {
+      obj.value = Math.round(message.value);
+    }
     return obj;
   },
 
@@ -1690,8 +1751,12 @@ export const SimpleWithMap_MapOfTimestampsEntry = {
 
   toJSON(message: SimpleWithMap_MapOfTimestampsEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = message.key);
-    message.value !== undefined && (obj.value = message.value.toISOString());
+    if (message.key !== "") {
+      obj.key = message.key;
+    }
+    if (message.value !== undefined) {
+      obj.value = message.value.toISOString();
+    }
     return obj;
   },
 
@@ -1765,9 +1830,12 @@ export const SimpleWithMap_MapOfBytesEntry = {
 
   toJSON(message: SimpleWithMap_MapOfBytesEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = message.key);
-    message.value !== undefined &&
-      (obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array(0)));
+    if (message.key !== "") {
+      obj.key = message.key;
+    }
+    if (message.value.length !== 0) {
+      obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array(0));
+    }
     return obj;
   },
 
@@ -1841,8 +1909,12 @@ export const SimpleWithMap_MapOfStringValuesEntry = {
 
   toJSON(message: SimpleWithMap_MapOfStringValuesEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = message.key);
-    message.value !== undefined && (obj.value = message.value);
+    if (message.key !== "") {
+      obj.key = message.key;
+    }
+    if (message.value !== undefined) {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -1915,8 +1987,12 @@ export const SimpleWithMap_LongLookupEntry = {
 
   toJSON(message: SimpleWithMap_LongLookupEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = Math.round(message.key));
-    message.value !== undefined && (obj.value = Math.round(message.value));
+    if (message.key !== 0) {
+      obj.key = Math.round(message.key);
+    }
+    if (message.value !== 0) {
+      obj.value = Math.round(message.value);
+    }
     return obj;
   },
 
@@ -1985,11 +2061,14 @@ export const SimpleWithSnakeCaseMap = {
 
   toJSON(message: SimpleWithSnakeCaseMap): unknown {
     const obj: any = {};
-    obj.entitiesById = {};
     if (message.entitiesById) {
-      Object.entries(message.entitiesById).forEach(([k, v]) => {
-        obj.entitiesById[k] = Entity.toJSON(v);
-      });
+      const entries = Object.entries(message.entitiesById);
+      if (entries.length > 0) {
+        obj.entitiesById = {};
+        entries.forEach(([k, v]) => {
+          obj.entitiesById[k] = Entity.toJSON(v);
+        });
+      }
     }
     return obj;
   },
@@ -2069,8 +2148,12 @@ export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
 
   toJSON(message: SimpleWithSnakeCaseMap_EntitiesByIdEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = Math.round(message.key));
-    message.value !== undefined && (obj.value = message.value ? Entity.toJSON(message.value) : undefined);
+    if (message.key !== 0) {
+      obj.key = Math.round(message.key);
+    }
+    if (message.value !== undefined) {
+      obj.value = message.value ? Entity.toJSON(message.value) : undefined;
+    }
     return obj;
   },
 
@@ -2145,11 +2228,14 @@ export const SimpleWithMapOfEnums = {
 
   toJSON(message: SimpleWithMapOfEnums): unknown {
     const obj: any = {};
-    obj.enumsById = {};
     if (message.enumsById) {
-      Object.entries(message.enumsById).forEach(([k, v]) => {
-        obj.enumsById[k] = stateEnumToJSON(v);
-      });
+      const entries = Object.entries(message.enumsById);
+      if (entries.length > 0) {
+        obj.enumsById = {};
+        entries.forEach(([k, v]) => {
+          obj.enumsById[k] = stateEnumToJSON(v);
+        });
+      }
     }
     return obj;
   },
@@ -2229,8 +2315,12 @@ export const SimpleWithMapOfEnums_EnumsByIdEntry = {
 
   toJSON(message: SimpleWithMapOfEnums_EnumsByIdEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = Math.round(message.key));
-    message.value !== undefined && (obj.value = stateEnumToJSON(message.value));
+    if (message.key !== 0) {
+      obj.key = Math.round(message.key);
+    }
+    if (message.value !== 0) {
+      obj.value = stateEnumToJSON(message.value);
+    }
     return obj;
   },
 
@@ -2293,7 +2383,9 @@ export const PingRequest = {
 
   toJSON(message: PingRequest): unknown {
     const obj: any = {};
-    message.input !== undefined && (obj.input = message.input);
+    if (message.input !== "") {
+      obj.input = message.input;
+    }
     return obj;
   },
 
@@ -2349,7 +2441,9 @@ export const PingResponse = {
 
   toJSON(message: PingResponse): unknown {
     const obj: any = {};
-    message.output !== undefined && (obj.output = message.output);
+    if (message.output !== "") {
+      obj.output = message.output;
+    }
     return obj;
   },
 
@@ -2541,18 +2635,42 @@ export const Numbers = {
 
   toJSON(message: Numbers): unknown {
     const obj: any = {};
-    message.double !== undefined && (obj.double = message.double);
-    message.float !== undefined && (obj.float = message.float);
-    message.int32 !== undefined && (obj.int32 = Math.round(message.int32));
-    message.int64 !== undefined && (obj.int64 = Math.round(message.int64));
-    message.uint32 !== undefined && (obj.uint32 = Math.round(message.uint32));
-    message.uint64 !== undefined && (obj.uint64 = Math.round(message.uint64));
-    message.sint32 !== undefined && (obj.sint32 = Math.round(message.sint32));
-    message.sint64 !== undefined && (obj.sint64 = Math.round(message.sint64));
-    message.fixed32 !== undefined && (obj.fixed32 = Math.round(message.fixed32));
-    message.fixed64 !== undefined && (obj.fixed64 = Math.round(message.fixed64));
-    message.sfixed32 !== undefined && (obj.sfixed32 = Math.round(message.sfixed32));
-    message.sfixed64 !== undefined && (obj.sfixed64 = Math.round(message.sfixed64));
+    if (message.double !== 0) {
+      obj.double = message.double;
+    }
+    if (message.float !== 0) {
+      obj.float = message.float;
+    }
+    if (message.int32 !== 0) {
+      obj.int32 = Math.round(message.int32);
+    }
+    if (message.int64 !== 0) {
+      obj.int64 = Math.round(message.int64);
+    }
+    if (message.uint32 !== 0) {
+      obj.uint32 = Math.round(message.uint32);
+    }
+    if (message.uint64 !== 0) {
+      obj.uint64 = Math.round(message.uint64);
+    }
+    if (message.sint32 !== 0) {
+      obj.sint32 = Math.round(message.sint32);
+    }
+    if (message.sint64 !== 0) {
+      obj.sint64 = Math.round(message.sint64);
+    }
+    if (message.fixed32 !== 0) {
+      obj.fixed32 = Math.round(message.fixed32);
+    }
+    if (message.fixed64 !== 0) {
+      obj.fixed64 = Math.round(message.fixed64);
+    }
+    if (message.sfixed32 !== 0) {
+      obj.sfixed32 = Math.round(message.sfixed32);
+    }
+    if (message.sfixed64 !== 0) {
+      obj.sfixed64 = Math.round(message.sfixed64);
+    }
     return obj;
   },
 
@@ -2695,15 +2813,27 @@ export const SimpleButOptional = {
 
   toJSON(message: SimpleButOptional): unknown {
     const obj: any = {};
-    message.name !== undefined && (obj.name = message.name);
-    message.age !== undefined && (obj.age = Math.round(message.age));
-    message.createdAt !== undefined && (obj.createdAt = message.createdAt.toISOString());
-    message.child !== undefined && (obj.child = message.child ? Child.toJSON(message.child) : undefined);
-    message.state !== undefined &&
-      (obj.state = message.state !== undefined ? stateEnumToJSON(message.state) : undefined);
-    message.thing !== undefined && (obj.thing = message.thing ? ImportedThing.toJSON(message.thing) : undefined);
-    message.birthday !== undefined &&
-      (obj.birthday = message.birthday ? DateMessage.toJSON(message.birthday) : undefined);
+    if (message.name !== undefined) {
+      obj.name = message.name;
+    }
+    if (message.age !== undefined) {
+      obj.age = Math.round(message.age);
+    }
+    if (message.createdAt !== undefined) {
+      obj.createdAt = message.createdAt.toISOString();
+    }
+    if (message.child !== undefined) {
+      obj.child = message.child ? Child.toJSON(message.child) : undefined;
+    }
+    if (message.state !== undefined) {
+      obj.state = message.state !== undefined ? stateEnumToJSON(message.state) : undefined;
+    }
+    if (message.thing !== undefined) {
+      obj.thing = message.thing ? ImportedThing.toJSON(message.thing) : undefined;
+    }
+    if (message.birthday !== undefined) {
+      obj.birthday = message.birthday ? DateMessage.toJSON(message.birthday) : undefined;
+    }
     return obj;
   },
 

--- a/integration/simple-prototype-defaults/simple.ts
+++ b/integration/simple-prototype-defaults/simple.ts
@@ -537,7 +537,7 @@ export const Simple = {
       obj.coins = message.coins.map((e) => Math.round(e));
     }
     if (message.snacks?.length) {
-      obj.snacks = message.snacks.map((e) => e);
+      obj.snacks = message.snacks;
     }
     if (message.oldStates?.length) {
       obj.oldStates = message.oldStates.map((e) => stateEnumToJSON(e));
@@ -1071,10 +1071,10 @@ export const SimpleWithWrappers = {
       obj.enabled = message.enabled;
     }
     if (message.coins?.length) {
-      obj.coins = message.coins.map((e) => e);
+      obj.coins = message.coins;
     }
     if (message.snacks?.length) {
-      obj.snacks = message.snacks.map((e) => e);
+      obj.snacks = message.snacks;
     }
     if (message.id !== undefined) {
       obj.id = message.id;

--- a/integration/simple-prototype-defaults/simple.ts
+++ b/integration/simple-prototype-defaults/simple.ts
@@ -525,13 +525,13 @@ export const Simple = {
       obj.createdAt = message.createdAt.toISOString();
     }
     if (message.child !== undefined) {
-      obj.child = message.child ? Child.toJSON(message.child) : undefined;
+      obj.child = Child.toJSON(message.child);
     }
     if (message.state !== 0) {
       obj.state = stateEnumToJSON(message.state);
     }
     if (message.grandChildren?.length) {
-      obj.grandChildren = message.grandChildren.map((e) => e ? Child.toJSON(e) : undefined);
+      obj.grandChildren = message.grandChildren.map((e) => Child.toJSON(e));
     }
     if (message.coins?.length) {
       obj.coins = message.coins.map((e) => Math.round(e));
@@ -543,16 +543,16 @@ export const Simple = {
       obj.oldStates = message.oldStates.map((e) => stateEnumToJSON(e));
     }
     if (message.thing !== undefined) {
-      obj.thing = message.thing ? ImportedThing.toJSON(message.thing) : undefined;
+      obj.thing = ImportedThing.toJSON(message.thing);
     }
     if (message.blobs?.length) {
-      obj.blobs = message.blobs.map((e) => base64FromBytes(e !== undefined ? e : new Uint8Array(0)));
+      obj.blobs = message.blobs.map((e) => base64FromBytes(e));
     }
     if (message.birthday !== undefined) {
-      obj.birthday = message.birthday ? DateMessage.toJSON(message.birthday) : undefined;
+      obj.birthday = DateMessage.toJSON(message.birthday);
     }
     if (message.blob.length !== 0) {
-      obj.blob = base64FromBytes(message.blob !== undefined ? message.blob : new Uint8Array(0));
+      obj.blob = base64FromBytes(message.blob);
     }
     return obj;
   },
@@ -728,7 +728,7 @@ export const Nested = {
       obj.name = message.name;
     }
     if (message.message !== undefined) {
-      obj.message = message.message ? Nested_InnerMessage.toJSON(message.message) : undefined;
+      obj.message = Nested_InnerMessage.toJSON(message.message);
     }
     if (message.state !== 0) {
       obj.state = nested_InnerEnumToJSON(message.state);
@@ -809,7 +809,7 @@ export const Nested_InnerMessage = {
       obj.name = message.name;
     }
     if (message.deep !== undefined) {
-      obj.deep = message.deep ? Nested_InnerMessage_DeepMessage.toJSON(message.deep) : undefined;
+      obj.deep = Nested_InnerMessage_DeepMessage.toJSON(message.deep);
     }
     return obj;
   },
@@ -1530,7 +1530,7 @@ export const SimpleWithMap_EntitiesByIdEntry = {
       obj.key = Math.round(message.key);
     }
     if (message.value !== undefined) {
-      obj.value = message.value ? Entity.toJSON(message.value) : undefined;
+      obj.value = Entity.toJSON(message.value);
     }
     return obj;
   },
@@ -1834,7 +1834,7 @@ export const SimpleWithMap_MapOfBytesEntry = {
       obj.key = message.key;
     }
     if (message.value.length !== 0) {
-      obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array(0));
+      obj.value = base64FromBytes(message.value);
     }
     return obj;
   },
@@ -2152,7 +2152,7 @@ export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
       obj.key = Math.round(message.key);
     }
     if (message.value !== undefined) {
-      obj.value = message.value ? Entity.toJSON(message.value) : undefined;
+      obj.value = Entity.toJSON(message.value);
     }
     return obj;
   },
@@ -2823,16 +2823,16 @@ export const SimpleButOptional = {
       obj.createdAt = message.createdAt.toISOString();
     }
     if (message.child !== undefined) {
-      obj.child = message.child ? Child.toJSON(message.child) : undefined;
+      obj.child = Child.toJSON(message.child);
     }
     if (message.state !== undefined) {
-      obj.state = message.state !== undefined ? stateEnumToJSON(message.state) : undefined;
+      obj.state = stateEnumToJSON(message.state);
     }
     if (message.thing !== undefined) {
-      obj.thing = message.thing ? ImportedThing.toJSON(message.thing) : undefined;
+      obj.thing = ImportedThing.toJSON(message.thing);
     }
     if (message.birthday !== undefined) {
-      obj.birthday = message.birthday ? DateMessage.toJSON(message.birthday) : undefined;
+      obj.birthday = DateMessage.toJSON(message.birthday);
     }
     return obj;
   },

--- a/integration/simple-snake/google/protobuf/struct.ts
+++ b/integration/simple-snake/google/protobuf/struct.ts
@@ -382,7 +382,7 @@ export const Value = {
   toJSON(message: Value): unknown {
     const obj: any = {};
     if (message.null_value !== undefined) {
-      obj.null_value = message.null_value !== undefined ? nullValueToJSON(message.null_value) : undefined;
+      obj.null_value = nullValueToJSON(message.null_value);
     }
     if (message.number_value !== undefined) {
       obj.number_value = message.number_value;

--- a/integration/simple-snake/google/protobuf/struct.ts
+++ b/integration/simple-snake/google/protobuf/struct.ts
@@ -153,11 +153,14 @@ export const Struct = {
 
   toJSON(message: Struct): unknown {
     const obj: any = {};
-    obj.fields = {};
     if (message.fields) {
-      Object.entries(message.fields).forEach(([k, v]) => {
-        obj.fields[k] = v;
-      });
+      const entries = Object.entries(message.fields);
+      if (entries.length > 0) {
+        obj.fields = {};
+        entries.forEach(([k, v]) => {
+          obj.fields[k] = v;
+        });
+      }
     }
     return obj;
   },
@@ -252,8 +255,12 @@ export const Struct_FieldsEntry = {
 
   toJSON(message: Struct_FieldsEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = message.key);
-    message.value !== undefined && (obj.value = message.value);
+    if (message.key !== "") {
+      obj.key = message.key;
+    }
+    if (message.value !== undefined) {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -374,13 +381,24 @@ export const Value = {
 
   toJSON(message: Value): unknown {
     const obj: any = {};
-    message.null_value !== undefined &&
-      (obj.null_value = message.null_value !== undefined ? nullValueToJSON(message.null_value) : undefined);
-    message.number_value !== undefined && (obj.number_value = message.number_value);
-    message.string_value !== undefined && (obj.string_value = message.string_value);
-    message.bool_value !== undefined && (obj.bool_value = message.bool_value);
-    message.struct_value !== undefined && (obj.struct_value = message.struct_value);
-    message.list_value !== undefined && (obj.list_value = message.list_value);
+    if (message.null_value !== undefined) {
+      obj.null_value = message.null_value !== undefined ? nullValueToJSON(message.null_value) : undefined;
+    }
+    if (message.number_value !== undefined) {
+      obj.number_value = message.number_value;
+    }
+    if (message.string_value !== undefined) {
+      obj.string_value = message.string_value;
+    }
+    if (message.bool_value !== undefined) {
+      obj.bool_value = message.bool_value;
+    }
+    if (message.struct_value !== undefined) {
+      obj.struct_value = message.struct_value;
+    }
+    if (message.list_value !== undefined) {
+      obj.list_value = message.list_value;
+    }
     return obj;
   },
 
@@ -478,10 +496,8 @@ export const ListValue = {
 
   toJSON(message: ListValue): unknown {
     const obj: any = {};
-    if (message.values) {
+    if (message.values?.length) {
       obj.values = message.values.map((e) => e);
-    } else {
-      obj.values = [];
     }
     return obj;
   },

--- a/integration/simple-snake/google/protobuf/struct.ts
+++ b/integration/simple-snake/google/protobuf/struct.ts
@@ -497,7 +497,7 @@ export const ListValue = {
   toJSON(message: ListValue): unknown {
     const obj: any = {};
     if (message.values?.length) {
-      obj.values = message.values.map((e) => e);
+      obj.values = message.values;
     }
     return obj;
   },

--- a/integration/simple-snake/google/protobuf/timestamp.ts
+++ b/integration/simple-snake/google/protobuf/timestamp.ts
@@ -165,8 +165,12 @@ export const Timestamp = {
 
   toJSON(message: Timestamp): unknown {
     const obj: any = {};
-    message.seconds !== undefined && (obj.seconds = Math.round(message.seconds));
-    message.nanos !== undefined && (obj.nanos = Math.round(message.nanos));
+    if (message.seconds !== 0) {
+      obj.seconds = Math.round(message.seconds);
+    }
+    if (message.nanos !== 0) {
+      obj.nanos = Math.round(message.nanos);
+    }
     return obj;
   },
 

--- a/integration/simple-snake/google/protobuf/wrappers.ts
+++ b/integration/simple-snake/google/protobuf/wrappers.ts
@@ -135,7 +135,9 @@ export const DoubleValue = {
 
   toJSON(message: DoubleValue): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = message.value);
+    if (message.value !== 0) {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -191,7 +193,9 @@ export const FloatValue = {
 
   toJSON(message: FloatValue): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = message.value);
+    if (message.value !== 0) {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -247,7 +251,9 @@ export const Int64Value = {
 
   toJSON(message: Int64Value): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = Math.round(message.value));
+    if (message.value !== 0) {
+      obj.value = Math.round(message.value);
+    }
     return obj;
   },
 
@@ -303,7 +309,9 @@ export const UInt64Value = {
 
   toJSON(message: UInt64Value): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = Math.round(message.value));
+    if (message.value !== 0) {
+      obj.value = Math.round(message.value);
+    }
     return obj;
   },
 
@@ -359,7 +367,9 @@ export const Int32Value = {
 
   toJSON(message: Int32Value): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = Math.round(message.value));
+    if (message.value !== 0) {
+      obj.value = Math.round(message.value);
+    }
     return obj;
   },
 
@@ -415,7 +425,9 @@ export const UInt32Value = {
 
   toJSON(message: UInt32Value): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = Math.round(message.value));
+    if (message.value !== 0) {
+      obj.value = Math.round(message.value);
+    }
     return obj;
   },
 
@@ -471,7 +483,9 @@ export const BoolValue = {
 
   toJSON(message: BoolValue): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = message.value);
+    if (message.value === true) {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -527,7 +541,9 @@ export const StringValue = {
 
   toJSON(message: StringValue): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = message.value);
+    if (message.value !== "") {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -583,8 +599,9 @@ export const BytesValue = {
 
   toJSON(message: BytesValue): unknown {
     const obj: any = {};
-    message.value !== undefined &&
-      (obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array(0)));
+    if (message.value.length !== 0) {
+      obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array(0));
+    }
     return obj;
   },
 

--- a/integration/simple-snake/google/protobuf/wrappers.ts
+++ b/integration/simple-snake/google/protobuf/wrappers.ts
@@ -600,7 +600,7 @@ export const BytesValue = {
   toJSON(message: BytesValue): unknown {
     const obj: any = {};
     if (message.value.length !== 0) {
-      obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array(0));
+      obj.value = base64FromBytes(message.value);
     }
     return obj;
   },

--- a/integration/simple-snake/import_dir/thing.ts
+++ b/integration/simple-snake/import_dir/thing.ts
@@ -49,7 +49,9 @@ export const ImportedThing = {
 
   toJSON(message: ImportedThing): unknown {
     const obj: any = {};
-    message.created_at !== undefined && (obj.created_at = message.created_at.toISOString());
+    if (message.created_at !== undefined) {
+      obj.created_at = message.created_at.toISOString();
+    }
     return obj;
   },
 

--- a/integration/simple-snake/simple.ts
+++ b/integration/simple-snake/simple.ts
@@ -422,32 +422,36 @@ export const Simple = {
 
   toJSON(message: Simple): unknown {
     const obj: any = {};
-    message.name !== undefined && (obj.name = message.name);
-    message.age !== undefined && (obj.age = Math.round(message.age));
-    message.created_at !== undefined && (obj.created_at = message.created_at.toISOString());
-    message.child !== undefined && (obj.child = message.child ? Child.toJSON(message.child) : undefined);
-    message.state !== undefined && (obj.state = stateEnumToJSON(message.state));
-    if (message.grand_children) {
+    if (message.name !== "") {
+      obj.name = message.name;
+    }
+    if (message.age !== 0) {
+      obj.age = Math.round(message.age);
+    }
+    if (message.created_at !== undefined) {
+      obj.created_at = message.created_at.toISOString();
+    }
+    if (message.child !== undefined) {
+      obj.child = message.child ? Child.toJSON(message.child) : undefined;
+    }
+    if (message.state !== 0) {
+      obj.state = stateEnumToJSON(message.state);
+    }
+    if (message.grand_children?.length) {
       obj.grand_children = message.grand_children.map((e) => e ? Child.toJSON(e) : undefined);
-    } else {
-      obj.grand_children = [];
     }
-    if (message.coins) {
+    if (message.coins?.length) {
       obj.coins = message.coins.map((e) => Math.round(e));
-    } else {
-      obj.coins = [];
     }
-    if (message.snacks) {
+    if (message.snacks?.length) {
       obj.snacks = message.snacks.map((e) => e);
-    } else {
-      obj.snacks = [];
     }
-    if (message.old_states) {
+    if (message.old_states?.length) {
       obj.old_states = message.old_states.map((e) => stateEnumToJSON(e));
-    } else {
-      obj.old_states = [];
     }
-    message.thing !== undefined && (obj.thing = message.thing ? ImportedThing.toJSON(message.thing) : undefined);
+    if (message.thing !== undefined) {
+      obj.thing = message.thing ? ImportedThing.toJSON(message.thing) : undefined;
+    }
     return obj;
   },
 
@@ -527,8 +531,12 @@ export const Child = {
 
   toJSON(message: Child): unknown {
     const obj: any = {};
-    message.name !== undefined && (obj.name = message.name);
-    message.type !== undefined && (obj.type = child_TypeToJSON(message.type));
+    if (message.name !== "") {
+      obj.name = message.name;
+    }
+    if (message.type !== 0) {
+      obj.type = child_TypeToJSON(message.type);
+    }
     return obj;
   },
 
@@ -609,10 +617,15 @@ export const Nested = {
 
   toJSON(message: Nested): unknown {
     const obj: any = {};
-    message.name !== undefined && (obj.name = message.name);
-    message.message !== undefined &&
-      (obj.message = message.message ? Nested_InnerMessage.toJSON(message.message) : undefined);
-    message.state !== undefined && (obj.state = nested_InnerEnumToJSON(message.state));
+    if (message.name !== "") {
+      obj.name = message.name;
+    }
+    if (message.message !== undefined) {
+      obj.message = message.message ? Nested_InnerMessage.toJSON(message.message) : undefined;
+    }
+    if (message.state !== 0) {
+      obj.state = nested_InnerEnumToJSON(message.state);
+    }
     return obj;
   },
 
@@ -685,9 +698,12 @@ export const Nested_InnerMessage = {
 
   toJSON(message: Nested_InnerMessage): unknown {
     const obj: any = {};
-    message.name !== undefined && (obj.name = message.name);
-    message.deep !== undefined &&
-      (obj.deep = message.deep ? Nested_InnerMessage_DeepMessage.toJSON(message.deep) : undefined);
+    if (message.name !== "") {
+      obj.name = message.name;
+    }
+    if (message.deep !== undefined) {
+      obj.deep = message.deep ? Nested_InnerMessage_DeepMessage.toJSON(message.deep) : undefined;
+    }
     return obj;
   },
 
@@ -746,7 +762,9 @@ export const Nested_InnerMessage_DeepMessage = {
 
   toJSON(message: Nested_InnerMessage_DeepMessage): unknown {
     const obj: any = {};
-    message.name !== undefined && (obj.name = message.name);
+    if (message.name !== "") {
+      obj.name = message.name;
+    }
     return obj;
   },
 
@@ -817,8 +835,12 @@ export const OneOfMessage = {
 
   toJSON(message: OneOfMessage): unknown {
     const obj: any = {};
-    message.first !== undefined && (obj.first = message.first);
-    message.last !== undefined && (obj.last = message.last);
+    if (message.first !== undefined) {
+      obj.first = message.first;
+    }
+    if (message.last !== undefined) {
+      obj.last = message.last;
+    }
     return obj;
   },
 
@@ -921,18 +943,20 @@ export const SimpleWithWrappers = {
 
   toJSON(message: SimpleWithWrappers): unknown {
     const obj: any = {};
-    message.name !== undefined && (obj.name = message.name);
-    message.age !== undefined && (obj.age = message.age);
-    message.enabled !== undefined && (obj.enabled = message.enabled);
-    if (message.coins) {
-      obj.coins = message.coins.map((e) => e);
-    } else {
-      obj.coins = [];
+    if (message.name !== undefined) {
+      obj.name = message.name;
     }
-    if (message.snacks) {
+    if (message.age !== undefined) {
+      obj.age = message.age;
+    }
+    if (message.enabled !== undefined) {
+      obj.enabled = message.enabled;
+    }
+    if (message.coins?.length) {
+      obj.coins = message.coins.map((e) => e);
+    }
+    if (message.snacks?.length) {
       obj.snacks = message.snacks.map((e) => e);
-    } else {
-      obj.snacks = [];
     }
     return obj;
   },
@@ -993,7 +1017,9 @@ export const Entity = {
 
   toJSON(message: Entity): unknown {
     const obj: any = {};
-    message.id !== undefined && (obj.id = Math.round(message.id));
+    if (message.id !== 0) {
+      obj.id = Math.round(message.id);
+    }
     return obj;
   },
 
@@ -1097,23 +1123,32 @@ export const SimpleWithMap = {
 
   toJSON(message: SimpleWithMap): unknown {
     const obj: any = {};
-    obj.entitiesById = {};
     if (message.entitiesById) {
-      Object.entries(message.entitiesById).forEach(([k, v]) => {
-        obj.entitiesById[k] = Entity.toJSON(v);
-      });
+      const entries = Object.entries(message.entitiesById);
+      if (entries.length > 0) {
+        obj.entitiesById = {};
+        entries.forEach(([k, v]) => {
+          obj.entitiesById[k] = Entity.toJSON(v);
+        });
+      }
     }
-    obj.nameLookup = {};
     if (message.nameLookup) {
-      Object.entries(message.nameLookup).forEach(([k, v]) => {
-        obj.nameLookup[k] = v;
-      });
+      const entries = Object.entries(message.nameLookup);
+      if (entries.length > 0) {
+        obj.nameLookup = {};
+        entries.forEach(([k, v]) => {
+          obj.nameLookup[k] = v;
+        });
+      }
     }
-    obj.intLookup = {};
     if (message.intLookup) {
-      Object.entries(message.intLookup).forEach(([k, v]) => {
-        obj.intLookup[k] = Math.round(v);
-      });
+      const entries = Object.entries(message.intLookup);
+      if (entries.length > 0) {
+        obj.intLookup = {};
+        entries.forEach(([k, v]) => {
+          obj.intLookup[k] = Math.round(v);
+        });
+      }
     }
     return obj;
   },
@@ -1209,8 +1244,12 @@ export const SimpleWithMap_EntitiesByIdEntry = {
 
   toJSON(message: SimpleWithMap_EntitiesByIdEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = Math.round(message.key));
-    message.value !== undefined && (obj.value = message.value ? Entity.toJSON(message.value) : undefined);
+    if (message.key !== 0) {
+      obj.key = Math.round(message.key);
+    }
+    if (message.value !== undefined) {
+      obj.value = message.value ? Entity.toJSON(message.value) : undefined;
+    }
     return obj;
   },
 
@@ -1281,8 +1320,12 @@ export const SimpleWithMap_NameLookupEntry = {
 
   toJSON(message: SimpleWithMap_NameLookupEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = message.key);
-    message.value !== undefined && (obj.value = message.value);
+    if (message.key !== "") {
+      obj.key = message.key;
+    }
+    if (message.value !== "") {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -1351,8 +1394,12 @@ export const SimpleWithMap_IntLookupEntry = {
 
   toJSON(message: SimpleWithMap_IntLookupEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = Math.round(message.key));
-    message.value !== undefined && (obj.value = Math.round(message.value));
+    if (message.key !== 0) {
+      obj.key = Math.round(message.key);
+    }
+    if (message.value !== 0) {
+      obj.value = Math.round(message.value);
+    }
     return obj;
   },
 
@@ -1419,11 +1466,14 @@ export const SimpleWithSnakeCaseMap = {
 
   toJSON(message: SimpleWithSnakeCaseMap): unknown {
     const obj: any = {};
-    obj.entities_by_id = {};
     if (message.entities_by_id) {
-      Object.entries(message.entities_by_id).forEach(([k, v]) => {
-        obj.entities_by_id[k] = Entity.toJSON(v);
-      });
+      const entries = Object.entries(message.entities_by_id);
+      if (entries.length > 0) {
+        obj.entities_by_id = {};
+        entries.forEach(([k, v]) => {
+          obj.entities_by_id[k] = Entity.toJSON(v);
+        });
+      }
     }
     return obj;
   },
@@ -1501,8 +1551,12 @@ export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
 
   toJSON(message: SimpleWithSnakeCaseMap_EntitiesByIdEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = Math.round(message.key));
-    message.value !== undefined && (obj.value = message.value ? Entity.toJSON(message.value) : undefined);
+    if (message.key !== 0) {
+      obj.key = Math.round(message.key);
+    }
+    if (message.value !== undefined) {
+      obj.value = message.value ? Entity.toJSON(message.value) : undefined;
+    }
     return obj;
   },
 
@@ -1565,7 +1619,9 @@ export const PingRequest = {
 
   toJSON(message: PingRequest): unknown {
     const obj: any = {};
-    message.input !== undefined && (obj.input = message.input);
+    if (message.input !== "") {
+      obj.input = message.input;
+    }
     return obj;
   },
 
@@ -1621,7 +1677,9 @@ export const PingResponse = {
 
   toJSON(message: PingResponse): unknown {
     const obj: any = {};
-    message.output !== undefined && (obj.output = message.output);
+    if (message.output !== "") {
+      obj.output = message.output;
+    }
     return obj;
   },
 
@@ -1813,18 +1871,42 @@ export const Numbers = {
 
   toJSON(message: Numbers): unknown {
     const obj: any = {};
-    message.double !== undefined && (obj.double = message.double);
-    message.float !== undefined && (obj.float = message.float);
-    message.int32 !== undefined && (obj.int32 = Math.round(message.int32));
-    message.int64 !== undefined && (obj.int64 = Math.round(message.int64));
-    message.uint32 !== undefined && (obj.uint32 = Math.round(message.uint32));
-    message.uint64 !== undefined && (obj.uint64 = Math.round(message.uint64));
-    message.sint32 !== undefined && (obj.sint32 = Math.round(message.sint32));
-    message.sint64 !== undefined && (obj.sint64 = Math.round(message.sint64));
-    message.fixed32 !== undefined && (obj.fixed32 = Math.round(message.fixed32));
-    message.fixed64 !== undefined && (obj.fixed64 = Math.round(message.fixed64));
-    message.sfixed32 !== undefined && (obj.sfixed32 = Math.round(message.sfixed32));
-    message.sfixed64 !== undefined && (obj.sfixed64 = Math.round(message.sfixed64));
+    if (message.double !== 0) {
+      obj.double = message.double;
+    }
+    if (message.float !== 0) {
+      obj.float = message.float;
+    }
+    if (message.int32 !== 0) {
+      obj.int32 = Math.round(message.int32);
+    }
+    if (message.int64 !== 0) {
+      obj.int64 = Math.round(message.int64);
+    }
+    if (message.uint32 !== 0) {
+      obj.uint32 = Math.round(message.uint32);
+    }
+    if (message.uint64 !== 0) {
+      obj.uint64 = Math.round(message.uint64);
+    }
+    if (message.sint32 !== 0) {
+      obj.sint32 = Math.round(message.sint32);
+    }
+    if (message.sint64 !== 0) {
+      obj.sint64 = Math.round(message.sint64);
+    }
+    if (message.fixed32 !== 0) {
+      obj.fixed32 = Math.round(message.fixed32);
+    }
+    if (message.fixed64 !== 0) {
+      obj.fixed64 = Math.round(message.fixed64);
+    }
+    if (message.sfixed32 !== 0) {
+      obj.sfixed32 = Math.round(message.sfixed32);
+    }
+    if (message.sfixed64 !== 0) {
+      obj.sfixed64 = Math.round(message.sfixed64);
+    }
     return obj;
   },
 
@@ -1891,7 +1973,9 @@ export const SimpleStruct = {
 
   toJSON(message: SimpleStruct): unknown {
     const obj: any = {};
-    message.simple_struct !== undefined && (obj.simple_struct = message.simple_struct);
+    if (message.simple_struct !== undefined) {
+      obj.simple_struct = message.simple_struct;
+    }
     return obj;
   },
 

--- a/integration/simple-snake/simple.ts
+++ b/integration/simple-snake/simple.ts
@@ -444,7 +444,7 @@ export const Simple = {
       obj.coins = message.coins.map((e) => Math.round(e));
     }
     if (message.snacks?.length) {
-      obj.snacks = message.snacks.map((e) => e);
+      obj.snacks = message.snacks;
     }
     if (message.old_states?.length) {
       obj.old_states = message.old_states.map((e) => stateEnumToJSON(e));
@@ -953,10 +953,10 @@ export const SimpleWithWrappers = {
       obj.enabled = message.enabled;
     }
     if (message.coins?.length) {
-      obj.coins = message.coins.map((e) => e);
+      obj.coins = message.coins;
     }
     if (message.snacks?.length) {
-      obj.snacks = message.snacks.map((e) => e);
+      obj.snacks = message.snacks;
     }
     return obj;
   },

--- a/integration/simple-snake/simple.ts
+++ b/integration/simple-snake/simple.ts
@@ -432,13 +432,13 @@ export const Simple = {
       obj.created_at = message.created_at.toISOString();
     }
     if (message.child !== undefined) {
-      obj.child = message.child ? Child.toJSON(message.child) : undefined;
+      obj.child = Child.toJSON(message.child);
     }
     if (message.state !== 0) {
       obj.state = stateEnumToJSON(message.state);
     }
     if (message.grand_children?.length) {
-      obj.grand_children = message.grand_children.map((e) => e ? Child.toJSON(e) : undefined);
+      obj.grand_children = message.grand_children.map((e) => Child.toJSON(e));
     }
     if (message.coins?.length) {
       obj.coins = message.coins.map((e) => Math.round(e));
@@ -450,7 +450,7 @@ export const Simple = {
       obj.old_states = message.old_states.map((e) => stateEnumToJSON(e));
     }
     if (message.thing !== undefined) {
-      obj.thing = message.thing ? ImportedThing.toJSON(message.thing) : undefined;
+      obj.thing = ImportedThing.toJSON(message.thing);
     }
     return obj;
   },
@@ -621,7 +621,7 @@ export const Nested = {
       obj.name = message.name;
     }
     if (message.message !== undefined) {
-      obj.message = message.message ? Nested_InnerMessage.toJSON(message.message) : undefined;
+      obj.message = Nested_InnerMessage.toJSON(message.message);
     }
     if (message.state !== 0) {
       obj.state = nested_InnerEnumToJSON(message.state);
@@ -702,7 +702,7 @@ export const Nested_InnerMessage = {
       obj.name = message.name;
     }
     if (message.deep !== undefined) {
-      obj.deep = message.deep ? Nested_InnerMessage_DeepMessage.toJSON(message.deep) : undefined;
+      obj.deep = Nested_InnerMessage_DeepMessage.toJSON(message.deep);
     }
     return obj;
   },
@@ -1248,7 +1248,7 @@ export const SimpleWithMap_EntitiesByIdEntry = {
       obj.key = Math.round(message.key);
     }
     if (message.value !== undefined) {
-      obj.value = message.value ? Entity.toJSON(message.value) : undefined;
+      obj.value = Entity.toJSON(message.value);
     }
     return obj;
   },
@@ -1555,7 +1555,7 @@ export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
       obj.key = Math.round(message.key);
     }
     if (message.value !== undefined) {
-      obj.value = message.value ? Entity.toJSON(message.value) : undefined;
+      obj.value = Entity.toJSON(message.value);
     }
     return obj;
   },

--- a/integration/simple-string-enums/google/protobuf/struct.ts
+++ b/integration/simple-string-enums/google/protobuf/struct.ts
@@ -507,7 +507,7 @@ export const ListValue = {
   toJSON(message: ListValue): unknown {
     const obj: any = {};
     if (message.values?.length) {
-      obj.values = message.values.map((e) => e);
+      obj.values = message.values;
     }
     return obj;
   },

--- a/integration/simple-string-enums/google/protobuf/struct.ts
+++ b/integration/simple-string-enums/google/protobuf/struct.ts
@@ -163,11 +163,14 @@ export const Struct = {
 
   toJSON(message: Struct): unknown {
     const obj: any = {};
-    obj.fields = {};
     if (message.fields) {
-      Object.entries(message.fields).forEach(([k, v]) => {
-        obj.fields[k] = v;
-      });
+      const entries = Object.entries(message.fields);
+      if (entries.length > 0) {
+        obj.fields = {};
+        entries.forEach(([k, v]) => {
+          obj.fields[k] = v;
+        });
+      }
     }
     return obj;
   },
@@ -262,8 +265,12 @@ export const Struct_FieldsEntry = {
 
   toJSON(message: Struct_FieldsEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = message.key);
-    message.value !== undefined && (obj.value = message.value);
+    if (message.key !== "") {
+      obj.key = message.key;
+    }
+    if (message.value !== undefined) {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -384,13 +391,24 @@ export const Value = {
 
   toJSON(message: Value): unknown {
     const obj: any = {};
-    message.nullValue !== undefined &&
-      (obj.nullValue = message.nullValue !== undefined ? nullValueToJSON(message.nullValue) : undefined);
-    message.numberValue !== undefined && (obj.numberValue = message.numberValue);
-    message.stringValue !== undefined && (obj.stringValue = message.stringValue);
-    message.boolValue !== undefined && (obj.boolValue = message.boolValue);
-    message.structValue !== undefined && (obj.structValue = message.structValue);
-    message.listValue !== undefined && (obj.listValue = message.listValue);
+    if (message.nullValue !== undefined) {
+      obj.nullValue = message.nullValue !== undefined ? nullValueToJSON(message.nullValue) : undefined;
+    }
+    if (message.numberValue !== undefined) {
+      obj.numberValue = message.numberValue;
+    }
+    if (message.stringValue !== undefined) {
+      obj.stringValue = message.stringValue;
+    }
+    if (message.boolValue !== undefined) {
+      obj.boolValue = message.boolValue;
+    }
+    if (message.structValue !== undefined) {
+      obj.structValue = message.structValue;
+    }
+    if (message.listValue !== undefined) {
+      obj.listValue = message.listValue;
+    }
     return obj;
   },
 
@@ -488,10 +506,8 @@ export const ListValue = {
 
   toJSON(message: ListValue): unknown {
     const obj: any = {};
-    if (message.values) {
+    if (message.values?.length) {
       obj.values = message.values.map((e) => e);
-    } else {
-      obj.values = [];
     }
     return obj;
   },

--- a/integration/simple-string-enums/google/protobuf/struct.ts
+++ b/integration/simple-string-enums/google/protobuf/struct.ts
@@ -392,7 +392,7 @@ export const Value = {
   toJSON(message: Value): unknown {
     const obj: any = {};
     if (message.nullValue !== undefined) {
-      obj.nullValue = message.nullValue !== undefined ? nullValueToJSON(message.nullValue) : undefined;
+      obj.nullValue = nullValueToJSON(message.nullValue);
     }
     if (message.numberValue !== undefined) {
       obj.numberValue = message.numberValue;

--- a/integration/simple-string-enums/simple.ts
+++ b/integration/simple-string-enums/simple.ts
@@ -177,19 +177,26 @@ export const Simple = {
 
   toJSON(message: Simple): unknown {
     const obj: any = {};
-    message.name !== undefined && (obj.name = message.name);
-    message.state !== undefined && (obj.state = stateEnumToJSON(message.state));
-    if (message.states) {
-      obj.states = message.states.map((e) => stateEnumToJSON(e));
-    } else {
-      obj.states = [];
+    if (message.name !== "") {
+      obj.name = message.name;
     }
-    message.nullValue !== undefined && (obj.nullValue = nullValueToJSON(message.nullValue));
-    obj.stateMap = {};
+    if (message.state !== StateEnum.UNKNOWN) {
+      obj.state = stateEnumToJSON(message.state);
+    }
+    if (message.states?.length) {
+      obj.states = message.states.map((e) => stateEnumToJSON(e));
+    }
+    if (message.nullValue !== NullValue.NULL_VALUE) {
+      obj.nullValue = nullValueToJSON(message.nullValue);
+    }
     if (message.stateMap) {
-      Object.entries(message.stateMap).forEach(([k, v]) => {
-        obj.stateMap[k] = stateEnumToJSON(v);
-      });
+      const entries = Object.entries(message.stateMap);
+      if (entries.length > 0) {
+        obj.stateMap = {};
+        entries.forEach(([k, v]) => {
+          obj.stateMap[k] = stateEnumToJSON(v);
+        });
+      }
     }
     return obj;
   },
@@ -271,8 +278,12 @@ export const Simple_StateMapEntry = {
 
   toJSON(message: Simple_StateMapEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = message.key);
-    message.value !== undefined && (obj.value = stateEnumToJSON(message.value));
+    if (message.key !== "") {
+      obj.key = message.key;
+    }
+    if (message.value !== StateEnum.UNKNOWN) {
+      obj.value = stateEnumToJSON(message.value);
+    }
     return obj;
   },
 

--- a/integration/simple-unrecognized-enum/google/protobuf/timestamp.ts
+++ b/integration/simple-unrecognized-enum/google/protobuf/timestamp.ts
@@ -165,8 +165,12 @@ export const Timestamp = {
 
   toJSON(message: Timestamp): unknown {
     const obj: any = {};
-    message.seconds !== undefined && (obj.seconds = Math.round(message.seconds));
-    message.nanos !== undefined && (obj.nanos = Math.round(message.nanos));
+    if (message.seconds !== 0) {
+      obj.seconds = Math.round(message.seconds);
+    }
+    if (message.nanos !== 0) {
+      obj.nanos = Math.round(message.nanos);
+    }
     return obj;
   },
 

--- a/integration/simple-unrecognized-enum/google/protobuf/wrappers.ts
+++ b/integration/simple-unrecognized-enum/google/protobuf/wrappers.ts
@@ -135,7 +135,9 @@ export const DoubleValue = {
 
   toJSON(message: DoubleValue): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = message.value);
+    if (message.value !== 0) {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -191,7 +193,9 @@ export const FloatValue = {
 
   toJSON(message: FloatValue): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = message.value);
+    if (message.value !== 0) {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -247,7 +251,9 @@ export const Int64Value = {
 
   toJSON(message: Int64Value): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = Math.round(message.value));
+    if (message.value !== 0) {
+      obj.value = Math.round(message.value);
+    }
     return obj;
   },
 
@@ -303,7 +309,9 @@ export const UInt64Value = {
 
   toJSON(message: UInt64Value): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = Math.round(message.value));
+    if (message.value !== 0) {
+      obj.value = Math.round(message.value);
+    }
     return obj;
   },
 
@@ -359,7 +367,9 @@ export const Int32Value = {
 
   toJSON(message: Int32Value): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = Math.round(message.value));
+    if (message.value !== 0) {
+      obj.value = Math.round(message.value);
+    }
     return obj;
   },
 
@@ -415,7 +425,9 @@ export const UInt32Value = {
 
   toJSON(message: UInt32Value): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = Math.round(message.value));
+    if (message.value !== 0) {
+      obj.value = Math.round(message.value);
+    }
     return obj;
   },
 
@@ -471,7 +483,9 @@ export const BoolValue = {
 
   toJSON(message: BoolValue): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = message.value);
+    if (message.value === true) {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -527,7 +541,9 @@ export const StringValue = {
 
   toJSON(message: StringValue): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = message.value);
+    if (message.value !== "") {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -583,8 +599,9 @@ export const BytesValue = {
 
   toJSON(message: BytesValue): unknown {
     const obj: any = {};
-    message.value !== undefined &&
-      (obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array(0)));
+    if (message.value.length !== 0) {
+      obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array(0));
+    }
     return obj;
   },
 

--- a/integration/simple-unrecognized-enum/google/protobuf/wrappers.ts
+++ b/integration/simple-unrecognized-enum/google/protobuf/wrappers.ts
@@ -600,7 +600,7 @@ export const BytesValue = {
   toJSON(message: BytesValue): unknown {
     const obj: any = {};
     if (message.value.length !== 0) {
-      obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array(0));
+      obj.value = base64FromBytes(message.value);
     }
     return obj;
   },

--- a/integration/simple-unrecognized-enum/import_dir/thing.ts
+++ b/integration/simple-unrecognized-enum/import_dir/thing.ts
@@ -49,7 +49,9 @@ export const ImportedThing = {
 
   toJSON(message: ImportedThing): unknown {
     const obj: any = {};
-    message.createdAt !== undefined && (obj.createdAt = message.createdAt.toISOString());
+    if (message.createdAt !== undefined) {
+      obj.createdAt = message.createdAt.toISOString();
+    }
     return obj;
   },
 

--- a/integration/simple-unrecognized-enum/simple.ts
+++ b/integration/simple-unrecognized-enum/simple.ts
@@ -427,7 +427,7 @@ export const Simple = {
       obj.coins = message.coins.map((e) => Math.round(e));
     }
     if (message.snacks?.length) {
-      obj.snacks = message.snacks.map((e) => e);
+      obj.snacks = message.snacks;
     }
     if (message.oldStates?.length) {
       obj.oldStates = message.oldStates.map((e) => stateEnumToJSON(e));
@@ -936,10 +936,10 @@ export const SimpleWithWrappers = {
       obj.enabled = message.enabled;
     }
     if (message.coins?.length) {
-      obj.coins = message.coins.map((e) => e);
+      obj.coins = message.coins;
     }
     if (message.snacks?.length) {
-      obj.snacks = message.snacks.map((e) => e);
+      obj.snacks = message.snacks;
     }
     return obj;
   },

--- a/integration/simple-unrecognized-enum/simple.ts
+++ b/integration/simple-unrecognized-enum/simple.ts
@@ -405,32 +405,36 @@ export const Simple = {
 
   toJSON(message: Simple): unknown {
     const obj: any = {};
-    message.name !== undefined && (obj.name = message.name);
-    message.age !== undefined && (obj.age = Math.round(message.age));
-    message.createdAt !== undefined && (obj.createdAt = message.createdAt.toISOString());
-    message.child !== undefined && (obj.child = message.child ? Child.toJSON(message.child) : undefined);
-    message.state !== undefined && (obj.state = stateEnumToJSON(message.state));
-    if (message.grandChildren) {
+    if (message.name !== "") {
+      obj.name = message.name;
+    }
+    if (message.age !== 0) {
+      obj.age = Math.round(message.age);
+    }
+    if (message.createdAt !== undefined) {
+      obj.createdAt = message.createdAt.toISOString();
+    }
+    if (message.child !== undefined) {
+      obj.child = message.child ? Child.toJSON(message.child) : undefined;
+    }
+    if (message.state !== 0) {
+      obj.state = stateEnumToJSON(message.state);
+    }
+    if (message.grandChildren?.length) {
       obj.grandChildren = message.grandChildren.map((e) => e ? Child.toJSON(e) : undefined);
-    } else {
-      obj.grandChildren = [];
     }
-    if (message.coins) {
+    if (message.coins?.length) {
       obj.coins = message.coins.map((e) => Math.round(e));
-    } else {
-      obj.coins = [];
     }
-    if (message.snacks) {
+    if (message.snacks?.length) {
       obj.snacks = message.snacks.map((e) => e);
-    } else {
-      obj.snacks = [];
     }
-    if (message.oldStates) {
+    if (message.oldStates?.length) {
       obj.oldStates = message.oldStates.map((e) => stateEnumToJSON(e));
-    } else {
-      obj.oldStates = [];
     }
-    message.thing !== undefined && (obj.thing = message.thing ? ImportedThing.toJSON(message.thing) : undefined);
+    if (message.thing !== undefined) {
+      obj.thing = message.thing ? ImportedThing.toJSON(message.thing) : undefined;
+    }
     return obj;
   },
 
@@ -510,8 +514,12 @@ export const Child = {
 
   toJSON(message: Child): unknown {
     const obj: any = {};
-    message.name !== undefined && (obj.name = message.name);
-    message.type !== undefined && (obj.type = child_TypeToJSON(message.type));
+    if (message.name !== "") {
+      obj.name = message.name;
+    }
+    if (message.type !== 0) {
+      obj.type = child_TypeToJSON(message.type);
+    }
     return obj;
   },
 
@@ -592,10 +600,15 @@ export const Nested = {
 
   toJSON(message: Nested): unknown {
     const obj: any = {};
-    message.name !== undefined && (obj.name = message.name);
-    message.message !== undefined &&
-      (obj.message = message.message ? Nested_InnerMessage.toJSON(message.message) : undefined);
-    message.state !== undefined && (obj.state = nested_InnerEnumToJSON(message.state));
+    if (message.name !== "") {
+      obj.name = message.name;
+    }
+    if (message.message !== undefined) {
+      obj.message = message.message ? Nested_InnerMessage.toJSON(message.message) : undefined;
+    }
+    if (message.state !== 0) {
+      obj.state = nested_InnerEnumToJSON(message.state);
+    }
     return obj;
   },
 
@@ -668,9 +681,12 @@ export const Nested_InnerMessage = {
 
   toJSON(message: Nested_InnerMessage): unknown {
     const obj: any = {};
-    message.name !== undefined && (obj.name = message.name);
-    message.deep !== undefined &&
-      (obj.deep = message.deep ? Nested_InnerMessage_DeepMessage.toJSON(message.deep) : undefined);
+    if (message.name !== "") {
+      obj.name = message.name;
+    }
+    if (message.deep !== undefined) {
+      obj.deep = message.deep ? Nested_InnerMessage_DeepMessage.toJSON(message.deep) : undefined;
+    }
     return obj;
   },
 
@@ -729,7 +745,9 @@ export const Nested_InnerMessage_DeepMessage = {
 
   toJSON(message: Nested_InnerMessage_DeepMessage): unknown {
     const obj: any = {};
-    message.name !== undefined && (obj.name = message.name);
+    if (message.name !== "") {
+      obj.name = message.name;
+    }
     return obj;
   },
 
@@ -800,8 +818,12 @@ export const OneOfMessage = {
 
   toJSON(message: OneOfMessage): unknown {
     const obj: any = {};
-    message.first !== undefined && (obj.first = message.first);
-    message.last !== undefined && (obj.last = message.last);
+    if (message.first !== undefined) {
+      obj.first = message.first;
+    }
+    if (message.last !== undefined) {
+      obj.last = message.last;
+    }
     return obj;
   },
 
@@ -904,18 +926,20 @@ export const SimpleWithWrappers = {
 
   toJSON(message: SimpleWithWrappers): unknown {
     const obj: any = {};
-    message.name !== undefined && (obj.name = message.name);
-    message.age !== undefined && (obj.age = message.age);
-    message.enabled !== undefined && (obj.enabled = message.enabled);
-    if (message.coins) {
-      obj.coins = message.coins.map((e) => e);
-    } else {
-      obj.coins = [];
+    if (message.name !== undefined) {
+      obj.name = message.name;
     }
-    if (message.snacks) {
+    if (message.age !== undefined) {
+      obj.age = message.age;
+    }
+    if (message.enabled !== undefined) {
+      obj.enabled = message.enabled;
+    }
+    if (message.coins?.length) {
+      obj.coins = message.coins.map((e) => e);
+    }
+    if (message.snacks?.length) {
       obj.snacks = message.snacks.map((e) => e);
-    } else {
-      obj.snacks = [];
     }
     return obj;
   },
@@ -976,7 +1000,9 @@ export const Entity = {
 
   toJSON(message: Entity): unknown {
     const obj: any = {};
-    message.id !== undefined && (obj.id = Math.round(message.id));
+    if (message.id !== 0) {
+      obj.id = Math.round(message.id);
+    }
     return obj;
   },
 
@@ -1080,23 +1106,32 @@ export const SimpleWithMap = {
 
   toJSON(message: SimpleWithMap): unknown {
     const obj: any = {};
-    obj.entitiesById = {};
     if (message.entitiesById) {
-      Object.entries(message.entitiesById).forEach(([k, v]) => {
-        obj.entitiesById[k] = Entity.toJSON(v);
-      });
+      const entries = Object.entries(message.entitiesById);
+      if (entries.length > 0) {
+        obj.entitiesById = {};
+        entries.forEach(([k, v]) => {
+          obj.entitiesById[k] = Entity.toJSON(v);
+        });
+      }
     }
-    obj.nameLookup = {};
     if (message.nameLookup) {
-      Object.entries(message.nameLookup).forEach(([k, v]) => {
-        obj.nameLookup[k] = v;
-      });
+      const entries = Object.entries(message.nameLookup);
+      if (entries.length > 0) {
+        obj.nameLookup = {};
+        entries.forEach(([k, v]) => {
+          obj.nameLookup[k] = v;
+        });
+      }
     }
-    obj.intLookup = {};
     if (message.intLookup) {
-      Object.entries(message.intLookup).forEach(([k, v]) => {
-        obj.intLookup[k] = Math.round(v);
-      });
+      const entries = Object.entries(message.intLookup);
+      if (entries.length > 0) {
+        obj.intLookup = {};
+        entries.forEach(([k, v]) => {
+          obj.intLookup[k] = Math.round(v);
+        });
+      }
     }
     return obj;
   },
@@ -1192,8 +1227,12 @@ export const SimpleWithMap_EntitiesByIdEntry = {
 
   toJSON(message: SimpleWithMap_EntitiesByIdEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = Math.round(message.key));
-    message.value !== undefined && (obj.value = message.value ? Entity.toJSON(message.value) : undefined);
+    if (message.key !== 0) {
+      obj.key = Math.round(message.key);
+    }
+    if (message.value !== undefined) {
+      obj.value = message.value ? Entity.toJSON(message.value) : undefined;
+    }
     return obj;
   },
 
@@ -1264,8 +1303,12 @@ export const SimpleWithMap_NameLookupEntry = {
 
   toJSON(message: SimpleWithMap_NameLookupEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = message.key);
-    message.value !== undefined && (obj.value = message.value);
+    if (message.key !== "") {
+      obj.key = message.key;
+    }
+    if (message.value !== "") {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -1334,8 +1377,12 @@ export const SimpleWithMap_IntLookupEntry = {
 
   toJSON(message: SimpleWithMap_IntLookupEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = Math.round(message.key));
-    message.value !== undefined && (obj.value = Math.round(message.value));
+    if (message.key !== 0) {
+      obj.key = Math.round(message.key);
+    }
+    if (message.value !== 0) {
+      obj.value = Math.round(message.value);
+    }
     return obj;
   },
 
@@ -1402,11 +1449,14 @@ export const SimpleWithSnakeCaseMap = {
 
   toJSON(message: SimpleWithSnakeCaseMap): unknown {
     const obj: any = {};
-    obj.entitiesById = {};
     if (message.entitiesById) {
-      Object.entries(message.entitiesById).forEach(([k, v]) => {
-        obj.entitiesById[k] = Entity.toJSON(v);
-      });
+      const entries = Object.entries(message.entitiesById);
+      if (entries.length > 0) {
+        obj.entitiesById = {};
+        entries.forEach(([k, v]) => {
+          obj.entitiesById[k] = Entity.toJSON(v);
+        });
+      }
     }
     return obj;
   },
@@ -1484,8 +1534,12 @@ export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
 
   toJSON(message: SimpleWithSnakeCaseMap_EntitiesByIdEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = Math.round(message.key));
-    message.value !== undefined && (obj.value = message.value ? Entity.toJSON(message.value) : undefined);
+    if (message.key !== 0) {
+      obj.key = Math.round(message.key);
+    }
+    if (message.value !== undefined) {
+      obj.value = message.value ? Entity.toJSON(message.value) : undefined;
+    }
     return obj;
   },
 
@@ -1548,7 +1602,9 @@ export const PingRequest = {
 
   toJSON(message: PingRequest): unknown {
     const obj: any = {};
-    message.input !== undefined && (obj.input = message.input);
+    if (message.input !== "") {
+      obj.input = message.input;
+    }
     return obj;
   },
 
@@ -1604,7 +1660,9 @@ export const PingResponse = {
 
   toJSON(message: PingResponse): unknown {
     const obj: any = {};
-    message.output !== undefined && (obj.output = message.output);
+    if (message.output !== "") {
+      obj.output = message.output;
+    }
     return obj;
   },
 
@@ -1796,18 +1854,42 @@ export const Numbers = {
 
   toJSON(message: Numbers): unknown {
     const obj: any = {};
-    message.double !== undefined && (obj.double = message.double);
-    message.float !== undefined && (obj.float = message.float);
-    message.int32 !== undefined && (obj.int32 = Math.round(message.int32));
-    message.int64 !== undefined && (obj.int64 = Math.round(message.int64));
-    message.uint32 !== undefined && (obj.uint32 = Math.round(message.uint32));
-    message.uint64 !== undefined && (obj.uint64 = Math.round(message.uint64));
-    message.sint32 !== undefined && (obj.sint32 = Math.round(message.sint32));
-    message.sint64 !== undefined && (obj.sint64 = Math.round(message.sint64));
-    message.fixed32 !== undefined && (obj.fixed32 = Math.round(message.fixed32));
-    message.fixed64 !== undefined && (obj.fixed64 = Math.round(message.fixed64));
-    message.sfixed32 !== undefined && (obj.sfixed32 = Math.round(message.sfixed32));
-    message.sfixed64 !== undefined && (obj.sfixed64 = Math.round(message.sfixed64));
+    if (message.double !== 0) {
+      obj.double = message.double;
+    }
+    if (message.float !== 0) {
+      obj.float = message.float;
+    }
+    if (message.int32 !== 0) {
+      obj.int32 = Math.round(message.int32);
+    }
+    if (message.int64 !== 0) {
+      obj.int64 = Math.round(message.int64);
+    }
+    if (message.uint32 !== 0) {
+      obj.uint32 = Math.round(message.uint32);
+    }
+    if (message.uint64 !== 0) {
+      obj.uint64 = Math.round(message.uint64);
+    }
+    if (message.sint32 !== 0) {
+      obj.sint32 = Math.round(message.sint32);
+    }
+    if (message.sint64 !== 0) {
+      obj.sint64 = Math.round(message.sint64);
+    }
+    if (message.fixed32 !== 0) {
+      obj.fixed32 = Math.round(message.fixed32);
+    }
+    if (message.fixed64 !== 0) {
+      obj.fixed64 = Math.round(message.fixed64);
+    }
+    if (message.sfixed32 !== 0) {
+      obj.sfixed32 = Math.round(message.sfixed32);
+    }
+    if (message.sfixed64 !== 0) {
+      obj.sfixed64 = Math.round(message.sfixed64);
+    }
     return obj;
   },
 

--- a/integration/simple-unrecognized-enum/simple.ts
+++ b/integration/simple-unrecognized-enum/simple.ts
@@ -415,13 +415,13 @@ export const Simple = {
       obj.createdAt = message.createdAt.toISOString();
     }
     if (message.child !== undefined) {
-      obj.child = message.child ? Child.toJSON(message.child) : undefined;
+      obj.child = Child.toJSON(message.child);
     }
     if (message.state !== 0) {
       obj.state = stateEnumToJSON(message.state);
     }
     if (message.grandChildren?.length) {
-      obj.grandChildren = message.grandChildren.map((e) => e ? Child.toJSON(e) : undefined);
+      obj.grandChildren = message.grandChildren.map((e) => Child.toJSON(e));
     }
     if (message.coins?.length) {
       obj.coins = message.coins.map((e) => Math.round(e));
@@ -433,7 +433,7 @@ export const Simple = {
       obj.oldStates = message.oldStates.map((e) => stateEnumToJSON(e));
     }
     if (message.thing !== undefined) {
-      obj.thing = message.thing ? ImportedThing.toJSON(message.thing) : undefined;
+      obj.thing = ImportedThing.toJSON(message.thing);
     }
     return obj;
   },
@@ -604,7 +604,7 @@ export const Nested = {
       obj.name = message.name;
     }
     if (message.message !== undefined) {
-      obj.message = message.message ? Nested_InnerMessage.toJSON(message.message) : undefined;
+      obj.message = Nested_InnerMessage.toJSON(message.message);
     }
     if (message.state !== 0) {
       obj.state = nested_InnerEnumToJSON(message.state);
@@ -685,7 +685,7 @@ export const Nested_InnerMessage = {
       obj.name = message.name;
     }
     if (message.deep !== undefined) {
-      obj.deep = message.deep ? Nested_InnerMessage_DeepMessage.toJSON(message.deep) : undefined;
+      obj.deep = Nested_InnerMessage_DeepMessage.toJSON(message.deep);
     }
     return obj;
   },
@@ -1231,7 +1231,7 @@ export const SimpleWithMap_EntitiesByIdEntry = {
       obj.key = Math.round(message.key);
     }
     if (message.value !== undefined) {
-      obj.value = message.value ? Entity.toJSON(message.value) : undefined;
+      obj.value = Entity.toJSON(message.value);
     }
     return obj;
   },
@@ -1538,7 +1538,7 @@ export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
       obj.key = Math.round(message.key);
     }
     if (message.value !== undefined) {
-      obj.value = message.value ? Entity.toJSON(message.value) : undefined;
+      obj.value = Entity.toJSON(message.value);
     }
     return obj;
   },

--- a/integration/simple/google/protobuf/timestamp.ts
+++ b/integration/simple/google/protobuf/timestamp.ts
@@ -165,8 +165,12 @@ export const Timestamp = {
 
   toJSON(message: Timestamp): unknown {
     const obj: any = {};
-    message.seconds !== undefined && (obj.seconds = Math.round(message.seconds));
-    message.nanos !== undefined && (obj.nanos = Math.round(message.nanos));
+    if (message.seconds !== 0) {
+      obj.seconds = Math.round(message.seconds);
+    }
+    if (message.nanos !== 0) {
+      obj.nanos = Math.round(message.nanos);
+    }
     return obj;
   },
 

--- a/integration/simple/google/protobuf/wrappers.ts
+++ b/integration/simple/google/protobuf/wrappers.ts
@@ -135,7 +135,9 @@ export const DoubleValue = {
 
   toJSON(message: DoubleValue): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = message.value);
+    if (message.value !== 0) {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -191,7 +193,9 @@ export const FloatValue = {
 
   toJSON(message: FloatValue): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = message.value);
+    if (message.value !== 0) {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -247,7 +251,9 @@ export const Int64Value = {
 
   toJSON(message: Int64Value): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = Math.round(message.value));
+    if (message.value !== 0) {
+      obj.value = Math.round(message.value);
+    }
     return obj;
   },
 
@@ -303,7 +309,9 @@ export const UInt64Value = {
 
   toJSON(message: UInt64Value): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = Math.round(message.value));
+    if (message.value !== 0) {
+      obj.value = Math.round(message.value);
+    }
     return obj;
   },
 
@@ -359,7 +367,9 @@ export const Int32Value = {
 
   toJSON(message: Int32Value): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = Math.round(message.value));
+    if (message.value !== 0) {
+      obj.value = Math.round(message.value);
+    }
     return obj;
   },
 
@@ -415,7 +425,9 @@ export const UInt32Value = {
 
   toJSON(message: UInt32Value): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = Math.round(message.value));
+    if (message.value !== 0) {
+      obj.value = Math.round(message.value);
+    }
     return obj;
   },
 
@@ -471,7 +483,9 @@ export const BoolValue = {
 
   toJSON(message: BoolValue): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = message.value);
+    if (message.value === true) {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -527,7 +541,9 @@ export const StringValue = {
 
   toJSON(message: StringValue): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = message.value);
+    if (message.value !== "") {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -583,8 +599,9 @@ export const BytesValue = {
 
   toJSON(message: BytesValue): unknown {
     const obj: any = {};
-    message.value !== undefined &&
-      (obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array(0)));
+    if (message.value.length !== 0) {
+      obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array(0));
+    }
     return obj;
   },
 

--- a/integration/simple/google/protobuf/wrappers.ts
+++ b/integration/simple/google/protobuf/wrappers.ts
@@ -600,7 +600,7 @@ export const BytesValue = {
   toJSON(message: BytesValue): unknown {
     const obj: any = {};
     if (message.value.length !== 0) {
-      obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array(0));
+      obj.value = base64FromBytes(message.value);
     }
     return obj;
   },

--- a/integration/simple/google/type/date.ts
+++ b/integration/simple/google/type/date.ts
@@ -99,9 +99,15 @@ export const DateMessage = {
 
   toJSON(message: DateMessage): unknown {
     const obj: any = {};
-    message.year !== undefined && (obj.year = Math.round(message.year));
-    message.month !== undefined && (obj.month = Math.round(message.month));
-    message.day !== undefined && (obj.day = Math.round(message.day));
+    if (message.year !== 0) {
+      obj.year = Math.round(message.year);
+    }
+    if (message.month !== 0) {
+      obj.month = Math.round(message.month);
+    }
+    if (message.day !== 0) {
+      obj.day = Math.round(message.day);
+    }
     return obj;
   },
 

--- a/integration/simple/import_dir/thing.ts
+++ b/integration/simple/import_dir/thing.ts
@@ -49,7 +49,9 @@ export const ImportedThing = {
 
   toJSON(message: ImportedThing): unknown {
     const obj: any = {};
-    message.createdAt !== undefined && (obj.createdAt = message.createdAt.toISOString());
+    if (message.createdAt !== undefined) {
+      obj.createdAt = message.createdAt.toISOString();
+    }
     return obj;
   },
 

--- a/integration/simple/simple-json-test.ts
+++ b/integration/simple/simple-json-test.ts
@@ -247,16 +247,10 @@ describe("simple json", () => {
     const json = SimpleWithMap.toJSON(s1);
     expect(json).toMatchInlineSnapshot(`
       {
-        "entitiesById": {},
-        "intLookup": {},
-        "longLookup": {},
         "mapOfBytes": {
           "a": "AQI=",
           "b": "AQID",
         },
-        "mapOfStringValues": {},
-        "mapOfTimestamps": {},
-        "nameLookup": {},
       }
     `);
   });
@@ -315,11 +309,8 @@ describe("simple json", () => {
     expect(Simple.toJSON(s1)).toMatchInlineSnapshot(`
       {
         "age": 1,
-        "blob": "",
-        "blobs": [],
         "child": {
           "name": "foo",
-          "type": "UNKNOWN",
         },
         "coins": [
           2,
@@ -331,11 +322,9 @@ describe("simple json", () => {
         "grandChildren": [
           {
             "name": "grand1",
-            "type": "UNKNOWN",
           },
           {
             "name": "grand2",
-            "type": "UNKNOWN",
           },
         ],
         "name": "asdf",
@@ -352,32 +341,15 @@ describe("simple json", () => {
     `);
   });
 
-  it("can encode empty objects", () => {
-    expect(Simple.toJSON({} as Simple)).toMatchInlineSnapshot(`
-      {
-        "blobs": [],
-        "coins": [],
-        "grandChildren": [],
-        "oldStates": [],
-        "snacks": [],
-      }
-    `);
-  });
-
   it("can encode nested enums", () => {
-    const s1 = { child: { name: "a", type: Child_Type.GOOD } } as Simple;
+    const s1 = Simple.fromPartial({ child: { name: "a", type: Child_Type.GOOD } });
     const s2 = Simple.toJSON(s1);
     expect(s2).toMatchInlineSnapshot(`
       {
-        "blobs": [],
         "child": {
           "name": "a",
           "type": "GOOD",
         },
-        "coins": [],
-        "grandChildren": [],
-        "oldStates": [],
-        "snacks": [],
       }
     `);
   });
@@ -425,12 +397,7 @@ describe("simple json", () => {
       id: undefined,
     };
     const s2 = SimpleWithWrappers.toJSON(s1);
-    expect(s2).toMatchInlineSnapshot(`
-      {
-        "coins": [],
-        "snacks": [],
-      }
-    `);
+    expect(s2).toMatchInlineSnapshot(`{}`);
   });
 
   it("can decode enum falsey values", () => {

--- a/integration/simple/simple.ts
+++ b/integration/simple/simple.ts
@@ -528,42 +528,48 @@ export const Simple = {
 
   toJSON(message: Simple): unknown {
     const obj: any = {};
-    message.name !== undefined && (obj.name = message.name);
-    message.age !== undefined && (obj.age = Math.round(message.age));
-    message.createdAt !== undefined && (obj.createdAt = message.createdAt.toISOString());
-    message.child !== undefined && (obj.child = message.child ? Child.toJSON(message.child) : undefined);
-    message.state !== undefined && (obj.state = stateEnumToJSON(message.state));
-    if (message.grandChildren) {
+    if (message.name !== "") {
+      obj.name = message.name;
+    }
+    if (message.age !== 0) {
+      obj.age = Math.round(message.age);
+    }
+    if (message.createdAt !== undefined) {
+      obj.createdAt = message.createdAt.toISOString();
+    }
+    if (message.child !== undefined) {
+      obj.child = message.child ? Child.toJSON(message.child) : undefined;
+    }
+    if (message.state !== 0) {
+      obj.state = stateEnumToJSON(message.state);
+    }
+    if (message.grandChildren?.length) {
       obj.grandChildren = message.grandChildren.map((e) => e ? Child.toJSON(e) : undefined);
-    } else {
-      obj.grandChildren = [];
     }
-    if (message.coins) {
+    if (message.coins?.length) {
       obj.coins = message.coins.map((e) => Math.round(e));
-    } else {
-      obj.coins = [];
     }
-    if (message.snacks) {
+    if (message.snacks?.length) {
       obj.snacks = message.snacks.map((e) => e);
-    } else {
-      obj.snacks = [];
     }
-    if (message.oldStates) {
+    if (message.oldStates?.length) {
       obj.oldStates = message.oldStates.map((e) => stateEnumToJSON(e));
-    } else {
-      obj.oldStates = [];
     }
-    message.thing !== undefined && (obj.thing = message.thing ? ImportedThing.toJSON(message.thing) : undefined);
-    if (message.blobs) {
+    if (message.thing !== undefined) {
+      obj.thing = message.thing ? ImportedThing.toJSON(message.thing) : undefined;
+    }
+    if (message.blobs?.length) {
       obj.blobs = message.blobs.map((e) => base64FromBytes(e !== undefined ? e : new Uint8Array(0)));
-    } else {
-      obj.blobs = [];
     }
-    message.birthday !== undefined &&
-      (obj.birthday = message.birthday ? DateMessage.toJSON(message.birthday) : undefined);
-    message.blob !== undefined &&
-      (obj.blob = base64FromBytes(message.blob !== undefined ? message.blob : new Uint8Array(0)));
-    message.enabled !== undefined && (obj.enabled = message.enabled);
+    if (message.birthday !== undefined) {
+      obj.birthday = message.birthday ? DateMessage.toJSON(message.birthday) : undefined;
+    }
+    if (message.blob.length !== 0) {
+      obj.blob = base64FromBytes(message.blob !== undefined ? message.blob : new Uint8Array(0));
+    }
+    if (message.enabled === true) {
+      obj.enabled = message.enabled;
+    }
     return obj;
   },
 
@@ -649,8 +655,12 @@ export const Child = {
 
   toJSON(message: Child): unknown {
     const obj: any = {};
-    message.name !== undefined && (obj.name = message.name);
-    message.type !== undefined && (obj.type = child_TypeToJSON(message.type));
+    if (message.name !== "") {
+      obj.name = message.name;
+    }
+    if (message.type !== 0) {
+      obj.type = child_TypeToJSON(message.type);
+    }
     return obj;
   },
 
@@ -731,10 +741,15 @@ export const Nested = {
 
   toJSON(message: Nested): unknown {
     const obj: any = {};
-    message.name !== undefined && (obj.name = message.name);
-    message.message !== undefined &&
-      (obj.message = message.message ? Nested_InnerMessage.toJSON(message.message) : undefined);
-    message.state !== undefined && (obj.state = nested_InnerEnumToJSON(message.state));
+    if (message.name !== "") {
+      obj.name = message.name;
+    }
+    if (message.message !== undefined) {
+      obj.message = message.message ? Nested_InnerMessage.toJSON(message.message) : undefined;
+    }
+    if (message.state !== 0) {
+      obj.state = nested_InnerEnumToJSON(message.state);
+    }
     return obj;
   },
 
@@ -807,9 +822,12 @@ export const Nested_InnerMessage = {
 
   toJSON(message: Nested_InnerMessage): unknown {
     const obj: any = {};
-    message.name !== undefined && (obj.name = message.name);
-    message.deep !== undefined &&
-      (obj.deep = message.deep ? Nested_InnerMessage_DeepMessage.toJSON(message.deep) : undefined);
+    if (message.name !== "") {
+      obj.name = message.name;
+    }
+    if (message.deep !== undefined) {
+      obj.deep = message.deep ? Nested_InnerMessage_DeepMessage.toJSON(message.deep) : undefined;
+    }
     return obj;
   },
 
@@ -868,7 +886,9 @@ export const Nested_InnerMessage_DeepMessage = {
 
   toJSON(message: Nested_InnerMessage_DeepMessage): unknown {
     const obj: any = {};
-    message.name !== undefined && (obj.name = message.name);
+    if (message.name !== "") {
+      obj.name = message.name;
+    }
     return obj;
   },
 
@@ -939,8 +959,12 @@ export const OneOfMessage = {
 
   toJSON(message: OneOfMessage): unknown {
     const obj: any = {};
-    message.first !== undefined && (obj.first = message.first);
-    message.last !== undefined && (obj.last = message.last);
+    if (message.first !== undefined) {
+      obj.first = message.first;
+    }
+    if (message.last !== undefined) {
+      obj.last = message.last;
+    }
     return obj;
   },
 
@@ -1054,20 +1078,24 @@ export const SimpleWithWrappers = {
 
   toJSON(message: SimpleWithWrappers): unknown {
     const obj: any = {};
-    message.name !== undefined && (obj.name = message.name);
-    message.age !== undefined && (obj.age = message.age);
-    message.enabled !== undefined && (obj.enabled = message.enabled);
-    if (message.coins) {
+    if (message.name !== undefined) {
+      obj.name = message.name;
+    }
+    if (message.age !== undefined) {
+      obj.age = message.age;
+    }
+    if (message.enabled !== undefined) {
+      obj.enabled = message.enabled;
+    }
+    if (message.coins?.length) {
       obj.coins = message.coins.map((e) => e);
-    } else {
-      obj.coins = [];
     }
-    if (message.snacks) {
+    if (message.snacks?.length) {
       obj.snacks = message.snacks.map((e) => e);
-    } else {
-      obj.snacks = [];
     }
-    message.id !== undefined && (obj.id = message.id);
+    if (message.id !== undefined) {
+      obj.id = message.id;
+    }
     return obj;
   },
 
@@ -1128,7 +1156,9 @@ export const Entity = {
 
   toJSON(message: Entity): unknown {
     const obj: any = {};
-    message.id !== undefined && (obj.id = Math.round(message.id));
+    if (message.id !== 0) {
+      obj.id = Math.round(message.id);
+    }
     return obj;
   },
 
@@ -1321,47 +1351,68 @@ export const SimpleWithMap = {
 
   toJSON(message: SimpleWithMap): unknown {
     const obj: any = {};
-    obj.entitiesById = {};
     if (message.entitiesById) {
-      Object.entries(message.entitiesById).forEach(([k, v]) => {
-        obj.entitiesById[k] = Entity.toJSON(v);
-      });
+      const entries = Object.entries(message.entitiesById);
+      if (entries.length > 0) {
+        obj.entitiesById = {};
+        entries.forEach(([k, v]) => {
+          obj.entitiesById[k] = Entity.toJSON(v);
+        });
+      }
     }
-    obj.nameLookup = {};
     if (message.nameLookup) {
-      Object.entries(message.nameLookup).forEach(([k, v]) => {
-        obj.nameLookup[k] = v;
-      });
+      const entries = Object.entries(message.nameLookup);
+      if (entries.length > 0) {
+        obj.nameLookup = {};
+        entries.forEach(([k, v]) => {
+          obj.nameLookup[k] = v;
+        });
+      }
     }
-    obj.intLookup = {};
     if (message.intLookup) {
-      Object.entries(message.intLookup).forEach(([k, v]) => {
-        obj.intLookup[k] = Math.round(v);
-      });
+      const entries = Object.entries(message.intLookup);
+      if (entries.length > 0) {
+        obj.intLookup = {};
+        entries.forEach(([k, v]) => {
+          obj.intLookup[k] = Math.round(v);
+        });
+      }
     }
-    obj.mapOfTimestamps = {};
     if (message.mapOfTimestamps) {
-      Object.entries(message.mapOfTimestamps).forEach(([k, v]) => {
-        obj.mapOfTimestamps[k] = v.toISOString();
-      });
+      const entries = Object.entries(message.mapOfTimestamps);
+      if (entries.length > 0) {
+        obj.mapOfTimestamps = {};
+        entries.forEach(([k, v]) => {
+          obj.mapOfTimestamps[k] = v.toISOString();
+        });
+      }
     }
-    obj.mapOfBytes = {};
     if (message.mapOfBytes) {
-      Object.entries(message.mapOfBytes).forEach(([k, v]) => {
-        obj.mapOfBytes[k] = base64FromBytes(v);
-      });
+      const entries = Object.entries(message.mapOfBytes);
+      if (entries.length > 0) {
+        obj.mapOfBytes = {};
+        entries.forEach(([k, v]) => {
+          obj.mapOfBytes[k] = base64FromBytes(v);
+        });
+      }
     }
-    obj.mapOfStringValues = {};
     if (message.mapOfStringValues) {
-      Object.entries(message.mapOfStringValues).forEach(([k, v]) => {
-        obj.mapOfStringValues[k] = v;
-      });
+      const entries = Object.entries(message.mapOfStringValues);
+      if (entries.length > 0) {
+        obj.mapOfStringValues = {};
+        entries.forEach(([k, v]) => {
+          obj.mapOfStringValues[k] = v;
+        });
+      }
     }
-    obj.longLookup = {};
     if (message.longLookup) {
-      Object.entries(message.longLookup).forEach(([k, v]) => {
-        obj.longLookup[k] = Math.round(v);
-      });
+      const entries = Object.entries(message.longLookup);
+      if (entries.length > 0) {
+        obj.longLookup = {};
+        entries.forEach(([k, v]) => {
+          obj.longLookup[k] = Math.round(v);
+        });
+      }
     }
     return obj;
   },
@@ -1492,8 +1543,12 @@ export const SimpleWithMap_EntitiesByIdEntry = {
 
   toJSON(message: SimpleWithMap_EntitiesByIdEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = Math.round(message.key));
-    message.value !== undefined && (obj.value = message.value ? Entity.toJSON(message.value) : undefined);
+    if (message.key !== 0) {
+      obj.key = Math.round(message.key);
+    }
+    if (message.value !== undefined) {
+      obj.value = message.value ? Entity.toJSON(message.value) : undefined;
+    }
     return obj;
   },
 
@@ -1564,8 +1619,12 @@ export const SimpleWithMap_NameLookupEntry = {
 
   toJSON(message: SimpleWithMap_NameLookupEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = message.key);
-    message.value !== undefined && (obj.value = message.value);
+    if (message.key !== "") {
+      obj.key = message.key;
+    }
+    if (message.value !== "") {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -1634,8 +1693,12 @@ export const SimpleWithMap_IntLookupEntry = {
 
   toJSON(message: SimpleWithMap_IntLookupEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = Math.round(message.key));
-    message.value !== undefined && (obj.value = Math.round(message.value));
+    if (message.key !== 0) {
+      obj.key = Math.round(message.key);
+    }
+    if (message.value !== 0) {
+      obj.value = Math.round(message.value);
+    }
     return obj;
   },
 
@@ -1705,8 +1768,12 @@ export const SimpleWithMap_MapOfTimestampsEntry = {
 
   toJSON(message: SimpleWithMap_MapOfTimestampsEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = message.key);
-    message.value !== undefined && (obj.value = message.value.toISOString());
+    if (message.key !== "") {
+      obj.key = message.key;
+    }
+    if (message.value !== undefined) {
+      obj.value = message.value.toISOString();
+    }
     return obj;
   },
 
@@ -1780,9 +1847,12 @@ export const SimpleWithMap_MapOfBytesEntry = {
 
   toJSON(message: SimpleWithMap_MapOfBytesEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = message.key);
-    message.value !== undefined &&
-      (obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array(0)));
+    if (message.key !== "") {
+      obj.key = message.key;
+    }
+    if (message.value.length !== 0) {
+      obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array(0));
+    }
     return obj;
   },
 
@@ -1854,8 +1924,12 @@ export const SimpleWithMap_MapOfStringValuesEntry = {
 
   toJSON(message: SimpleWithMap_MapOfStringValuesEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = message.key);
-    message.value !== undefined && (obj.value = message.value);
+    if (message.key !== "") {
+      obj.key = message.key;
+    }
+    if (message.value !== undefined) {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -1926,8 +2000,12 @@ export const SimpleWithMap_LongLookupEntry = {
 
   toJSON(message: SimpleWithMap_LongLookupEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = Math.round(message.key));
-    message.value !== undefined && (obj.value = Math.round(message.value));
+    if (message.key !== 0) {
+      obj.key = Math.round(message.key);
+    }
+    if (message.value !== 0) {
+      obj.value = Math.round(message.value);
+    }
     return obj;
   },
 
@@ -1996,11 +2074,14 @@ export const SimpleWithSnakeCaseMap = {
 
   toJSON(message: SimpleWithSnakeCaseMap): unknown {
     const obj: any = {};
-    obj.entitiesById = {};
     if (message.entitiesById) {
-      Object.entries(message.entitiesById).forEach(([k, v]) => {
-        obj.entitiesById[k] = Entity.toJSON(v);
-      });
+      const entries = Object.entries(message.entitiesById);
+      if (entries.length > 0) {
+        obj.entitiesById = {};
+        entries.forEach(([k, v]) => {
+          obj.entitiesById[k] = Entity.toJSON(v);
+        });
+      }
     }
     return obj;
   },
@@ -2078,8 +2159,12 @@ export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
 
   toJSON(message: SimpleWithSnakeCaseMap_EntitiesByIdEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = Math.round(message.key));
-    message.value !== undefined && (obj.value = message.value ? Entity.toJSON(message.value) : undefined);
+    if (message.key !== 0) {
+      obj.key = Math.round(message.key);
+    }
+    if (message.value !== undefined) {
+      obj.value = message.value ? Entity.toJSON(message.value) : undefined;
+    }
     return obj;
   },
 
@@ -2152,11 +2237,14 @@ export const SimpleWithMapOfEnums = {
 
   toJSON(message: SimpleWithMapOfEnums): unknown {
     const obj: any = {};
-    obj.enumsById = {};
     if (message.enumsById) {
-      Object.entries(message.enumsById).forEach(([k, v]) => {
-        obj.enumsById[k] = stateEnumToJSON(v);
-      });
+      const entries = Object.entries(message.enumsById);
+      if (entries.length > 0) {
+        obj.enumsById = {};
+        entries.forEach(([k, v]) => {
+          obj.enumsById[k] = stateEnumToJSON(v);
+        });
+      }
     }
     return obj;
   },
@@ -2234,8 +2322,12 @@ export const SimpleWithMapOfEnums_EnumsByIdEntry = {
 
   toJSON(message: SimpleWithMapOfEnums_EnumsByIdEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = Math.round(message.key));
-    message.value !== undefined && (obj.value = stateEnumToJSON(message.value));
+    if (message.key !== 0) {
+      obj.key = Math.round(message.key);
+    }
+    if (message.value !== 0) {
+      obj.value = stateEnumToJSON(message.value);
+    }
     return obj;
   },
 
@@ -2296,7 +2388,9 @@ export const PingRequest = {
 
   toJSON(message: PingRequest): unknown {
     const obj: any = {};
-    message.input !== undefined && (obj.input = message.input);
+    if (message.input !== "") {
+      obj.input = message.input;
+    }
     return obj;
   },
 
@@ -2352,7 +2446,9 @@ export const PingResponse = {
 
   toJSON(message: PingResponse): unknown {
     const obj: any = {};
-    message.output !== undefined && (obj.output = message.output);
+    if (message.output !== "") {
+      obj.output = message.output;
+    }
     return obj;
   },
 
@@ -2544,18 +2640,42 @@ export const Numbers = {
 
   toJSON(message: Numbers): unknown {
     const obj: any = {};
-    message.double !== undefined && (obj.double = message.double);
-    message.float !== undefined && (obj.float = message.float);
-    message.int32 !== undefined && (obj.int32 = Math.round(message.int32));
-    message.int64 !== undefined && (obj.int64 = Math.round(message.int64));
-    message.uint32 !== undefined && (obj.uint32 = Math.round(message.uint32));
-    message.uint64 !== undefined && (obj.uint64 = Math.round(message.uint64));
-    message.sint32 !== undefined && (obj.sint32 = Math.round(message.sint32));
-    message.sint64 !== undefined && (obj.sint64 = Math.round(message.sint64));
-    message.fixed32 !== undefined && (obj.fixed32 = Math.round(message.fixed32));
-    message.fixed64 !== undefined && (obj.fixed64 = Math.round(message.fixed64));
-    message.sfixed32 !== undefined && (obj.sfixed32 = Math.round(message.sfixed32));
-    message.sfixed64 !== undefined && (obj.sfixed64 = Math.round(message.sfixed64));
+    if (message.double !== 0) {
+      obj.double = message.double;
+    }
+    if (message.float !== 0) {
+      obj.float = message.float;
+    }
+    if (message.int32 !== 0) {
+      obj.int32 = Math.round(message.int32);
+    }
+    if (message.int64 !== 0) {
+      obj.int64 = Math.round(message.int64);
+    }
+    if (message.uint32 !== 0) {
+      obj.uint32 = Math.round(message.uint32);
+    }
+    if (message.uint64 !== 0) {
+      obj.uint64 = Math.round(message.uint64);
+    }
+    if (message.sint32 !== 0) {
+      obj.sint32 = Math.round(message.sint32);
+    }
+    if (message.sint64 !== 0) {
+      obj.sint64 = Math.round(message.sint64);
+    }
+    if (message.fixed32 !== 0) {
+      obj.fixed32 = Math.round(message.fixed32);
+    }
+    if (message.fixed64 !== 0) {
+      obj.fixed64 = Math.round(message.fixed64);
+    }
+    if (message.sfixed32 !== 0) {
+      obj.sfixed32 = Math.round(message.sfixed32);
+    }
+    if (message.sfixed64 !== 0) {
+      obj.sfixed64 = Math.round(message.sfixed64);
+    }
     return obj;
   },
 
@@ -2698,15 +2818,27 @@ export const SimpleButOptional = {
 
   toJSON(message: SimpleButOptional): unknown {
     const obj: any = {};
-    message.name !== undefined && (obj.name = message.name);
-    message.age !== undefined && (obj.age = Math.round(message.age));
-    message.createdAt !== undefined && (obj.createdAt = message.createdAt.toISOString());
-    message.child !== undefined && (obj.child = message.child ? Child.toJSON(message.child) : undefined);
-    message.state !== undefined &&
-      (obj.state = message.state !== undefined ? stateEnumToJSON(message.state) : undefined);
-    message.thing !== undefined && (obj.thing = message.thing ? ImportedThing.toJSON(message.thing) : undefined);
-    message.birthday !== undefined &&
-      (obj.birthday = message.birthday ? DateMessage.toJSON(message.birthday) : undefined);
+    if (message.name !== undefined) {
+      obj.name = message.name;
+    }
+    if (message.age !== undefined) {
+      obj.age = Math.round(message.age);
+    }
+    if (message.createdAt !== undefined) {
+      obj.createdAt = message.createdAt.toISOString();
+    }
+    if (message.child !== undefined) {
+      obj.child = message.child ? Child.toJSON(message.child) : undefined;
+    }
+    if (message.state !== undefined) {
+      obj.state = message.state !== undefined ? stateEnumToJSON(message.state) : undefined;
+    }
+    if (message.thing !== undefined) {
+      obj.thing = message.thing ? ImportedThing.toJSON(message.thing) : undefined;
+    }
+    if (message.birthday !== undefined) {
+      obj.birthday = message.birthday ? DateMessage.toJSON(message.birthday) : undefined;
+    }
     return obj;
   },
 

--- a/integration/simple/simple.ts
+++ b/integration/simple/simple.ts
@@ -538,13 +538,13 @@ export const Simple = {
       obj.createdAt = message.createdAt.toISOString();
     }
     if (message.child !== undefined) {
-      obj.child = message.child ? Child.toJSON(message.child) : undefined;
+      obj.child = Child.toJSON(message.child);
     }
     if (message.state !== 0) {
       obj.state = stateEnumToJSON(message.state);
     }
     if (message.grandChildren?.length) {
-      obj.grandChildren = message.grandChildren.map((e) => e ? Child.toJSON(e) : undefined);
+      obj.grandChildren = message.grandChildren.map((e) => Child.toJSON(e));
     }
     if (message.coins?.length) {
       obj.coins = message.coins.map((e) => Math.round(e));
@@ -556,16 +556,16 @@ export const Simple = {
       obj.oldStates = message.oldStates.map((e) => stateEnumToJSON(e));
     }
     if (message.thing !== undefined) {
-      obj.thing = message.thing ? ImportedThing.toJSON(message.thing) : undefined;
+      obj.thing = ImportedThing.toJSON(message.thing);
     }
     if (message.blobs?.length) {
-      obj.blobs = message.blobs.map((e) => base64FromBytes(e !== undefined ? e : new Uint8Array(0)));
+      obj.blobs = message.blobs.map((e) => base64FromBytes(e));
     }
     if (message.birthday !== undefined) {
-      obj.birthday = message.birthday ? DateMessage.toJSON(message.birthday) : undefined;
+      obj.birthday = DateMessage.toJSON(message.birthday);
     }
     if (message.blob.length !== 0) {
-      obj.blob = base64FromBytes(message.blob !== undefined ? message.blob : new Uint8Array(0));
+      obj.blob = base64FromBytes(message.blob);
     }
     if (message.enabled === true) {
       obj.enabled = message.enabled;
@@ -745,7 +745,7 @@ export const Nested = {
       obj.name = message.name;
     }
     if (message.message !== undefined) {
-      obj.message = message.message ? Nested_InnerMessage.toJSON(message.message) : undefined;
+      obj.message = Nested_InnerMessage.toJSON(message.message);
     }
     if (message.state !== 0) {
       obj.state = nested_InnerEnumToJSON(message.state);
@@ -826,7 +826,7 @@ export const Nested_InnerMessage = {
       obj.name = message.name;
     }
     if (message.deep !== undefined) {
-      obj.deep = message.deep ? Nested_InnerMessage_DeepMessage.toJSON(message.deep) : undefined;
+      obj.deep = Nested_InnerMessage_DeepMessage.toJSON(message.deep);
     }
     return obj;
   },
@@ -1547,7 +1547,7 @@ export const SimpleWithMap_EntitiesByIdEntry = {
       obj.key = Math.round(message.key);
     }
     if (message.value !== undefined) {
-      obj.value = message.value ? Entity.toJSON(message.value) : undefined;
+      obj.value = Entity.toJSON(message.value);
     }
     return obj;
   },
@@ -1851,7 +1851,7 @@ export const SimpleWithMap_MapOfBytesEntry = {
       obj.key = message.key;
     }
     if (message.value.length !== 0) {
-      obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array(0));
+      obj.value = base64FromBytes(message.value);
     }
     return obj;
   },
@@ -2163,7 +2163,7 @@ export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
       obj.key = Math.round(message.key);
     }
     if (message.value !== undefined) {
-      obj.value = message.value ? Entity.toJSON(message.value) : undefined;
+      obj.value = Entity.toJSON(message.value);
     }
     return obj;
   },
@@ -2828,16 +2828,16 @@ export const SimpleButOptional = {
       obj.createdAt = message.createdAt.toISOString();
     }
     if (message.child !== undefined) {
-      obj.child = message.child ? Child.toJSON(message.child) : undefined;
+      obj.child = Child.toJSON(message.child);
     }
     if (message.state !== undefined) {
-      obj.state = message.state !== undefined ? stateEnumToJSON(message.state) : undefined;
+      obj.state = stateEnumToJSON(message.state);
     }
     if (message.thing !== undefined) {
-      obj.thing = message.thing ? ImportedThing.toJSON(message.thing) : undefined;
+      obj.thing = ImportedThing.toJSON(message.thing);
     }
     if (message.birthday !== undefined) {
-      obj.birthday = message.birthday ? DateMessage.toJSON(message.birthday) : undefined;
+      obj.birthday = DateMessage.toJSON(message.birthday);
     }
     return obj;
   },

--- a/integration/simple/simple.ts
+++ b/integration/simple/simple.ts
@@ -550,7 +550,7 @@ export const Simple = {
       obj.coins = message.coins.map((e) => Math.round(e));
     }
     if (message.snacks?.length) {
-      obj.snacks = message.snacks.map((e) => e);
+      obj.snacks = message.snacks;
     }
     if (message.oldStates?.length) {
       obj.oldStates = message.oldStates.map((e) => stateEnumToJSON(e));
@@ -1088,10 +1088,10 @@ export const SimpleWithWrappers = {
       obj.enabled = message.enabled;
     }
     if (message.coins?.length) {
-      obj.coins = message.coins.map((e) => e);
+      obj.coins = message.coins;
     }
     if (message.snacks?.length) {
-      obj.snacks = message.snacks.map((e) => e);
+      obj.snacks = message.snacks;
     }
     if (message.id !== undefined) {
       obj.id = message.id;

--- a/integration/static-only-type-registry/bar/bar.ts
+++ b/integration/static-only-type-registry/bar/bar.ts
@@ -52,7 +52,9 @@ export const Bar = {
 
   toJSON(message: Bar): unknown {
     const obj: any = {};
-    message.foo !== undefined && (obj.foo = message.foo ? Foo.toJSON(message.foo) : undefined);
+    if (message.foo !== undefined) {
+      obj.foo = message.foo ? Foo.toJSON(message.foo) : undefined;
+    }
     return obj;
   },
 

--- a/integration/static-only-type-registry/bar/bar.ts
+++ b/integration/static-only-type-registry/bar/bar.ts
@@ -53,7 +53,7 @@ export const Bar = {
   toJSON(message: Bar): unknown {
     const obj: any = {};
     if (message.foo !== undefined) {
-      obj.foo = message.foo ? Foo.toJSON(message.foo) : undefined;
+      obj.foo = Foo.toJSON(message.foo);
     }
     return obj;
   },

--- a/integration/static-only-type-registry/foo.ts
+++ b/integration/static-only-type-registry/foo.ts
@@ -61,7 +61,9 @@ export const Foo = {
 
   toJSON(message: Foo): unknown {
     const obj: any = {};
-    message.timestamp !== undefined && (obj.timestamp = message.timestamp.toISOString());
+    if (message.timestamp !== undefined) {
+      obj.timestamp = message.timestamp.toISOString();
+    }
     return obj;
   },
 
@@ -121,7 +123,9 @@ export const Foo2 = {
 
   toJSON(message: Foo2): unknown {
     const obj: any = {};
-    message.timestamp !== undefined && (obj.timestamp = message.timestamp.toISOString());
+    if (message.timestamp !== undefined) {
+      obj.timestamp = message.timestamp.toISOString();
+    }
     return obj;
   },
 
@@ -181,7 +185,9 @@ export const WithStruct = {
 
   toJSON(message: WithStruct): unknown {
     const obj: any = {};
-    message.struct !== undefined && (obj.struct = message.struct);
+    if (message.struct !== undefined) {
+      obj.struct = message.struct;
+    }
     return obj;
   },
 

--- a/integration/static-only-type-registry/google/protobuf/struct.ts
+++ b/integration/static-only-type-registry/google/protobuf/struct.ts
@@ -156,11 +156,14 @@ export const Struct = {
 
   toJSON(message: Struct): unknown {
     const obj: any = {};
-    obj.fields = {};
     if (message.fields) {
-      Object.entries(message.fields).forEach(([k, v]) => {
-        obj.fields[k] = v;
-      });
+      const entries = Object.entries(message.fields);
+      if (entries.length > 0) {
+        obj.fields = {};
+        entries.forEach(([k, v]) => {
+          obj.fields[k] = v;
+        });
+      }
     }
     return obj;
   },
@@ -259,8 +262,12 @@ export const Struct_FieldsEntry = {
 
   toJSON(message: Struct_FieldsEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = message.key);
-    message.value !== undefined && (obj.value = message.value);
+    if (message.key !== "") {
+      obj.key = message.key;
+    }
+    if (message.value !== undefined) {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -385,13 +392,24 @@ export const Value = {
 
   toJSON(message: Value): unknown {
     const obj: any = {};
-    message.nullValue !== undefined &&
-      (obj.nullValue = message.nullValue !== undefined ? nullValueToJSON(message.nullValue) : undefined);
-    message.numberValue !== undefined && (obj.numberValue = message.numberValue);
-    message.stringValue !== undefined && (obj.stringValue = message.stringValue);
-    message.boolValue !== undefined && (obj.boolValue = message.boolValue);
-    message.structValue !== undefined && (obj.structValue = message.structValue);
-    message.listValue !== undefined && (obj.listValue = message.listValue);
+    if (message.nullValue !== undefined) {
+      obj.nullValue = message.nullValue !== undefined ? nullValueToJSON(message.nullValue) : undefined;
+    }
+    if (message.numberValue !== undefined) {
+      obj.numberValue = message.numberValue;
+    }
+    if (message.stringValue !== undefined) {
+      obj.stringValue = message.stringValue;
+    }
+    if (message.boolValue !== undefined) {
+      obj.boolValue = message.boolValue;
+    }
+    if (message.structValue !== undefined) {
+      obj.structValue = message.structValue;
+    }
+    if (message.listValue !== undefined) {
+      obj.listValue = message.listValue;
+    }
     return obj;
   },
 
@@ -493,10 +511,8 @@ export const ListValue = {
 
   toJSON(message: ListValue): unknown {
     const obj: any = {};
-    if (message.values) {
+    if (message.values?.length) {
       obj.values = message.values.map((e) => e);
-    } else {
-      obj.values = [];
     }
     return obj;
   },

--- a/integration/static-only-type-registry/google/protobuf/struct.ts
+++ b/integration/static-only-type-registry/google/protobuf/struct.ts
@@ -512,7 +512,7 @@ export const ListValue = {
   toJSON(message: ListValue): unknown {
     const obj: any = {};
     if (message.values?.length) {
-      obj.values = message.values.map((e) => e);
+      obj.values = message.values;
     }
     return obj;
   },

--- a/integration/static-only-type-registry/google/protobuf/struct.ts
+++ b/integration/static-only-type-registry/google/protobuf/struct.ts
@@ -393,7 +393,7 @@ export const Value = {
   toJSON(message: Value): unknown {
     const obj: any = {};
     if (message.nullValue !== undefined) {
-      obj.nullValue = message.nullValue !== undefined ? nullValueToJSON(message.nullValue) : undefined;
+      obj.nullValue = nullValueToJSON(message.nullValue);
     }
     if (message.numberValue !== undefined) {
       obj.numberValue = message.numberValue;

--- a/integration/static-only-type-registry/google/protobuf/timestamp.ts
+++ b/integration/static-only-type-registry/google/protobuf/timestamp.ts
@@ -168,8 +168,12 @@ export const Timestamp = {
 
   toJSON(message: Timestamp): unknown {
     const obj: any = {};
-    message.seconds !== undefined && (obj.seconds = Math.round(message.seconds));
-    message.nanos !== undefined && (obj.nanos = Math.round(message.nanos));
+    if (message.seconds !== 0) {
+      obj.seconds = Math.round(message.seconds);
+    }
+    if (message.nanos !== 0) {
+      obj.nanos = Math.round(message.nanos);
+    }
     return obj;
   },
 

--- a/integration/static-only/bar/bar.ts
+++ b/integration/static-only/bar/bar.ts
@@ -52,7 +52,7 @@ export const Bar = {
   toJSON(message: Bar): unknown {
     const obj: any = {};
     if (message.foo !== undefined) {
-      obj.foo = message.foo ? Foo.toJSON(message.foo) : undefined;
+      obj.foo = Foo.toJSON(message.foo);
     }
     return obj;
   },

--- a/integration/static-only/bar/bar.ts
+++ b/integration/static-only/bar/bar.ts
@@ -51,7 +51,9 @@ export const Bar = {
 
   toJSON(message: Bar): unknown {
     const obj: any = {};
-    message.foo !== undefined && (obj.foo = message.foo ? Foo.toJSON(message.foo) : undefined);
+    if (message.foo !== undefined) {
+      obj.foo = message.foo ? Foo.toJSON(message.foo) : undefined;
+    }
     return obj;
   },
 

--- a/integration/static-only/foo.ts
+++ b/integration/static-only/foo.ts
@@ -60,7 +60,9 @@ export const Foo = {
 
   toJSON(message: Foo): unknown {
     const obj: any = {};
-    message.timestamp !== undefined && (obj.timestamp = message.timestamp.toISOString());
+    if (message.timestamp !== undefined) {
+      obj.timestamp = message.timestamp.toISOString();
+    }
     return obj;
   },
 
@@ -118,7 +120,9 @@ export const Foo2 = {
 
   toJSON(message: Foo2): unknown {
     const obj: any = {};
-    message.timestamp !== undefined && (obj.timestamp = message.timestamp.toISOString());
+    if (message.timestamp !== undefined) {
+      obj.timestamp = message.timestamp.toISOString();
+    }
     return obj;
   },
 
@@ -176,7 +180,9 @@ export const WithStruct = {
 
   toJSON(message: WithStruct): unknown {
     const obj: any = {};
-    message.struct !== undefined && (obj.struct = message.struct);
+    if (message.struct !== undefined) {
+      obj.struct = message.struct;
+    }
     return obj;
   },
 

--- a/integration/static-only/google/protobuf/struct.ts
+++ b/integration/static-only/google/protobuf/struct.ts
@@ -505,7 +505,7 @@ export const ListValue = {
   toJSON(message: ListValue): unknown {
     const obj: any = {};
     if (message.values?.length) {
-      obj.values = message.values.map((e) => e);
+      obj.values = message.values;
     }
     return obj;
   },

--- a/integration/static-only/google/protobuf/struct.ts
+++ b/integration/static-only/google/protobuf/struct.ts
@@ -388,7 +388,7 @@ export const Value = {
   toJSON(message: Value): unknown {
     const obj: any = {};
     if (message.nullValue !== undefined) {
-      obj.nullValue = message.nullValue !== undefined ? nullValueToJSON(message.nullValue) : undefined;
+      obj.nullValue = nullValueToJSON(message.nullValue);
     }
     if (message.numberValue !== undefined) {
       obj.numberValue = message.numberValue;

--- a/integration/static-only/google/protobuf/struct.ts
+++ b/integration/static-only/google/protobuf/struct.ts
@@ -155,11 +155,14 @@ export const Struct = {
 
   toJSON(message: Struct): unknown {
     const obj: any = {};
-    obj.fields = {};
     if (message.fields) {
-      Object.entries(message.fields).forEach(([k, v]) => {
-        obj.fields[k] = v;
-      });
+      const entries = Object.entries(message.fields);
+      if (entries.length > 0) {
+        obj.fields = {};
+        entries.forEach(([k, v]) => {
+          obj.fields[k] = v;
+        });
+      }
     }
     return obj;
   },
@@ -256,8 +259,12 @@ export const Struct_FieldsEntry = {
 
   toJSON(message: Struct_FieldsEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = message.key);
-    message.value !== undefined && (obj.value = message.value);
+    if (message.key !== "") {
+      obj.key = message.key;
+    }
+    if (message.value !== undefined) {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -380,13 +387,24 @@ export const Value = {
 
   toJSON(message: Value): unknown {
     const obj: any = {};
-    message.nullValue !== undefined &&
-      (obj.nullValue = message.nullValue !== undefined ? nullValueToJSON(message.nullValue) : undefined);
-    message.numberValue !== undefined && (obj.numberValue = message.numberValue);
-    message.stringValue !== undefined && (obj.stringValue = message.stringValue);
-    message.boolValue !== undefined && (obj.boolValue = message.boolValue);
-    message.structValue !== undefined && (obj.structValue = message.structValue);
-    message.listValue !== undefined && (obj.listValue = message.listValue);
+    if (message.nullValue !== undefined) {
+      obj.nullValue = message.nullValue !== undefined ? nullValueToJSON(message.nullValue) : undefined;
+    }
+    if (message.numberValue !== undefined) {
+      obj.numberValue = message.numberValue;
+    }
+    if (message.stringValue !== undefined) {
+      obj.stringValue = message.stringValue;
+    }
+    if (message.boolValue !== undefined) {
+      obj.boolValue = message.boolValue;
+    }
+    if (message.structValue !== undefined) {
+      obj.structValue = message.structValue;
+    }
+    if (message.listValue !== undefined) {
+      obj.listValue = message.listValue;
+    }
     return obj;
   },
 
@@ -486,10 +504,8 @@ export const ListValue = {
 
   toJSON(message: ListValue): unknown {
     const obj: any = {};
-    if (message.values) {
+    if (message.values?.length) {
       obj.values = message.values.map((e) => e);
-    } else {
-      obj.values = [];
     }
     return obj;
   },

--- a/integration/static-only/google/protobuf/timestamp.ts
+++ b/integration/static-only/google/protobuf/timestamp.ts
@@ -167,8 +167,12 @@ export const Timestamp = {
 
   toJSON(message: Timestamp): unknown {
     const obj: any = {};
-    message.seconds !== undefined && (obj.seconds = Math.round(message.seconds));
-    message.nanos !== undefined && (obj.nanos = Math.round(message.nanos));
+    if (message.seconds !== 0) {
+      obj.seconds = Math.round(message.seconds);
+    }
+    if (message.nanos !== 0) {
+      obj.nanos = Math.round(message.nanos);
+    }
     return obj;
   },
 

--- a/integration/struct/google/protobuf/struct.ts
+++ b/integration/struct/google/protobuf/struct.ts
@@ -382,7 +382,7 @@ export const Value = {
   toJSON(message: Value): unknown {
     const obj: any = {};
     if (message.nullValue !== undefined) {
-      obj.nullValue = message.nullValue !== undefined ? nullValueToJSON(message.nullValue) : undefined;
+      obj.nullValue = nullValueToJSON(message.nullValue);
     }
     if (message.numberValue !== undefined) {
       obj.numberValue = message.numberValue;

--- a/integration/struct/google/protobuf/struct.ts
+++ b/integration/struct/google/protobuf/struct.ts
@@ -497,7 +497,7 @@ export const ListValue = {
   toJSON(message: ListValue): unknown {
     const obj: any = {};
     if (message.values?.length) {
-      obj.values = message.values.map((e) => e);
+      obj.values = message.values;
     }
     return obj;
   },

--- a/integration/struct/google/protobuf/struct.ts
+++ b/integration/struct/google/protobuf/struct.ts
@@ -153,11 +153,14 @@ export const Struct = {
 
   toJSON(message: Struct): unknown {
     const obj: any = {};
-    obj.fields = {};
     if (message.fields) {
-      Object.entries(message.fields).forEach(([k, v]) => {
-        obj.fields[k] = v;
-      });
+      const entries = Object.entries(message.fields);
+      if (entries.length > 0) {
+        obj.fields = {};
+        entries.forEach(([k, v]) => {
+          obj.fields[k] = v;
+        });
+      }
     }
     return obj;
   },
@@ -252,8 +255,12 @@ export const Struct_FieldsEntry = {
 
   toJSON(message: Struct_FieldsEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = message.key);
-    message.value !== undefined && (obj.value = message.value);
+    if (message.key !== "") {
+      obj.key = message.key;
+    }
+    if (message.value !== undefined) {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -374,13 +381,24 @@ export const Value = {
 
   toJSON(message: Value): unknown {
     const obj: any = {};
-    message.nullValue !== undefined &&
-      (obj.nullValue = message.nullValue !== undefined ? nullValueToJSON(message.nullValue) : undefined);
-    message.numberValue !== undefined && (obj.numberValue = message.numberValue);
-    message.stringValue !== undefined && (obj.stringValue = message.stringValue);
-    message.boolValue !== undefined && (obj.boolValue = message.boolValue);
-    message.structValue !== undefined && (obj.structValue = message.structValue);
-    message.listValue !== undefined && (obj.listValue = message.listValue);
+    if (message.nullValue !== undefined) {
+      obj.nullValue = message.nullValue !== undefined ? nullValueToJSON(message.nullValue) : undefined;
+    }
+    if (message.numberValue !== undefined) {
+      obj.numberValue = message.numberValue;
+    }
+    if (message.stringValue !== undefined) {
+      obj.stringValue = message.stringValue;
+    }
+    if (message.boolValue !== undefined) {
+      obj.boolValue = message.boolValue;
+    }
+    if (message.structValue !== undefined) {
+      obj.structValue = message.structValue;
+    }
+    if (message.listValue !== undefined) {
+      obj.listValue = message.listValue;
+    }
     return obj;
   },
 
@@ -478,10 +496,8 @@ export const ListValue = {
 
   toJSON(message: ListValue): unknown {
     const obj: any = {};
-    if (message.values) {
+    if (message.values?.length) {
       obj.values = message.values.map((e) => e);
-    } else {
-      obj.values = [];
     }
     return obj;
   },

--- a/integration/struct/struct.ts
+++ b/integration/struct/struct.ts
@@ -49,7 +49,9 @@ export const StructMessage = {
 
   toJSON(message: StructMessage): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = message.value);
+    if (message.value !== undefined) {
+      obj.value = message.value;
+    }
     return obj;
   },
 

--- a/integration/type-annotations/bar/bar.ts
+++ b/integration/type-annotations/bar/bar.ts
@@ -52,7 +52,9 @@ export const Bar = {
 
   toJSON(message: Bar): unknown {
     const obj: any = {};
-    message.foo !== undefined && (obj.foo = message.foo ? Foo.toJSON(message.foo) : undefined);
+    if (message.foo !== undefined) {
+      obj.foo = message.foo ? Foo.toJSON(message.foo) : undefined;
+    }
     return obj;
   },
 

--- a/integration/type-annotations/bar/bar.ts
+++ b/integration/type-annotations/bar/bar.ts
@@ -53,7 +53,7 @@ export const Bar = {
   toJSON(message: Bar): unknown {
     const obj: any = {};
     if (message.foo !== undefined) {
-      obj.foo = message.foo ? Foo.toJSON(message.foo) : undefined;
+      obj.foo = Foo.toJSON(message.foo);
     }
     return obj;
   },

--- a/integration/type-annotations/foo.ts
+++ b/integration/type-annotations/foo.ts
@@ -63,7 +63,9 @@ export const Foo = {
 
   toJSON(message: Foo): unknown {
     const obj: any = {};
-    message.timestamp !== undefined && (obj.timestamp = message.timestamp.toISOString());
+    if (message.timestamp !== undefined) {
+      obj.timestamp = message.timestamp.toISOString();
+    }
     return obj;
   },
 
@@ -121,7 +123,9 @@ export const Foo2 = {
 
   toJSON(message: Foo2): unknown {
     const obj: any = {};
-    message.timestamp !== undefined && (obj.timestamp = message.timestamp.toISOString());
+    if (message.timestamp !== undefined) {
+      obj.timestamp = message.timestamp.toISOString();
+    }
     return obj;
   },
 
@@ -179,7 +183,9 @@ export const WithStruct = {
 
   toJSON(message: WithStruct): unknown {
     const obj: any = {};
-    message.struct !== undefined && (obj.struct = message.struct);
+    if (message.struct !== undefined) {
+      obj.struct = message.struct;
+    }
     return obj;
   },
 

--- a/integration/type-annotations/google/protobuf/struct.ts
+++ b/integration/type-annotations/google/protobuf/struct.ts
@@ -402,7 +402,7 @@ export const Value = {
   toJSON(message: Value): unknown {
     const obj: any = {};
     if (message.nullValue !== undefined) {
-      obj.nullValue = message.nullValue !== undefined ? nullValueToJSON(message.nullValue) : undefined;
+      obj.nullValue = nullValueToJSON(message.nullValue);
     }
     if (message.numberValue !== undefined) {
       obj.numberValue = message.numberValue;

--- a/integration/type-annotations/google/protobuf/struct.ts
+++ b/integration/type-annotations/google/protobuf/struct.ts
@@ -519,7 +519,7 @@ export const ListValue = {
   toJSON(message: ListValue): unknown {
     const obj: any = {};
     if (message.values?.length) {
-      obj.values = message.values.map((e) => e);
+      obj.values = message.values;
     }
     return obj;
   },

--- a/integration/type-annotations/google/protobuf/struct.ts
+++ b/integration/type-annotations/google/protobuf/struct.ts
@@ -163,11 +163,14 @@ export const Struct = {
 
   toJSON(message: Struct): unknown {
     const obj: any = {};
-    obj.fields = {};
     if (message.fields) {
-      Object.entries(message.fields).forEach(([k, v]) => {
-        obj.fields[k] = v;
-      });
+      const entries = Object.entries(message.fields);
+      if (entries.length > 0) {
+        obj.fields = {};
+        entries.forEach(([k, v]) => {
+          obj.fields[k] = v;
+        });
+      }
     }
     return obj;
   },
@@ -268,8 +271,12 @@ export const Struct_FieldsEntry = {
 
   toJSON(message: Struct_FieldsEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = message.key);
-    message.value !== undefined && (obj.value = message.value);
+    if (message.key !== "") {
+      obj.key = message.key;
+    }
+    if (message.value !== undefined) {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -394,13 +401,24 @@ export const Value = {
 
   toJSON(message: Value): unknown {
     const obj: any = {};
-    message.nullValue !== undefined &&
-      (obj.nullValue = message.nullValue !== undefined ? nullValueToJSON(message.nullValue) : undefined);
-    message.numberValue !== undefined && (obj.numberValue = message.numberValue);
-    message.stringValue !== undefined && (obj.stringValue = message.stringValue);
-    message.boolValue !== undefined && (obj.boolValue = message.boolValue);
-    message.structValue !== undefined && (obj.structValue = message.structValue);
-    message.listValue !== undefined && (obj.listValue = message.listValue);
+    if (message.nullValue !== undefined) {
+      obj.nullValue = message.nullValue !== undefined ? nullValueToJSON(message.nullValue) : undefined;
+    }
+    if (message.numberValue !== undefined) {
+      obj.numberValue = message.numberValue;
+    }
+    if (message.stringValue !== undefined) {
+      obj.stringValue = message.stringValue;
+    }
+    if (message.boolValue !== undefined) {
+      obj.boolValue = message.boolValue;
+    }
+    if (message.structValue !== undefined) {
+      obj.structValue = message.structValue;
+    }
+    if (message.listValue !== undefined) {
+      obj.listValue = message.listValue;
+    }
     return obj;
   },
 
@@ -500,10 +518,8 @@ export const ListValue = {
 
   toJSON(message: ListValue): unknown {
     const obj: any = {};
-    if (message.values) {
+    if (message.values?.length) {
       obj.values = message.values.map((e) => e);
-    } else {
-      obj.values = [];
     }
     return obj;
   },

--- a/integration/type-annotations/google/protobuf/timestamp.ts
+++ b/integration/type-annotations/google/protobuf/timestamp.ts
@@ -169,8 +169,12 @@ export const Timestamp = {
 
   toJSON(message: Timestamp): unknown {
     const obj: any = {};
-    message.seconds !== undefined && (obj.seconds = Math.round(message.seconds));
-    message.nanos !== undefined && (obj.nanos = Math.round(message.nanos));
+    if (message.seconds !== 0) {
+      obj.seconds = Math.round(message.seconds);
+    }
+    if (message.nanos !== 0) {
+      obj.nanos = Math.round(message.nanos);
+    }
     return obj;
   },
 

--- a/integration/type-registry/bar/bar.ts
+++ b/integration/type-registry/bar/bar.ts
@@ -54,7 +54,7 @@ export const Bar = {
   toJSON(message: Bar): unknown {
     const obj: any = {};
     if (message.foo !== undefined) {
-      obj.foo = message.foo ? Foo.toJSON(message.foo) : undefined;
+      obj.foo = Foo.toJSON(message.foo);
     }
     return obj;
   },

--- a/integration/type-registry/bar/bar.ts
+++ b/integration/type-registry/bar/bar.ts
@@ -53,7 +53,9 @@ export const Bar = {
 
   toJSON(message: Bar): unknown {
     const obj: any = {};
-    message.foo !== undefined && (obj.foo = message.foo ? Foo.toJSON(message.foo) : undefined);
+    if (message.foo !== undefined) {
+      obj.foo = message.foo ? Foo.toJSON(message.foo) : undefined;
+    }
     return obj;
   },
 

--- a/integration/type-registry/foo.ts
+++ b/integration/type-registry/foo.ts
@@ -64,7 +64,9 @@ export const Foo = {
 
   toJSON(message: Foo): unknown {
     const obj: any = {};
-    message.timestamp !== undefined && (obj.timestamp = message.timestamp.toISOString());
+    if (message.timestamp !== undefined) {
+      obj.timestamp = message.timestamp.toISOString();
+    }
     return obj;
   },
 
@@ -124,7 +126,9 @@ export const Foo2 = {
 
   toJSON(message: Foo2): unknown {
     const obj: any = {};
-    message.timestamp !== undefined && (obj.timestamp = message.timestamp.toISOString());
+    if (message.timestamp !== undefined) {
+      obj.timestamp = message.timestamp.toISOString();
+    }
     return obj;
   },
 
@@ -184,7 +188,9 @@ export const WithStruct = {
 
   toJSON(message: WithStruct): unknown {
     const obj: any = {};
-    message.struct !== undefined && (obj.struct = message.struct);
+    if (message.struct !== undefined) {
+      obj.struct = message.struct;
+    }
     return obj;
   },
 

--- a/integration/type-registry/google/protobuf/struct.ts
+++ b/integration/type-registry/google/protobuf/struct.ts
@@ -407,7 +407,7 @@ export const Value = {
   toJSON(message: Value): unknown {
     const obj: any = {};
     if (message.nullValue !== undefined) {
-      obj.nullValue = message.nullValue !== undefined ? nullValueToJSON(message.nullValue) : undefined;
+      obj.nullValue = nullValueToJSON(message.nullValue);
     }
     if (message.numberValue !== undefined) {
       obj.numberValue = message.numberValue;

--- a/integration/type-registry/google/protobuf/struct.ts
+++ b/integration/type-registry/google/protobuf/struct.ts
@@ -526,7 +526,7 @@ export const ListValue = {
   toJSON(message: ListValue): unknown {
     const obj: any = {};
     if (message.values?.length) {
-      obj.values = message.values.map((e) => e);
+      obj.values = message.values;
     }
     return obj;
   },

--- a/integration/type-registry/google/protobuf/struct.ts
+++ b/integration/type-registry/google/protobuf/struct.ts
@@ -164,11 +164,14 @@ export const Struct = {
 
   toJSON(message: Struct): unknown {
     const obj: any = {};
-    obj.fields = {};
     if (message.fields) {
-      Object.entries(message.fields).forEach(([k, v]) => {
-        obj.fields[k] = v;
-      });
+      const entries = Object.entries(message.fields);
+      if (entries.length > 0) {
+        obj.fields = {};
+        entries.forEach(([k, v]) => {
+          obj.fields[k] = v;
+        });
+      }
     }
     return obj;
   },
@@ -271,8 +274,12 @@ export const Struct_FieldsEntry = {
 
   toJSON(message: Struct_FieldsEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = message.key);
-    message.value !== undefined && (obj.value = message.value);
+    if (message.key !== "") {
+      obj.key = message.key;
+    }
+    if (message.value !== undefined) {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -399,13 +406,24 @@ export const Value = {
 
   toJSON(message: Value): unknown {
     const obj: any = {};
-    message.nullValue !== undefined &&
-      (obj.nullValue = message.nullValue !== undefined ? nullValueToJSON(message.nullValue) : undefined);
-    message.numberValue !== undefined && (obj.numberValue = message.numberValue);
-    message.stringValue !== undefined && (obj.stringValue = message.stringValue);
-    message.boolValue !== undefined && (obj.boolValue = message.boolValue);
-    message.structValue !== undefined && (obj.structValue = message.structValue);
-    message.listValue !== undefined && (obj.listValue = message.listValue);
+    if (message.nullValue !== undefined) {
+      obj.nullValue = message.nullValue !== undefined ? nullValueToJSON(message.nullValue) : undefined;
+    }
+    if (message.numberValue !== undefined) {
+      obj.numberValue = message.numberValue;
+    }
+    if (message.stringValue !== undefined) {
+      obj.stringValue = message.stringValue;
+    }
+    if (message.boolValue !== undefined) {
+      obj.boolValue = message.boolValue;
+    }
+    if (message.structValue !== undefined) {
+      obj.structValue = message.structValue;
+    }
+    if (message.listValue !== undefined) {
+      obj.listValue = message.listValue;
+    }
     return obj;
   },
 
@@ -507,10 +525,8 @@ export const ListValue = {
 
   toJSON(message: ListValue): unknown {
     const obj: any = {};
-    if (message.values) {
+    if (message.values?.length) {
       obj.values = message.values.map((e) => e);
-    } else {
-      obj.values = [];
     }
     return obj;
   },

--- a/integration/type-registry/google/protobuf/timestamp.ts
+++ b/integration/type-registry/google/protobuf/timestamp.ts
@@ -170,8 +170,12 @@ export const Timestamp = {
 
   toJSON(message: Timestamp): unknown {
     const obj: any = {};
-    message.seconds !== undefined && (obj.seconds = Math.round(message.seconds));
-    message.nanos !== undefined && (obj.nanos = Math.round(message.nanos));
+    if (message.seconds !== 0) {
+      obj.seconds = Math.round(message.seconds);
+    }
+    if (message.nanos !== 0) {
+      obj.nanos = Math.round(message.nanos);
+    }
     return obj;
   },
 

--- a/integration/types-with-underscores/file.ts
+++ b/integration/types-with-underscores/file.ts
@@ -51,7 +51,9 @@ export const Baz = {
 
   toJSON(message: Baz): unknown {
     const obj: any = {};
-    message.foo !== undefined && (obj.foo = message.foo ? FooBar.toJSON(message.foo) : undefined);
+    if (message.foo !== undefined) {
+      obj.foo = message.foo ? FooBar.toJSON(message.foo) : undefined;
+    }
     return obj;
   },
 

--- a/integration/types-with-underscores/file.ts
+++ b/integration/types-with-underscores/file.ts
@@ -52,7 +52,7 @@ export const Baz = {
   toJSON(message: Baz): unknown {
     const obj: any = {};
     if (message.foo !== undefined) {
-      obj.foo = message.foo ? FooBar.toJSON(message.foo) : undefined;
+      obj.foo = FooBar.toJSON(message.foo);
     }
     return obj;
   },

--- a/integration/use-date-false/google/protobuf/timestamp.ts
+++ b/integration/use-date-false/google/protobuf/timestamp.ts
@@ -165,8 +165,12 @@ export const Timestamp = {
 
   toJSON(message: Timestamp): unknown {
     const obj: any = {};
-    message.seconds !== undefined && (obj.seconds = Math.round(message.seconds));
-    message.nanos !== undefined && (obj.nanos = Math.round(message.nanos));
+    if (message.seconds !== 0) {
+      obj.seconds = Math.round(message.seconds);
+    }
+    if (message.nanos !== 0) {
+      obj.nanos = Math.round(message.nanos);
+    }
     return obj;
   },
 

--- a/integration/use-date-false/metadata.ts
+++ b/integration/use-date-false/metadata.ts
@@ -49,7 +49,9 @@ export const Metadata = {
 
   toJSON(message: Metadata): unknown {
     const obj: any = {};
-    message.lastEdited !== undefined && (obj.lastEdited = fromTimestamp(message.lastEdited).toISOString());
+    if (message.lastEdited !== undefined) {
+      obj.lastEdited = fromTimestamp(message.lastEdited).toISOString();
+    }
     return obj;
   },
 

--- a/integration/use-date-string/google/protobuf/timestamp.ts
+++ b/integration/use-date-string/google/protobuf/timestamp.ts
@@ -165,8 +165,12 @@ export const Timestamp = {
 
   toJSON(message: Timestamp): unknown {
     const obj: any = {};
-    message.seconds !== undefined && (obj.seconds = Math.round(message.seconds));
-    message.nanos !== undefined && (obj.nanos = Math.round(message.nanos));
+    if (message.seconds !== 0) {
+      obj.seconds = Math.round(message.seconds);
+    }
+    if (message.nanos !== 0) {
+      obj.nanos = Math.round(message.nanos);
+    }
     return obj;
   },
 

--- a/integration/use-date-string/use-date-string.ts
+++ b/integration/use-date-string/use-date-string.ts
@@ -121,7 +121,7 @@ export const Todo = {
       obj.timestamp = message.timestamp;
     }
     if (message.repeatedTimestamp?.length) {
-      obj.repeatedTimestamp = message.repeatedTimestamp.map((e) => e);
+      obj.repeatedTimestamp = message.repeatedTimestamp;
     }
     if (message.optionalTimestamp !== undefined) {
       obj.optionalTimestamp = message.optionalTimestamp;

--- a/integration/use-date-string/use-date-string.ts
+++ b/integration/use-date-string/use-date-string.ts
@@ -114,19 +114,26 @@ export const Todo = {
 
   toJSON(message: Todo): unknown {
     const obj: any = {};
-    message.id !== undefined && (obj.id = message.id);
-    message.timestamp !== undefined && (obj.timestamp = message.timestamp);
-    if (message.repeatedTimestamp) {
-      obj.repeatedTimestamp = message.repeatedTimestamp.map((e) => e);
-    } else {
-      obj.repeatedTimestamp = [];
+    if (message.id !== "") {
+      obj.id = message.id;
     }
-    message.optionalTimestamp !== undefined && (obj.optionalTimestamp = message.optionalTimestamp);
-    obj.mapOfTimestamps = {};
+    if (message.timestamp !== undefined) {
+      obj.timestamp = message.timestamp;
+    }
+    if (message.repeatedTimestamp?.length) {
+      obj.repeatedTimestamp = message.repeatedTimestamp.map((e) => e);
+    }
+    if (message.optionalTimestamp !== undefined) {
+      obj.optionalTimestamp = message.optionalTimestamp;
+    }
     if (message.mapOfTimestamps) {
-      Object.entries(message.mapOfTimestamps).forEach(([k, v]) => {
-        obj.mapOfTimestamps[k] = v;
-      });
+      const entries = Object.entries(message.mapOfTimestamps);
+      if (entries.length > 0) {
+        obj.mapOfTimestamps = {};
+        entries.forEach(([k, v]) => {
+          obj.mapOfTimestamps[k] = v;
+        });
+      }
     }
     return obj;
   },
@@ -208,8 +215,12 @@ export const Todo_MapOfTimestampsEntry = {
 
   toJSON(message: Todo_MapOfTimestampsEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = message.key);
-    message.value !== undefined && (obj.value = message.value);
+    if (message.key !== "") {
+      obj.key = message.key;
+    }
+    if (message.value !== undefined) {
+      obj.value = message.value;
+    }
     return obj;
   },
 

--- a/integration/use-date-true/google/protobuf/timestamp.ts
+++ b/integration/use-date-true/google/protobuf/timestamp.ts
@@ -165,8 +165,12 @@ export const Timestamp = {
 
   toJSON(message: Timestamp): unknown {
     const obj: any = {};
-    message.seconds !== undefined && (obj.seconds = Math.round(message.seconds));
-    message.nanos !== undefined && (obj.nanos = Math.round(message.nanos));
+    if (message.seconds !== 0) {
+      obj.seconds = Math.round(message.seconds);
+    }
+    if (message.nanos !== 0) {
+      obj.nanos = Math.round(message.nanos);
+    }
     return obj;
   },
 

--- a/integration/use-date-true/use-date-true.ts
+++ b/integration/use-date-true/use-date-true.ts
@@ -115,19 +115,26 @@ export const Todo = {
 
   toJSON(message: Todo): unknown {
     const obj: any = {};
-    message.id !== undefined && (obj.id = message.id);
-    message.timestamp !== undefined && (obj.timestamp = message.timestamp.toISOString());
-    if (message.repeatedTimestamp) {
-      obj.repeatedTimestamp = message.repeatedTimestamp.map((e) => e.toISOString());
-    } else {
-      obj.repeatedTimestamp = [];
+    if (message.id !== "") {
+      obj.id = message.id;
     }
-    message.optionalTimestamp !== undefined && (obj.optionalTimestamp = message.optionalTimestamp.toISOString());
-    obj.mapOfTimestamps = {};
+    if (message.timestamp !== undefined) {
+      obj.timestamp = message.timestamp.toISOString();
+    }
+    if (message.repeatedTimestamp?.length) {
+      obj.repeatedTimestamp = message.repeatedTimestamp.map((e) => e.toISOString());
+    }
+    if (message.optionalTimestamp !== undefined) {
+      obj.optionalTimestamp = message.optionalTimestamp.toISOString();
+    }
     if (message.mapOfTimestamps) {
-      Object.entries(message.mapOfTimestamps).forEach(([k, v]) => {
-        obj.mapOfTimestamps[k] = v.toISOString();
-      });
+      const entries = Object.entries(message.mapOfTimestamps);
+      if (entries.length > 0) {
+        obj.mapOfTimestamps = {};
+        entries.forEach(([k, v]) => {
+          obj.mapOfTimestamps[k] = v.toISOString();
+        });
+      }
     }
     return obj;
   },
@@ -209,8 +216,12 @@ export const Todo_MapOfTimestampsEntry = {
 
   toJSON(message: Todo_MapOfTimestampsEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = message.key);
-    message.value !== undefined && (obj.value = message.value.toISOString());
+    if (message.key !== "") {
+      obj.key = message.key;
+    }
+    if (message.value !== undefined) {
+      obj.value = message.value.toISOString();
+    }
     return obj;
   },
 

--- a/integration/use-exact-types-false/foo.ts
+++ b/integration/use-exact-types-false/foo.ts
@@ -59,8 +59,12 @@ export const Foo = {
 
   toJSON(message: Foo): unknown {
     const obj: any = {};
-    message.bar !== undefined && (obj.bar = message.bar);
-    message.baz !== undefined && (obj.baz = message.baz);
+    if (message.bar !== "") {
+      obj.bar = message.bar;
+    }
+    if (message.baz !== "") {
+      obj.baz = message.baz;
+    }
     return obj;
   },
 

--- a/integration/use-map-type/google/protobuf/struct.ts
+++ b/integration/use-map-type/google/protobuf/struct.ts
@@ -153,8 +153,8 @@ export const Struct = {
 
   toJSON(message: Struct): unknown {
     const obj: any = {};
-    obj.fields = {};
-    if (message.fields) {
+    if (message.fields?.size) {
+      obj.fields = {};
       message.fields.forEach((v, k) => {
         obj.fields[k] = v;
       });
@@ -250,8 +250,12 @@ export const Struct_FieldsEntry = {
 
   toJSON(message: Struct_FieldsEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = message.key);
-    message.value !== undefined && (obj.value = message.value);
+    if (message.key !== "") {
+      obj.key = message.key;
+    }
+    if (message.value !== undefined) {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -372,13 +376,24 @@ export const Value = {
 
   toJSON(message: Value): unknown {
     const obj: any = {};
-    message.nullValue !== undefined &&
-      (obj.nullValue = message.nullValue !== undefined ? nullValueToJSON(message.nullValue) : undefined);
-    message.numberValue !== undefined && (obj.numberValue = message.numberValue);
-    message.stringValue !== undefined && (obj.stringValue = message.stringValue);
-    message.boolValue !== undefined && (obj.boolValue = message.boolValue);
-    message.structValue !== undefined && (obj.structValue = message.structValue);
-    message.listValue !== undefined && (obj.listValue = message.listValue);
+    if (message.nullValue !== undefined) {
+      obj.nullValue = message.nullValue !== undefined ? nullValueToJSON(message.nullValue) : undefined;
+    }
+    if (message.numberValue !== undefined) {
+      obj.numberValue = message.numberValue;
+    }
+    if (message.stringValue !== undefined) {
+      obj.stringValue = message.stringValue;
+    }
+    if (message.boolValue !== undefined) {
+      obj.boolValue = message.boolValue;
+    }
+    if (message.structValue !== undefined) {
+      obj.structValue = message.structValue;
+    }
+    if (message.listValue !== undefined) {
+      obj.listValue = message.listValue;
+    }
     return obj;
   },
 
@@ -476,10 +491,8 @@ export const ListValue = {
 
   toJSON(message: ListValue): unknown {
     const obj: any = {};
-    if (message.values) {
+    if (message.values?.length) {
       obj.values = message.values.map((e) => e);
-    } else {
-      obj.values = [];
     }
     return obj;
   },

--- a/integration/use-map-type/google/protobuf/struct.ts
+++ b/integration/use-map-type/google/protobuf/struct.ts
@@ -377,7 +377,7 @@ export const Value = {
   toJSON(message: Value): unknown {
     const obj: any = {};
     if (message.nullValue !== undefined) {
-      obj.nullValue = message.nullValue !== undefined ? nullValueToJSON(message.nullValue) : undefined;
+      obj.nullValue = nullValueToJSON(message.nullValue);
     }
     if (message.numberValue !== undefined) {
       obj.numberValue = message.numberValue;

--- a/integration/use-map-type/google/protobuf/struct.ts
+++ b/integration/use-map-type/google/protobuf/struct.ts
@@ -492,7 +492,7 @@ export const ListValue = {
   toJSON(message: ListValue): unknown {
     const obj: any = {};
     if (message.values?.length) {
-      obj.values = message.values.map((e) => e);
+      obj.values = message.values;
     }
     return obj;
   },

--- a/integration/use-map-type/google/protobuf/timestamp.ts
+++ b/integration/use-map-type/google/protobuf/timestamp.ts
@@ -165,8 +165,12 @@ export const Timestamp = {
 
   toJSON(message: Timestamp): unknown {
     const obj: any = {};
-    message.seconds !== undefined && (obj.seconds = Math.round(message.seconds));
-    message.nanos !== undefined && (obj.nanos = Math.round(message.nanos));
+    if (message.seconds !== 0) {
+      obj.seconds = Math.round(message.seconds);
+    }
+    if (message.nanos !== 0) {
+      obj.nanos = Math.round(message.nanos);
+    }
     return obj;
   },
 

--- a/integration/use-map-type/use-map-type.ts
+++ b/integration/use-map-type/use-map-type.ts
@@ -397,7 +397,7 @@ export const Maps_StrToEntityEntry = {
       obj.key = message.key;
     }
     if (message.value !== undefined) {
-      obj.value = message.value ? Entity.toJSON(message.value) : undefined;
+      obj.value = Entity.toJSON(message.value);
     }
     return obj;
   },
@@ -546,7 +546,7 @@ export const Maps_StringToBytesEntry = {
       obj.key = message.key;
     }
     if (message.value.length !== 0) {
-      obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array(0));
+      obj.value = base64FromBytes(message.value);
     }
     return obj;
   },

--- a/integration/use-map-type/use-map-type.ts
+++ b/integration/use-map-type/use-map-type.ts
@@ -85,7 +85,9 @@ export const Entity = {
 
   toJSON(message: Entity): unknown {
     const obj: any = {};
-    message.id !== undefined && (obj.id = Math.round(message.id));
+    if (message.id !== 0) {
+      obj.id = Math.round(message.id);
+    }
     return obj;
   },
 
@@ -245,37 +247,39 @@ export const Maps = {
 
   toJSON(message: Maps): unknown {
     const obj: any = {};
-    obj.strToEntity = {};
-    if (message.strToEntity) {
+    if (message.strToEntity?.size) {
+      obj.strToEntity = {};
       message.strToEntity.forEach((v, k) => {
         obj.strToEntity[k] = Entity.toJSON(v);
       });
     }
-    obj.int32ToInt32 = {};
-    if (message.int32ToInt32) {
+    if (message.int32ToInt32?.size) {
+      obj.int32ToInt32 = {};
       message.int32ToInt32.forEach((v, k) => {
         obj.int32ToInt32[k] = Math.round(v);
       });
     }
-    obj.stringToBytes = {};
-    if (message.stringToBytes) {
+    if (message.stringToBytes?.size) {
+      obj.stringToBytes = {};
       message.stringToBytes.forEach((v, k) => {
         obj.stringToBytes[k] = base64FromBytes(v);
       });
     }
-    obj.int64ToInt64 = {};
-    if (message.int64ToInt64) {
+    if (message.int64ToInt64?.size) {
+      obj.int64ToInt64 = {};
       message.int64ToInt64.forEach((v, k) => {
         obj.int64ToInt64[k] = Math.round(v);
       });
     }
-    obj.mapOfTimestamps = {};
-    if (message.mapOfTimestamps) {
+    if (message.mapOfTimestamps?.size) {
+      obj.mapOfTimestamps = {};
       message.mapOfTimestamps.forEach((v, k) => {
         obj.mapOfTimestamps[k] = v.toISOString();
       });
     }
-    message.struct !== undefined && (obj.struct = message.struct);
+    if (message.struct !== undefined) {
+      obj.struct = message.struct;
+    }
     return obj;
   },
 
@@ -389,8 +393,12 @@ export const Maps_StrToEntityEntry = {
 
   toJSON(message: Maps_StrToEntityEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = message.key);
-    message.value !== undefined && (obj.value = message.value ? Entity.toJSON(message.value) : undefined);
+    if (message.key !== "") {
+      obj.key = message.key;
+    }
+    if (message.value !== undefined) {
+      obj.value = message.value ? Entity.toJSON(message.value) : undefined;
+    }
     return obj;
   },
 
@@ -459,8 +467,12 @@ export const Maps_Int32ToInt32Entry = {
 
   toJSON(message: Maps_Int32ToInt32Entry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = Math.round(message.key));
-    message.value !== undefined && (obj.value = Math.round(message.value));
+    if (message.key !== 0) {
+      obj.key = Math.round(message.key);
+    }
+    if (message.value !== 0) {
+      obj.value = Math.round(message.value);
+    }
     return obj;
   },
 
@@ -530,9 +542,12 @@ export const Maps_StringToBytesEntry = {
 
   toJSON(message: Maps_StringToBytesEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = message.key);
-    message.value !== undefined &&
-      (obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array(0)));
+    if (message.key !== "") {
+      obj.key = message.key;
+    }
+    if (message.value.length !== 0) {
+      obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array(0));
+    }
     return obj;
   },
 
@@ -599,8 +614,12 @@ export const Maps_Int64ToInt64Entry = {
 
   toJSON(message: Maps_Int64ToInt64Entry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = Math.round(message.key));
-    message.value !== undefined && (obj.value = Math.round(message.value));
+    if (message.key !== 0) {
+      obj.key = Math.round(message.key);
+    }
+    if (message.value !== 0) {
+      obj.value = Math.round(message.value);
+    }
     return obj;
   },
 
@@ -670,8 +689,12 @@ export const Maps_MapOfTimestampsEntry = {
 
   toJSON(message: Maps_MapOfTimestampsEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = message.key);
-    message.value !== undefined && (obj.value = message.value.toISOString());
+    if (message.key !== "") {
+      obj.key = message.key;
+    }
+    if (message.value !== undefined) {
+      obj.value = message.value.toISOString();
+    }
     return obj;
   },
 

--- a/integration/use-numeric-enum-json/google/protobuf/struct.ts
+++ b/integration/use-numeric-enum-json/google/protobuf/struct.ts
@@ -382,7 +382,7 @@ export const Value = {
   toJSON(message: Value): unknown {
     const obj: any = {};
     if (message.nullValue !== undefined) {
-      obj.nullValue = message.nullValue !== undefined ? nullValueToJSON(message.nullValue) : undefined;
+      obj.nullValue = nullValueToJSON(message.nullValue);
     }
     if (message.numberValue !== undefined) {
       obj.numberValue = message.numberValue;

--- a/integration/use-numeric-enum-json/google/protobuf/struct.ts
+++ b/integration/use-numeric-enum-json/google/protobuf/struct.ts
@@ -497,7 +497,7 @@ export const ListValue = {
   toJSON(message: ListValue): unknown {
     const obj: any = {};
     if (message.values?.length) {
-      obj.values = message.values.map((e) => e);
+      obj.values = message.values;
     }
     return obj;
   },

--- a/integration/use-numeric-enum-json/google/protobuf/struct.ts
+++ b/integration/use-numeric-enum-json/google/protobuf/struct.ts
@@ -153,11 +153,14 @@ export const Struct = {
 
   toJSON(message: Struct): unknown {
     const obj: any = {};
-    obj.fields = {};
     if (message.fields) {
-      Object.entries(message.fields).forEach(([k, v]) => {
-        obj.fields[k] = v;
-      });
+      const entries = Object.entries(message.fields);
+      if (entries.length > 0) {
+        obj.fields = {};
+        entries.forEach(([k, v]) => {
+          obj.fields[k] = v;
+        });
+      }
     }
     return obj;
   },
@@ -252,8 +255,12 @@ export const Struct_FieldsEntry = {
 
   toJSON(message: Struct_FieldsEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = message.key);
-    message.value !== undefined && (obj.value = message.value);
+    if (message.key !== "") {
+      obj.key = message.key;
+    }
+    if (message.value !== undefined) {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -374,13 +381,24 @@ export const Value = {
 
   toJSON(message: Value): unknown {
     const obj: any = {};
-    message.nullValue !== undefined &&
-      (obj.nullValue = message.nullValue !== undefined ? nullValueToJSON(message.nullValue) : undefined);
-    message.numberValue !== undefined && (obj.numberValue = message.numberValue);
-    message.stringValue !== undefined && (obj.stringValue = message.stringValue);
-    message.boolValue !== undefined && (obj.boolValue = message.boolValue);
-    message.structValue !== undefined && (obj.structValue = message.structValue);
-    message.listValue !== undefined && (obj.listValue = message.listValue);
+    if (message.nullValue !== undefined) {
+      obj.nullValue = message.nullValue !== undefined ? nullValueToJSON(message.nullValue) : undefined;
+    }
+    if (message.numberValue !== undefined) {
+      obj.numberValue = message.numberValue;
+    }
+    if (message.stringValue !== undefined) {
+      obj.stringValue = message.stringValue;
+    }
+    if (message.boolValue !== undefined) {
+      obj.boolValue = message.boolValue;
+    }
+    if (message.structValue !== undefined) {
+      obj.structValue = message.structValue;
+    }
+    if (message.listValue !== undefined) {
+      obj.listValue = message.listValue;
+    }
     return obj;
   },
 
@@ -478,10 +496,8 @@ export const ListValue = {
 
   toJSON(message: ListValue): unknown {
     const obj: any = {};
-    if (message.values) {
+    if (message.values?.length) {
       obj.values = message.values.map((e) => e);
-    } else {
-      obj.values = [];
     }
     return obj;
   },

--- a/integration/use-numeric-enum-json/simple-test.ts
+++ b/integration/use-numeric-enum-json/simple-test.ts
@@ -14,7 +14,7 @@ describe('use-numeric-enum-json', () => {
     const json = Simple.toJSON(s);
 
     // Make sure that enum values are encoded as integers.
-    expect(json).toEqual({ name: 'a', nullValue: 0, state: 2, stateMap: { on: 2 }, states: [2, 3] });
+    expect(json).toEqual({ name: 'a', state: 2, stateMap: { on: 2 }, states: [2, 3] });
 
     // Original object can be recovered from the json.
     expect(Simple.fromJSON(json)).toEqual(s);

--- a/integration/use-numeric-enum-json/simple.ts
+++ b/integration/use-numeric-enum-json/simple.ts
@@ -163,19 +163,26 @@ export const Simple = {
 
   toJSON(message: Simple): unknown {
     const obj: any = {};
-    message.name !== undefined && (obj.name = message.name);
-    message.state !== undefined && (obj.state = stateEnumToJSON(message.state));
-    if (message.states) {
-      obj.states = message.states.map((e) => stateEnumToJSON(e));
-    } else {
-      obj.states = [];
+    if (message.name !== "") {
+      obj.name = message.name;
     }
-    message.nullValue !== undefined && (obj.nullValue = nullValueToJSON(message.nullValue));
-    obj.stateMap = {};
+    if (message.state !== 0) {
+      obj.state = stateEnumToJSON(message.state);
+    }
+    if (message.states?.length) {
+      obj.states = message.states.map((e) => stateEnumToJSON(e));
+    }
+    if (message.nullValue !== 0) {
+      obj.nullValue = nullValueToJSON(message.nullValue);
+    }
     if (message.stateMap) {
-      Object.entries(message.stateMap).forEach(([k, v]) => {
-        obj.stateMap[k] = stateEnumToJSON(v);
-      });
+      const entries = Object.entries(message.stateMap);
+      if (entries.length > 0) {
+        obj.stateMap = {};
+        entries.forEach(([k, v]) => {
+          obj.stateMap[k] = stateEnumToJSON(v);
+        });
+      }
     }
     return obj;
   },
@@ -257,8 +264,12 @@ export const Simple_StateMapEntry = {
 
   toJSON(message: Simple_StateMapEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = message.key);
-    message.value !== undefined && (obj.value = stateEnumToJSON(message.value));
+    if (message.key !== "") {
+      obj.key = message.key;
+    }
+    if (message.value !== 0) {
+      obj.value = stateEnumToJSON(message.value);
+    }
     return obj;
   },
 

--- a/integration/use-objectid-true-external-import/objectid/objectid.ts
+++ b/integration/use-objectid-true-external-import/objectid/objectid.ts
@@ -48,7 +48,9 @@ export const ObjectId = {
 
   toJSON(message: ObjectId): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = message.value);
+    if (message.value !== "") {
+      obj.value = message.value;
+    }
     return obj;
   },
 

--- a/integration/use-objectid-true-external-import/use-objectid-true.ts
+++ b/integration/use-objectid-true-external-import/use-objectid-true.ts
@@ -113,19 +113,26 @@ export const Todo = {
 
   toJSON(message: Todo): unknown {
     const obj: any = {};
-    message.id !== undefined && (obj.id = message.id);
-    message.oid !== undefined && (obj.oid = message.oid.toString());
-    if (message.repeatedOid) {
-      obj.repeatedOid = message.repeatedOid.map((e) => e.toString());
-    } else {
-      obj.repeatedOid = [];
+    if (message.id !== "") {
+      obj.id = message.id;
     }
-    message.optionalOid !== undefined && (obj.optionalOid = message.optionalOid.toString());
-    obj.mapOfOids = {};
+    if (message.oid !== undefined) {
+      obj.oid = message.oid.toString();
+    }
+    if (message.repeatedOid?.length) {
+      obj.repeatedOid = message.repeatedOid.map((e) => e.toString());
+    }
+    if (message.optionalOid !== undefined) {
+      obj.optionalOid = message.optionalOid.toString();
+    }
     if (message.mapOfOids) {
-      Object.entries(message.mapOfOids).forEach(([k, v]) => {
-        obj.mapOfOids[k] = v.toString();
-      });
+      const entries = Object.entries(message.mapOfOids);
+      if (entries.length > 0) {
+        obj.mapOfOids = {};
+        entries.forEach(([k, v]) => {
+          obj.mapOfOids[k] = v.toString();
+        });
+      }
     }
     return obj;
   },
@@ -209,8 +216,12 @@ export const Todo_MapOfOidsEntry = {
 
   toJSON(message: Todo_MapOfOidsEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = message.key);
-    message.value !== undefined && (obj.value = message.value.toString());
+    if (message.key !== "") {
+      obj.key = message.key;
+    }
+    if (message.value !== undefined) {
+      obj.value = message.value.toString();
+    }
     return obj;
   },
 

--- a/integration/use-optionals-all/google/protobuf/timestamp.ts
+++ b/integration/use-optionals-all/google/protobuf/timestamp.ts
@@ -167,8 +167,12 @@ export const Timestamp = {
 
   toJSON(message: Timestamp): unknown {
     const obj: any = {};
-    message.seconds !== undefined && (obj.seconds = Math.round(message.seconds));
-    message.nanos !== undefined && (obj.nanos = Math.round(message.nanos));
+    if (message.seconds !== undefined && message.seconds !== 0) {
+      obj.seconds = Math.round(message.seconds);
+    }
+    if (message.nanos !== undefined && message.nanos !== 0) {
+      obj.nanos = Math.round(message.nanos);
+    }
     return obj;
   },
 

--- a/integration/use-optionals-all/test.ts
+++ b/integration/use-optionals-all/test.ts
@@ -457,65 +457,81 @@ export const OptionalsTest = {
 
   toJSON(message: OptionalsTest): unknown {
     const obj: any = {};
-    message.id !== undefined && (obj.id = Math.round(message.id));
-    message.child !== undefined && (obj.child = message.child ? Child.toJSON(message.child) : undefined);
-    message.state !== undefined && (obj.state = stateEnumToJSON(message.state));
-    message.long !== undefined && (obj.long = Math.round(message.long));
-    message.truth !== undefined && (obj.truth = message.truth);
-    message.description !== undefined && (obj.description = message.description);
-    message.data !== undefined &&
-      (obj.data = base64FromBytes(message.data !== undefined ? message.data : new Uint8Array(0)));
-    if (message.repId) {
+    if (message.id !== undefined && message.id !== 0) {
+      obj.id = Math.round(message.id);
+    }
+    if (message.child !== undefined) {
+      obj.child = message.child ? Child.toJSON(message.child) : undefined;
+    }
+    if (message.state !== undefined && message.state !== 0) {
+      obj.state = stateEnumToJSON(message.state);
+    }
+    if (message.long !== undefined && message.long !== 0) {
+      obj.long = Math.round(message.long);
+    }
+    if (message.truth === true) {
+      obj.truth = message.truth;
+    }
+    if (message.description !== undefined && message.description !== "") {
+      obj.description = message.description;
+    }
+    if (message.data !== undefined && message.data.length !== 0) {
+      obj.data = base64FromBytes(message.data !== undefined ? message.data : new Uint8Array(0));
+    }
+    if (message.repId?.length) {
       obj.repId = message.repId.map((e) => Math.round(e));
-    } else {
-      obj.repId = [];
     }
-    if (message.repChild) {
+    if (message.repChild?.length) {
       obj.repChild = message.repChild.map((e) => e ? Child.toJSON(e) : undefined);
-    } else {
-      obj.repChild = [];
     }
-    if (message.repState) {
+    if (message.repState?.length) {
       obj.repState = message.repState.map((e) => stateEnumToJSON(e));
-    } else {
-      obj.repState = [];
     }
-    if (message.repLong) {
+    if (message.repLong?.length) {
       obj.repLong = message.repLong.map((e) => Math.round(e));
-    } else {
-      obj.repLong = [];
     }
-    if (message.repTruth) {
+    if (message.repTruth?.length) {
       obj.repTruth = message.repTruth.map((e) => e);
-    } else {
-      obj.repTruth = [];
     }
-    if (message.repDescription) {
+    if (message.repDescription?.length) {
       obj.repDescription = message.repDescription.map((e) => e);
-    } else {
-      obj.repDescription = [];
     }
-    if (message.repData) {
+    if (message.repData?.length) {
       obj.repData = message.repData.map((e) => base64FromBytes(e !== undefined ? e : new Uint8Array(0)));
-    } else {
-      obj.repData = [];
     }
-    message.optId !== undefined && (obj.optId = Math.round(message.optId));
-    message.optChild !== undefined && (obj.optChild = message.optChild ? Child.toJSON(message.optChild) : undefined);
-    message.optState !== undefined &&
-      (obj.optState = message.optState !== undefined ? stateEnumToJSON(message.optState) : undefined);
-    message.optLong !== undefined && (obj.optLong = Math.round(message.optLong));
-    message.optTruth !== undefined && (obj.optTruth = message.optTruth);
-    message.optDescription !== undefined && (obj.optDescription = message.optDescription);
-    message.optData !== undefined &&
-      (obj.optData = message.optData !== undefined ? base64FromBytes(message.optData) : undefined);
-    obj.translations = {};
+    if (message.optId !== undefined) {
+      obj.optId = Math.round(message.optId);
+    }
+    if (message.optChild !== undefined) {
+      obj.optChild = message.optChild ? Child.toJSON(message.optChild) : undefined;
+    }
+    if (message.optState !== undefined) {
+      obj.optState = message.optState !== undefined ? stateEnumToJSON(message.optState) : undefined;
+    }
+    if (message.optLong !== undefined) {
+      obj.optLong = Math.round(message.optLong);
+    }
+    if (message.optTruth !== undefined) {
+      obj.optTruth = message.optTruth;
+    }
+    if (message.optDescription !== undefined) {
+      obj.optDescription = message.optDescription;
+    }
+    if (message.optData !== undefined) {
+      obj.optData = message.optData !== undefined ? base64FromBytes(message.optData) : undefined;
+    }
     if (message.translations) {
-      Object.entries(message.translations).forEach(([k, v]) => {
-        obj.translations[k] = v;
-      });
+      const entries = Object.entries(message.translations);
+      if (entries.length > 0) {
+        obj.translations = {};
+        entries.forEach(([k, v]) => {
+          obj.translations[k] = v;
+        });
+      }
     }
-    message.timestamp !== undefined && (obj.timestamp = message.timestamp.toISOString());
+    if (message.timestamp !== undefined) {
+      obj.timestamp = message.timestamp.toISOString();
+    }
     return obj;
   },
 
@@ -613,8 +629,12 @@ export const OptionalsTest_TranslationsEntry = {
 
   toJSON(message: OptionalsTest_TranslationsEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = message.key);
-    message.value !== undefined && (obj.value = message.value);
+    if (message.key !== "") {
+      obj.key = message.key;
+    }
+    if (message.value !== "") {
+      obj.value = message.value;
+    }
     return obj;
   },
 

--- a/integration/use-optionals-all/test.ts
+++ b/integration/use-optionals-all/test.ts
@@ -461,7 +461,7 @@ export const OptionalsTest = {
       obj.id = Math.round(message.id);
     }
     if (message.child !== undefined) {
-      obj.child = message.child ? Child.toJSON(message.child) : undefined;
+      obj.child = Child.toJSON(message.child);
     }
     if (message.state !== undefined && message.state !== 0) {
       obj.state = stateEnumToJSON(message.state);
@@ -476,13 +476,13 @@ export const OptionalsTest = {
       obj.description = message.description;
     }
     if (message.data !== undefined && message.data.length !== 0) {
-      obj.data = base64FromBytes(message.data !== undefined ? message.data : new Uint8Array(0));
+      obj.data = base64FromBytes(message.data);
     }
     if (message.repId?.length) {
       obj.repId = message.repId.map((e) => Math.round(e));
     }
     if (message.repChild?.length) {
-      obj.repChild = message.repChild.map((e) => e ? Child.toJSON(e) : undefined);
+      obj.repChild = message.repChild.map((e) => Child.toJSON(e));
     }
     if (message.repState?.length) {
       obj.repState = message.repState.map((e) => stateEnumToJSON(e));
@@ -497,16 +497,16 @@ export const OptionalsTest = {
       obj.repDescription = message.repDescription;
     }
     if (message.repData?.length) {
-      obj.repData = message.repData.map((e) => base64FromBytes(e !== undefined ? e : new Uint8Array(0)));
+      obj.repData = message.repData.map((e) => base64FromBytes(e));
     }
     if (message.optId !== undefined) {
       obj.optId = Math.round(message.optId);
     }
     if (message.optChild !== undefined) {
-      obj.optChild = message.optChild ? Child.toJSON(message.optChild) : undefined;
+      obj.optChild = Child.toJSON(message.optChild);
     }
     if (message.optState !== undefined) {
-      obj.optState = message.optState !== undefined ? stateEnumToJSON(message.optState) : undefined;
+      obj.optState = stateEnumToJSON(message.optState);
     }
     if (message.optLong !== undefined) {
       obj.optLong = Math.round(message.optLong);
@@ -518,7 +518,7 @@ export const OptionalsTest = {
       obj.optDescription = message.optDescription;
     }
     if (message.optData !== undefined) {
-      obj.optData = message.optData !== undefined ? base64FromBytes(message.optData) : undefined;
+      obj.optData = base64FromBytes(message.optData);
     }
     if (message.translations) {
       const entries = Object.entries(message.translations);

--- a/integration/use-optionals-all/test.ts
+++ b/integration/use-optionals-all/test.ts
@@ -491,10 +491,10 @@ export const OptionalsTest = {
       obj.repLong = message.repLong.map((e) => Math.round(e));
     }
     if (message.repTruth?.length) {
-      obj.repTruth = message.repTruth.map((e) => e);
+      obj.repTruth = message.repTruth;
     }
     if (message.repDescription?.length) {
-      obj.repDescription = message.repDescription.map((e) => e);
+      obj.repDescription = message.repDescription;
     }
     if (message.repData?.length) {
       obj.repData = message.repData.map((e) => base64FromBytes(e !== undefined ? e : new Uint8Array(0)));

--- a/integration/use-optionals-no-undefined/test.ts
+++ b/integration/use-optionals-no-undefined/test.ts
@@ -492,10 +492,10 @@ export const OptionalsTest = {
       obj.repLong = message.repLong.map((e) => Math.round(e));
     }
     if (message.repTruth?.length) {
-      obj.repTruth = message.repTruth.map((e) => e);
+      obj.repTruth = message.repTruth;
     }
     if (message.repDescription?.length) {
-      obj.repDescription = message.repDescription.map((e) => e);
+      obj.repDescription = message.repDescription;
     }
     if (message.repData?.length) {
       obj.repData = message.repData.map((e) => base64FromBytes(e !== undefined ? e : new Uint8Array(0)));

--- a/integration/use-optionals-no-undefined/test.ts
+++ b/integration/use-optionals-no-undefined/test.ts
@@ -458,63 +458,77 @@ export const OptionalsTest = {
 
   toJSON(message: OptionalsTest): unknown {
     const obj: any = {};
-    message.id !== undefined && (obj.id = Math.round(message.id));
-    message.child !== undefined && (obj.child = message.child ? Child.toJSON(message.child) : undefined);
-    message.state !== undefined && (obj.state = stateEnumToJSON(message.state));
-    message.long !== undefined && (obj.long = Math.round(message.long));
-    message.truth !== undefined && (obj.truth = message.truth);
-    message.description !== undefined && (obj.description = message.description);
-    message.data !== undefined &&
-      (obj.data = base64FromBytes(message.data !== undefined ? message.data : new Uint8Array(0)));
-    if (message.repId) {
+    if (message.id !== undefined && message.id !== 0) {
+      obj.id = Math.round(message.id);
+    }
+    if (message.child !== undefined) {
+      obj.child = message.child ? Child.toJSON(message.child) : undefined;
+    }
+    if (message.state !== undefined && message.state !== 0) {
+      obj.state = stateEnumToJSON(message.state);
+    }
+    if (message.long !== undefined && message.long !== 0) {
+      obj.long = Math.round(message.long);
+    }
+    if (message.truth === true) {
+      obj.truth = message.truth;
+    }
+    if (message.description !== undefined && message.description !== "") {
+      obj.description = message.description;
+    }
+    if (message.data !== undefined && message.data.length !== 0) {
+      obj.data = base64FromBytes(message.data !== undefined ? message.data : new Uint8Array(0));
+    }
+    if (message.repId?.length) {
       obj.repId = message.repId.map((e) => Math.round(e));
-    } else {
-      obj.repId = [];
     }
-    if (message.repChild) {
+    if (message.repChild?.length) {
       obj.repChild = message.repChild.map((e) => e ? Child.toJSON(e) : undefined);
-    } else {
-      obj.repChild = [];
     }
-    if (message.repState) {
+    if (message.repState?.length) {
       obj.repState = message.repState.map((e) => stateEnumToJSON(e));
-    } else {
-      obj.repState = [];
     }
-    if (message.repLong) {
+    if (message.repLong?.length) {
       obj.repLong = message.repLong.map((e) => Math.round(e));
-    } else {
-      obj.repLong = [];
     }
-    if (message.repTruth) {
+    if (message.repTruth?.length) {
       obj.repTruth = message.repTruth.map((e) => e);
-    } else {
-      obj.repTruth = [];
     }
-    if (message.repDescription) {
+    if (message.repDescription?.length) {
       obj.repDescription = message.repDescription.map((e) => e);
-    } else {
-      obj.repDescription = [];
     }
-    if (message.repData) {
+    if (message.repData?.length) {
       obj.repData = message.repData.map((e) => base64FromBytes(e !== undefined ? e : new Uint8Array(0)));
-    } else {
-      obj.repData = [];
     }
-    message.optId !== undefined && (obj.optId = Math.round(message.optId));
-    message.optChild !== undefined && (obj.optChild = message.optChild ? Child.toJSON(message.optChild) : undefined);
-    message.optState !== undefined &&
-      (obj.optState = message.optState !== undefined ? stateEnumToJSON(message.optState) : undefined);
-    message.optLong !== undefined && (obj.optLong = Math.round(message.optLong));
-    message.optTruth !== undefined && (obj.optTruth = message.optTruth);
-    message.optDescription !== undefined && (obj.optDescription = message.optDescription);
-    message.optData !== undefined &&
-      (obj.optData = message.optData !== undefined ? base64FromBytes(message.optData) : undefined);
-    obj.translations = {};
+    if (message.optId !== undefined) {
+      obj.optId = Math.round(message.optId);
+    }
+    if (message.optChild !== undefined) {
+      obj.optChild = message.optChild ? Child.toJSON(message.optChild) : undefined;
+    }
+    if (message.optState !== undefined) {
+      obj.optState = message.optState !== undefined ? stateEnumToJSON(message.optState) : undefined;
+    }
+    if (message.optLong !== undefined) {
+      obj.optLong = Math.round(message.optLong);
+    }
+    if (message.optTruth !== undefined) {
+      obj.optTruth = message.optTruth;
+    }
+    if (message.optDescription !== undefined) {
+      obj.optDescription = message.optDescription;
+    }
+    if (message.optData !== undefined) {
+      obj.optData = message.optData !== undefined ? base64FromBytes(message.optData) : undefined;
+    }
     if (message.translations) {
-      Object.entries(message.translations).forEach(([k, v]) => {
-        obj.translations[k] = v;
-      });
+      const entries = Object.entries(message.translations);
+      if (entries.length > 0) {
+        obj.translations = {};
+        entries.forEach(([k, v]) => {
+          obj.translations[k] = v;
+        });
+      }
     }
     return obj;
   },
@@ -611,8 +625,12 @@ export const OptionalsTest_TranslationsEntry = {
 
   toJSON(message: OptionalsTest_TranslationsEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = message.key);
-    message.value !== undefined && (obj.value = message.value);
+    if (message.key !== "") {
+      obj.key = message.key;
+    }
+    if (message.value !== "") {
+      obj.value = message.value;
+    }
     return obj;
   },
 

--- a/integration/use-optionals-no-undefined/test.ts
+++ b/integration/use-optionals-no-undefined/test.ts
@@ -462,7 +462,7 @@ export const OptionalsTest = {
       obj.id = Math.round(message.id);
     }
     if (message.child !== undefined) {
-      obj.child = message.child ? Child.toJSON(message.child) : undefined;
+      obj.child = Child.toJSON(message.child);
     }
     if (message.state !== undefined && message.state !== 0) {
       obj.state = stateEnumToJSON(message.state);
@@ -477,13 +477,13 @@ export const OptionalsTest = {
       obj.description = message.description;
     }
     if (message.data !== undefined && message.data.length !== 0) {
-      obj.data = base64FromBytes(message.data !== undefined ? message.data : new Uint8Array(0));
+      obj.data = base64FromBytes(message.data);
     }
     if (message.repId?.length) {
       obj.repId = message.repId.map((e) => Math.round(e));
     }
     if (message.repChild?.length) {
-      obj.repChild = message.repChild.map((e) => e ? Child.toJSON(e) : undefined);
+      obj.repChild = message.repChild.map((e) => Child.toJSON(e));
     }
     if (message.repState?.length) {
       obj.repState = message.repState.map((e) => stateEnumToJSON(e));
@@ -498,16 +498,16 @@ export const OptionalsTest = {
       obj.repDescription = message.repDescription;
     }
     if (message.repData?.length) {
-      obj.repData = message.repData.map((e) => base64FromBytes(e !== undefined ? e : new Uint8Array(0)));
+      obj.repData = message.repData.map((e) => base64FromBytes(e));
     }
     if (message.optId !== undefined) {
       obj.optId = Math.round(message.optId);
     }
     if (message.optChild !== undefined) {
-      obj.optChild = message.optChild ? Child.toJSON(message.optChild) : undefined;
+      obj.optChild = Child.toJSON(message.optChild);
     }
     if (message.optState !== undefined) {
-      obj.optState = message.optState !== undefined ? stateEnumToJSON(message.optState) : undefined;
+      obj.optState = stateEnumToJSON(message.optState);
     }
     if (message.optLong !== undefined) {
       obj.optLong = Math.round(message.optLong);
@@ -519,7 +519,7 @@ export const OptionalsTest = {
       obj.optDescription = message.optDescription;
     }
     if (message.optData !== undefined) {
-      obj.optData = message.optData !== undefined ? base64FromBytes(message.optData) : undefined;
+      obj.optData = base64FromBytes(message.optData);
     }
     if (message.translations) {
       const entries = Object.entries(message.translations);

--- a/integration/use-readonly-types/google/protobuf/struct.ts
+++ b/integration/use-readonly-types/google/protobuf/struct.ts
@@ -139,11 +139,14 @@ export const Struct = {
 
   toJSON(message: Struct): unknown {
     const obj: any = {};
-    obj.fields = {};
     if (message.fields) {
-      Object.entries(message.fields).forEach(([k, v]) => {
-        obj.fields[k] = v;
-      });
+      const entries = Object.entries(message.fields);
+      if (entries.length > 0) {
+        obj.fields = {};
+        entries.forEach(([k, v]) => {
+          obj.fields[k] = v;
+        });
+      }
     }
     return obj;
   },
@@ -238,8 +241,12 @@ export const Struct_FieldsEntry = {
 
   toJSON(message: Struct_FieldsEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = message.key);
-    message.value !== undefined && (obj.value = message.value);
+    if (message.key !== "") {
+      obj.key = message.key;
+    }
+    if (message.value !== undefined) {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -362,13 +369,24 @@ export const Value = {
 
   toJSON(message: Value): unknown {
     const obj: any = {};
-    message.kind?.$case === "nullValue" &&
-      (obj.nullValue = message.kind?.nullValue !== undefined ? nullValueToJSON(message.kind?.nullValue) : undefined);
-    message.kind?.$case === "numberValue" && (obj.numberValue = message.kind?.numberValue);
-    message.kind?.$case === "stringValue" && (obj.stringValue = message.kind?.stringValue);
-    message.kind?.$case === "boolValue" && (obj.boolValue = message.kind?.boolValue);
-    message.kind?.$case === "structValue" && (obj.structValue = message.kind?.structValue);
-    message.kind?.$case === "listValue" && (obj.listValue = message.kind?.listValue);
+    if (message.kind?.$case === "nullValue") {
+      obj.nullValue = message.kind?.nullValue !== undefined ? nullValueToJSON(message.kind?.nullValue) : undefined;
+    }
+    if (message.kind?.$case === "numberValue") {
+      obj.numberValue = message.kind?.numberValue;
+    }
+    if (message.kind?.$case === "stringValue") {
+      obj.stringValue = message.kind?.stringValue;
+    }
+    if (message.kind?.$case === "boolValue") {
+      obj.boolValue = message.kind?.boolValue;
+    }
+    if (message.kind?.$case === "structValue") {
+      obj.structValue = message.kind?.structValue;
+    }
+    if (message.kind?.$case === "listValue") {
+      obj.listValue = message.kind?.listValue;
+    }
     return obj;
   },
 
@@ -491,10 +509,8 @@ export const ListValue = {
 
   toJSON(message: ListValue): unknown {
     const obj: any = {};
-    if (message.values) {
+    if (message.values?.length) {
       obj.values = message.values.map((e) => e);
-    } else {
-      obj.values = [];
     }
     return obj;
   },

--- a/integration/use-readonly-types/google/protobuf/struct.ts
+++ b/integration/use-readonly-types/google/protobuf/struct.ts
@@ -370,22 +370,22 @@ export const Value = {
   toJSON(message: Value): unknown {
     const obj: any = {};
     if (message.kind?.$case === "nullValue") {
-      obj.nullValue = message.kind?.nullValue !== undefined ? nullValueToJSON(message.kind?.nullValue) : undefined;
+      obj.nullValue = nullValueToJSON(message.kind.nullValue);
     }
     if (message.kind?.$case === "numberValue") {
-      obj.numberValue = message.kind?.numberValue;
+      obj.numberValue = message.kind.numberValue;
     }
     if (message.kind?.$case === "stringValue") {
-      obj.stringValue = message.kind?.stringValue;
+      obj.stringValue = message.kind.stringValue;
     }
     if (message.kind?.$case === "boolValue") {
-      obj.boolValue = message.kind?.boolValue;
+      obj.boolValue = message.kind.boolValue;
     }
     if (message.kind?.$case === "structValue") {
-      obj.structValue = message.kind?.structValue;
+      obj.structValue = message.kind.structValue;
     }
     if (message.kind?.$case === "listValue") {
-      obj.listValue = message.kind?.listValue;
+      obj.listValue = message.kind.listValue;
     }
     return obj;
   },

--- a/integration/use-readonly-types/google/protobuf/struct.ts
+++ b/integration/use-readonly-types/google/protobuf/struct.ts
@@ -510,7 +510,7 @@ export const ListValue = {
   toJSON(message: ListValue): unknown {
     const obj: any = {};
     if (message.values?.length) {
-      obj.values = message.values.map((e) => e);
+      obj.values = message.values;
     }
     return obj;
   },

--- a/integration/use-readonly-types/use-readonly-types.ts
+++ b/integration/use-readonly-types/use-readonly-types.ts
@@ -221,31 +221,42 @@ export const Entity = {
 
   toJSON(message: Entity): unknown {
     const obj: any = {};
-    message.intVal !== undefined && (obj.intVal = Math.round(message.intVal));
-    message.stringVal !== undefined && (obj.stringVal = message.stringVal);
-    if (message.intArray) {
+    if (message.intVal !== 0) {
+      obj.intVal = Math.round(message.intVal);
+    }
+    if (message.stringVal !== "") {
+      obj.stringVal = message.stringVal;
+    }
+    if (message.intArray?.length) {
       obj.intArray = message.intArray.map((e) => Math.round(e));
-    } else {
-      obj.intArray = [];
     }
-    if (message.stringArray) {
+    if (message.stringArray?.length) {
       obj.stringArray = message.stringArray.map((e) => e);
-    } else {
-      obj.stringArray = [];
     }
-    message.subEntity !== undefined &&
-      (obj.subEntity = message.subEntity ? SubEntity.toJSON(message.subEntity) : undefined);
-    if (message.subEntityArray) {
+    if (message.subEntity !== undefined) {
+      obj.subEntity = message.subEntity ? SubEntity.toJSON(message.subEntity) : undefined;
+    }
+    if (message.subEntityArray?.length) {
       obj.subEntityArray = message.subEntityArray.map((e) => e ? SubEntity.toJSON(e) : undefined);
-    } else {
-      obj.subEntityArray = [];
     }
-    message.optionalIntVal !== undefined && (obj.optionalIntVal = Math.round(message.optionalIntVal));
-    message.fieldMask !== undefined && (obj.fieldMask = FieldMask.toJSON(FieldMask.wrap(message.fieldMask)));
-    message.listValue !== undefined && (obj.listValue = message.listValue);
-    message.structValue !== undefined && (obj.structValue = message.structValue);
-    message.oneOfValue?.$case === "theStringValue" && (obj.theStringValue = message.oneOfValue?.theStringValue);
-    message.oneOfValue?.$case === "theIntValue" && (obj.theIntValue = Math.round(message.oneOfValue?.theIntValue));
+    if (message.optionalIntVal !== undefined) {
+      obj.optionalIntVal = Math.round(message.optionalIntVal);
+    }
+    if (message.fieldMask !== undefined) {
+      obj.fieldMask = FieldMask.toJSON(FieldMask.wrap(message.fieldMask));
+    }
+    if (message.listValue !== undefined) {
+      obj.listValue = message.listValue;
+    }
+    if (message.structValue !== undefined) {
+      obj.structValue = message.structValue;
+    }
+    if (message.oneOfValue?.$case === "theStringValue") {
+      obj.theStringValue = message.oneOfValue?.theStringValue;
+    }
+    if (message.oneOfValue?.$case === "theIntValue") {
+      obj.theIntValue = Math.round(message.oneOfValue?.theIntValue);
+    }
     return obj;
   },
 
@@ -326,7 +337,9 @@ export const SubEntity = {
 
   toJSON(message: SubEntity): unknown {
     const obj: any = {};
-    message.subVal !== undefined && (obj.subVal = Math.round(message.subVal));
+    if (message.subVal !== 0) {
+      obj.subVal = Math.round(message.subVal);
+    }
     return obj;
   },
 

--- a/integration/use-readonly-types/use-readonly-types.ts
+++ b/integration/use-readonly-types/use-readonly-types.ts
@@ -231,7 +231,7 @@ export const Entity = {
       obj.intArray = message.intArray.map((e) => Math.round(e));
     }
     if (message.stringArray?.length) {
-      obj.stringArray = message.stringArray.map((e) => e);
+      obj.stringArray = message.stringArray;
     }
     if (message.subEntity !== undefined) {
       obj.subEntity = message.subEntity ? SubEntity.toJSON(message.subEntity) : undefined;

--- a/integration/use-readonly-types/use-readonly-types.ts
+++ b/integration/use-readonly-types/use-readonly-types.ts
@@ -234,10 +234,10 @@ export const Entity = {
       obj.stringArray = message.stringArray;
     }
     if (message.subEntity !== undefined) {
-      obj.subEntity = message.subEntity ? SubEntity.toJSON(message.subEntity) : undefined;
+      obj.subEntity = SubEntity.toJSON(message.subEntity);
     }
     if (message.subEntityArray?.length) {
-      obj.subEntityArray = message.subEntityArray.map((e) => e ? SubEntity.toJSON(e) : undefined);
+      obj.subEntityArray = message.subEntityArray.map((e) => SubEntity.toJSON(e));
     }
     if (message.optionalIntVal !== undefined) {
       obj.optionalIntVal = Math.round(message.optionalIntVal);
@@ -252,10 +252,10 @@ export const Entity = {
       obj.structValue = message.structValue;
     }
     if (message.oneOfValue?.$case === "theStringValue") {
-      obj.theStringValue = message.oneOfValue?.theStringValue;
+      obj.theStringValue = message.oneOfValue.theStringValue;
     }
     if (message.oneOfValue?.$case === "theIntValue") {
-      obj.theIntValue = Math.round(message.oneOfValue?.theIntValue);
+      obj.theIntValue = Math.round(message.oneOfValue.theIntValue);
     }
     return obj;
   },

--- a/integration/value/google/protobuf/struct.ts
+++ b/integration/value/google/protobuf/struct.ts
@@ -382,7 +382,7 @@ export const Value = {
   toJSON(message: Value): unknown {
     const obj: any = {};
     if (message.nullValue !== undefined) {
-      obj.nullValue = message.nullValue !== undefined ? nullValueToJSON(message.nullValue) : undefined;
+      obj.nullValue = nullValueToJSON(message.nullValue);
     }
     if (message.numberValue !== undefined) {
       obj.numberValue = message.numberValue;

--- a/integration/value/google/protobuf/struct.ts
+++ b/integration/value/google/protobuf/struct.ts
@@ -497,7 +497,7 @@ export const ListValue = {
   toJSON(message: ListValue): unknown {
     const obj: any = {};
     if (message.values?.length) {
-      obj.values = message.values.map((e) => e);
+      obj.values = message.values;
     }
     return obj;
   },

--- a/integration/value/google/protobuf/struct.ts
+++ b/integration/value/google/protobuf/struct.ts
@@ -153,11 +153,14 @@ export const Struct = {
 
   toJSON(message: Struct): unknown {
     const obj: any = {};
-    obj.fields = {};
     if (message.fields) {
-      Object.entries(message.fields).forEach(([k, v]) => {
-        obj.fields[k] = v;
-      });
+      const entries = Object.entries(message.fields);
+      if (entries.length > 0) {
+        obj.fields = {};
+        entries.forEach(([k, v]) => {
+          obj.fields[k] = v;
+        });
+      }
     }
     return obj;
   },
@@ -252,8 +255,12 @@ export const Struct_FieldsEntry = {
 
   toJSON(message: Struct_FieldsEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = message.key);
-    message.value !== undefined && (obj.value = message.value);
+    if (message.key !== "") {
+      obj.key = message.key;
+    }
+    if (message.value !== undefined) {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -374,13 +381,24 @@ export const Value = {
 
   toJSON(message: Value): unknown {
     const obj: any = {};
-    message.nullValue !== undefined &&
-      (obj.nullValue = message.nullValue !== undefined ? nullValueToJSON(message.nullValue) : undefined);
-    message.numberValue !== undefined && (obj.numberValue = message.numberValue);
-    message.stringValue !== undefined && (obj.stringValue = message.stringValue);
-    message.boolValue !== undefined && (obj.boolValue = message.boolValue);
-    message.structValue !== undefined && (obj.structValue = message.structValue);
-    message.listValue !== undefined && (obj.listValue = message.listValue);
+    if (message.nullValue !== undefined) {
+      obj.nullValue = message.nullValue !== undefined ? nullValueToJSON(message.nullValue) : undefined;
+    }
+    if (message.numberValue !== undefined) {
+      obj.numberValue = message.numberValue;
+    }
+    if (message.stringValue !== undefined) {
+      obj.stringValue = message.stringValue;
+    }
+    if (message.boolValue !== undefined) {
+      obj.boolValue = message.boolValue;
+    }
+    if (message.structValue !== undefined) {
+      obj.structValue = message.structValue;
+    }
+    if (message.listValue !== undefined) {
+      obj.listValue = message.listValue;
+    }
     return obj;
   },
 
@@ -478,10 +496,8 @@ export const ListValue = {
 
   toJSON(message: ListValue): unknown {
     const obj: any = {};
-    if (message.values) {
+    if (message.values?.length) {
       obj.values = message.values.map((e) => e);
-    } else {
-      obj.values = [];
     }
     return obj;
   },

--- a/integration/value/google/protobuf/wrappers.ts
+++ b/integration/value/google/protobuf/wrappers.ts
@@ -135,7 +135,9 @@ export const DoubleValue = {
 
   toJSON(message: DoubleValue): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = message.value);
+    if (message.value !== 0) {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -191,7 +193,9 @@ export const FloatValue = {
 
   toJSON(message: FloatValue): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = message.value);
+    if (message.value !== 0) {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -247,7 +251,9 @@ export const Int64Value = {
 
   toJSON(message: Int64Value): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = Math.round(message.value));
+    if (message.value !== 0) {
+      obj.value = Math.round(message.value);
+    }
     return obj;
   },
 
@@ -303,7 +309,9 @@ export const UInt64Value = {
 
   toJSON(message: UInt64Value): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = Math.round(message.value));
+    if (message.value !== 0) {
+      obj.value = Math.round(message.value);
+    }
     return obj;
   },
 
@@ -359,7 +367,9 @@ export const Int32Value = {
 
   toJSON(message: Int32Value): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = Math.round(message.value));
+    if (message.value !== 0) {
+      obj.value = Math.round(message.value);
+    }
     return obj;
   },
 
@@ -415,7 +425,9 @@ export const UInt32Value = {
 
   toJSON(message: UInt32Value): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = Math.round(message.value));
+    if (message.value !== 0) {
+      obj.value = Math.round(message.value);
+    }
     return obj;
   },
 
@@ -471,7 +483,9 @@ export const BoolValue = {
 
   toJSON(message: BoolValue): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = message.value);
+    if (message.value === true) {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -527,7 +541,9 @@ export const StringValue = {
 
   toJSON(message: StringValue): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = message.value);
+    if (message.value !== "") {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -583,8 +599,9 @@ export const BytesValue = {
 
   toJSON(message: BytesValue): unknown {
     const obj: any = {};
-    message.value !== undefined &&
-      (obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array(0)));
+    if (message.value.length !== 0) {
+      obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array(0));
+    }
     return obj;
   },
 

--- a/integration/value/google/protobuf/wrappers.ts
+++ b/integration/value/google/protobuf/wrappers.ts
@@ -600,7 +600,7 @@ export const BytesValue = {
   toJSON(message: BytesValue): unknown {
     const obj: any = {};
     if (message.value.length !== 0) {
-      obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array(0));
+      obj.value = base64FromBytes(message.value);
     }
     return obj;
   },

--- a/integration/value/value.ts
+++ b/integration/value/value.ts
@@ -107,10 +107,10 @@ export const ValueMessage = {
       obj.anyList = message.anyList;
     }
     if (message.repeatedAny?.length) {
-      obj.repeatedAny = message.repeatedAny.map((e) => e);
+      obj.repeatedAny = message.repeatedAny;
     }
     if (message.repeatedStrings?.length) {
-      obj.repeatedStrings = message.repeatedStrings.map((e) => e);
+      obj.repeatedStrings = message.repeatedStrings;
     }
     if (message.structValue !== undefined) {
       obj.structValue = message.structValue;

--- a/integration/value/value.ts
+++ b/integration/value/value.ts
@@ -100,19 +100,21 @@ export const ValueMessage = {
 
   toJSON(message: ValueMessage): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = message.value);
-    message.anyList !== undefined && (obj.anyList = message.anyList);
-    if (message.repeatedAny) {
+    if (message.value !== undefined) {
+      obj.value = message.value;
+    }
+    if (message.anyList !== undefined) {
+      obj.anyList = message.anyList;
+    }
+    if (message.repeatedAny?.length) {
       obj.repeatedAny = message.repeatedAny.map((e) => e);
-    } else {
-      obj.repeatedAny = [];
     }
-    if (message.repeatedStrings) {
+    if (message.repeatedStrings?.length) {
       obj.repeatedStrings = message.repeatedStrings.map((e) => e);
-    } else {
-      obj.repeatedStrings = [];
     }
-    message.structValue !== undefined && (obj.structValue = message.structValue);
+    if (message.structValue !== undefined) {
+      obj.structValue = message.structValue;
+    }
     return obj;
   },
 

--- a/integration/vector-tile/vector_tile.ts
+++ b/integration/vector-tile/vector_tile.ts
@@ -120,10 +120,8 @@ export const Tile = {
 
   toJSON(message: Tile): unknown {
     const obj: any = {};
-    if (message.layers) {
+    if (message.layers?.length) {
       obj.layers = message.layers.map((e) => e ? Tile_Layer.toJSON(e) : undefined);
-    } else {
-      obj.layers = [];
     }
     return obj;
   },
@@ -248,13 +246,27 @@ export const Tile_Value = {
 
   toJSON(message: Tile_Value): unknown {
     const obj: any = {};
-    message.stringValue !== undefined && (obj.stringValue = message.stringValue);
-    message.floatValue !== undefined && (obj.floatValue = message.floatValue);
-    message.doubleValue !== undefined && (obj.doubleValue = message.doubleValue);
-    message.intValue !== undefined && (obj.intValue = Math.round(message.intValue));
-    message.uintValue !== undefined && (obj.uintValue = Math.round(message.uintValue));
-    message.sintValue !== undefined && (obj.sintValue = Math.round(message.sintValue));
-    message.boolValue !== undefined && (obj.boolValue = message.boolValue);
+    if (message.stringValue !== "") {
+      obj.stringValue = message.stringValue;
+    }
+    if (message.floatValue !== 0) {
+      obj.floatValue = message.floatValue;
+    }
+    if (message.doubleValue !== 0) {
+      obj.doubleValue = message.doubleValue;
+    }
+    if (message.intValue !== 0) {
+      obj.intValue = Math.round(message.intValue);
+    }
+    if (message.uintValue !== 0) {
+      obj.uintValue = Math.round(message.uintValue);
+    }
+    if (message.sintValue !== 0) {
+      obj.sintValue = Math.round(message.sintValue);
+    }
+    if (message.boolValue === true) {
+      obj.boolValue = message.boolValue;
+    }
     return obj;
   },
 
@@ -375,17 +387,17 @@ export const Tile_Feature = {
 
   toJSON(message: Tile_Feature): unknown {
     const obj: any = {};
-    message.id !== undefined && (obj.id = Math.round(message.id));
-    if (message.tags) {
-      obj.tags = message.tags.map((e) => Math.round(e));
-    } else {
-      obj.tags = [];
+    if (message.id !== 0) {
+      obj.id = Math.round(message.id);
     }
-    message.type !== undefined && (obj.type = tile_GeomTypeToJSON(message.type));
-    if (message.geometry) {
+    if (message.tags?.length) {
+      obj.tags = message.tags.map((e) => Math.round(e));
+    }
+    if (message.type !== 0) {
+      obj.type = tile_GeomTypeToJSON(message.type);
+    }
+    if (message.geometry?.length) {
       obj.geometry = message.geometry.map((e) => Math.round(e));
-    } else {
-      obj.geometry = [];
     }
     return obj;
   },
@@ -502,24 +514,24 @@ export const Tile_Layer = {
 
   toJSON(message: Tile_Layer): unknown {
     const obj: any = {};
-    message.version !== undefined && (obj.version = Math.round(message.version));
-    message.name !== undefined && (obj.name = message.name);
-    if (message.features) {
+    if (message.version !== 0) {
+      obj.version = Math.round(message.version);
+    }
+    if (message.name !== "") {
+      obj.name = message.name;
+    }
+    if (message.features?.length) {
       obj.features = message.features.map((e) => e ? Tile_Feature.toJSON(e) : undefined);
-    } else {
-      obj.features = [];
     }
-    if (message.keys) {
+    if (message.keys?.length) {
       obj.keys = message.keys.map((e) => e);
-    } else {
-      obj.keys = [];
     }
-    if (message.values) {
+    if (message.values?.length) {
       obj.values = message.values.map((e) => e ? Tile_Value.toJSON(e) : undefined);
-    } else {
-      obj.values = [];
     }
-    message.extent !== undefined && (obj.extent = Math.round(message.extent));
+    if (message.extent !== 0) {
+      obj.extent = Math.round(message.extent);
+    }
     return obj;
   },
 

--- a/integration/vector-tile/vector_tile.ts
+++ b/integration/vector-tile/vector_tile.ts
@@ -121,7 +121,7 @@ export const Tile = {
   toJSON(message: Tile): unknown {
     const obj: any = {};
     if (message.layers?.length) {
-      obj.layers = message.layers.map((e) => e ? Tile_Layer.toJSON(e) : undefined);
+      obj.layers = message.layers.map((e) => Tile_Layer.toJSON(e));
     }
     return obj;
   },
@@ -521,13 +521,13 @@ export const Tile_Layer = {
       obj.name = message.name;
     }
     if (message.features?.length) {
-      obj.features = message.features.map((e) => e ? Tile_Feature.toJSON(e) : undefined);
+      obj.features = message.features.map((e) => Tile_Feature.toJSON(e));
     }
     if (message.keys?.length) {
       obj.keys = message.keys;
     }
     if (message.values?.length) {
-      obj.values = message.values.map((e) => e ? Tile_Value.toJSON(e) : undefined);
+      obj.values = message.values.map((e) => Tile_Value.toJSON(e));
     }
     if (message.extent !== 0) {
       obj.extent = Math.round(message.extent);

--- a/integration/vector-tile/vector_tile.ts
+++ b/integration/vector-tile/vector_tile.ts
@@ -524,7 +524,7 @@ export const Tile_Layer = {
       obj.features = message.features.map((e) => e ? Tile_Feature.toJSON(e) : undefined);
     }
     if (message.keys?.length) {
-      obj.keys = message.keys.map((e) => e);
+      obj.keys = message.keys;
     }
     if (message.values?.length) {
       obj.values = message.values.map((e) => e ? Tile_Value.toJSON(e) : undefined);

--- a/integration/wrappers-regression/google/protobuf/timestamp.ts
+++ b/integration/wrappers-regression/google/protobuf/timestamp.ts
@@ -165,8 +165,12 @@ export const Timestamp = {
 
   toJSON(message: Timestamp): unknown {
     const obj: any = {};
-    message.seconds !== undefined && (obj.seconds = Math.round(message.seconds));
-    message.nanos !== undefined && (obj.nanos = Math.round(message.nanos));
+    if (message.seconds !== 0) {
+      obj.seconds = Math.round(message.seconds);
+    }
+    if (message.nanos !== 0) {
+      obj.nanos = Math.round(message.nanos);
+    }
     return obj;
   },
 

--- a/integration/wrappers-regression/google/protobuf/wrappers.ts
+++ b/integration/wrappers-regression/google/protobuf/wrappers.ts
@@ -135,7 +135,9 @@ export const DoubleValue = {
 
   toJSON(message: DoubleValue): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = message.value);
+    if (message.value !== 0) {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -191,7 +193,9 @@ export const FloatValue = {
 
   toJSON(message: FloatValue): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = message.value);
+    if (message.value !== 0) {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -247,7 +251,9 @@ export const Int64Value = {
 
   toJSON(message: Int64Value): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = Math.round(message.value));
+    if (message.value !== 0) {
+      obj.value = Math.round(message.value);
+    }
     return obj;
   },
 
@@ -303,7 +309,9 @@ export const UInt64Value = {
 
   toJSON(message: UInt64Value): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = Math.round(message.value));
+    if (message.value !== 0) {
+      obj.value = Math.round(message.value);
+    }
     return obj;
   },
 
@@ -359,7 +367,9 @@ export const Int32Value = {
 
   toJSON(message: Int32Value): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = Math.round(message.value));
+    if (message.value !== 0) {
+      obj.value = Math.round(message.value);
+    }
     return obj;
   },
 
@@ -415,7 +425,9 @@ export const UInt32Value = {
 
   toJSON(message: UInt32Value): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = Math.round(message.value));
+    if (message.value !== 0) {
+      obj.value = Math.round(message.value);
+    }
     return obj;
   },
 
@@ -471,7 +483,9 @@ export const BoolValue = {
 
   toJSON(message: BoolValue): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = message.value);
+    if (message.value === true) {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -527,7 +541,9 @@ export const StringValue = {
 
   toJSON(message: StringValue): unknown {
     const obj: any = {};
-    message.value !== undefined && (obj.value = message.value);
+    if (message.value !== "") {
+      obj.value = message.value;
+    }
     return obj;
   },
 
@@ -583,8 +599,9 @@ export const BytesValue = {
 
   toJSON(message: BytesValue): unknown {
     const obj: any = {};
-    message.value !== undefined &&
-      (obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array(0)));
+    if (message.value.length !== 0) {
+      obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array(0));
+    }
     return obj;
   },
 

--- a/integration/wrappers-regression/google/protobuf/wrappers.ts
+++ b/integration/wrappers-regression/google/protobuf/wrappers.ts
@@ -600,7 +600,7 @@ export const BytesValue = {
   toJSON(message: BytesValue): unknown {
     const obj: any = {};
     if (message.value.length !== 0) {
-      obj.value = base64FromBytes(message.value !== undefined ? message.value : new Uint8Array(0));
+      obj.value = base64FromBytes(message.value);
     }
     return obj;
   },

--- a/src/main.ts
+++ b/src/main.ts
@@ -2071,9 +2071,11 @@ function generateToJson(
       }
     } else if (isRepeated(field)) {
       // Arrays might need their elements transformed
+      const transformElement = readSnippet("e");
+      const maybeMap = transformElement.toCodeString([]) !== "e" ? code`.map(e => ${transformElement})` : "";
       chunks.push(code`
         if (message.${fieldName}?.length) {
-          ${jsonProperty} = message.${fieldName}.map(e => ${readSnippet("e")});
+          ${jsonProperty} = message.${fieldName}${maybeMap};
         }
       `);
     } else if (isWithinOneOfThatShouldBeUnion(options, field)) {


### PR DESCRIPTION
This PR implements the "possible future behavior" described in the README by omitting fields set to their default values from the `toJSON` output.

I haven't made this configurable to avoid adding yet another option. Let me know if you feel like this should not be the default.