### PR TITLE
fix: error handling on non-`Error` type errors

### DIFF
--- a/integration/handle-error-in-default-service/handle-error-test.ts
+++ b/integration/handle-error-in-default-service/handle-error-test.ts
@@ -52,6 +52,22 @@ describe("before-after-request", () => {
     decodeSpy.mockRestore();
   });
 
+  it("performs handleError even if error is not an Error instance", async () => {
+    const errString = "some error";
+    const decodeSpy = jest.spyOn(GetBasicResponse, "decode").mockImplementation(() => {
+      throw errString;
+    });
+    const req = GetBasicRequest.create(exampleData);
+    client = new BasicServiceClientImpl({ ...rpc, handleError: handleError });
+    try {
+      await client.GetBasic(req);
+    } catch (error) {
+      expect(error).toBe(modifiedError);
+      expect(handleError).toHaveBeenCalledWith(BasicServiceServiceName, "GetBasic", errString);
+    }
+    decodeSpy.mockRestore();
+  });
+
   it("doesn't perform handleError if it is not specified", async () => {
     const req = GetBasicRequest.create(exampleData);
     client = new BasicServiceClientImpl(rpc);

--- a/integration/handle-error-in-default-service/simple.ts
+++ b/integration/handle-error-in-default-service/simple.ts
@@ -148,7 +148,7 @@ export class BasicServiceClientImpl implements BasicService {
         return Promise.reject(error);
       }
     }).catch((error) => {
-      if (error instanceof Error && this.rpc.handleError) {
+      if (this.rpc.handleError) {
         return Promise.reject(this.rpc.handleError(this.service, "GetBasic", error));
       }
       return Promise.reject(error);

--- a/integration/handle-error-with-after-response/handle-error-test.ts
+++ b/integration/handle-error-with-after-response/handle-error-test.ts
@@ -52,6 +52,22 @@ describe("before-after-request", () => {
     decodeSpy.mockRestore();
   });
 
+  it("performs handleError if error is not an Error instance", async () => {
+    const errString = "some error";
+    const decodeSpy = jest.spyOn(GetBasicResponse, "decode").mockImplementation(() => {
+      throw errString;
+    });
+    const req = GetBasicRequest.create(exampleData);
+    client = new BasicServiceClientImpl({ ...rpc, handleError: handleError });
+    try {
+      await client.GetBasic(req);
+    } catch (error) {
+      expect(error).toBe(modifiedError);
+      expect(handleError).toHaveBeenCalledWith(BasicServiceServiceName, "GetBasic", errString);
+    }
+    decodeSpy.mockRestore();
+  });
+
   it("performs handleError if error occurs when calling afterResponse", async () => {
     const decodeSpy = jest.spyOn(GetBasicResponse, "decode").mockReturnValue(exampleData);
     const req = GetBasicRequest.create(exampleData);

--- a/integration/handle-error-with-after-response/simple.ts
+++ b/integration/handle-error-with-after-response/simple.ts
@@ -152,7 +152,7 @@ export class BasicServiceClientImpl implements BasicService {
         return Promise.reject(error);
       }
     }).catch((error) => {
-      if (error instanceof Error && this.rpc.handleError) {
+      if (this.rpc.handleError) {
         return Promise.reject(this.rpc.handleError(this.service, "GetBasic", error));
       }
       return Promise.reject(error);

--- a/src/generate-services.ts
+++ b/src/generate-services.ts
@@ -123,7 +123,7 @@ function generateRegularRpcMethod(ctx: Context, methodDesc: MethodDescriptorProt
   let errorHandler;
   if (options.rpcErrorHandler) {
     errorHandler = code`
-      if (error instanceof Error && this.rpc.handleError) {
+      if (this.rpc.handleError) {
         return Promise.reject(this.rpc.handleError(this.service, "${methodDesc.name}", error));
       }
       return Promise.reject(error);


### PR DESCRIPTION
### Description

Small issue noticed with the behavior of the default service implementation `handleError` method. If the throw error was an instance of Error, then the handleError function is called correctly. However, if it was not, we had a check that prevented `handleError` from called. This isn't desired behavior as errors can be strings. 

### Testing performed

Tested in a consuming application and this issue is resolved. Unit tests have been updated and are passing.