### PR TITLE
fix: Update type imports syntax on gRPC generation

### DIFF
--- a/integration/grpc-js-use-date-false/grpc-js-use-date-false.ts
+++ b/integration/grpc-js-use-date-false/grpc-js-use-date-false.ts
@@ -1,13 +1,10 @@
 /* eslint-disable */
-import {
+import { ChannelCredentials, Client, makeGenericClientConstructor, Metadata } from "@grpc/grpc-js";
+import type {
   CallOptions,
-  ChannelCredentials,
-  Client,
   ClientOptions,
   ClientUnaryCall,
   handleUnaryCall,
-  makeGenericClientConstructor,
-  Metadata,
   ServiceError,
   UntypedServiceImplementation,
 } from "@grpc/grpc-js";

--- a/integration/grpc-js-use-date-string/grpc-js-use-date-string.ts
+++ b/integration/grpc-js-use-date-string/grpc-js-use-date-string.ts
@@ -1,13 +1,10 @@
 /* eslint-disable */
-import {
+import { ChannelCredentials, Client, makeGenericClientConstructor, Metadata } from "@grpc/grpc-js";
+import type {
   CallOptions,
-  ChannelCredentials,
-  Client,
   ClientOptions,
   ClientUnaryCall,
   handleUnaryCall,
-  makeGenericClientConstructor,
-  Metadata,
   ServiceError,
   UntypedServiceImplementation,
 } from "@grpc/grpc-js";

--- a/integration/grpc-js-use-date-true/grpc-js-use-date-true.ts
+++ b/integration/grpc-js-use-date-true/grpc-js-use-date-true.ts
@@ -1,13 +1,10 @@
 /* eslint-disable */
-import {
+import { ChannelCredentials, Client, makeGenericClientConstructor, Metadata } from "@grpc/grpc-js";
+import type {
   CallOptions,
-  ChannelCredentials,
-  Client,
   ClientOptions,
   ClientUnaryCall,
   handleUnaryCall,
-  makeGenericClientConstructor,
-  Metadata,
   ServiceError,
   UntypedServiceImplementation,
 } from "@grpc/grpc-js";

--- a/integration/grpc-js/simple.ts
+++ b/integration/grpc-js/simple.ts
@@ -1,19 +1,21 @@
 /* eslint-disable */
 import {
-  CallOptions,
   ChannelCredentials,
   Client,
   ClientDuplexStream,
-  ClientOptions,
   ClientReadableStream,
-  ClientUnaryCall,
   ClientWritableStream,
   handleBidiStreamingCall,
   handleClientStreamingCall,
   handleServerStreamingCall,
-  handleUnaryCall,
   makeGenericClientConstructor,
   Metadata,
+} from "@grpc/grpc-js";
+import type {
+  CallOptions,
+  ClientOptions,
+  ClientUnaryCall,
+  handleUnaryCall,
   ServiceError,
   UntypedServiceImplementation,
 } from "@grpc/grpc-js";

--- a/src/generate-grpc-js.ts
+++ b/src/generate-grpc-js.ts
@@ -6,22 +6,22 @@ import { messageToTypeName } from "./types";
 import { assertInstanceOf, FormattedMethodDescriptor, maybeAddComment, maybePrefixPackage } from "./utils";
 import { generateDecoder, generateEncoder } from "./encode";
 
-const CallOptions = imp("CallOptions@@grpc/grpc-js");
+const CallOptions = imp("t:CallOptions@@grpc/grpc-js");
 const ChannelCredentials = imp("ChannelCredentials@@grpc/grpc-js");
-const ClientOptions = imp("ClientOptions@@grpc/grpc-js");
+const ClientOptions = imp("t:ClientOptions@@grpc/grpc-js");
 const Client = imp("Client@@grpc/grpc-js");
 const ClientDuplexStream = imp("ClientDuplexStream@@grpc/grpc-js");
 const ClientReadableStream = imp("ClientReadableStream@@grpc/grpc-js");
-const ClientUnaryCall = imp("ClientUnaryCall@@grpc/grpc-js");
+const ClientUnaryCall = imp("t:ClientUnaryCall@@grpc/grpc-js");
 const ClientWritableStream = imp("ClientWritableStream@@grpc/grpc-js");
 const handleBidiStreamingCall = imp("handleBidiStreamingCall@@grpc/grpc-js");
 const handleClientStreamingCall = imp("handleClientStreamingCall@@grpc/grpc-js");
 const handleServerStreamingCall = imp("handleServerStreamingCall@@grpc/grpc-js");
-const handleUnaryCall = imp("handleUnaryCall@@grpc/grpc-js");
-const UntypedServiceImplementation = imp("UntypedServiceImplementation@@grpc/grpc-js");
+const handleUnaryCall = imp("t:handleUnaryCall@@grpc/grpc-js");
+const UntypedServiceImplementation = imp("t:UntypedServiceImplementation@@grpc/grpc-js");
 const makeGenericClientConstructor = imp("makeGenericClientConstructor@@grpc/grpc-js");
 const Metadata = imp("Metadata@@grpc/grpc-js");
-const ServiceError = imp("ServiceError@@grpc/grpc-js");
+const ServiceError = imp("t:ServiceError@@grpc/grpc-js");
 
 /**
  * Generates a service definition and server / client stubs for the


### PR DESCRIPTION
Fixes #920.

This PR adds the `t:` prefix to gRPC generation imports when the import is only a type.

This makes sure that the TypeScript compiler is happy when [`verbatimModuleSyntax`](https://www.typescriptlang.org/tsconfig#verbatimModuleSyntax) is enabled 🙂