### PR TITLE
fix: conflicting option with nestJs and outputIndex

### DIFF
--- a/integration/nestjs-metadata-grpc-js/hero.ts
+++ b/integration/nestjs-metadata-grpc-js/hero.ts
@@ -5,8 +5,6 @@ import { GrpcMethod, GrpcStreamMethod } from "@nestjs/microservices";
 import * as _m0 from "protobufjs/minimal";
 import { Observable } from "rxjs";
 
-export const protobufPackage = "hero";
-
 export interface HeroById {
   id: number;
 }

--- a/integration/nestjs-metadata-observables/hero.ts
+++ b/integration/nestjs-metadata-observables/hero.ts
@@ -3,8 +3,6 @@ import { Metadata } from "@grpc/grpc-js";
 import { GrpcMethod, GrpcStreamMethod } from "@nestjs/microservices";
 import { Observable } from "rxjs";
 
-export const protobufPackage = "hero";
-
 export interface HeroById {
   id: number;
 }

--- a/integration/nestjs-metadata-restparameters/hero.ts
+++ b/integration/nestjs-metadata-restparameters/hero.ts
@@ -3,8 +3,6 @@ import { Metadata } from "@grpc/grpc-js";
 import { GrpcMethod, GrpcStreamMethod } from "@nestjs/microservices";
 import { Observable } from "rxjs";
 
-export const protobufPackage = "hero";
-
 export interface HeroById {
   id: number;
 }

--- a/integration/nestjs-metadata/hero.ts
+++ b/integration/nestjs-metadata/hero.ts
@@ -3,8 +3,6 @@ import { Metadata } from "@grpc/grpc-js";
 import { GrpcMethod, GrpcStreamMethod } from "@nestjs/microservices";
 import { Observable } from "rxjs";
 
-export const protobufPackage = "hero";
-
 export interface HeroById {
   id: number;
 }

--- a/integration/nestjs-restparameters/hero.ts
+++ b/integration/nestjs-restparameters/hero.ts
@@ -2,8 +2,6 @@
 import { GrpcMethod, GrpcStreamMethod } from "@nestjs/microservices";
 import { Observable } from "rxjs";
 
-export const protobufPackage = "hero";
-
 export interface HeroById {
   id: number;
 }

--- a/integration/nestjs-simple-observables/hero.ts
+++ b/integration/nestjs-simple-observables/hero.ts
@@ -2,8 +2,6 @@
 import { GrpcMethod, GrpcStreamMethod } from "@nestjs/microservices";
 import { Observable } from "rxjs";
 
-export const protobufPackage = "hero";
-
 export interface HeroById {
   id: number;
 }

--- a/integration/nestjs-simple-restparameters/google/protobuf/empty.ts
+++ b/integration/nestjs-simple-restparameters/google/protobuf/empty.ts
@@ -1,7 +1,5 @@
 /* eslint-disable */
 
-export const protobufPackage = "google.protobuf";
-
 /**
  * A generic empty message that you can re-use to avoid defining duplicated
  * empty messages in your APIs. A typical example is to use it as the request

--- a/integration/nestjs-simple-restparameters/hero.ts
+++ b/integration/nestjs-simple-restparameters/hero.ts
@@ -3,8 +3,6 @@ import { GrpcMethod, GrpcStreamMethod } from "@nestjs/microservices";
 import { Observable } from "rxjs";
 import { Empty } from "./google/protobuf/empty";
 
-export const protobufPackage = "hero";
-
 export interface User {
   id: number;
   name: string;

--- a/integration/nestjs-simple-usedate/google/protobuf/empty.ts
+++ b/integration/nestjs-simple-usedate/google/protobuf/empty.ts
@@ -1,7 +1,5 @@
 /* eslint-disable */
 
-export const protobufPackage = "google.protobuf";
-
 /**
  * A generic empty message that you can re-use to avoid defining duplicated
  * empty messages in your APIs. A typical example is to use it as the request

--- a/integration/nestjs-simple-usedate/google/protobuf/timestamp.ts
+++ b/integration/nestjs-simple-usedate/google/protobuf/timestamp.ts
@@ -1,7 +1,5 @@
 /* eslint-disable */
 
-export const protobufPackage = "google.protobuf";
-
 /**
  * A Timestamp represents a point in time independent of any time zone or local
  * calendar, encoded as a count of seconds and fractions of seconds at

--- a/integration/nestjs-simple-usedate/hero.ts
+++ b/integration/nestjs-simple-usedate/hero.ts
@@ -4,8 +4,6 @@ import { wrappers } from "protobufjs";
 import { Observable } from "rxjs";
 import { Empty } from "./google/protobuf/empty";
 
-export const protobufPackage = "hero";
-
 export interface HeroById {
   id: number;
 }

--- a/integration/nestjs-simple/google/protobuf/empty.ts
+++ b/integration/nestjs-simple/google/protobuf/empty.ts
@@ -1,7 +1,5 @@
 /* eslint-disable */
 
-export const protobufPackage = "google.protobuf";
-
 /**
  * A generic empty message that you can re-use to avoid defining duplicated
  * empty messages in your APIs. A typical example is to use it as the request

--- a/integration/nestjs-simple/google/protobuf/struct.ts
+++ b/integration/nestjs-simple/google/protobuf/struct.ts
@@ -1,8 +1,6 @@
 /* eslint-disable */
 import { wrappers } from "protobufjs";
 
-export const protobufPackage = "google.protobuf";
-
 /**
  * `NullValue` is a singleton enumeration to represent the null value for the
  * `Value` type union.

--- a/integration/nestjs-simple/google/protobuf/timestamp.ts
+++ b/integration/nestjs-simple/google/protobuf/timestamp.ts
@@ -1,7 +1,5 @@
 /* eslint-disable */
 
-export const protobufPackage = "google.protobuf";
-
 /**
  * A Timestamp represents a point in time independent of any time zone or local
  * calendar, encoded as a count of seconds and fractions of seconds at

--- a/integration/nestjs-simple/hero.ts
+++ b/integration/nestjs-simple/hero.ts
@@ -6,8 +6,6 @@ import { Empty } from "./google/protobuf/empty";
 import { Struct } from "./google/protobuf/struct";
 import { Timestamp } from "./google/protobuf/timestamp";
 
-export const protobufPackage = "hero";
-
 export interface HeroById {
   id: number;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -132,7 +132,8 @@ export function generateFile(ctx: Context, fileDesc: FileDescriptorProto): [stri
   const chunks: Code[] = [];
 
   // Indicate this file's source protobuf package for reflective use with google.protobuf.Any
-  if (options.exportCommonSymbols) {
+  // since when nestJs=true, we have distinct protobuf package names we should exclude it here
+  if (options.exportCommonSymbols && !options.nestJs) {
     chunks.push(code`export const protobufPackage = '${fileDesc.package}';`);
   }
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -258,7 +258,9 @@ export function optionsFromParameter(parameter: string | undefined): Options {
     options.initializeFieldsAsUndefined = false;
   }
 
-  if (options.outputIndex) {
+  // since when nestJs=true, we have distinct protobuf package names we should exclude it here
+  // otherwise, the common symbols won't be generated at all
+  if (options.outputIndex && !options.nestJs) {
     options.exportCommonSymbols = false;
   }
 


### PR DESCRIPTION
Changes: 

- when we have nestJs=true and outputIndex=true, multiple protobufPackage variables will be generated, which breaks the barrel 
  file type checking, since we have multiple exports with the same name.
- the default nestjs distinct PACKAGE_NAME and SERVICE_NAME variables won't be generated.


@stephenh there is a conflict of options and behavior when we have `nestJs=true` and `outputIndex=true` at the same time, in which `outputIndex` overrides the default  `PACKAGE_NAME` and `SERVICE_NAME` generation of `nestjs` option. 
dropping these two variables is a huge loss IMO, since we use them as injection tokens in services and in module initializations.
please let me know what you think, thanks thanks :pray: 

Note: 
the changes on generated tests are needed TBH, current generated codes are counter-productive in actual Nestjs GRPC Microservices setup.  