### PR TITLE
fix: ensure docker-compose platform is amd64

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       dockerfile: "protoc.Dockerfile"
       args:
         - "ARCH=${ARCH:-x86_64}"
+    platform: linux/amd64
     volumes:
       - ".:/ts-proto"
       - "${PWD:-.}:/host"


### PR DESCRIPTION
When running build/test process on arm machines (M1 etc), the docker-compose setup attempts to run arm images. This in turn causes protoc to fail as the `Dockerfile.protoc` forces use of protoc-x86.

This PR updates the `docker-compose.yml` file to ensure amd64 platform base images are used when running.

Before:
```
$ yarn build:test
[+] Building 1.1s (10/11)                                                                                                                                                                                    docker:desktop-linux
 => [protoc internal] load build definition from protoc.Dockerfile                                                                                                                                                           0.0s
 => => transferring dockerfile: 570B                                                                                                                                                                                         0.0s
 => [protoc internal] load .dockerignore                                                                                                                                                                                     0.0s
 => => transferring context: 2B                                                                                                                                                                                              0.0s
 => [protoc internal] load metadata for docker.io/library/node:current-slim                                                                                                                                                  0.4s
 => [protoc 1/7] FROM docker.io/library/node:current-slim@sha256:e8a7eb273ef8a9ebc03f0ad03c0fd4bbc3562ec244691e6fc37344ee2c4357d2                                                                                            0.0s
 => [protoc] https://github.com/protocolbuffers/protobuf/releases/download/v3.19.1/protoc-3.19.1-linux-x86_64.zip                                                                                                            0.6s
 => CACHED [protoc 2/7] RUN apt-get update --yes && apt-get install --yes unzip                                                                                                                                              0.0s
 => CACHED [protoc 3/7] ADD https://github.com/protocolbuffers/protobuf/releases/download/v3.19.1/protoc-3.19.1-linux-x86_64.zip protoc.zip                                                                                  0.0s
 => CACHED [protoc 4/7] RUN mkdir /usr/local/lib/protoc && unzip protoc.zip -d /usr/local/lib/protoc && rm protoc.zip                                                                                                        0.0s
 => CACHED [protoc 5/7] RUN ln -s /usr/local/lib/protoc/bin/protoc /usr/local/bin/protoc                                                                                                                                     0.0s
 => ERROR [protoc 6/7] RUN protoc --version                                                                                                                                                                                  0.1s
------                                                                                                                                                                                                                            
 > [protoc 6/7] RUN protoc --version:
0.108 rosetta error: failed to open elf at /lib64/ld-linux-x86-64.so.2
0.108  Trace/breakpoint trap
------
failed to solve: process "/bin/sh -c protoc --version" did not complete successfully: exit code: 133
```

After:
```
$ yarn build:test
[+] Building 11.9s (12/12) FINISHED
```