### PR TITLE
fix: camelToSnake to respect uppercase words, such as "GetAPIValue" -> "GET_API_VALUE"

### DIFF
--- a/src/case.ts
+++ b/src/case.ts
@@ -1,4 +1,4 @@
-import { camelCase as camelCaseAnything } from "case-anything";
+import { camelCase as camelCaseAnything, snakeCase as snakeCaseAnything } from "case-anything";
 
 import { Options } from "./options";
 
@@ -24,7 +24,7 @@ export function snakeToCamel(s: string): string {
 }
 
 export function camelToSnake(s: string): string {
-  return s.replace(/\w([A-Z])/g, (m) => m[0] + "_" + m[1]).toUpperCase();
+  return snakeCaseAnything(s).toUpperCase();
 }
 
 export function capitalize(s: string): string {

--- a/tests/case-test.ts
+++ b/tests/case-test.ts
@@ -1,4 +1,4 @@
-import { maybeSnakeToCamel, camelCaseGrpc } from "../src/case";
+import { maybeSnakeToCamel, camelCaseGrpc, camelToSnake } from "../src/case";
 import { Options, optionsFromParameter } from "../src/options";
 import { getFieldJsonName } from "../src/utils";
 
@@ -49,6 +49,14 @@ describe("case", () => {
 
   it("converts string to camel case respecting word separation, getAPIValue === getApiValue", () => {
     expect(camelCaseGrpc("GetAPIValue")).toEqual("getApiValue");
+  });
+
+  it("converts simple string to snake case, getApiValue === GET_API_VALUE", () => {
+    expect(camelToSnake("GetApiValue")).toEqual("GET_API_VALUE");
+  });
+
+  it("converts string to snake case respecting word separation, getAPIValue === GET_API_VALUE", () => {
+    expect(camelToSnake("getAPIValue")).toEqual("GET_API_VALUE");
   });
 
   describe("getFieldJsonName", () => {


### PR DESCRIPTION
## Problem
`camelToSnake()` is converting the example string "TestAPI" -> "TEST_AP_I" when converting a 3rd party integration proto files that I am attempting to generate with the Nest option. I believe that the conversion should respect the "API" part of the string and not split it into two parts like so. 

## Fix
I swapped the logic to use the already imported "case-anything" library's `snakeCase()` function as `snakeCaseAnything()` and added a couple of simple tests to ensure the logic.

I would love for this fix to go through as it is a pretty inconvenient problem at the moment (:

Thanks!