### PR TITLE
fix: use `globalThis.Error` in case there is a proto `Error` message

### DIFF
--- a/integration/before-after-request-streaming/example.ts
+++ b/integration/before-after-request-streaming/example.ts
@@ -1022,7 +1022,7 @@ interface Rpc {
   bidirectionalStreamingRequest(service: string, method: string, data: Observable<Uint8Array>): Observable<Uint8Array>;
   beforeRequest?<T extends { [k in keyof T]: unknown }>(service: string, method: string, request: T): void;
   afterResponse?<T extends { [k in keyof T]: unknown }>(service: string, method: string, response: T): void;
-  handleError?(service: string, method: string, error: Error): Error;
+  handleError?(service: string, method: string, error: globalThis.Error): globalThis.Error;
 }
 
 type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;

--- a/integration/handle-error-in-default-service/simple.ts
+++ b/integration/handle-error-in-default-service/simple.ts
@@ -158,7 +158,7 @@ export class BasicServiceClientImpl implements BasicService {
 
 interface Rpc {
   request(service: string, method: string, data: Uint8Array): Promise<Uint8Array>;
-  handleError?(service: string, method: string, error: Error): Error;
+  handleError?(service: string, method: string, error: globalThis.Error): globalThis.Error;
 }
 
 type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;

--- a/integration/handle-error-with-after-response/simple.ts
+++ b/integration/handle-error-with-after-response/simple.ts
@@ -163,7 +163,7 @@ export class BasicServiceClientImpl implements BasicService {
 interface Rpc {
   request(service: string, method: string, data: Uint8Array): Promise<Uint8Array>;
   afterResponse?<T extends { [k in keyof T]: unknown }>(service: string, method: string, response: T): void;
-  handleError?(service: string, method: string, error: Error): Error;
+  handleError?(service: string, method: string, error: globalThis.Error): globalThis.Error;
 }
 
 type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;

--- a/src/generate-services.ts
+++ b/src/generate-services.ts
@@ -432,7 +432,9 @@ export function generateRpcType(ctx: Context, hasStreamingMethods: boolean): Cod
     );
   }
   if (options.rpcErrorHandler) {
-    additionalMethods.push(code`handleError?(service: string, method: string, error: Error): Error;`);
+    additionalMethods.push(
+      code`handleError?(service: string, method: string, error: globalThis.Error): globalThis.Error;`,
+    );
   }
 
   if (hasStreamingMethods) {


### PR DESCRIPTION
### Description

`handleError` receives and returns an instance of `Error`. However, if there is a proto message named `Error` that is declared or  imported into this file, then we run into a Typescript problem. This PR forces the `handleError` function to always expect `globalThis.Error` instead.

### TODO:

- [ ] Handle case where globalThisPolyfill is set to true