### PR TITLE
feat: generate type namespaces for enums as literals

### DIFF
--- a/integration/enums-as-literals-with-string-enums/enums-as-literals-with-string-enums.ts
+++ b/integration/enums-as-literals-with-string-enums/enums-as-literals-with-string-enums.ts
@@ -17,6 +17,14 @@ export const DividerData_DividerType = {
 
 export type DividerData_DividerType = typeof DividerData_DividerType[keyof typeof DividerData_DividerType];
 
+export namespace DividerData_DividerType {
+  export type DOUBLE = typeof DividerData_DividerType.DOUBLE;
+  export type SINGLE = typeof DividerData_DividerType.SINGLE;
+  export type DASHED = typeof DividerData_DividerType.DASHED;
+  export type DOTTED = typeof DividerData_DividerType.DOTTED;
+  export type UNRECOGNIZED = typeof DividerData_DividerType.UNRECOGNIZED;
+}
+
 export function dividerData_DividerTypeFromJSON(object: any): DividerData_DividerType {
   switch (object) {
     case 0:

--- a/integration/enums-as-literals/enums-as-literals.ts
+++ b/integration/enums-as-literals/enums-as-literals.ts
@@ -11,6 +11,14 @@ export const DividerData_DividerType = { DOUBLE: 0, SINGLE: 1, DASHED: 2, DOTTED
 
 export type DividerData_DividerType = typeof DividerData_DividerType[keyof typeof DividerData_DividerType];
 
+export namespace DividerData_DividerType {
+  export type DOUBLE = typeof DividerData_DividerType.DOUBLE;
+  export type SINGLE = typeof DividerData_DividerType.SINGLE;
+  export type DASHED = typeof DividerData_DividerType.DASHED;
+  export type DOTTED = typeof DividerData_DividerType.DOTTED;
+  export type UNRECOGNIZED = typeof DividerData_DividerType.UNRECOGNIZED;
+}
+
 export function dividerData_DividerTypeFromJSON(object: any): DividerData_DividerType {
   switch (object) {
     case 0:

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -52,6 +52,21 @@ export function generateEnum(
     chunks.push(code`} as const`);
     chunks.push(code`\n`);
     chunks.push(code`export type ${def(fullName)} = typeof ${def(fullName)}[keyof typeof ${def(fullName)}]`);
+    chunks.push(code`\n`)
+    chunks.push(code`export namespace ${def(fullName)} {`)
+
+    enumDesc.value.forEach((valueDesc) => {
+      const memberName = getMemberName(ctx, enumDesc, valueDesc);
+      chunks.push(code`export type ${memberName} = typeof ${def(fullName)}.${memberName};`);
+    });
+
+    if (options.unrecognizedEnum && !unrecognizedEnum.present) {
+      chunks.push(
+        code`export type ${options.unrecognizedEnumName} = typeof ${def(fullName)}.${options.unrecognizedEnumName};`
+      );
+    }
+
+    chunks.push(code`}`);
   } else {
     chunks.push(code`}`);
   }

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -52,8 +52,8 @@ export function generateEnum(
     chunks.push(code`} as const`);
     chunks.push(code`\n`);
     chunks.push(code`export type ${def(fullName)} = typeof ${def(fullName)}[keyof typeof ${def(fullName)}]`);
-    chunks.push(code`\n`)
-    chunks.push(code`export namespace ${def(fullName)} {`)
+    chunks.push(code`\n`);
+    chunks.push(code`export namespace ${def(fullName)} {`);
 
     enumDesc.value.forEach((valueDesc) => {
       const memberName = getMemberName(ctx, enumDesc, valueDesc);
@@ -62,7 +62,7 @@ export function generateEnum(
 
     if (options.unrecognizedEnum && !unrecognizedEnum.present) {
       chunks.push(
-        code`export type ${options.unrecognizedEnumName} = typeof ${def(fullName)}.${options.unrecognizedEnumName};`
+        code`export type ${options.unrecognizedEnumName} = typeof ${def(fullName)}.${options.unrecognizedEnumName};`,
       );
     }
 


### PR DESCRIPTION
this pull request adds code for generating a namespace of type declarations for enums as literals that let you use them like regular enums:
old:
```ts
let foo: typeof Foo.Bar
```

new:
```ts
let foo: Foo.Bar
```

this means a library that was previously using `ts-proto` without the `enumsAsLiterals=true` can add it with less breakages.

---

`Foo.proto`
```proto
enum Foo {
	Bar = 0;
	Baz = 1;
	Qux = 2;
}
```

old generated `Foo.ts`
```ts
export const Foo = { Bar: 0, Baz: 1, Qux: 2, UNRECOGNIZED: -1 } as const;

export type Foo = typeof Foo[keyof typeof Foo];
```

new generated `Foo.ts`
```ts
export const Foo = { Bar: 0, Baz: 1, Qux: 2, UNRECOGNIZED: -1 } as const;

export type Foo = typeof Foo[keyof typeof Foo];

export namespace Foo {
  export type Bar = typeof Foo.Bar;
  export type Baz = typeof Foo.Baz;
  export type Qux = typeof Foo.Qux;
  export type UNRECOGNIZED = typeof Foo.UNRECOGNIZED;
}
```

---

I've not looked into adding any tests or anything for this change, but if this feature is something you're interested in, I wouldn't mind adding tests (and making any other changes you request)