### PR TITLE
Support unwrapped value type rpc method arguments

### DIFF
--- a/integration/grpc-web/example.ts
+++ b/integration/grpc-web/example.ts
@@ -853,8 +853,8 @@ export class DashAPICredsClientImpl implements DashAPICreds {
     return this.rpc.unary(DashAPICredsDeleteDesc, DashAPICredsDeleteReq.fromPartial(request), metadata);
   }
 
-  Uppercase(request: DeepPartial<StringValue>, metadata?: grpc.Metadata): Promise<StringValue> {
-    return this.rpc.unary(DashAPICredsUppercaseDesc, StringValue.fromPartial(request), metadata);
+  Uppercase(request: string | undefined, metadata?: grpc.Metadata): Promise<StringValue> {
+    return this.rpc.unary(DashAPICredsUppercaseDesc, StringValue.fromPartial({ value: request }), metadata);
   }
 }
 

--- a/src/generate-grpc-web.ts
+++ b/src/generate-grpc-web.ts
@@ -1,5 +1,5 @@
 import { MethodDescriptorProto, FileDescriptorProto, ServiceDescriptorProto } from "ts-proto-descriptors";
-import { rawRequestType, requestType, responsePromiseOrObservable, responseType, observableType } from "./types";
+import { rawRequestType, requestType, responsePromiseOrObservable, responseType, observableType, valueTypeName} from "./types";
 import { Code, code, imp, joinCode } from "ts-poet";
 import { Context } from "./context";
 import { assertInstanceOf, FormattedMethodDescriptor, maybePrefixPackage } from "./utils";
@@ -50,8 +50,10 @@ function generateRpcMethod(ctx: Context, serviceDesc: ServiceDescriptorProto, me
   assertInstanceOf(methodDesc, FormattedMethodDescriptor);
   const { options } = ctx;
   const { useAbortSignal } = options;
+  const isValueType = valueTypeName(ctx, methodDesc.inputType) !== undefined;
+  const inputType = isValueType ? rawRequestType(ctx, methodDesc) : requestType(ctx, methodDesc, true);
+  const inputValue = isValueType ? '{ value: request }' : 'request';
   const requestMessage = requestType(ctx, methodDesc, false);
-  const inputType = requestType(ctx, methodDesc, true);
   const returns = responsePromiseOrObservable(ctx, methodDesc);
 
   if (methodDesc.clientStreaming) {
@@ -75,7 +77,7 @@ function generateRpcMethod(ctx: Context, serviceDesc: ServiceDescriptorProto, me
     ): ${returns} {
       return this.rpc.${method}(
         ${methodDescName(serviceDesc, methodDesc)},
-        ${requestMessage}.fromPartial(request),
+        ${requestMessage}.fromPartial(${inputValue}),
         metadata,
         ${useAbortSignal ? "abortSignal," : ""}
       );


### PR DESCRIPTION
This part only adds support of unwrapped arguments, not return values.
Currently I do not have any value-type return types in my projects so I don't have an ability to check whether generated code does work if it contains such return values.
So this specific PR contains only stable code which I was able to check in a real project.

Either I'll create another PR when unwrapping of value-type return values is supported or just add commits to this one later.