### PR TITLE
fix: Don't close client if we've already aborted

### DIFF
--- a/integration/grpc-web/example.ts
+++ b/integration/grpc-web/example.ts
@@ -1028,9 +1028,7 @@ export class GrpcWebImpl {
             }
           },
         });
-        observer.add(() => {
-          return client.close();
-        });
+        observer.add(() => client.close());
       });
       upStream();
     }).pipe(share());


### PR DESCRIPTION
grpc-web throw an error if you close the client after it's already been closed:

https://github.com/improbable-eng/grpc-web/blob/1d9bbb09a0990bdaff0e37499570dbc7d6e58ce8/client/grpc-web/src/client.ts#L327

This can happen with the abort signals if the observer is finished first and then the abort signal is triggered, causing an exception. Here I'm changing the code generator to remove the abort signal listener in the observer finish handler.