### PR TITLE
fix: add serviceName to grpc-js client constructor type

### DIFF
--- a/integration/grpc-js-use-date-false/grpc-js-use-date-false.ts
+++ b/integration/grpc-js-use-date-false/grpc-js-use-date-false.ts
@@ -136,6 +136,7 @@ export interface TestClient extends Client {
 export const TestClient = makeGenericClientConstructor(TestService, "simple.Test") as unknown as {
   new (address: string, credentials: ChannelCredentials, options?: Partial<ClientOptions>): TestClient;
   service: typeof TestService;
+  serviceName: string;
 };
 
 type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;

--- a/integration/grpc-js-use-date-string/grpc-js-use-date-string.ts
+++ b/integration/grpc-js-use-date-string/grpc-js-use-date-string.ts
@@ -134,6 +134,7 @@ export interface TestClient extends Client {
 export const TestClient = makeGenericClientConstructor(TestService, "simple.Test") as unknown as {
   new (address: string, credentials: ChannelCredentials, options?: Partial<ClientOptions>): TestClient;
   service: typeof TestService;
+  serviceName: string;
 };
 
 type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;

--- a/integration/grpc-js-use-date-true/grpc-js-use-date-true.ts
+++ b/integration/grpc-js-use-date-true/grpc-js-use-date-true.ts
@@ -134,6 +134,7 @@ export interface TestClient extends Client {
 export const TestClient = makeGenericClientConstructor(TestService, "simple.Test") as unknown as {
   new (address: string, credentials: ChannelCredentials, options?: Partial<ClientOptions>): TestClient;
   service: typeof TestService;
+  serviceName: string;
 };
 
 type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;

--- a/integration/grpc-js/simple.ts
+++ b/integration/grpc-js/simple.ts
@@ -631,6 +631,7 @@ export interface TestClient extends Client {
 export const TestClient = makeGenericClientConstructor(TestService, "simple.Test") as unknown as {
   new (address: string, credentials: ChannelCredentials, options?: Partial<ClientOptions>): TestClient;
   service: typeof TestService;
+  serviceName: string;
 };
 
 type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;

--- a/src/generate-grpc-js.ts
+++ b/src/generate-grpc-js.ts
@@ -238,6 +238,7 @@ function generateClientConstructor(fileDesc: FileDescriptorProto, serviceDesc: S
         options?: Partial<${ClientOptions}>,
       ): ${serviceDesc.name}Client;
       service: typeof ${serviceDesc.name}Service;
+      serviceName: string;
     }
   `;
 }


### PR DESCRIPTION
Currently type exported by generated code does not match the return value of `makeConstructor` function from grpc-js

https://github.com/grpc/grpc-node/blob/c5d35fe22db9503fb7ec2f03370cfc1723efe6e8/packages/grpc-js/src/make-client.ts#L124

because it's missing  the `serviceName` field

https://github.com/grpc/grpc-node/blob/c5d35fe22db9503fb7ec2f03370cfc1723efe6e8/packages/grpc-js/src/make-client.ts#L94

This PR adds `serviceName` field to the generated type.