### PR TITLE
feat: Add interface for static message methods

### DIFF
--- a/integration/affixes/affixes.ts
+++ b/integration/affixes/affixes.ts
@@ -55,7 +55,7 @@ function createBasePrefixAwesomeMessageSuffix(): PrefixAwesomeMessageSuffix {
   return {};
 }
 
-export const PrefixAwesomeMessageSuffix = {
+export const PrefixAwesomeMessageSuffix: MessageFns<PrefixAwesomeMessageSuffix> = {
   encode(_: PrefixAwesomeMessageSuffix, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     return writer;
   },
@@ -98,7 +98,7 @@ function createBasePrefixAwesomeMessage_InnerSuffix(): PrefixAwesomeMessage_Inne
   return {};
 }
 
-export const PrefixAwesomeMessage_InnerSuffix = {
+export const PrefixAwesomeMessage_InnerSuffix: MessageFns<PrefixAwesomeMessage_InnerSuffix> = {
   encode(_: PrefixAwesomeMessage_InnerSuffix, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     return writer;
   },
@@ -169,3 +169,12 @@ export type DeepPartial<T> = T extends Builtin ? T
 type KeysOfUnion<T> = T extends T ? keyof T : never;
 export type Exact<P, I extends P> = P extends Builtin ? P
   : P & { [K in keyof P]: Exact<P[K], I[K]> } & { [K in Exclude<keyof I, KeysOfUnion<P>>]: never };
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
+}

--- a/integration/angular/simple-message.ts
+++ b/integration/angular/simple-message.ts
@@ -14,7 +14,7 @@ function createBaseSimpleMessage(): SimpleMessage {
   return { numberField: 0 };
 }
 
-export const SimpleMessage = {
+export const SimpleMessage: MessageFns<SimpleMessage> = {
   encode(message: SimpleMessage, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.numberField !== 0) {
       writer.uint32(8).int32(message.numberField);
@@ -81,4 +81,13 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/async-iterable-services-abort-signal/simple.ts
+++ b/integration/async-iterable-services-abort-signal/simple.ts
@@ -15,7 +15,7 @@ function createBaseEchoMsg(): EchoMsg {
   return { body: "" };
 }
 
-export const EchoMsg = {
+export const EchoMsg: MessageFns<EchoMsg> = {
   encode(message: EchoMsg, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.body !== "") {
       writer.uint32(10).string(message.body);
@@ -190,4 +190,17 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  encodeTransform(source: AsyncIterable<T | T[]> | Iterable<T | T[]>): AsyncIterable<Uint8Array>;
+  decodeTransform(
+    source: AsyncIterable<Uint8Array | Uint8Array[]> | Iterable<Uint8Array | Uint8Array[]>,
+  ): AsyncIterable<T>;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/async-iterable-services/simple.ts
+++ b/integration/async-iterable-services/simple.ts
@@ -15,7 +15,7 @@ function createBaseEchoMsg(): EchoMsg {
   return { body: "" };
 }
 
-export const EchoMsg = {
+export const EchoMsg: MessageFns<EchoMsg> = {
   encode(message: EchoMsg, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.body !== "") {
       writer.uint32(10).string(message.body);
@@ -174,4 +174,17 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  encodeTransform(source: AsyncIterable<T | T[]> | Iterable<T | T[]>): AsyncIterable<Uint8Array>;
+  decodeTransform(
+    source: AsyncIterable<Uint8Array | Uint8Array[]> | Iterable<Uint8Array | Uint8Array[]>,
+  ): AsyncIterable<T>;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/avoid-import-conflicts-folder-name/ui.ts
+++ b/integration/avoid-import-conflicts-folder-name/ui.ts
@@ -54,7 +54,7 @@ function createBaseSimple(): Simple {
   return { simple2Name: "", simple2Age: 0 };
 }
 
-export const Simple = {
+export const Simple: MessageFns<Simple> = {
   encode(message: Simple, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.simple2Name !== "") {
       writer.uint32(10).string(message.simple2Name);
@@ -138,4 +138,13 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/avoid-import-conflicts-folder-name/ui/simple.ts
+++ b/integration/avoid-import-conflicts-folder-name/ui/simple.ts
@@ -65,7 +65,7 @@ function createBaseSimple(): Simple {
   return { name: "", otherSimple: undefined };
 }
 
-export const Simple = {
+export const Simple: MessageFns<Simple> = {
   encode(message: Simple, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -141,7 +141,7 @@ function createBaseSimpleEnums(): SimpleEnums {
   return { localEnum: 0, importEnum: 0 };
 }
 
-export const SimpleEnums = {
+export const SimpleEnums: MessageFns<SimpleEnums> = {
   encode(message: SimpleEnums, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.localEnum !== 0) {
       writer.uint32(8).int32(message.localEnum);
@@ -225,4 +225,13 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/avoid-import-conflicts/simple.ts
+++ b/integration/avoid-import-conflicts/simple.ts
@@ -81,7 +81,7 @@ function createBaseSimple(): Simple {
   return { name: "", otherSimple: undefined };
 }
 
-export const Simple = {
+export const Simple: MessageFns<Simple> = {
   encode(message: Simple, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -157,7 +157,7 @@ function createBaseDifferentSimple(): DifferentSimple {
   return { name: "", otherOptionalSimple2: undefined };
 }
 
-export const DifferentSimple = {
+export const DifferentSimple: MessageFns<DifferentSimple> = {
   encode(message: DifferentSimple, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -235,7 +235,7 @@ function createBaseSimpleEnums(): SimpleEnums {
   return { localEnum: 0, importEnum: 0 };
 }
 
-export const SimpleEnums = {
+export const SimpleEnums: MessageFns<SimpleEnums> = {
   encode(message: SimpleEnums, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.localEnum !== 0) {
       writer.uint32(8).int32(message.localEnum);
@@ -309,7 +309,7 @@ function createBaseFooServiceCreateRequest(): FooServiceCreateRequest {
   return { kind: 0 };
 }
 
-export const FooServiceCreateRequest = {
+export const FooServiceCreateRequest: MessageFns<FooServiceCreateRequest> = {
   encode(message: FooServiceCreateRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.kind !== 0) {
       writer.uint32(8).int32(message.kind);
@@ -366,7 +366,7 @@ function createBaseFooServiceCreateResponse(): FooServiceCreateResponse {
   return { kind: 0 };
 }
 
-export const FooServiceCreateResponse = {
+export const FooServiceCreateResponse: MessageFns<FooServiceCreateResponse> = {
   encode(message: FooServiceCreateResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.kind !== 0) {
       writer.uint32(8).int32(message.kind);
@@ -457,4 +457,13 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/avoid-import-conflicts/simple2.ts
+++ b/integration/avoid-import-conflicts/simple2.ts
@@ -93,7 +93,7 @@ function createBaseSimple(): Simple {
   return { name: "", age: 0 };
 }
 
-export const Simple = {
+export const Simple: MessageFns<Simple> = {
   encode(message: Simple, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -177,4 +177,13 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/barrel-imports/bar.ts
+++ b/integration/barrel-imports/bar.ts
@@ -13,7 +13,7 @@ function createBaseBar(): Bar {
   return { name: "", age: 0 };
 }
 
-export const Bar = {
+export const Bar: MessageFns<Bar> = {
   encode(message: Bar, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -97,4 +97,13 @@ type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/barrel-imports/foo.ts
+++ b/integration/barrel-imports/foo.ts
@@ -14,7 +14,7 @@ function createBaseFoo(): Foo {
   return { name: "", bar: undefined };
 }
 
-export const Foo = {
+export const Foo: MessageFns<Foo> = {
   encode(message: Foo, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -98,4 +98,13 @@ type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/batching-with-context-esModuleInterop/batching.ts
+++ b/integration/batching-with-context-esModuleInterop/batching.ts
@@ -53,7 +53,7 @@ function createBaseBatchQueryRequest(): BatchQueryRequest {
   return { ids: [] };
 }
 
-export const BatchQueryRequest = {
+export const BatchQueryRequest: MessageFns<BatchQueryRequest> = {
   encode(message: BatchQueryRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     for (const v of message.ids) {
       writer.uint32(10).string(v!);
@@ -110,7 +110,7 @@ function createBaseBatchQueryResponse(): BatchQueryResponse {
   return { entities: [] };
 }
 
-export const BatchQueryResponse = {
+export const BatchQueryResponse: MessageFns<BatchQueryResponse> = {
   encode(message: BatchQueryResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     for (const v of message.entities) {
       Entity.encode(v!, writer.uint32(10).fork()).join();
@@ -169,7 +169,7 @@ function createBaseBatchMapQueryRequest(): BatchMapQueryRequest {
   return { ids: [] };
 }
 
-export const BatchMapQueryRequest = {
+export const BatchMapQueryRequest: MessageFns<BatchMapQueryRequest> = {
   encode(message: BatchMapQueryRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     for (const v of message.ids) {
       writer.uint32(10).string(v!);
@@ -226,7 +226,7 @@ function createBaseBatchMapQueryResponse(): BatchMapQueryResponse {
   return { entities: {} };
 }
 
-export const BatchMapQueryResponse = {
+export const BatchMapQueryResponse: MessageFns<BatchMapQueryResponse> = {
   encode(message: BatchMapQueryResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     Object.entries(message.entities).forEach(([key, value]) => {
       BatchMapQueryResponse_EntitiesEntry.encode({ key: key as any, value }, writer.uint32(10).fork()).join();
@@ -304,7 +304,7 @@ function createBaseBatchMapQueryResponse_EntitiesEntry(): BatchMapQueryResponse_
   return { key: "", value: undefined };
 }
 
-export const BatchMapQueryResponse_EntitiesEntry = {
+export const BatchMapQueryResponse_EntitiesEntry: MessageFns<BatchMapQueryResponse_EntitiesEntry> = {
   encode(message: BatchMapQueryResponse_EntitiesEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== "") {
       writer.uint32(10).string(message.key);
@@ -384,7 +384,7 @@ function createBaseGetOnlyMethodRequest(): GetOnlyMethodRequest {
   return { id: "" };
 }
 
-export const GetOnlyMethodRequest = {
+export const GetOnlyMethodRequest: MessageFns<GetOnlyMethodRequest> = {
   encode(message: GetOnlyMethodRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.id !== "") {
       writer.uint32(10).string(message.id);
@@ -441,7 +441,7 @@ function createBaseGetOnlyMethodResponse(): GetOnlyMethodResponse {
   return { entity: undefined };
 }
 
-export const GetOnlyMethodResponse = {
+export const GetOnlyMethodResponse: MessageFns<GetOnlyMethodResponse> = {
   encode(message: GetOnlyMethodResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.entity !== undefined) {
       Entity.encode(message.entity, writer.uint32(10).fork()).join();
@@ -500,7 +500,7 @@ function createBaseWriteMethodRequest(): WriteMethodRequest {
   return { id: "" };
 }
 
-export const WriteMethodRequest = {
+export const WriteMethodRequest: MessageFns<WriteMethodRequest> = {
   encode(message: WriteMethodRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.id !== "") {
       writer.uint32(10).string(message.id);
@@ -557,7 +557,7 @@ function createBaseWriteMethodResponse(): WriteMethodResponse {
   return {};
 }
 
-export const WriteMethodResponse = {
+export const WriteMethodResponse: MessageFns<WriteMethodResponse> = {
   encode(_: WriteMethodResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     return writer;
   },
@@ -600,7 +600,7 @@ function createBaseEntity(): Entity {
   return { id: "", name: "" };
 }
 
-export const Entity = {
+export const Entity: MessageFns<Entity> = {
   encode(message: Entity, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.id !== "") {
       writer.uint32(10).string(message.id);
@@ -783,4 +783,13 @@ function isSet(value: any): boolean {
 
 function fail(message?: string): never {
   throw new globalThis.Error(message ?? "Failed");
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/batching-with-context/batching.ts
+++ b/integration/batching-with-context/batching.ts
@@ -53,7 +53,7 @@ function createBaseBatchQueryRequest(): BatchQueryRequest {
   return { ids: [] };
 }
 
-export const BatchQueryRequest = {
+export const BatchQueryRequest: MessageFns<BatchQueryRequest> = {
   encode(message: BatchQueryRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     for (const v of message.ids) {
       writer.uint32(10).string(v!);
@@ -110,7 +110,7 @@ function createBaseBatchQueryResponse(): BatchQueryResponse {
   return { entities: [] };
 }
 
-export const BatchQueryResponse = {
+export const BatchQueryResponse: MessageFns<BatchQueryResponse> = {
   encode(message: BatchQueryResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     for (const v of message.entities) {
       Entity.encode(v!, writer.uint32(10).fork()).join();
@@ -169,7 +169,7 @@ function createBaseBatchMapQueryRequest(): BatchMapQueryRequest {
   return { ids: [] };
 }
 
-export const BatchMapQueryRequest = {
+export const BatchMapQueryRequest: MessageFns<BatchMapQueryRequest> = {
   encode(message: BatchMapQueryRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     for (const v of message.ids) {
       writer.uint32(10).string(v!);
@@ -226,7 +226,7 @@ function createBaseBatchMapQueryResponse(): BatchMapQueryResponse {
   return { entities: {} };
 }
 
-export const BatchMapQueryResponse = {
+export const BatchMapQueryResponse: MessageFns<BatchMapQueryResponse> = {
   encode(message: BatchMapQueryResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     Object.entries(message.entities).forEach(([key, value]) => {
       BatchMapQueryResponse_EntitiesEntry.encode({ key: key as any, value }, writer.uint32(10).fork()).join();
@@ -304,7 +304,7 @@ function createBaseBatchMapQueryResponse_EntitiesEntry(): BatchMapQueryResponse_
   return { key: "", value: undefined };
 }
 
-export const BatchMapQueryResponse_EntitiesEntry = {
+export const BatchMapQueryResponse_EntitiesEntry: MessageFns<BatchMapQueryResponse_EntitiesEntry> = {
   encode(message: BatchMapQueryResponse_EntitiesEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== "") {
       writer.uint32(10).string(message.key);
@@ -384,7 +384,7 @@ function createBaseGetOnlyMethodRequest(): GetOnlyMethodRequest {
   return { id: "" };
 }
 
-export const GetOnlyMethodRequest = {
+export const GetOnlyMethodRequest: MessageFns<GetOnlyMethodRequest> = {
   encode(message: GetOnlyMethodRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.id !== "") {
       writer.uint32(10).string(message.id);
@@ -441,7 +441,7 @@ function createBaseGetOnlyMethodResponse(): GetOnlyMethodResponse {
   return { entity: undefined };
 }
 
-export const GetOnlyMethodResponse = {
+export const GetOnlyMethodResponse: MessageFns<GetOnlyMethodResponse> = {
   encode(message: GetOnlyMethodResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.entity !== undefined) {
       Entity.encode(message.entity, writer.uint32(10).fork()).join();
@@ -500,7 +500,7 @@ function createBaseWriteMethodRequest(): WriteMethodRequest {
   return { id: "" };
 }
 
-export const WriteMethodRequest = {
+export const WriteMethodRequest: MessageFns<WriteMethodRequest> = {
   encode(message: WriteMethodRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.id !== "") {
       writer.uint32(10).string(message.id);
@@ -557,7 +557,7 @@ function createBaseWriteMethodResponse(): WriteMethodResponse {
   return {};
 }
 
-export const WriteMethodResponse = {
+export const WriteMethodResponse: MessageFns<WriteMethodResponse> = {
   encode(_: WriteMethodResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     return writer;
   },
@@ -600,7 +600,7 @@ function createBaseEntity(): Entity {
   return { id: "", name: "" };
 }
 
-export const Entity = {
+export const Entity: MessageFns<Entity> = {
   encode(message: Entity, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.id !== "") {
       writer.uint32(10).string(message.id);
@@ -783,4 +783,13 @@ function isSet(value: any): boolean {
 
 function fail(message?: string): never {
   throw new globalThis.Error(message ?? "Failed");
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/batching/batching.ts
+++ b/integration/batching/batching.ts
@@ -51,7 +51,7 @@ function createBaseBatchQueryRequest(): BatchQueryRequest {
   return { ids: [] };
 }
 
-export const BatchQueryRequest = {
+export const BatchQueryRequest: MessageFns<BatchQueryRequest> = {
   encode(message: BatchQueryRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     for (const v of message.ids) {
       writer.uint32(10).string(v!);
@@ -108,7 +108,7 @@ function createBaseBatchQueryResponse(): BatchQueryResponse {
   return { entities: [] };
 }
 
-export const BatchQueryResponse = {
+export const BatchQueryResponse: MessageFns<BatchQueryResponse> = {
   encode(message: BatchQueryResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     for (const v of message.entities) {
       Entity.encode(v!, writer.uint32(10).fork()).join();
@@ -167,7 +167,7 @@ function createBaseBatchMapQueryRequest(): BatchMapQueryRequest {
   return { ids: [] };
 }
 
-export const BatchMapQueryRequest = {
+export const BatchMapQueryRequest: MessageFns<BatchMapQueryRequest> = {
   encode(message: BatchMapQueryRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     for (const v of message.ids) {
       writer.uint32(10).string(v!);
@@ -224,7 +224,7 @@ function createBaseBatchMapQueryResponse(): BatchMapQueryResponse {
   return { entities: {} };
 }
 
-export const BatchMapQueryResponse = {
+export const BatchMapQueryResponse: MessageFns<BatchMapQueryResponse> = {
   encode(message: BatchMapQueryResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     Object.entries(message.entities).forEach(([key, value]) => {
       BatchMapQueryResponse_EntitiesEntry.encode({ key: key as any, value }, writer.uint32(10).fork()).join();
@@ -302,7 +302,7 @@ function createBaseBatchMapQueryResponse_EntitiesEntry(): BatchMapQueryResponse_
   return { key: "", value: undefined };
 }
 
-export const BatchMapQueryResponse_EntitiesEntry = {
+export const BatchMapQueryResponse_EntitiesEntry: MessageFns<BatchMapQueryResponse_EntitiesEntry> = {
   encode(message: BatchMapQueryResponse_EntitiesEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== "") {
       writer.uint32(10).string(message.key);
@@ -382,7 +382,7 @@ function createBaseGetOnlyMethodRequest(): GetOnlyMethodRequest {
   return { id: "" };
 }
 
-export const GetOnlyMethodRequest = {
+export const GetOnlyMethodRequest: MessageFns<GetOnlyMethodRequest> = {
   encode(message: GetOnlyMethodRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.id !== "") {
       writer.uint32(10).string(message.id);
@@ -439,7 +439,7 @@ function createBaseGetOnlyMethodResponse(): GetOnlyMethodResponse {
   return { entity: undefined };
 }
 
-export const GetOnlyMethodResponse = {
+export const GetOnlyMethodResponse: MessageFns<GetOnlyMethodResponse> = {
   encode(message: GetOnlyMethodResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.entity !== undefined) {
       Entity.encode(message.entity, writer.uint32(10).fork()).join();
@@ -498,7 +498,7 @@ function createBaseWriteMethodRequest(): WriteMethodRequest {
   return { id: "" };
 }
 
-export const WriteMethodRequest = {
+export const WriteMethodRequest: MessageFns<WriteMethodRequest> = {
   encode(message: WriteMethodRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.id !== "") {
       writer.uint32(10).string(message.id);
@@ -555,7 +555,7 @@ function createBaseWriteMethodResponse(): WriteMethodResponse {
   return {};
 }
 
-export const WriteMethodResponse = {
+export const WriteMethodResponse: MessageFns<WriteMethodResponse> = {
   encode(_: WriteMethodResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     return writer;
   },
@@ -598,7 +598,7 @@ function createBaseEntity(): Entity {
   return { id: "", name: "" };
 }
 
-export const Entity = {
+export const Entity: MessageFns<Entity> = {
   encode(message: Entity, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.id !== "") {
       writer.uint32(10).string(message.id);
@@ -736,4 +736,13 @@ function isObject(value: any): boolean {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/before-after-request-streaming/example.ts
+++ b/integration/before-after-request-streaming/example.ts
@@ -101,7 +101,7 @@ function createBaseDashFlash(): DashFlash {
   return { msg: "", type: 0 };
 }
 
-export const DashFlash = {
+export const DashFlash: MessageFns<DashFlash> = {
   encode(message: DashFlash, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.msg !== "") {
       writer.uint32(10).string(message.msg);
@@ -175,7 +175,7 @@ function createBaseDashUserSettingsState(): DashUserSettingsState {
   return { email: "", urls: undefined, flashes: [] };
 }
 
-export const DashUserSettingsState = {
+export const DashUserSettingsState: MessageFns<DashUserSettingsState> = {
   encode(message: DashUserSettingsState, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.email !== "") {
       writer.uint32(10).string(message.email);
@@ -266,7 +266,7 @@ function createBaseDashUserSettingsState_URLs(): DashUserSettingsState_URLs {
   return { connectGoogle: "", connectGithub: "" };
 }
 
-export const DashUserSettingsState_URLs = {
+export const DashUserSettingsState_URLs: MessageFns<DashUserSettingsState_URLs> = {
   encode(message: DashUserSettingsState_URLs, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.connectGoogle !== "") {
       writer.uint32(10).string(message.connectGoogle);
@@ -340,7 +340,7 @@ function createBaseDashCred(): DashCred {
   return { description: "", metadata: "", token: "", id: "" };
 }
 
-export const DashCred = {
+export const DashCred: MessageFns<DashCred> = {
   encode(message: DashCred, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.description !== "") {
       writer.uint32(18).string(message.description);
@@ -444,7 +444,7 @@ function createBaseDashAPICredsCreateReq(): DashAPICredsCreateReq {
   return { description: "", metadata: "" };
 }
 
-export const DashAPICredsCreateReq = {
+export const DashAPICredsCreateReq: MessageFns<DashAPICredsCreateReq> = {
   encode(message: DashAPICredsCreateReq, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.description !== "") {
       writer.uint32(10).string(message.description);
@@ -518,7 +518,7 @@ function createBaseDashAPICredsUpdateReq(): DashAPICredsUpdateReq {
   return { credSid: "", description: "", metadata: "", id: "" };
 }
 
-export const DashAPICredsUpdateReq = {
+export const DashAPICredsUpdateReq: MessageFns<DashAPICredsUpdateReq> = {
   encode(message: DashAPICredsUpdateReq, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.credSid !== "") {
       writer.uint32(10).string(message.credSid);
@@ -622,7 +622,7 @@ function createBaseDashAPICredsDeleteReq(): DashAPICredsDeleteReq {
   return { credSid: "", id: "" };
 }
 
-export const DashAPICredsDeleteReq = {
+export const DashAPICredsDeleteReq: MessageFns<DashAPICredsDeleteReq> = {
   encode(message: DashAPICredsDeleteReq, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.credSid !== "") {
       writer.uint32(10).string(message.credSid);
@@ -696,7 +696,7 @@ function createBaseEmpty(): Empty {
   return {};
 }
 
-export const Empty = {
+export const Empty: MessageFns<Empty> = {
   encode(_: Empty, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     return writer;
   },
@@ -1042,4 +1042,13 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/before-after-request-streaming/google/protobuf/wrappers.ts
+++ b/integration/before-after-request-streaming/google/protobuf/wrappers.ts
@@ -100,7 +100,7 @@ function createBaseDoubleValue(): DoubleValue {
   return { value: 0 };
 }
 
-export const DoubleValue = {
+export const DoubleValue: MessageFns<DoubleValue> = {
   encode(message: DoubleValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(9).double(message.value);
@@ -157,7 +157,7 @@ function createBaseFloatValue(): FloatValue {
   return { value: 0 };
 }
 
-export const FloatValue = {
+export const FloatValue: MessageFns<FloatValue> = {
   encode(message: FloatValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(13).float(message.value);
@@ -214,7 +214,7 @@ function createBaseInt64Value(): Int64Value {
   return { value: 0 };
 }
 
-export const Int64Value = {
+export const Int64Value: MessageFns<Int64Value> = {
   encode(message: Int64Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).int64(message.value);
@@ -271,7 +271,7 @@ function createBaseUInt64Value(): UInt64Value {
   return { value: 0 };
 }
 
-export const UInt64Value = {
+export const UInt64Value: MessageFns<UInt64Value> = {
   encode(message: UInt64Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).uint64(message.value);
@@ -328,7 +328,7 @@ function createBaseInt32Value(): Int32Value {
   return { value: 0 };
 }
 
-export const Int32Value = {
+export const Int32Value: MessageFns<Int32Value> = {
   encode(message: Int32Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).int32(message.value);
@@ -385,7 +385,7 @@ function createBaseUInt32Value(): UInt32Value {
   return { value: 0 };
 }
 
-export const UInt32Value = {
+export const UInt32Value: MessageFns<UInt32Value> = {
   encode(message: UInt32Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).uint32(message.value);
@@ -442,7 +442,7 @@ function createBaseBoolValue(): BoolValue {
   return { value: false };
 }
 
-export const BoolValue = {
+export const BoolValue: MessageFns<BoolValue> = {
   encode(message: BoolValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== false) {
       writer.uint32(8).bool(message.value);
@@ -499,7 +499,7 @@ function createBaseStringValue(): StringValue {
   return { value: "" };
 }
 
-export const StringValue = {
+export const StringValue: MessageFns<StringValue> = {
   encode(message: StringValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== "") {
       writer.uint32(10).string(message.value);
@@ -556,7 +556,7 @@ function createBaseBytesValue(): BytesValue {
   return { value: new Uint8Array(0) };
 }
 
-export const BytesValue = {
+export const BytesValue: MessageFns<BytesValue> = {
   encode(message: BytesValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value.length !== 0) {
       writer.uint32(10).bytes(message.value);
@@ -659,4 +659,13 @@ function longToNumber(int64: { toString(): string }): number {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/before-after-request/simple.ts
+++ b/integration/before-after-request/simple.ts
@@ -81,7 +81,7 @@ function createBaseSimple(): Simple {
   return { name: "", otherSimple: undefined };
 }
 
-export const Simple = {
+export const Simple: MessageFns<Simple> = {
   encode(message: Simple, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -157,7 +157,7 @@ function createBaseDifferentSimple(): DifferentSimple {
   return { name: "", otherOptionalSimple2: undefined };
 }
 
-export const DifferentSimple = {
+export const DifferentSimple: MessageFns<DifferentSimple> = {
   encode(message: DifferentSimple, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -235,7 +235,7 @@ function createBaseSimpleEnums(): SimpleEnums {
   return { localEnum: 0, importEnum: 0 };
 }
 
-export const SimpleEnums = {
+export const SimpleEnums: MessageFns<SimpleEnums> = {
   encode(message: SimpleEnums, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.localEnum !== 0) {
       writer.uint32(8).int32(message.localEnum);
@@ -309,7 +309,7 @@ function createBaseFooServiceCreateRequest(): FooServiceCreateRequest {
   return { kind: 0 };
 }
 
-export const FooServiceCreateRequest = {
+export const FooServiceCreateRequest: MessageFns<FooServiceCreateRequest> = {
   encode(message: FooServiceCreateRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.kind !== 0) {
       writer.uint32(8).int32(message.kind);
@@ -366,7 +366,7 @@ function createBaseFooServiceCreateResponse(): FooServiceCreateResponse {
   return { kind: 0 };
 }
 
-export const FooServiceCreateResponse = {
+export const FooServiceCreateResponse: MessageFns<FooServiceCreateResponse> = {
   encode(message: FooServiceCreateResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.kind !== 0) {
       writer.uint32(8).int32(message.kind);
@@ -484,4 +484,13 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/before-after-request/simple2.ts
+++ b/integration/before-after-request/simple2.ts
@@ -93,7 +93,7 @@ function createBaseSimple(): Simple {
   return { name: "", age: 0 };
 }
 
-export const Simple = {
+export const Simple: MessageFns<Simple> = {
   encode(message: Simple, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -177,4 +177,13 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/bytes-as-base64-browser/message.ts
+++ b/integration/bytes-as-base64-browser/message.ts
@@ -13,7 +13,7 @@ function createBaseMessage(): Message {
   return { data: new Uint8Array(0) };
 }
 
-export const Message = {
+export const Message: MessageFns<Message> = {
   fromJSON(object: any): Message {
     return { data: isSet(object.data) ? bytesFromBase64(object.data) : new Uint8Array(0) };
   },
@@ -67,4 +67,11 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/bytes-as-base64-node/message.ts
+++ b/integration/bytes-as-base64-node/message.ts
@@ -13,7 +13,7 @@ function createBaseMessage(): Message {
   return { data: Buffer.alloc(0) };
 }
 
-export const Message = {
+export const Message: MessageFns<Message> = {
   fromJSON(object: any): Message {
     return { data: isSet(object.data) ? Buffer.from(bytesFromBase64(object.data)) : Buffer.alloc(0) };
   },
@@ -58,4 +58,11 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/bytes-as-base64/message.ts
+++ b/integration/bytes-as-base64/message.ts
@@ -13,7 +13,7 @@ function createBaseMessage(): Message {
   return { data: new Uint8Array(0) };
 }
 
-export const Message = {
+export const Message: MessageFns<Message> = {
   fromJSON(object: any): Message {
     return { data: isSet(object.data) ? bytesFromBase64(object.data) : new Uint8Array(0) };
   },
@@ -75,4 +75,11 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/bytes-node/google/protobuf/wrappers.ts
+++ b/integration/bytes-node/google/protobuf/wrappers.ts
@@ -100,7 +100,7 @@ function createBaseDoubleValue(): DoubleValue {
   return { value: 0 };
 }
 
-export const DoubleValue = {
+export const DoubleValue: MessageFns<DoubleValue> = {
   encode(message: DoubleValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(9).double(message.value);
@@ -157,7 +157,7 @@ function createBaseFloatValue(): FloatValue {
   return { value: 0 };
 }
 
-export const FloatValue = {
+export const FloatValue: MessageFns<FloatValue> = {
   encode(message: FloatValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(13).float(message.value);
@@ -214,7 +214,7 @@ function createBaseInt64Value(): Int64Value {
   return { value: 0 };
 }
 
-export const Int64Value = {
+export const Int64Value: MessageFns<Int64Value> = {
   encode(message: Int64Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).int64(message.value);
@@ -271,7 +271,7 @@ function createBaseUInt64Value(): UInt64Value {
   return { value: 0 };
 }
 
-export const UInt64Value = {
+export const UInt64Value: MessageFns<UInt64Value> = {
   encode(message: UInt64Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).uint64(message.value);
@@ -328,7 +328,7 @@ function createBaseInt32Value(): Int32Value {
   return { value: 0 };
 }
 
-export const Int32Value = {
+export const Int32Value: MessageFns<Int32Value> = {
   encode(message: Int32Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).int32(message.value);
@@ -385,7 +385,7 @@ function createBaseUInt32Value(): UInt32Value {
   return { value: 0 };
 }
 
-export const UInt32Value = {
+export const UInt32Value: MessageFns<UInt32Value> = {
   encode(message: UInt32Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).uint32(message.value);
@@ -442,7 +442,7 @@ function createBaseBoolValue(): BoolValue {
   return { value: false };
 }
 
-export const BoolValue = {
+export const BoolValue: MessageFns<BoolValue> = {
   encode(message: BoolValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== false) {
       writer.uint32(8).bool(message.value);
@@ -499,7 +499,7 @@ function createBaseStringValue(): StringValue {
   return { value: "" };
 }
 
-export const StringValue = {
+export const StringValue: MessageFns<StringValue> = {
   encode(message: StringValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== "") {
       writer.uint32(10).string(message.value);
@@ -556,7 +556,7 @@ function createBaseBytesValue(): BytesValue {
   return { value: Buffer.alloc(0) };
 }
 
-export const BytesValue = {
+export const BytesValue: MessageFns<BytesValue> = {
   encode(message: BytesValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value.length !== 0) {
       writer.uint32(10).bytes(message.value);
@@ -642,4 +642,13 @@ function longToNumber(int64: { toString(): string }): number {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/bytes-node/point.ts
+++ b/integration/bytes-node/point.ts
@@ -16,7 +16,7 @@ function createBasePoint(): Point {
   return { data: Buffer.alloc(0), dataWrapped: undefined };
 }
 
-export const Point = {
+export const Point: MessageFns<Point> = {
   encode(message: Point, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.data.length !== 0) {
       writer.uint32(10).bytes(message.data);
@@ -108,4 +108,13 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/const-enum/const-enum.ts
+++ b/integration/const-enum/const-enum.ts
@@ -81,7 +81,7 @@ function createBaseDividerData(): DividerData {
   return { type: DividerData_DividerType.DOUBLE, typeMap: {} };
 }
 
-export const DividerData = {
+export const DividerData: MessageFns<DividerData> = {
   encode(message: DividerData, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.type !== DividerData_DividerType.DOUBLE) {
       writer.uint32(8).int32(dividerData_DividerTypeToNumber(message.type));
@@ -177,7 +177,7 @@ function createBaseDividerData_TypeMapEntry(): DividerData_TypeMapEntry {
   return { key: "", value: DividerData_DividerType.DOUBLE };
 }
 
-export const DividerData_TypeMapEntry = {
+export const DividerData_TypeMapEntry: MessageFns<DividerData_TypeMapEntry> = {
   encode(message: DividerData_TypeMapEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== "") {
       writer.uint32(10).string(message.key);
@@ -265,4 +265,13 @@ function isObject(value: any): boolean {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/default-with-custom-metadata/default-with-custom-metadata.ts
+++ b/integration/default-with-custom-metadata/default-with-custom-metadata.ts
@@ -19,7 +19,7 @@ function createBaseGetBasicRequest(): GetBasicRequest {
   return { name: "" };
 }
 
-export const GetBasicRequest = {
+export const GetBasicRequest: MessageFns<GetBasicRequest> = {
   encode(message: GetBasicRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -76,7 +76,7 @@ function createBaseGetBasicResponse(): GetBasicResponse {
   return { name: "" };
 }
 
-export const GetBasicResponse = {
+export const GetBasicResponse: MessageFns<GetBasicResponse> = {
   encode(message: GetBasicResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -167,4 +167,13 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/default-with-metadata/default-with-metadata.ts
+++ b/integration/default-with-metadata/default-with-metadata.ts
@@ -19,7 +19,7 @@ function createBaseGetBasicRequest(): GetBasicRequest {
   return { name: "" };
 }
 
-export const GetBasicRequest = {
+export const GetBasicRequest: MessageFns<GetBasicRequest> = {
   encode(message: GetBasicRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -76,7 +76,7 @@ function createBaseGetBasicResponse(): GetBasicResponse {
   return { name: "" };
 }
 
-export const GetBasicResponse = {
+export const GetBasicResponse: MessageFns<GetBasicResponse> = {
   encode(message: GetBasicResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -167,4 +167,13 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/emit-default-values-json/google/protobuf/timestamp.ts
+++ b/integration/emit-default-values-json/google/protobuf/timestamp.ts
@@ -117,7 +117,7 @@ function createBaseTimestamp(): Timestamp {
   return { seconds: 0, nanos: 0 };
 }
 
-export const Timestamp = {
+export const Timestamp: MessageFns<Timestamp> = {
   encode(message: Timestamp, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.seconds !== 0) {
       writer.uint32(8).int64(message.seconds);
@@ -212,4 +212,13 @@ function longToNumber(int64: { toString(): string }): number {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/emit-default-values-json/test.ts
+++ b/integration/emit-default-values-json/test.ts
@@ -108,7 +108,7 @@ function createBaseDefaultValuesTest(): DefaultValuesTest {
   };
 }
 
-export const DefaultValuesTest = {
+export const DefaultValuesTest: MessageFns<DefaultValuesTest> = {
   encode(message: DefaultValuesTest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.id !== 0) {
       writer.uint32(8).int32(message.id);
@@ -573,7 +573,7 @@ function createBaseDefaultValuesTest_TranslationsEntry(): DefaultValuesTest_Tran
   return { key: "", value: "" };
 }
 
-export const DefaultValuesTest_TranslationsEntry = {
+export const DefaultValuesTest_TranslationsEntry: MessageFns<DefaultValuesTest_TranslationsEntry> = {
   encode(message: DefaultValuesTest_TranslationsEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== "") {
       writer.uint32(10).string(message.key);
@@ -651,7 +651,7 @@ function createBaseChild(): Child {
   return {};
 }
 
-export const Child = {
+export const Child: MessageFns<Child> = {
   encode(_: Child, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     return writer;
   },
@@ -766,4 +766,13 @@ function isObject(value: any): boolean {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/enums-as-literals-with-string-enums/enums-as-literals-with-string-enums.ts
+++ b/integration/enums-as-literals-with-string-enums/enums-as-literals-with-string-enums.ts
@@ -85,7 +85,7 @@ function createBaseDividerData(): DividerData {
   return { type: DividerData_DividerType.DOUBLE };
 }
 
-export const DividerData = {
+export const DividerData: MessageFns<DividerData> = {
   encode(message: DividerData, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.type !== DividerData_DividerType.DOUBLE) {
       writer.uint32(8).int32(dividerData_DividerTypeToNumber(message.type));
@@ -152,4 +152,13 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/enums-as-literals/enums-as-literals.ts
+++ b/integration/enums-as-literals/enums-as-literals.ts
@@ -63,7 +63,7 @@ function createBaseDividerData(): DividerData {
   return { type: 0 };
 }
 
-export const DividerData = {
+export const DividerData: MessageFns<DividerData> = {
   encode(message: DividerData, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.type !== 0) {
       writer.uint32(8).int32(message.type);
@@ -130,4 +130,13 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/extension-import/base.ts
+++ b/integration/extension-import/base.ts
@@ -12,7 +12,7 @@ function createBaseExtendable(): Extendable {
   return { field: "" };
 }
 
-export const Extendable = {
+export const Extendable: MessageFns<Extendable> = {
   encode(message: Extendable, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.field !== "") {
       writer.uint32(10).string(message.field);
@@ -79,4 +79,13 @@ type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/extensions/test.ts
+++ b/integration/extensions/test.ts
@@ -66,7 +66,7 @@ function createBaseExtendable(): Extendable {
   return {};
 }
 
-export const Extendable = {
+export const Extendable: MessageFns<Extendable> & ExtensionFns<Extendable> = {
   encode(message: Extendable, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.field !== undefined && message.field !== "") {
       writer.uint32(10).string(message.field);
@@ -195,7 +195,7 @@ function createBaseNested(): Nested {
   return {};
 }
 
-export const Nested = {
+export const Nested: MessageFns<Nested> & ExtensionHolder<"message", Nested[]> = {
   message: <Extension<Nested[]>> {
     number: 4,
     tag: 34,
@@ -297,7 +297,7 @@ function createBaseGroup(): Group {
   return {};
 }
 
-export const Group = {
+export const Group: MessageFns<Group> = {
   encode(message: Group, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== undefined && message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -604,3 +604,19 @@ export interface Extension<T> {
 function fail(message?: string): never {
   throw new globalThis.Error(message ?? "Failed");
 }
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
+}
+
+export interface ExtensionFns<T> {
+  setExtension<E>(message: T, extension: Extension<E>, value: E): void;
+  getExtension<E>(message: T, extension: Extension<E>): E | undefined;
+}
+
+export type ExtensionHolder<T extends string, V> = { [key in T]: Extension<V> };

--- a/integration/fieldmask-optional-all/fieldmask-optional.ts
+++ b/integration/fieldmask-optional-all/fieldmask-optional.ts
@@ -15,7 +15,7 @@ function createBaseExample(): Example {
   return { mask: undefined };
 }
 
-export const Example = {
+export const Example: MessageFns<Example> = {
   encode(message: Example, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.mask !== undefined) {
       FieldMask.encode(FieldMask.wrap(message.mask), writer.uint32(10).fork()).join();
@@ -82,4 +82,13 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/fieldmask-optional-all/google/protobuf/field_mask.ts
+++ b/integration/fieldmask-optional-all/google/protobuf/field_mask.ts
@@ -215,7 +215,7 @@ function createBaseFieldMask(): FieldMask {
   return { paths: [] };
 }
 
-export const FieldMask = {
+export const FieldMask: MessageFns<FieldMask> & FieldMaskWrapperFns = {
   encode(message: FieldMask, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.paths !== undefined && message.paths.length !== 0) {
       for (const v of message.paths) {
@@ -293,3 +293,17 @@ export type DeepPartial<T> = T extends Builtin ? T
 type KeysOfUnion<T> = T extends T ? keyof T : never;
 export type Exact<P, I extends P> = P extends Builtin ? P
   : P & { [K in keyof P]: Exact<P[K], I[K]> } & { [K in Exclude<keyof I, KeysOfUnion<P>>]: never };
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
+}
+
+export interface FieldMaskWrapperFns {
+  wrap(paths: string[]): FieldMask;
+  unwrap(message: FieldMask): string[] | undefined;
+}

--- a/integration/fieldmask/fieldmask.ts
+++ b/integration/fieldmask/fieldmask.ts
@@ -15,7 +15,7 @@ function createBaseFieldMaskMessage(): FieldMaskMessage {
   return { fieldMask: undefined };
 }
 
-export const FieldMaskMessage = {
+export const FieldMaskMessage: MessageFns<FieldMaskMessage> = {
   encode(message: FieldMaskMessage, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.fieldMask !== undefined) {
       FieldMask.encode(FieldMask.wrap(message.fieldMask), writer.uint32(10).fork()).join();
@@ -82,4 +82,13 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/fieldmask/google/protobuf/field_mask.ts
+++ b/integration/fieldmask/google/protobuf/field_mask.ts
@@ -215,7 +215,7 @@ function createBaseFieldMask(): FieldMask {
   return { paths: [] };
 }
 
-export const FieldMask = {
+export const FieldMask: MessageFns<FieldMask> & FieldMaskWrapperFns = {
   encode(message: FieldMask, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     for (const v of message.paths) {
       writer.uint32(10).string(v!);
@@ -291,3 +291,17 @@ export type DeepPartial<T> = T extends Builtin ? T
 type KeysOfUnion<T> = T extends T ? keyof T : never;
 export type Exact<P, I extends P> = P extends Builtin ? P
   : P & { [K in keyof P]: Exact<P[K], I[K]> } & { [K in Exclude<keyof I, KeysOfUnion<P>>]: never };
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
+}
+
+export interface FieldMaskWrapperFns {
+  wrap(paths: string[]): FieldMask;
+  unwrap(message: FieldMask): string[];
+}

--- a/integration/fieldoption-jstype-with-forcelong-bigint/fieldoption-jstype-with-forcelong-bigint.ts
+++ b/integration/fieldoption-jstype-with-forcelong-bigint/fieldoption-jstype-with-forcelong-bigint.ts
@@ -16,7 +16,7 @@ function createBaseFieldOption(): FieldOption {
   return { normalField: 0n, numberField: 0, stringField: "0" };
 }
 
-export const FieldOption = {
+export const FieldOption: MessageFns<FieldOption> = {
   encode(message: FieldOption, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.normalField !== 0n) {
       if (BigInt.asIntN(64, message.normalField) !== message.normalField) {
@@ -135,4 +135,13 @@ function longToNumber(int64: { toString(): string }): number {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/fieldoption-jstype-with-forcelong-long/fieldoption-jstype-with-forcelong-long.ts
+++ b/integration/fieldoption-jstype-with-forcelong-long/fieldoption-jstype-with-forcelong-long.ts
@@ -17,7 +17,7 @@ function createBaseFieldOption(): FieldOption {
   return { normalField: Long.ZERO, numberField: 0, stringField: "0" };
 }
 
-export const FieldOption = {
+export const FieldOption: MessageFns<FieldOption> = {
   encode(message: FieldOption, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (!message.normalField.equals(Long.ZERO)) {
       writer.uint32(8).int64(message.normalField.toString());
@@ -129,4 +129,13 @@ function longToNumber(int64: { toString(): string }): number {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/fieldoption-jstype-with-forcelong-number/fieldoption-jstype-with-forcelong-number.ts
+++ b/integration/fieldoption-jstype-with-forcelong-number/fieldoption-jstype-with-forcelong-number.ts
@@ -16,7 +16,7 @@ function createBaseFieldOption(): FieldOption {
   return { normalField: 0, numberField: 0, stringField: "0" };
 }
 
-export const FieldOption = {
+export const FieldOption: MessageFns<FieldOption> = {
   encode(message: FieldOption, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.normalField !== 0) {
       writer.uint32(8).int64(message.normalField);
@@ -126,4 +126,13 @@ function longToNumber(int64: { toString(): string }): number {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/fieldoption-jstype-with-forcelong-string/fieldoption-jstype-with-forcelong-string.ts
+++ b/integration/fieldoption-jstype-with-forcelong-string/fieldoption-jstype-with-forcelong-string.ts
@@ -16,7 +16,7 @@ function createBaseFieldOption(): FieldOption {
   return { normalField: "0", numberField: 0, stringField: "0" };
 }
 
-export const FieldOption = {
+export const FieldOption: MessageFns<FieldOption> = {
   encode(message: FieldOption, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.normalField !== "0") {
       writer.uint32(8).int64(message.normalField);
@@ -126,4 +126,13 @@ function longToNumber(int64: { toString(): string }): number {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/fieldoption-jstype/fieldoption-jstype.ts
+++ b/integration/fieldoption-jstype/fieldoption-jstype.ts
@@ -40,7 +40,7 @@ function createBaseInt64FieldOption(): Int64FieldOption {
   return { normalField: 0, numberField: 0, stringField: "0" };
 }
 
-export const Int64FieldOption = {
+export const Int64FieldOption: MessageFns<Int64FieldOption> = {
   encode(message: Int64FieldOption, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.normalField !== 0) {
       writer.uint32(8).int64(message.normalField);
@@ -129,7 +129,7 @@ function createBaseUInt64FieldOption(): UInt64FieldOption {
   return { normalField: 0, numberField: 0, stringField: "0" };
 }
 
-export const UInt64FieldOption = {
+export const UInt64FieldOption: MessageFns<UInt64FieldOption> = {
   encode(message: UInt64FieldOption, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.normalField !== 0) {
       writer.uint32(8).uint64(message.normalField);
@@ -218,7 +218,7 @@ function createBaseSInt64FieldOption(): SInt64FieldOption {
   return { normalField: 0, numberField: 0, stringField: "0" };
 }
 
-export const SInt64FieldOption = {
+export const SInt64FieldOption: MessageFns<SInt64FieldOption> = {
   encode(message: SInt64FieldOption, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.normalField !== 0) {
       writer.uint32(8).sint64(message.normalField);
@@ -307,7 +307,7 @@ function createBaseFixed64FieldOption(): Fixed64FieldOption {
   return { normalField: 0, numberField: 0, stringField: "0" };
 }
 
-export const Fixed64FieldOption = {
+export const Fixed64FieldOption: MessageFns<Fixed64FieldOption> = {
   encode(message: Fixed64FieldOption, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.normalField !== 0) {
       writer.uint32(9).fixed64(message.normalField);
@@ -396,7 +396,7 @@ function createBaseSFixed64FieldOption(): SFixed64FieldOption {
   return { normalField: 0, numberField: 0, stringField: "0" };
 }
 
-export const SFixed64FieldOption = {
+export const SFixed64FieldOption: MessageFns<SFixed64FieldOption> = {
   encode(message: SFixed64FieldOption, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.normalField !== 0) {
       writer.uint32(9).sfixed64(message.normalField);
@@ -506,4 +506,13 @@ function longToNumber(int64: { toString(): string }): number {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/file-suffix/child.pb.ts
+++ b/integration/file-suffix/child.pb.ts
@@ -47,7 +47,7 @@ function createBaseChild(): Child {
   return { name: "" };
 }
 
-export const Child = {
+export const Child: MessageFns<Child> = {
   encode(message: Child, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -114,4 +114,13 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/file-suffix/google/protobuf/timestamp.pb.ts
+++ b/integration/file-suffix/google/protobuf/timestamp.pb.ts
@@ -117,7 +117,7 @@ function createBaseTimestamp(): Timestamp {
   return { seconds: 0, nanos: 0 };
 }
 
-export const Timestamp = {
+export const Timestamp: MessageFns<Timestamp> = {
   encode(message: Timestamp, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.seconds !== 0) {
       writer.uint32(8).int64(message.seconds);
@@ -212,4 +212,13 @@ function longToNumber(int64: { toString(): string }): number {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/file-suffix/parent.pb.ts
+++ b/integration/file-suffix/parent.pb.ts
@@ -18,7 +18,7 @@ function createBaseParent(): Parent {
   return { child: undefined, childEnum: 0, createdAt: undefined };
 }
 
-export const Parent = {
+export const Parent: MessageFns<Parent> = {
   encode(message: Parent, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.child !== undefined) {
       Child.encode(message.child, writer.uint32(10).fork()).join();
@@ -139,4 +139,13 @@ function fromJsonTimestamp(o: any): Date {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/from-partial-no-initialize/test.ts
+++ b/integration/from-partial-no-initialize/test.ts
@@ -29,7 +29,7 @@ function createBaseTPartialMessage(): TPartialMessage {
   return {};
 }
 
-export const TPartialMessage = {
+export const TPartialMessage: MessageFns<TPartialMessage> = {
   encode(message: TPartialMessage, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.field !== undefined && message.field !== "") {
       writer.uint32(10).string(message.field);
@@ -86,7 +86,7 @@ function createBaseTPartial(): TPartial {
   return {};
 }
 
-export const TPartial = {
+export const TPartial: MessageFns<TPartial> = {
   encode(message: TPartial, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.number !== undefined && message.number !== 0) {
       writer.uint32(8).int32(message.number);
@@ -297,7 +297,7 @@ function createBaseTPartial_MapEntry(): TPartial_MapEntry {
   return { key: "", value: "" };
 }
 
-export const TPartial_MapEntry = {
+export const TPartial_MapEntry: MessageFns<TPartial_MapEntry> = {
   encode(message: TPartial_MapEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== "") {
       writer.uint32(10).string(message.key);
@@ -385,4 +385,13 @@ function isObject(value: any): boolean {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/fromJson-enums/from-json.ts
+++ b/integration/fromJson-enums/from-json.ts
@@ -32,9 +32,13 @@ export function test_TestTypeToJSON(object: Test_TestType): string {
   }
 }
 
-export const Test = {
+export const Test: MessageFns<Test> = {
   toJSON(_: Test): unknown {
     const obj: any = {};
     return obj;
   },
 };
+
+export interface MessageFns<T> {
+  toJSON(message: T): unknown;
+}

--- a/integration/generic-metadata/hero.ts
+++ b/integration/generic-metadata/hero.ts
@@ -31,7 +31,7 @@ function createBaseHeroById(): HeroById {
   return { id: 0 };
 }
 
-export const HeroById = {
+export const HeroById: MessageFns<HeroById> = {
   encode(message: HeroById, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.id !== 0) {
       writer.uint32(8).int32(message.id);
@@ -88,7 +88,7 @@ function createBaseVillainById(): VillainById {
   return { id: 0 };
 }
 
-export const VillainById = {
+export const VillainById: MessageFns<VillainById> = {
   encode(message: VillainById, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.id !== 0) {
       writer.uint32(8).int32(message.id);
@@ -145,7 +145,7 @@ function createBaseHero(): Hero {
   return { id: 0, name: "" };
 }
 
-export const Hero = {
+export const Hero: MessageFns<Hero> = {
   encode(message: Hero, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.id !== 0) {
       writer.uint32(8).int32(message.id);
@@ -219,7 +219,7 @@ function createBaseVillain(): Villain {
   return { id: 0, name: "" };
 }
 
-export const Villain = {
+export const Villain: MessageFns<Villain> = {
   encode(message: Villain, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.id !== 0) {
       writer.uint32(8).int32(message.id);
@@ -388,4 +388,13 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/generic-service-definitions-and-services/simple.ts
+++ b/integration/generic-service-definitions-and-services/simple.ts
@@ -14,7 +14,7 @@ function createBaseTestMessage(): TestMessage {
   return { value: "" };
 }
 
-export const TestMessage = {
+export const TestMessage: MessageFns<TestMessage> = {
   encode(message: TestMessage, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== "") {
       writer.uint32(10).string(message.value);
@@ -147,4 +147,13 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/generic-service-definitions/simple.ts
+++ b/integration/generic-service-definitions/simple.ts
@@ -14,7 +14,7 @@ function createBaseTestMessage(): TestMessage {
   return { value: "" };
 }
 
-export const TestMessage = {
+export const TestMessage: MessageFns<TestMessage> = {
   encode(message: TestMessage, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== "") {
       writer.uint32(10).string(message.value);
@@ -147,4 +147,13 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/global-this/global-this.ts
+++ b/integration/global-this/global-this.ts
@@ -34,7 +34,7 @@ function createBaseObject(): Object {
   return { name: "" };
 }
 
-export const Object = {
+export const Object: MessageFns<Object> = {
   encode(message: Object, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -91,7 +91,7 @@ function createBaseError(): Error {
   return { name: "" };
 }
 
-export const Error = {
+export const Error: MessageFns<Error> = {
   encode(message: Error, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -148,7 +148,7 @@ function createBaseString(): String {
   return { value: "" };
 }
 
-export const String = {
+export const String: MessageFns<String> = {
   encode(message: String, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== "") {
       writer.uint32(10).string(message.value);
@@ -205,7 +205,7 @@ function createBaseBoolean(): Boolean {
   return { value: false };
 }
 
-export const Boolean = {
+export const Boolean: MessageFns<Boolean> = {
   encode(message: Boolean, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== false) {
       writer.uint32(8).bool(message.value);
@@ -262,7 +262,7 @@ function createBaseNumber(): Number {
   return { value: 0 };
 }
 
-export const Number = {
+export const Number: MessageFns<Number> = {
   encode(message: Number, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(9).double(message.value);
@@ -319,7 +319,7 @@ function createBaseArray(): Array {
   return { values: [] };
 }
 
-export const Array = {
+export const Array: MessageFns<Array> = {
   encode(message: Array, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     for (const v of message.values) {
       String.encode(v!, writer.uint32(10).fork()).join();
@@ -405,4 +405,13 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/groups/test.ts
+++ b/integration/groups/test.ts
@@ -58,7 +58,7 @@ function createBaseGroupsOptionalTest(): GroupsOptionalTest {
   return {};
 }
 
-export const GroupsOptionalTest = {
+export const GroupsOptionalTest: MessageFns<GroupsOptionalTest> = {
   encode(message: GroupsOptionalTest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.int1 !== undefined && message.int1 !== 0) {
       writer.uint32(8).int32(message.int1);
@@ -169,7 +169,7 @@ function createBaseGroupsOptionalTest_Group(): GroupsOptionalTest_Group {
   return {};
 }
 
-export const GroupsOptionalTest_Group = {
+export const GroupsOptionalTest_Group: MessageFns<GroupsOptionalTest_Group> = {
   encode(message: GroupsOptionalTest_Group, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== undefined && message.key !== "") {
       writer.uint32(10).string(message.key);
@@ -263,7 +263,7 @@ function createBaseGroupsRepeatedTest(): GroupsRepeatedTest {
   return {};
 }
 
-export const GroupsRepeatedTest = {
+export const GroupsRepeatedTest: MessageFns<GroupsRepeatedTest> = {
   encode(message: GroupsRepeatedTest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.int1 !== undefined && message.int1.length !== 0) {
       writer.uint32(10).fork();
@@ -419,7 +419,7 @@ function createBaseGroupsRepeatedTest_Group(): GroupsRepeatedTest_Group {
   return {};
 }
 
-export const GroupsRepeatedTest_Group = {
+export const GroupsRepeatedTest_Group: MessageFns<GroupsRepeatedTest_Group> = {
   encode(message: GroupsRepeatedTest_Group, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== undefined && message.key.length !== 0) {
       for (const v of message.key) {
@@ -523,7 +523,7 @@ function createBaseGroupsNestedTest(): GroupsNestedTest {
   return {};
 }
 
-export const GroupsNestedTest = {
+export const GroupsNestedTest: MessageFns<GroupsNestedTest> = {
   encode(message: GroupsNestedTest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.int1 !== undefined && message.int1.length !== 0) {
       writer.uint32(10).fork();
@@ -679,7 +679,7 @@ function createBaseGroupsNestedTest_Group(): GroupsNestedTest_Group {
   return {};
 }
 
-export const GroupsNestedTest_Group = {
+export const GroupsNestedTest_Group: MessageFns<GroupsNestedTest_Group> = {
   encode(message: GroupsNestedTest_Group, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.nested !== undefined && message.nested.length !== 0) {
       for (const v of message.nested) {
@@ -765,7 +765,7 @@ function createBaseGroupsNestedTest_Group_Nested(): GroupsNestedTest_Group_Neste
   return {};
 }
 
-export const GroupsNestedTest_Group_Nested = {
+export const GroupsNestedTest_Group_Nested: MessageFns<GroupsNestedTest_Group_Nested> = {
   encode(message: GroupsNestedTest_Group_Nested, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.nested2 !== undefined && message.nested2.length !== 0) {
       for (const v of message.nested2) {
@@ -853,7 +853,7 @@ function createBaseGroupsNestedTest_Group_Nested_Nested2(): GroupsNestedTest_Gro
   return {};
 }
 
-export const GroupsNestedTest_Group_Nested_Nested2 = {
+export const GroupsNestedTest_Group_Nested_Nested2: MessageFns<GroupsNestedTest_Group_Nested_Nested2> = {
   encode(message: GroupsNestedTest_Group_Nested_Nested2, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.string1 !== undefined && message.string1 !== "") {
       writer.uint32(10).string(message.string1);
@@ -944,4 +944,13 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/grpc-js-use-date-false/google/protobuf/timestamp.ts
+++ b/integration/grpc-js-use-date-false/google/protobuf/timestamp.ts
@@ -117,7 +117,7 @@ function createBaseTimestamp(): Timestamp {
   return { seconds: 0, nanos: 0 };
 }
 
-export const Timestamp = {
+export const Timestamp: MessageFns<Timestamp> = {
   encode(message: Timestamp, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.seconds !== 0) {
       writer.uint32(8).int64(message.seconds);
@@ -212,4 +212,13 @@ function longToNumber(int64: { toString(): string }): number {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/grpc-js-use-date-false/grpc-js-use-date-false.ts
+++ b/integration/grpc-js-use-date-false/grpc-js-use-date-false.ts
@@ -24,7 +24,7 @@ function createBaseTimestampMessage(): TimestampMessage {
   return { timestamp: undefined };
 }
 
-export const TimestampMessage = {
+export const TimestampMessage: MessageFns<TimestampMessage> = {
   encode(message: TimestampMessage, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.timestamp !== undefined) {
       Timestamp.encode(message.timestamp, writer.uint32(10).fork()).join();
@@ -178,4 +178,13 @@ function fromJsonTimestamp(o: any): Timestamp {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/grpc-js-use-date-string-nano/google/protobuf/timestamp.ts
+++ b/integration/grpc-js-use-date-string-nano/google/protobuf/timestamp.ts
@@ -117,7 +117,7 @@ function createBaseTimestamp(): Timestamp {
   return { seconds: 0, nanos: 0 };
 }
 
-export const Timestamp = {
+export const Timestamp: MessageFns<Timestamp> = {
   encode(message: Timestamp, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.seconds !== 0) {
       writer.uint32(8).int64(message.seconds);
@@ -212,4 +212,13 @@ function longToNumber(int64: { toString(): string }): number {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/grpc-js-use-date-string-nano/grpc-js-use-date-string-nano.ts
+++ b/integration/grpc-js-use-date-string-nano/grpc-js-use-date-string-nano.ts
@@ -25,7 +25,7 @@ function createBaseTimestampMessage(): TimestampMessage {
   return { timestamp: undefined };
 }
 
-export const TimestampMessage = {
+export const TimestampMessage: MessageFns<TimestampMessage> = {
   encode(message: TimestampMessage, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.timestamp !== undefined) {
       Timestamp.encode(toTimestamp(message.timestamp), writer.uint32(10).fork()).join();
@@ -182,4 +182,13 @@ function fromTimestamp(t: Timestamp): string {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/grpc-js-use-date-string/google/protobuf/timestamp.ts
+++ b/integration/grpc-js-use-date-string/google/protobuf/timestamp.ts
@@ -117,7 +117,7 @@ function createBaseTimestamp(): Timestamp {
   return { seconds: 0, nanos: 0 };
 }
 
-export const Timestamp = {
+export const Timestamp: MessageFns<Timestamp> = {
   encode(message: Timestamp, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.seconds !== 0) {
       writer.uint32(8).int64(message.seconds);
@@ -212,4 +212,13 @@ function longToNumber(int64: { toString(): string }): number {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/grpc-js-use-date-string/grpc-js-use-date-string.ts
+++ b/integration/grpc-js-use-date-string/grpc-js-use-date-string.ts
@@ -24,7 +24,7 @@ function createBaseTimestampMessage(): TimestampMessage {
   return { timestamp: undefined };
 }
 
-export const TimestampMessage = {
+export const TimestampMessage: MessageFns<TimestampMessage> = {
   encode(message: TimestampMessage, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.timestamp !== undefined) {
       Timestamp.encode(toTimestamp(message.timestamp), writer.uint32(10).fork()).join();
@@ -167,4 +167,13 @@ function fromTimestamp(t: Timestamp): string {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/grpc-js-use-date-true/google/protobuf/timestamp.ts
+++ b/integration/grpc-js-use-date-true/google/protobuf/timestamp.ts
@@ -117,7 +117,7 @@ function createBaseTimestamp(): Timestamp {
   return { seconds: 0, nanos: 0 };
 }
 
-export const Timestamp = {
+export const Timestamp: MessageFns<Timestamp> = {
   encode(message: Timestamp, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.seconds !== 0) {
       writer.uint32(8).int64(message.seconds);
@@ -212,4 +212,13 @@ function longToNumber(int64: { toString(): string }): number {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/grpc-js-use-date-true/grpc-js-use-date-true.ts
+++ b/integration/grpc-js-use-date-true/grpc-js-use-date-true.ts
@@ -24,7 +24,7 @@ function createBaseTimestampMessage(): TimestampMessage {
   return { timestamp: undefined };
 }
 
-export const TimestampMessage = {
+export const TimestampMessage: MessageFns<TimestampMessage> = {
   encode(message: TimestampMessage, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.timestamp !== undefined) {
       Timestamp.encode(toTimestamp(message.timestamp), writer.uint32(10).fork()).join();
@@ -176,4 +176,13 @@ function fromJsonTimestamp(o: any): Date {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/grpc-js/google/protobuf/empty.ts
+++ b/integration/grpc-js/google/protobuf/empty.ts
@@ -24,7 +24,7 @@ function createBaseEmpty(): Empty {
   return {};
 }
 
-export const Empty = {
+export const Empty: MessageFns<Empty> = {
   encode(_: Empty, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     return writer;
   },
@@ -74,3 +74,12 @@ export type DeepPartial<T> = T extends Builtin ? T
 type KeysOfUnion<T> = T extends T ? keyof T : never;
 export type Exact<P, I extends P> = P extends Builtin ? P
   : P & { [K in keyof P]: Exact<P[K], I[K]> } & { [K in Exclude<keyof I, KeysOfUnion<P>>]: never };
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
+}

--- a/integration/grpc-js/google/protobuf/struct.ts
+++ b/integration/grpc-js/google/protobuf/struct.ts
@@ -107,7 +107,7 @@ function createBaseStruct(): Struct {
   return { fields: {} };
 }
 
-export const Struct = {
+export const Struct: MessageFns<Struct> & StructWrapperFns = {
   encode(message: Struct, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     Object.entries(message.fields).forEach(([key, value]) => {
       if (value !== undefined) {
@@ -211,7 +211,7 @@ function createBaseStruct_FieldsEntry(): Struct_FieldsEntry {
   return { key: "", value: undefined };
 }
 
-export const Struct_FieldsEntry = {
+export const Struct_FieldsEntry: MessageFns<Struct_FieldsEntry> = {
   encode(message: Struct_FieldsEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== "") {
       writer.uint32(10).string(message.key);
@@ -292,7 +292,7 @@ function createBaseValue(): Value {
   };
 }
 
-export const Value = {
+export const Value: MessageFns<Value> & AnyValueWrapperFns = {
   encode(message: Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.nullValue !== undefined) {
       writer.uint32(8).int32(message.nullValue);
@@ -463,7 +463,7 @@ function createBaseListValue(): ListValue {
   return { values: [] };
 }
 
-export const ListValue = {
+export const ListValue: MessageFns<ListValue> & ListValueWrapperFns = {
   encode(message: ListValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     for (const v of message.values) {
       Value.encode(Value.wrap(v!), writer.uint32(10).fork()).join();
@@ -548,4 +548,28 @@ function isObject(value: any): boolean {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
+}
+
+export interface StructWrapperFns {
+  wrap(object: { [key: string]: any } | undefined): Struct;
+  unwrap(message: Struct): { [key: string]: any };
+}
+
+export interface AnyValueWrapperFns {
+  wrap(value: any): Value;
+  unwrap(message: any): string | number | boolean | Object | null | Array<any> | undefined;
+}
+
+export interface ListValueWrapperFns {
+  wrap(array: Array<any> | undefined): ListValue;
+  unwrap(message: ListValue): Array<any>;
 }

--- a/integration/grpc-js/google/protobuf/timestamp.ts
+++ b/integration/grpc-js/google/protobuf/timestamp.ts
@@ -117,7 +117,7 @@ function createBaseTimestamp(): Timestamp {
   return { seconds: 0, nanos: 0 };
 }
 
-export const Timestamp = {
+export const Timestamp: MessageFns<Timestamp> = {
   encode(message: Timestamp, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.seconds !== 0) {
       writer.uint32(8).int64(message.seconds);
@@ -212,4 +212,13 @@ function longToNumber(int64: { toString(): string }): number {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/grpc-js/google/protobuf/wrappers.ts
+++ b/integration/grpc-js/google/protobuf/wrappers.ts
@@ -100,7 +100,7 @@ function createBaseDoubleValue(): DoubleValue {
   return { value: 0 };
 }
 
-export const DoubleValue = {
+export const DoubleValue: MessageFns<DoubleValue> = {
   encode(message: DoubleValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(9).double(message.value);
@@ -157,7 +157,7 @@ function createBaseFloatValue(): FloatValue {
   return { value: 0 };
 }
 
-export const FloatValue = {
+export const FloatValue: MessageFns<FloatValue> = {
   encode(message: FloatValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(13).float(message.value);
@@ -214,7 +214,7 @@ function createBaseInt64Value(): Int64Value {
   return { value: 0 };
 }
 
-export const Int64Value = {
+export const Int64Value: MessageFns<Int64Value> = {
   encode(message: Int64Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).int64(message.value);
@@ -271,7 +271,7 @@ function createBaseUInt64Value(): UInt64Value {
   return { value: 0 };
 }
 
-export const UInt64Value = {
+export const UInt64Value: MessageFns<UInt64Value> = {
   encode(message: UInt64Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).uint64(message.value);
@@ -328,7 +328,7 @@ function createBaseInt32Value(): Int32Value {
   return { value: 0 };
 }
 
-export const Int32Value = {
+export const Int32Value: MessageFns<Int32Value> = {
   encode(message: Int32Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).int32(message.value);
@@ -385,7 +385,7 @@ function createBaseUInt32Value(): UInt32Value {
   return { value: 0 };
 }
 
-export const UInt32Value = {
+export const UInt32Value: MessageFns<UInt32Value> = {
   encode(message: UInt32Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).uint32(message.value);
@@ -442,7 +442,7 @@ function createBaseBoolValue(): BoolValue {
   return { value: false };
 }
 
-export const BoolValue = {
+export const BoolValue: MessageFns<BoolValue> = {
   encode(message: BoolValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== false) {
       writer.uint32(8).bool(message.value);
@@ -499,7 +499,7 @@ function createBaseStringValue(): StringValue {
   return { value: "" };
 }
 
-export const StringValue = {
+export const StringValue: MessageFns<StringValue> = {
   encode(message: StringValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== "") {
       writer.uint32(10).string(message.value);
@@ -556,7 +556,7 @@ function createBaseBytesValue(): BytesValue {
   return { value: new Uint8Array(0) };
 }
 
-export const BytesValue = {
+export const BytesValue: MessageFns<BytesValue> = {
   encode(message: BytesValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value.length !== 0) {
       writer.uint32(10).bytes(message.value);
@@ -659,4 +659,13 @@ function longToNumber(int64: { toString(): string }): number {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/grpc-js/simple.ts
+++ b/integration/grpc-js/simple.ts
@@ -48,7 +48,7 @@ function createBaseTestMessage(): TestMessage {
   return { timestamp: undefined };
 }
 
-export const TestMessage = {
+export const TestMessage: MessageFns<TestMessage> = {
   encode(message: TestMessage, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.timestamp !== undefined) {
       Timestamp.encode(toTimestamp(message.timestamp), writer.uint32(10).fork()).join();
@@ -673,4 +673,13 @@ function fromJsonTimestamp(o: any): Date {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/grpc-web-abort-signal/example.ts
+++ b/integration/grpc-web-abort-signal/example.ts
@@ -102,7 +102,7 @@ function createBaseDashFlash(): DashFlash {
   return { msg: "", type: 0 };
 }
 
-export const DashFlash = {
+export const DashFlash: MessageFns<DashFlash> = {
   encode(message: DashFlash, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.msg !== "") {
       writer.uint32(10).string(message.msg);
@@ -176,7 +176,7 @@ function createBaseDashUserSettingsState(): DashUserSettingsState {
   return { email: "", urls: undefined, flashes: [] };
 }
 
-export const DashUserSettingsState = {
+export const DashUserSettingsState: MessageFns<DashUserSettingsState> = {
   encode(message: DashUserSettingsState, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.email !== "") {
       writer.uint32(10).string(message.email);
@@ -267,7 +267,7 @@ function createBaseDashUserSettingsState_URLs(): DashUserSettingsState_URLs {
   return { connectGoogle: "", connectGithub: "" };
 }
 
-export const DashUserSettingsState_URLs = {
+export const DashUserSettingsState_URLs: MessageFns<DashUserSettingsState_URLs> = {
   encode(message: DashUserSettingsState_URLs, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.connectGoogle !== "") {
       writer.uint32(10).string(message.connectGoogle);
@@ -341,7 +341,7 @@ function createBaseDashCred(): DashCred {
   return { description: "", metadata: "", token: "", id: "" };
 }
 
-export const DashCred = {
+export const DashCred: MessageFns<DashCred> = {
   encode(message: DashCred, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.description !== "") {
       writer.uint32(18).string(message.description);
@@ -445,7 +445,7 @@ function createBaseDashAPICredsCreateReq(): DashAPICredsCreateReq {
   return { description: "", metadata: "" };
 }
 
-export const DashAPICredsCreateReq = {
+export const DashAPICredsCreateReq: MessageFns<DashAPICredsCreateReq> = {
   encode(message: DashAPICredsCreateReq, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.description !== "") {
       writer.uint32(10).string(message.description);
@@ -519,7 +519,7 @@ function createBaseDashAPICredsUpdateReq(): DashAPICredsUpdateReq {
   return { credSid: "", description: "", metadata: "", id: "" };
 }
 
-export const DashAPICredsUpdateReq = {
+export const DashAPICredsUpdateReq: MessageFns<DashAPICredsUpdateReq> = {
   encode(message: DashAPICredsUpdateReq, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.credSid !== "") {
       writer.uint32(10).string(message.credSid);
@@ -623,7 +623,7 @@ function createBaseDashAPICredsDeleteReq(): DashAPICredsDeleteReq {
   return { credSid: "", id: "" };
 }
 
-export const DashAPICredsDeleteReq = {
+export const DashAPICredsDeleteReq: MessageFns<DashAPICredsDeleteReq> = {
   encode(message: DashAPICredsDeleteReq, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.credSid !== "") {
       writer.uint32(10).string(message.credSid);
@@ -697,7 +697,7 @@ function createBaseEmpty(): Empty {
   return {};
 }
 
-export const Empty = {
+export const Empty: MessageFns<Empty> = {
   encode(_: Empty, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     return writer;
   },
@@ -1128,4 +1128,13 @@ export class GrpcWebError extends globalThis.Error {
   constructor(message: string, public code: grpc.Code, public metadata: grpc.Metadata) {
     super(message);
   }
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/grpc-web-go-server/example.ts
+++ b/integration/grpc-web-go-server/example.ts
@@ -100,7 +100,7 @@ function createBaseDashFlash(): DashFlash {
   return { msg: "", type: 0 };
 }
 
-export const DashFlash = {
+export const DashFlash: MessageFns<DashFlash> = {
   encode(message: DashFlash, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.msg !== "") {
       writer.uint32(10).string(message.msg);
@@ -174,7 +174,7 @@ function createBaseDashUserSettingsState(): DashUserSettingsState {
   return { email: "", urls: undefined, flashes: [] };
 }
 
-export const DashUserSettingsState = {
+export const DashUserSettingsState: MessageFns<DashUserSettingsState> = {
   encode(message: DashUserSettingsState, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.email !== "") {
       writer.uint32(10).string(message.email);
@@ -265,7 +265,7 @@ function createBaseDashUserSettingsState_URLs(): DashUserSettingsState_URLs {
   return { connectGoogle: "", connectGithub: "" };
 }
 
-export const DashUserSettingsState_URLs = {
+export const DashUserSettingsState_URLs: MessageFns<DashUserSettingsState_URLs> = {
   encode(message: DashUserSettingsState_URLs, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.connectGoogle !== "") {
       writer.uint32(10).string(message.connectGoogle);
@@ -339,7 +339,7 @@ function createBaseDashCred(): DashCred {
   return { description: "", metadata: "", token: "", id: "" };
 }
 
-export const DashCred = {
+export const DashCred: MessageFns<DashCred> = {
   encode(message: DashCred, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.description !== "") {
       writer.uint32(18).string(message.description);
@@ -443,7 +443,7 @@ function createBaseDashAPICredsCreateReq(): DashAPICredsCreateReq {
   return { description: "", metadata: "" };
 }
 
-export const DashAPICredsCreateReq = {
+export const DashAPICredsCreateReq: MessageFns<DashAPICredsCreateReq> = {
   encode(message: DashAPICredsCreateReq, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.description !== "") {
       writer.uint32(10).string(message.description);
@@ -517,7 +517,7 @@ function createBaseDashAPICredsUpdateReq(): DashAPICredsUpdateReq {
   return { credSid: "", description: "", metadata: "", id: "" };
 }
 
-export const DashAPICredsUpdateReq = {
+export const DashAPICredsUpdateReq: MessageFns<DashAPICredsUpdateReq> = {
   encode(message: DashAPICredsUpdateReq, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.credSid !== "") {
       writer.uint32(10).string(message.credSid);
@@ -621,7 +621,7 @@ function createBaseDashAPICredsDeleteReq(): DashAPICredsDeleteReq {
   return { credSid: "", id: "" };
 }
 
-export const DashAPICredsDeleteReq = {
+export const DashAPICredsDeleteReq: MessageFns<DashAPICredsDeleteReq> = {
   encode(message: DashAPICredsDeleteReq, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.credSid !== "") {
       writer.uint32(10).string(message.credSid);
@@ -695,7 +695,7 @@ function createBaseEmpty(): Empty {
   return {};
 }
 
-export const Empty = {
+export const Empty: MessageFns<Empty> = {
   encode(_: Empty, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     return writer;
   },
@@ -824,4 +824,13 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/grpc-web-no-streaming-observable/example.ts
+++ b/integration/grpc-web-no-streaming-observable/example.ts
@@ -78,7 +78,7 @@ function createBaseDashFlash(): DashFlash {
   return { msg: "", type: 0 };
 }
 
-export const DashFlash = {
+export const DashFlash: MessageFns<DashFlash> = {
   encode(message: DashFlash, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.msg !== "") {
       writer.uint32(10).string(message.msg);
@@ -152,7 +152,7 @@ function createBaseDashUserSettingsState(): DashUserSettingsState {
   return { email: "", urls: undefined, flashes: [] };
 }
 
-export const DashUserSettingsState = {
+export const DashUserSettingsState: MessageFns<DashUserSettingsState> = {
   encode(message: DashUserSettingsState, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.email !== "") {
       writer.uint32(10).string(message.email);
@@ -243,7 +243,7 @@ function createBaseDashUserSettingsState_URLs(): DashUserSettingsState_URLs {
   return { connectGoogle: "", connectGithub: "" };
 }
 
-export const DashUserSettingsState_URLs = {
+export const DashUserSettingsState_URLs: MessageFns<DashUserSettingsState_URLs> = {
   encode(message: DashUserSettingsState_URLs, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.connectGoogle !== "") {
       writer.uint32(10).string(message.connectGoogle);
@@ -317,7 +317,7 @@ function createBaseEmpty(): Empty {
   return {};
 }
 
-export const Empty = {
+export const Empty: MessageFns<Empty> = {
   encode(_: Empty, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     return writer;
   },
@@ -491,4 +491,13 @@ export class GrpcWebError extends globalThis.Error {
   constructor(message: string, public code: grpc.Code, public metadata: grpc.Metadata) {
     super(message);
   }
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/grpc-web-no-streaming/example.ts
+++ b/integration/grpc-web-no-streaming/example.ts
@@ -76,7 +76,7 @@ function createBaseDashFlash(): DashFlash {
   return { msg: "", type: 0 };
 }
 
-export const DashFlash = {
+export const DashFlash: MessageFns<DashFlash> = {
   encode(message: DashFlash, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.msg !== "") {
       writer.uint32(10).string(message.msg);
@@ -150,7 +150,7 @@ function createBaseDashUserSettingsState(): DashUserSettingsState {
   return { email: "", urls: undefined, flashes: [] };
 }
 
-export const DashUserSettingsState = {
+export const DashUserSettingsState: MessageFns<DashUserSettingsState> = {
   encode(message: DashUserSettingsState, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.email !== "") {
       writer.uint32(10).string(message.email);
@@ -241,7 +241,7 @@ function createBaseDashUserSettingsState_URLs(): DashUserSettingsState_URLs {
   return { connectGoogle: "", connectGithub: "" };
 }
 
-export const DashUserSettingsState_URLs = {
+export const DashUserSettingsState_URLs: MessageFns<DashUserSettingsState_URLs> = {
   encode(message: DashUserSettingsState_URLs, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.connectGoogle !== "") {
       writer.uint32(10).string(message.connectGoogle);
@@ -315,7 +315,7 @@ function createBaseEmpty(): Empty {
   return {};
 }
 
-export const Empty = {
+export const Empty: MessageFns<Empty> = {
   encode(_: Empty, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     return writer;
   },
@@ -488,4 +488,13 @@ export class GrpcWebError extends globalThis.Error {
   constructor(message: string, public code: grpc.Code, public metadata: grpc.Metadata) {
     super(message);
   }
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/grpc-web/example.ts
+++ b/integration/grpc-web/example.ts
@@ -103,7 +103,7 @@ function createBaseDashFlash(): DashFlash {
   return { msg: "", type: 0 };
 }
 
-export const DashFlash = {
+export const DashFlash: MessageFns<DashFlash> = {
   encode(message: DashFlash, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.msg !== "") {
       writer.uint32(10).string(message.msg);
@@ -177,7 +177,7 @@ function createBaseDashUserSettingsState(): DashUserSettingsState {
   return { email: "", urls: undefined, flashes: [] };
 }
 
-export const DashUserSettingsState = {
+export const DashUserSettingsState: MessageFns<DashUserSettingsState> = {
   encode(message: DashUserSettingsState, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.email !== "") {
       writer.uint32(10).string(message.email);
@@ -268,7 +268,7 @@ function createBaseDashUserSettingsState_URLs(): DashUserSettingsState_URLs {
   return { connectGoogle: "", connectGithub: "" };
 }
 
-export const DashUserSettingsState_URLs = {
+export const DashUserSettingsState_URLs: MessageFns<DashUserSettingsState_URLs> = {
   encode(message: DashUserSettingsState_URLs, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.connectGoogle !== "") {
       writer.uint32(10).string(message.connectGoogle);
@@ -342,7 +342,7 @@ function createBaseDashCred(): DashCred {
   return { description: "", metadata: "", token: "", id: "" };
 }
 
-export const DashCred = {
+export const DashCred: MessageFns<DashCred> = {
   encode(message: DashCred, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.description !== "") {
       writer.uint32(18).string(message.description);
@@ -446,7 +446,7 @@ function createBaseDashAPICredsCreateReq(): DashAPICredsCreateReq {
   return { description: "", metadata: "" };
 }
 
-export const DashAPICredsCreateReq = {
+export const DashAPICredsCreateReq: MessageFns<DashAPICredsCreateReq> = {
   encode(message: DashAPICredsCreateReq, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.description !== "") {
       writer.uint32(10).string(message.description);
@@ -520,7 +520,7 @@ function createBaseDashAPICredsUpdateReq(): DashAPICredsUpdateReq {
   return { credSid: "", description: "", metadata: "", id: "" };
 }
 
-export const DashAPICredsUpdateReq = {
+export const DashAPICredsUpdateReq: MessageFns<DashAPICredsUpdateReq> = {
   encode(message: DashAPICredsUpdateReq, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.credSid !== "") {
       writer.uint32(10).string(message.credSid);
@@ -624,7 +624,7 @@ function createBaseDashAPICredsDeleteReq(): DashAPICredsDeleteReq {
   return { credSid: "", id: "" };
 }
 
-export const DashAPICredsDeleteReq = {
+export const DashAPICredsDeleteReq: MessageFns<DashAPICredsDeleteReq> = {
   encode(message: DashAPICredsDeleteReq, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.credSid !== "") {
       writer.uint32(10).string(message.credSid);
@@ -698,7 +698,7 @@ function createBaseEmpty(): Empty {
   return {};
 }
 
-export const Empty = {
+export const Empty: MessageFns<Empty> = {
   encode(_: Empty, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     return writer;
   },
@@ -1088,4 +1088,13 @@ export class GrpcWebError extends globalThis.Error {
   constructor(message: string, public code: grpc.Code, public metadata: grpc.Metadata) {
     super(message);
   }
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/grpc-web/google/protobuf/wrappers.ts
+++ b/integration/grpc-web/google/protobuf/wrappers.ts
@@ -100,7 +100,7 @@ function createBaseDoubleValue(): DoubleValue {
   return { value: 0 };
 }
 
-export const DoubleValue = {
+export const DoubleValue: MessageFns<DoubleValue> = {
   encode(message: DoubleValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(9).double(message.value);
@@ -157,7 +157,7 @@ function createBaseFloatValue(): FloatValue {
   return { value: 0 };
 }
 
-export const FloatValue = {
+export const FloatValue: MessageFns<FloatValue> = {
   encode(message: FloatValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(13).float(message.value);
@@ -214,7 +214,7 @@ function createBaseInt64Value(): Int64Value {
   return { value: 0 };
 }
 
-export const Int64Value = {
+export const Int64Value: MessageFns<Int64Value> = {
   encode(message: Int64Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).int64(message.value);
@@ -271,7 +271,7 @@ function createBaseUInt64Value(): UInt64Value {
   return { value: 0 };
 }
 
-export const UInt64Value = {
+export const UInt64Value: MessageFns<UInt64Value> = {
   encode(message: UInt64Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).uint64(message.value);
@@ -328,7 +328,7 @@ function createBaseInt32Value(): Int32Value {
   return { value: 0 };
 }
 
-export const Int32Value = {
+export const Int32Value: MessageFns<Int32Value> = {
   encode(message: Int32Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).int32(message.value);
@@ -385,7 +385,7 @@ function createBaseUInt32Value(): UInt32Value {
   return { value: 0 };
 }
 
-export const UInt32Value = {
+export const UInt32Value: MessageFns<UInt32Value> = {
   encode(message: UInt32Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).uint32(message.value);
@@ -442,7 +442,7 @@ function createBaseBoolValue(): BoolValue {
   return { value: false };
 }
 
-export const BoolValue = {
+export const BoolValue: MessageFns<BoolValue> = {
   encode(message: BoolValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== false) {
       writer.uint32(8).bool(message.value);
@@ -499,7 +499,7 @@ function createBaseStringValue(): StringValue {
   return { value: "" };
 }
 
-export const StringValue = {
+export const StringValue: MessageFns<StringValue> = {
   encode(message: StringValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== "") {
       writer.uint32(10).string(message.value);
@@ -556,7 +556,7 @@ function createBaseBytesValue(): BytesValue {
   return { value: new Uint8Array(0) };
 }
 
-export const BytesValue = {
+export const BytesValue: MessageFns<BytesValue> = {
   encode(message: BytesValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value.length !== 0) {
       writer.uint32(10).bytes(message.value);
@@ -659,4 +659,13 @@ function longToNumber(int64: { toString(): string }): number {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/handle-error-in-default-service/simple.ts
+++ b/integration/handle-error-in-default-service/simple.ts
@@ -18,7 +18,7 @@ function createBaseGetBasicRequest(): GetBasicRequest {
   return { name: "" };
 }
 
-export const GetBasicRequest = {
+export const GetBasicRequest: MessageFns<GetBasicRequest> = {
   encode(message: GetBasicRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -75,7 +75,7 @@ function createBaseGetBasicResponse(): GetBasicResponse {
   return { name: "" };
 }
 
-export const GetBasicResponse = {
+export const GetBasicResponse: MessageFns<GetBasicResponse> = {
   encode(message: GetBasicResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -178,4 +178,13 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/handle-error-with-after-response/simple.ts
+++ b/integration/handle-error-with-after-response/simple.ts
@@ -18,7 +18,7 @@ function createBaseGetBasicRequest(): GetBasicRequest {
   return { name: "" };
 }
 
-export const GetBasicRequest = {
+export const GetBasicRequest: MessageFns<GetBasicRequest> = {
   encode(message: GetBasicRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -75,7 +75,7 @@ function createBaseGetBasicResponse(): GetBasicResponse {
   return { name: "" };
 }
 
-export const GetBasicResponse = {
+export const GetBasicResponse: MessageFns<GetBasicResponse> = {
   encode(message: GetBasicResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -183,4 +183,13 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/import-mapping/google/protobuf/timestamp.ts
+++ b/integration/import-mapping/google/protobuf/timestamp.ts
@@ -117,7 +117,7 @@ function createBaseTimestamp(): Timestamp {
   return { seconds: 0, nanos: 0 };
 }
 
-export const Timestamp = {
+export const Timestamp: MessageFns<Timestamp> = {
   encode(message: Timestamp, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.seconds !== 0) {
       writer.uint32(8).int64(message.seconds);
@@ -212,4 +212,13 @@ function longToNumber(int64: { toString(): string }): number {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/import-mapping/mapping.ts
+++ b/integration/import-mapping/mapping.ts
@@ -35,7 +35,7 @@ function createBaseWithEmtpy(): WithEmtpy {
   return { empty: undefined };
 }
 
-export const WithEmtpy = {
+export const WithEmtpy: MessageFns<WithEmtpy> = {
   encode(message: WithEmtpy, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.empty !== undefined) {
       Empty.encode(message.empty, writer.uint32(10).fork()).join();
@@ -92,7 +92,7 @@ function createBaseWithStruct(): WithStruct {
   return { strut: undefined };
 }
 
-export const WithStruct = {
+export const WithStruct: MessageFns<WithStruct> = {
   encode(message: WithStruct, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.strut !== undefined) {
       Struct.encode(Struct.wrap(message.strut), writer.uint32(10).fork()).join();
@@ -149,7 +149,7 @@ function createBaseWithTimestamp(): WithTimestamp {
   return { timestamp: undefined };
 }
 
-export const WithTimestamp = {
+export const WithTimestamp: MessageFns<WithTimestamp> = {
   encode(message: WithTimestamp, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.timestamp !== undefined) {
       Timestamp.encode(toTimestamp(message.timestamp), writer.uint32(10).fork()).join();
@@ -206,7 +206,7 @@ function createBaseWithAll(): WithAll {
   return { empty: undefined, strut: undefined, timestamp: undefined, duration: undefined, veryVerySecret: undefined };
 }
 
-export const WithAll = {
+export const WithAll: MessageFns<WithAll> = {
   encode(message: WithAll, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.empty !== undefined) {
       Empty.encode(message.empty, writer.uint32(10).fork()).join();
@@ -365,4 +365,13 @@ function isObject(value: any): boolean {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/import-suffix/child.pb.ts
+++ b/integration/import-suffix/child.pb.ts
@@ -47,7 +47,7 @@ function createBaseChild(): Child {
   return { name: "" };
 }
 
-export const Child = {
+export const Child: MessageFns<Child> = {
   encode(message: Child, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -114,4 +114,13 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/import-suffix/google/protobuf/timestamp.pb.ts
+++ b/integration/import-suffix/google/protobuf/timestamp.pb.ts
@@ -117,7 +117,7 @@ function createBaseTimestamp(): Timestamp {
   return { seconds: 0, nanos: 0 };
 }
 
-export const Timestamp = {
+export const Timestamp: MessageFns<Timestamp> = {
   encode(message: Timestamp, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.seconds !== 0) {
       writer.uint32(8).int64(message.seconds);
@@ -212,4 +212,13 @@ function longToNumber(int64: { toString(): string }): number {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/import-suffix/parent.pb.ts
+++ b/integration/import-suffix/parent.pb.ts
@@ -18,7 +18,7 @@ function createBaseParent(): Parent {
   return { child: undefined, childEnum: 0, createdAt: undefined };
 }
 
-export const Parent = {
+export const Parent: MessageFns<Parent> = {
   encode(message: Parent, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.child !== undefined) {
       Child.encode(message.child, writer.uint32(10).fork()).join();
@@ -139,4 +139,13 @@ function fromJsonTimestamp(o: any): Date {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/lower-case-svc-methods/math.ts
+++ b/integration/lower-case-svc-methods/math.ts
@@ -25,7 +25,7 @@ function createBaseNumPair(): NumPair {
   return { num1: 0, num2: 0 };
 }
 
-export const NumPair = {
+export const NumPair: MessageFns<NumPair> = {
   encode(message: NumPair, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.num1 !== 0) {
       writer.uint32(9).double(message.num1);
@@ -99,7 +99,7 @@ function createBaseNumSingle(): NumSingle {
   return { num: 0 };
 }
 
-export const NumSingle = {
+export const NumSingle: MessageFns<NumSingle> = {
   encode(message: NumSingle, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.num !== 0) {
       writer.uint32(9).double(message.num);
@@ -156,7 +156,7 @@ function createBaseNumbers(): Numbers {
   return { num: [] };
 }
 
-export const Numbers = {
+export const Numbers: MessageFns<Numbers> = {
   encode(message: Numbers, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     writer.uint32(10).fork();
     for (const v of message.num) {
@@ -295,4 +295,13 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/map-bigint-optional/test.ts
+++ b/integration/map-bigint-optional/test.ts
@@ -21,7 +21,7 @@ function createBaseMapBigInt(): MapBigInt {
   return {};
 }
 
-export const MapBigInt = {
+export const MapBigInt: MessageFns<MapBigInt> = {
   encode(message: MapBigInt, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     (message.map || new Map()).forEach((value, key) => {
       MapBigInt_MapEntry.encode({ key: key as any, value }, writer.uint32(10).fork()).join();
@@ -122,7 +122,7 @@ function createBaseMapBigInt_MapEntry(): MapBigInt_MapEntry {
   return { key: 0n, value: 0n };
 }
 
-export const MapBigInt_MapEntry = {
+export const MapBigInt_MapEntry: MessageFns<MapBigInt_MapEntry> = {
   encode(message: MapBigInt_MapEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== 0n) {
       if (BigInt.asUintN(64, message.key) !== message.key) {
@@ -233,4 +233,13 @@ function isObject(value: any): boolean {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/map-long-optional/test.ts
+++ b/integration/map-long-optional/test.ts
@@ -22,7 +22,7 @@ function createBaseMapBigInt(): MapBigInt {
   return {};
 }
 
-export const MapBigInt = {
+export const MapBigInt: MessageFns<MapBigInt> = {
   encode(message: MapBigInt, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     (message.map || new Map()).forEach((value, key) => {
       MapBigInt_MapEntry.encode({ key: key as any, value }, writer.uint32(10).fork()).join();
@@ -123,7 +123,7 @@ function createBaseMapBigInt_MapEntry(): MapBigInt_MapEntry {
   return { key: Long.UZERO, value: Long.ZERO };
 }
 
-export const MapBigInt_MapEntry = {
+export const MapBigInt_MapEntry: MessageFns<MapBigInt_MapEntry> = {
   encode(message: MapBigInt_MapEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (!message.key.equals(Long.UZERO)) {
       writer.uint32(9).fixed64(message.key.toString());
@@ -242,4 +242,13 @@ function isObject(value: any): boolean {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/map-longstring-optional/test.ts
+++ b/integration/map-longstring-optional/test.ts
@@ -21,7 +21,7 @@ function createBaseMapBigInt(): MapBigInt {
   return {};
 }
 
-export const MapBigInt = {
+export const MapBigInt: MessageFns<MapBigInt> = {
   encode(message: MapBigInt, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     (message.map || new Map()).forEach((value, key) => {
       MapBigInt_MapEntry.encode({ key: key as any, value }, writer.uint32(10).fork()).join();
@@ -122,7 +122,7 @@ function createBaseMapBigInt_MapEntry(): MapBigInt_MapEntry {
   return { key: "0", value: "0" };
 }
 
-export const MapBigInt_MapEntry = {
+export const MapBigInt_MapEntry: MessageFns<MapBigInt_MapEntry> = {
   encode(message: MapBigInt_MapEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== "0") {
       writer.uint32(9).fixed64(message.key);
@@ -230,4 +230,13 @@ function isObject(value: any): boolean {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/meta-typings-as-const/google/protobuf/descriptor.ts
+++ b/integration/meta-typings-as-const/google/protobuf/descriptor.ts
@@ -959,7 +959,7 @@ function createBaseFileDescriptorSet(): FileDescriptorSet {
   return { file: [] };
 }
 
-export const FileDescriptorSet = {
+export const FileDescriptorSet: MessageFns<FileDescriptorSet> = {
   encode(message: FileDescriptorSet, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     for (const v of message.file) {
       FileDescriptorProto.encode(v!, writer.uint32(10).fork()).join();
@@ -1008,7 +1008,7 @@ function createBaseFileDescriptorProto(): FileDescriptorProto {
   };
 }
 
-export const FileDescriptorProto = {
+export const FileDescriptorProto: MessageFns<FileDescriptorProto> = {
   encode(message: FileDescriptorProto, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== undefined && message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -1189,7 +1189,7 @@ function createBaseDescriptorProto(): DescriptorProto {
   };
 }
 
-export const DescriptorProto = {
+export const DescriptorProto: MessageFns<DescriptorProto> = {
   encode(message: DescriptorProto, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== undefined && message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -1315,7 +1315,7 @@ function createBaseDescriptorProto_ExtensionRange(): DescriptorProto_ExtensionRa
   return { start: 0, end: 0, options: undefined };
 }
 
-export const DescriptorProto_ExtensionRange = {
+export const DescriptorProto_ExtensionRange: MessageFns<DescriptorProto_ExtensionRange> = {
   encode(message: DescriptorProto_ExtensionRange, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.start !== undefined && message.start !== 0) {
       writer.uint32(8).int32(message.start);
@@ -1371,7 +1371,7 @@ function createBaseDescriptorProto_ReservedRange(): DescriptorProto_ReservedRang
   return { start: 0, end: 0 };
 }
 
-export const DescriptorProto_ReservedRange = {
+export const DescriptorProto_ReservedRange: MessageFns<DescriptorProto_ReservedRange> = {
   encode(message: DescriptorProto_ReservedRange, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.start !== undefined && message.start !== 0) {
       writer.uint32(8).int32(message.start);
@@ -1417,7 +1417,7 @@ function createBaseExtensionRangeOptions(): ExtensionRangeOptions {
   return { uninterpretedOption: [] };
 }
 
-export const ExtensionRangeOptions = {
+export const ExtensionRangeOptions: MessageFns<ExtensionRangeOptions> = {
   encode(message: ExtensionRangeOptions, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     for (const v of message.uninterpretedOption) {
       UninterpretedOption.encode(v!, writer.uint32(7994).fork()).join();
@@ -1465,7 +1465,7 @@ function createBaseFieldDescriptorProto(): FieldDescriptorProto {
   };
 }
 
-export const FieldDescriptorProto = {
+export const FieldDescriptorProto: MessageFns<FieldDescriptorProto> = {
   encode(message: FieldDescriptorProto, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== undefined && message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -1601,7 +1601,7 @@ function createBaseOneofDescriptorProto(): OneofDescriptorProto {
   return { name: "", options: undefined };
 }
 
-export const OneofDescriptorProto = {
+export const OneofDescriptorProto: MessageFns<OneofDescriptorProto> = {
   encode(message: OneofDescriptorProto, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== undefined && message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -1647,7 +1647,7 @@ function createBaseEnumDescriptorProto(): EnumDescriptorProto {
   return { name: "", value: [], options: undefined, reservedRange: [], reservedName: [] };
 }
 
-export const EnumDescriptorProto = {
+export const EnumDescriptorProto: MessageFns<EnumDescriptorProto> = {
   encode(message: EnumDescriptorProto, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== undefined && message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -1723,7 +1723,7 @@ function createBaseEnumDescriptorProto_EnumReservedRange(): EnumDescriptorProto_
   return { start: 0, end: 0 };
 }
 
-export const EnumDescriptorProto_EnumReservedRange = {
+export const EnumDescriptorProto_EnumReservedRange: MessageFns<EnumDescriptorProto_EnumReservedRange> = {
   encode(message: EnumDescriptorProto_EnumReservedRange, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.start !== undefined && message.start !== 0) {
       writer.uint32(8).int32(message.start);
@@ -1769,7 +1769,7 @@ function createBaseEnumValueDescriptorProto(): EnumValueDescriptorProto {
   return { name: "", number: 0, options: undefined };
 }
 
-export const EnumValueDescriptorProto = {
+export const EnumValueDescriptorProto: MessageFns<EnumValueDescriptorProto> = {
   encode(message: EnumValueDescriptorProto, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== undefined && message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -1825,7 +1825,7 @@ function createBaseServiceDescriptorProto(): ServiceDescriptorProto {
   return { name: "", method: [], options: undefined };
 }
 
-export const ServiceDescriptorProto = {
+export const ServiceDescriptorProto: MessageFns<ServiceDescriptorProto> = {
   encode(message: ServiceDescriptorProto, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== undefined && message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -1888,7 +1888,7 @@ function createBaseMethodDescriptorProto(): MethodDescriptorProto {
   };
 }
 
-export const MethodDescriptorProto = {
+export const MethodDescriptorProto: MessageFns<MethodDescriptorProto> = {
   encode(message: MethodDescriptorProto, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== undefined && message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -1996,7 +1996,7 @@ function createBaseFileOptions(): FileOptions {
   };
 }
 
-export const FileOptions = {
+export const FileOptions: MessageFns<FileOptions> = {
   encode(message: FileOptions, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.javaPackage !== undefined && message.javaPackage !== "") {
       writer.uint32(10).string(message.javaPackage);
@@ -2238,7 +2238,7 @@ function createBaseMessageOptions(): MessageOptions {
   };
 }
 
-export const MessageOptions = {
+export const MessageOptions: MessageFns<MessageOptions> = {
   encode(message: MessageOptions, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.messageSetWireFormat !== undefined && message.messageSetWireFormat !== false) {
       writer.uint32(8).bool(message.messageSetWireFormat);
@@ -2314,7 +2314,7 @@ function createBaseFieldOptions(): FieldOptions {
   return { ctype: 0, packed: false, jstype: 0, lazy: false, deprecated: false, weak: false, uninterpretedOption: [] };
 }
 
-export const FieldOptions = {
+export const FieldOptions: MessageFns<FieldOptions> = {
   encode(message: FieldOptions, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.ctype !== undefined && message.ctype !== 0) {
       writer.uint32(8).int32(message.ctype);
@@ -2410,7 +2410,7 @@ function createBaseOneofOptions(): OneofOptions {
   return { uninterpretedOption: [] };
 }
 
-export const OneofOptions = {
+export const OneofOptions: MessageFns<OneofOptions> = {
   encode(message: OneofOptions, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     for (const v of message.uninterpretedOption) {
       UninterpretedOption.encode(v!, writer.uint32(7994).fork()).join();
@@ -2446,7 +2446,7 @@ function createBaseEnumOptions(): EnumOptions {
   return { allowAlias: false, deprecated: false, uninterpretedOption: [] };
 }
 
-export const EnumOptions = {
+export const EnumOptions: MessageFns<EnumOptions> = {
   encode(message: EnumOptions, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.allowAlias !== undefined && message.allowAlias !== false) {
       writer.uint32(16).bool(message.allowAlias);
@@ -2502,7 +2502,7 @@ function createBaseEnumValueOptions(): EnumValueOptions {
   return { deprecated: false, uninterpretedOption: [] };
 }
 
-export const EnumValueOptions = {
+export const EnumValueOptions: MessageFns<EnumValueOptions> = {
   encode(message: EnumValueOptions, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.deprecated !== undefined && message.deprecated !== false) {
       writer.uint32(8).bool(message.deprecated);
@@ -2548,7 +2548,7 @@ function createBaseServiceOptions(): ServiceOptions {
   return { deprecated: false, uninterpretedOption: [] };
 }
 
-export const ServiceOptions = {
+export const ServiceOptions: MessageFns<ServiceOptions> = {
   encode(message: ServiceOptions, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.deprecated !== undefined && message.deprecated !== false) {
       writer.uint32(264).bool(message.deprecated);
@@ -2594,7 +2594,7 @@ function createBaseMethodOptions(): MethodOptions {
   return { deprecated: false, idempotencyLevel: 0, uninterpretedOption: [] };
 }
 
-export const MethodOptions = {
+export const MethodOptions: MessageFns<MethodOptions> = {
   encode(message: MethodOptions, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.deprecated !== undefined && message.deprecated !== false) {
       writer.uint32(264).bool(message.deprecated);
@@ -2658,7 +2658,7 @@ function createBaseUninterpretedOption(): UninterpretedOption {
   };
 }
 
-export const UninterpretedOption = {
+export const UninterpretedOption: MessageFns<UninterpretedOption> = {
   encode(message: UninterpretedOption, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     for (const v of message.name) {
       UninterpretedOption_NamePart.encode(v!, writer.uint32(18).fork()).join();
@@ -2754,7 +2754,7 @@ function createBaseUninterpretedOption_NamePart(): UninterpretedOption_NamePart 
   return { namePart: "", isExtension: false };
 }
 
-export const UninterpretedOption_NamePart = {
+export const UninterpretedOption_NamePart: MessageFns<UninterpretedOption_NamePart> = {
   encode(message: UninterpretedOption_NamePart, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.namePart !== "") {
       writer.uint32(10).string(message.namePart);
@@ -2800,7 +2800,7 @@ function createBaseSourceCodeInfo(): SourceCodeInfo {
   return { location: [] };
 }
 
-export const SourceCodeInfo = {
+export const SourceCodeInfo: MessageFns<SourceCodeInfo> = {
   encode(message: SourceCodeInfo, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     for (const v of message.location) {
       SourceCodeInfo_Location.encode(v!, writer.uint32(10).fork()).join();
@@ -2836,7 +2836,7 @@ function createBaseSourceCodeInfo_Location(): SourceCodeInfo_Location {
   return { path: [], span: [], leadingComments: "", trailingComments: "", leadingDetachedComments: [] };
 }
 
-export const SourceCodeInfo_Location = {
+export const SourceCodeInfo_Location: MessageFns<SourceCodeInfo_Location> = {
   encode(message: SourceCodeInfo_Location, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     writer.uint32(10).fork();
     for (const v of message.path) {
@@ -2936,7 +2936,7 @@ function createBaseGeneratedCodeInfo(): GeneratedCodeInfo {
   return { annotation: [] };
 }
 
-export const GeneratedCodeInfo = {
+export const GeneratedCodeInfo: MessageFns<GeneratedCodeInfo> = {
   encode(message: GeneratedCodeInfo, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     for (const v of message.annotation) {
       GeneratedCodeInfo_Annotation.encode(v!, writer.uint32(10).fork()).join();
@@ -2972,7 +2972,7 @@ function createBaseGeneratedCodeInfo_Annotation(): GeneratedCodeInfo_Annotation 
   return { path: [], sourceFile: "", begin: 0, end: 0 };
 }
 
-export const GeneratedCodeInfo_Annotation = {
+export const GeneratedCodeInfo_Annotation: MessageFns<GeneratedCodeInfo_Annotation> = {
   encode(message: GeneratedCodeInfo_Annotation, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     writer.uint32(10).fork();
     for (const v of message.path) {
@@ -5885,4 +5885,9 @@ function longToNumber(int64: { toString(): string }): number {
     throw new globalThis.Error("Value is smaller than Number.MIN_SAFE_INTEGER");
   }
   return num;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
 }

--- a/integration/meta-typings-as-const/simple.ts
+++ b/integration/meta-typings-as-const/simple.ts
@@ -23,7 +23,7 @@ function createBaseTest(): Test {
   return { enum: 0 };
 }
 
-export const Test = {
+export const Test: MessageFns<Test> = {
   encode(message: Test, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.enum !== 0) {
       writer.uint32(8).int32(message.enum);
@@ -150,3 +150,8 @@ export const protoMetadata = {
     enums: { "TestEnum": { values: { "VALUE_A": { "string_value": "A" }, "VALUE_B": { "string_value": "B" } } } },
   },
 } as const satisfies ProtoMetadata;
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+}

--- a/integration/meta-typings/google/protobuf/timestamp.ts
+++ b/integration/meta-typings/google/protobuf/timestamp.ts
@@ -118,7 +118,7 @@ function createBaseTimestamp(): Timestamp {
   return { seconds: 0, nanos: 0 };
 }
 
-export const Timestamp = {
+export const Timestamp: MessageFns<Timestamp> = {
   encode(message: Timestamp, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.seconds !== 0) {
       writer.uint32(8).int64(message.seconds);
@@ -289,4 +289,9 @@ function longToNumber(int64: { toString(): string }): number {
     throw new globalThis.Error("Value is smaller than Number.MIN_SAFE_INTEGER");
   }
   return num;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
 }

--- a/integration/meta-typings/google/protobuf/wrappers.ts
+++ b/integration/meta-typings/google/protobuf/wrappers.ts
@@ -101,7 +101,7 @@ function createBaseDoubleValue(): DoubleValue {
   return { value: 0 };
 }
 
-export const DoubleValue = {
+export const DoubleValue: MessageFns<DoubleValue> = {
   encode(message: DoubleValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(9).double(message.value);
@@ -137,7 +137,7 @@ function createBaseFloatValue(): FloatValue {
   return { value: 0 };
 }
 
-export const FloatValue = {
+export const FloatValue: MessageFns<FloatValue> = {
   encode(message: FloatValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(13).float(message.value);
@@ -173,7 +173,7 @@ function createBaseInt64Value(): Int64Value {
   return { value: 0 };
 }
 
-export const Int64Value = {
+export const Int64Value: MessageFns<Int64Value> = {
   encode(message: Int64Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).int64(message.value);
@@ -209,7 +209,7 @@ function createBaseUInt64Value(): UInt64Value {
   return { value: 0 };
 }
 
-export const UInt64Value = {
+export const UInt64Value: MessageFns<UInt64Value> = {
   encode(message: UInt64Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).uint64(message.value);
@@ -245,7 +245,7 @@ function createBaseInt32Value(): Int32Value {
   return { value: 0 };
 }
 
-export const Int32Value = {
+export const Int32Value: MessageFns<Int32Value> = {
   encode(message: Int32Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).int32(message.value);
@@ -281,7 +281,7 @@ function createBaseUInt32Value(): UInt32Value {
   return { value: 0 };
 }
 
-export const UInt32Value = {
+export const UInt32Value: MessageFns<UInt32Value> = {
   encode(message: UInt32Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).uint32(message.value);
@@ -317,7 +317,7 @@ function createBaseBoolValue(): BoolValue {
   return { value: false };
 }
 
-export const BoolValue = {
+export const BoolValue: MessageFns<BoolValue> = {
   encode(message: BoolValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== false) {
       writer.uint32(8).bool(message.value);
@@ -353,7 +353,7 @@ function createBaseStringValue(): StringValue {
   return { value: "" };
 }
 
-export const StringValue = {
+export const StringValue: MessageFns<StringValue> = {
   encode(message: StringValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== "") {
       writer.uint32(10).string(message.value);
@@ -389,7 +389,7 @@ function createBaseBytesValue(): BytesValue {
   return { value: new Uint8Array(0) };
 }
 
-export const BytesValue = {
+export const BytesValue: MessageFns<BytesValue> = {
   encode(message: BytesValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value.length !== 0) {
       writer.uint32(10).bytes(message.value);
@@ -828,4 +828,9 @@ function longToNumber(int64: { toString(): string }): number {
     throw new globalThis.Error("Value is smaller than Number.MIN_SAFE_INTEGER");
   }
   return num;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
 }

--- a/integration/meta-typings/google/type/date.ts
+++ b/integration/meta-typings/google/type/date.ts
@@ -42,7 +42,7 @@ function createBaseDateMessage(): DateMessage {
   return { year: 0, month: 0, day: 0 };
 }
 
-export const DateMessage = {
+export const DateMessage: MessageFns<DateMessage> = {
   encode(message: DateMessage, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.year !== 0) {
       writer.uint32(8).int32(message.year);
@@ -231,3 +231,8 @@ export const protoMetadata: ProtoMetadata = {
   references: { ".google.type.DateMessage": DateMessage },
   dependencies: [],
 };
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+}

--- a/integration/meta-typings/import_dir/thing.ts
+++ b/integration/meta-typings/import_dir/thing.ts
@@ -16,7 +16,7 @@ function createBaseImportedThing(): ImportedThing {
   return { createdAt: undefined };
 }
 
-export const ImportedThing = {
+export const ImportedThing: MessageFns<ImportedThing> = {
   encode(message: ImportedThing, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.createdAt !== undefined) {
       Timestamp.encode(toTimestamp(message.createdAt), writer.uint32(10).fork()).join();
@@ -121,4 +121,9 @@ function fromTimestamp(t: Timestamp): Date {
   let millis = (t.seconds || 0) * 1_000;
   millis += (t.nanos || 0) / 1_000_000;
   return new globalThis.Date(millis);
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
 }

--- a/integration/meta-typings/simple.ts
+++ b/integration/meta-typings/simple.ts
@@ -212,7 +212,7 @@ function createBaseSimple(): Simple {
   };
 }
 
-export const Simple = {
+export const Simple: MessageFns<Simple> = {
   encode(message: Simple, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -392,7 +392,7 @@ function createBaseChild(): Child {
   return { name: "", type: 0 };
 }
 
-export const Child = {
+export const Child: MessageFns<Child> = {
   encode(message: Child, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -438,7 +438,7 @@ function createBaseNested(): Nested {
   return { name: "", message: undefined, state: 0 };
 }
 
-export const Nested = {
+export const Nested: MessageFns<Nested> = {
   encode(message: Nested, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -494,7 +494,7 @@ function createBaseNested_InnerMessage(): Nested_InnerMessage {
   return { name: "", deep: undefined };
 }
 
-export const Nested_InnerMessage = {
+export const Nested_InnerMessage: MessageFns<Nested_InnerMessage> = {
   encode(message: Nested_InnerMessage, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -540,7 +540,7 @@ function createBaseNested_InnerMessage_DeepMessage(): Nested_InnerMessage_DeepMe
   return { name: "" };
 }
 
-export const Nested_InnerMessage_DeepMessage = {
+export const Nested_InnerMessage_DeepMessage: MessageFns<Nested_InnerMessage_DeepMessage> = {
   encode(message: Nested_InnerMessage_DeepMessage, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -576,7 +576,7 @@ function createBaseOneOfMessage(): OneOfMessage {
   return { first: undefined, last: undefined };
 }
 
-export const OneOfMessage = {
+export const OneOfMessage: MessageFns<OneOfMessage> = {
   encode(message: OneOfMessage, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.first !== undefined) {
       writer.uint32(10).string(message.first);
@@ -622,7 +622,7 @@ function createBaseSimpleWithWrappers(): SimpleWithWrappers {
   return { name: undefined, age: undefined, enabled: undefined, coins: [], snacks: [] };
 }
 
-export const SimpleWithWrappers = {
+export const SimpleWithWrappers: MessageFns<SimpleWithWrappers> = {
   encode(message: SimpleWithWrappers, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== undefined) {
       StringValue.encode({ value: message.name! }, writer.uint32(10).fork()).join();
@@ -698,7 +698,7 @@ function createBaseEntity(): Entity {
   return { id: 0 };
 }
 
-export const Entity = {
+export const Entity: MessageFns<Entity> = {
   encode(message: Entity, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.id !== 0) {
       writer.uint32(8).int32(message.id);
@@ -734,7 +734,7 @@ function createBaseSimpleWithMap(): SimpleWithMap {
   return { entitiesById: {}, nameLookup: {}, intLookup: {}, mapOfTimestamps: {}, mapOfBytes: {} };
 }
 
-export const SimpleWithMap = {
+export const SimpleWithMap: MessageFns<SimpleWithMap> = {
   encode(message: SimpleWithMap, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     Object.entries(message.entitiesById).forEach(([key, value]) => {
       SimpleWithMap_EntitiesByIdEntry.encode({ key: key as any, value }, writer.uint32(10).fork()).join();
@@ -825,7 +825,7 @@ function createBaseSimpleWithMap_EntitiesByIdEntry(): SimpleWithMap_EntitiesById
   return { key: 0, value: undefined };
 }
 
-export const SimpleWithMap_EntitiesByIdEntry = {
+export const SimpleWithMap_EntitiesByIdEntry: MessageFns<SimpleWithMap_EntitiesByIdEntry> = {
   encode(message: SimpleWithMap_EntitiesByIdEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== 0) {
       writer.uint32(8).int32(message.key);
@@ -871,7 +871,7 @@ function createBaseSimpleWithMap_NameLookupEntry(): SimpleWithMap_NameLookupEntr
   return { key: "", value: "" };
 }
 
-export const SimpleWithMap_NameLookupEntry = {
+export const SimpleWithMap_NameLookupEntry: MessageFns<SimpleWithMap_NameLookupEntry> = {
   encode(message: SimpleWithMap_NameLookupEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== "") {
       writer.uint32(10).string(message.key);
@@ -917,7 +917,7 @@ function createBaseSimpleWithMap_IntLookupEntry(): SimpleWithMap_IntLookupEntry 
   return { key: 0, value: 0 };
 }
 
-export const SimpleWithMap_IntLookupEntry = {
+export const SimpleWithMap_IntLookupEntry: MessageFns<SimpleWithMap_IntLookupEntry> = {
   encode(message: SimpleWithMap_IntLookupEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== 0) {
       writer.uint32(8).int32(message.key);
@@ -963,7 +963,7 @@ function createBaseSimpleWithMap_MapOfTimestampsEntry(): SimpleWithMap_MapOfTime
   return { key: "", value: undefined };
 }
 
-export const SimpleWithMap_MapOfTimestampsEntry = {
+export const SimpleWithMap_MapOfTimestampsEntry: MessageFns<SimpleWithMap_MapOfTimestampsEntry> = {
   encode(message: SimpleWithMap_MapOfTimestampsEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== "") {
       writer.uint32(10).string(message.key);
@@ -1009,7 +1009,7 @@ function createBaseSimpleWithMap_MapOfBytesEntry(): SimpleWithMap_MapOfBytesEntr
   return { key: "", value: new Uint8Array(0) };
 }
 
-export const SimpleWithMap_MapOfBytesEntry = {
+export const SimpleWithMap_MapOfBytesEntry: MessageFns<SimpleWithMap_MapOfBytesEntry> = {
   encode(message: SimpleWithMap_MapOfBytesEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== "") {
       writer.uint32(10).string(message.key);
@@ -1055,7 +1055,7 @@ function createBaseSimpleWithSnakeCaseMap(): SimpleWithSnakeCaseMap {
   return { entitiesById: {} };
 }
 
-export const SimpleWithSnakeCaseMap = {
+export const SimpleWithSnakeCaseMap: MessageFns<SimpleWithSnakeCaseMap> = {
   encode(message: SimpleWithSnakeCaseMap, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     Object.entries(message.entitiesById).forEach(([key, value]) => {
       SimpleWithSnakeCaseMap_EntitiesByIdEntry.encode({ key: key as any, value }, writer.uint32(10).fork()).join();
@@ -1094,7 +1094,7 @@ function createBaseSimpleWithSnakeCaseMap_EntitiesByIdEntry(): SimpleWithSnakeCa
   return { key: 0, value: undefined };
 }
 
-export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
+export const SimpleWithSnakeCaseMap_EntitiesByIdEntry: MessageFns<SimpleWithSnakeCaseMap_EntitiesByIdEntry> = {
   encode(message: SimpleWithSnakeCaseMap_EntitiesByIdEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== 0) {
       writer.uint32(8).int32(message.key);
@@ -1140,7 +1140,7 @@ function createBaseSimpleWithMapOfEnums(): SimpleWithMapOfEnums {
   return { enumsById: {} };
 }
 
-export const SimpleWithMapOfEnums = {
+export const SimpleWithMapOfEnums: MessageFns<SimpleWithMapOfEnums> = {
   encode(message: SimpleWithMapOfEnums, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     Object.entries(message.enumsById).forEach(([key, value]) => {
       SimpleWithMapOfEnums_EnumsByIdEntry.encode({ key: key as any, value }, writer.uint32(10).fork()).join();
@@ -1179,7 +1179,7 @@ function createBaseSimpleWithMapOfEnums_EnumsByIdEntry(): SimpleWithMapOfEnums_E
   return { key: 0, value: 0 };
 }
 
-export const SimpleWithMapOfEnums_EnumsByIdEntry = {
+export const SimpleWithMapOfEnums_EnumsByIdEntry: MessageFns<SimpleWithMapOfEnums_EnumsByIdEntry> = {
   encode(message: SimpleWithMapOfEnums_EnumsByIdEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== 0) {
       writer.uint32(8).int32(message.key);
@@ -1225,7 +1225,7 @@ function createBasePingRequest(): PingRequest {
   return { input: "" };
 }
 
-export const PingRequest = {
+export const PingRequest: MessageFns<PingRequest> = {
   encode(message: PingRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.input !== "") {
       writer.uint32(10).string(message.input);
@@ -1261,7 +1261,7 @@ function createBasePingResponse(): PingResponse {
   return { output: "" };
 }
 
-export const PingResponse = {
+export const PingResponse: MessageFns<PingResponse> = {
   encode(message: PingResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.output !== "") {
       writer.uint32(10).string(message.output);
@@ -1310,7 +1310,7 @@ function createBaseNumbers(): Numbers {
   };
 }
 
-export const Numbers = {
+export const Numbers: MessageFns<Numbers> = {
   encode(message: Numbers, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.double !== 0) {
       writer.uint32(9).double(message.double);
@@ -1464,7 +1464,7 @@ function createBaseSimpleButOptional(): SimpleButOptional {
   };
 }
 
-export const SimpleButOptional = {
+export const SimpleButOptional: MessageFns<SimpleButOptional> = {
   encode(message: SimpleButOptional, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
@@ -1560,7 +1560,7 @@ function createBaseEmpty(): Empty {
   return {};
 }
 
-export const Empty = {
+export const Empty: MessageFns<Empty> = {
   encode(_: Empty, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     return writer;
   },
@@ -2973,4 +2973,9 @@ function longToNumber(int64: { toString(): string }): number {
     throw new globalThis.Error("Value is smaller than Number.MIN_SAFE_INTEGER");
   }
   return num;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
 }

--- a/integration/nestjs-metadata-grpc-js/hero.ts
+++ b/integration/nestjs-metadata-grpc-js/hero.ts
@@ -34,7 +34,7 @@ function createBaseHeroById(): HeroById {
   return { id: 0 };
 }
 
-export const HeroById = {
+export const HeroById: MessageFns<HeroById> = {
   encode(message: HeroById, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.id !== 0) {
       writer.uint32(8).int32(message.id);
@@ -70,7 +70,7 @@ function createBaseVillainById(): VillainById {
   return { id: 0 };
 }
 
-export const VillainById = {
+export const VillainById: MessageFns<VillainById> = {
   encode(message: VillainById, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.id !== 0) {
       writer.uint32(8).int32(message.id);
@@ -106,7 +106,7 @@ function createBaseHero(): Hero {
   return { id: 0, name: "" };
 }
 
-export const Hero = {
+export const Hero: MessageFns<Hero> = {
   encode(message: Hero, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.id !== 0) {
       writer.uint32(8).int32(message.id);
@@ -152,7 +152,7 @@ function createBaseVillain(): Villain {
   return { id: 0, name: "" };
 }
 
-export const Villain = {
+export const Villain: MessageFns<Villain> = {
   encode(message: Villain, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.id !== 0) {
       writer.uint32(8).int32(message.id);
@@ -262,4 +262,9 @@ export interface HeroServiceServer extends UntypedServiceImplementation {
   findOneHero: handleUnaryCall<HeroById, Hero>;
   findOneVillain: handleUnaryCall<VillainById, Villain>;
   findManyVillain: handleBidiStreamingCall<VillainById, Villain>;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
 }

--- a/integration/nestjs-simple/google/protobuf/struct.ts
+++ b/integration/nestjs-simple/google/protobuf/struct.ts
@@ -87,7 +87,7 @@ function createBaseStruct(): Struct {
   return { fields: {} };
 }
 
-export const Struct = {
+export const Struct: MessageFns<Struct> & StructWrapperFns = {
   wrap(object: { [key: string]: any } | undefined): Struct {
     const struct = createBaseStruct();
 
@@ -114,7 +114,7 @@ function createBaseValue(): Value {
   return {};
 }
 
-export const Value = {
+export const Value: MessageFns<Value> & AnyValueWrapperFns = {
   wrap(value: any): Value {
     const result = {} as any;
     if (value === null) {
@@ -157,7 +157,7 @@ function createBaseListValue(): ListValue {
   return { values: [] };
 }
 
-export const ListValue = {
+export const ListValue: MessageFns<ListValue> & ListValueWrapperFns = {
   wrap(array: Array<any> | undefined): ListValue {
     const result = createBaseListValue();
     result.values = (array ?? []).map(Value.wrap);
@@ -193,3 +193,21 @@ const gt: any = (() => {
   }
   throw "Unable to locate global object";
 })();
+
+export interface MessageFns<T> {
+}
+
+export interface StructWrapperFns {
+  wrap(object: { [key: string]: any } | undefined): Struct;
+  unwrap(message: Struct): { [key: string]: any };
+}
+
+export interface AnyValueWrapperFns {
+  wrap(value: any): Value;
+  unwrap(message: any): string | number | boolean | Object | null | Array<any> | undefined;
+}
+
+export interface ListValueWrapperFns {
+  wrap(array: Array<any> | undefined): ListValue;
+  unwrap(message: ListValue): Array<any>;
+}

--- a/integration/nice-grpc/google/protobuf/empty.ts
+++ b/integration/nice-grpc/google/protobuf/empty.ts
@@ -24,7 +24,7 @@ function createBaseEmpty(): Empty {
   return {};
 }
 
-export const Empty = {
+export const Empty: MessageFns<Empty> = {
   encode(_: Empty, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     return writer;
   },
@@ -70,3 +70,12 @@ export type DeepPartial<T> = T extends Builtin ? T
   : T extends ReadonlyArray<infer U> ? ReadonlyArray<DeepPartial<U>>
   : T extends {} ? { [K in keyof T]?: DeepPartial<T[K]> }
   : Partial<T>;
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create(base?: DeepPartial<T>): T;
+  fromPartial(object: DeepPartial<T>): T;
+}

--- a/integration/nice-grpc/google/protobuf/struct.ts
+++ b/integration/nice-grpc/google/protobuf/struct.ts
@@ -107,7 +107,7 @@ function createBaseStruct(): Struct {
   return { fields: {} };
 }
 
-export const Struct = {
+export const Struct: MessageFns<Struct> & StructWrapperFns = {
   encode(message: Struct, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     Object.entries(message.fields).forEach(([key, value]) => {
       if (value !== undefined) {
@@ -211,7 +211,7 @@ function createBaseStruct_FieldsEntry(): Struct_FieldsEntry {
   return { key: "", value: undefined };
 }
 
-export const Struct_FieldsEntry = {
+export const Struct_FieldsEntry: MessageFns<Struct_FieldsEntry> = {
   encode(message: Struct_FieldsEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== "") {
       writer.uint32(10).string(message.key);
@@ -292,7 +292,7 @@ function createBaseValue(): Value {
   };
 }
 
-export const Value = {
+export const Value: MessageFns<Value> & AnyValueWrapperFns = {
   encode(message: Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.nullValue !== undefined) {
       writer.uint32(8).int32(message.nullValue);
@@ -463,7 +463,7 @@ function createBaseListValue(): ListValue {
   return { values: [] };
 }
 
-export const ListValue = {
+export const ListValue: MessageFns<ListValue> & ListValueWrapperFns = {
   encode(message: ListValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     for (const v of message.values) {
       Value.encode(Value.wrap(v!), writer.uint32(10).fork()).join();
@@ -544,4 +544,28 @@ function isObject(value: any): boolean {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create(base?: DeepPartial<T>): T;
+  fromPartial(object: DeepPartial<T>): T;
+}
+
+export interface StructWrapperFns {
+  wrap(object: { [key: string]: any } | undefined): Struct;
+  unwrap(message: Struct): { [key: string]: any };
+}
+
+export interface AnyValueWrapperFns {
+  wrap(value: any): Value;
+  unwrap(message: any): string | number | boolean | Object | null | Array<any> | undefined;
+}
+
+export interface ListValueWrapperFns {
+  wrap(array: Array<any> | undefined): ListValue;
+  unwrap(message: ListValue): Array<any>;
 }

--- a/integration/nice-grpc/google/protobuf/timestamp.ts
+++ b/integration/nice-grpc/google/protobuf/timestamp.ts
@@ -117,7 +117,7 @@ function createBaseTimestamp(): Timestamp {
   return { seconds: 0, nanos: 0 };
 }
 
-export const Timestamp = {
+export const Timestamp: MessageFns<Timestamp> = {
   encode(message: Timestamp, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.seconds !== 0) {
       writer.uint32(8).int64(message.seconds);
@@ -208,4 +208,13 @@ function longToNumber(int64: { toString(): string }): number {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create(base?: DeepPartial<T>): T;
+  fromPartial(object: DeepPartial<T>): T;
 }

--- a/integration/nice-grpc/google/protobuf/wrappers.ts
+++ b/integration/nice-grpc/google/protobuf/wrappers.ts
@@ -100,7 +100,7 @@ function createBaseDoubleValue(): DoubleValue {
   return { value: 0 };
 }
 
-export const DoubleValue = {
+export const DoubleValue: MessageFns<DoubleValue> = {
   encode(message: DoubleValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(9).double(message.value);
@@ -157,7 +157,7 @@ function createBaseFloatValue(): FloatValue {
   return { value: 0 };
 }
 
-export const FloatValue = {
+export const FloatValue: MessageFns<FloatValue> = {
   encode(message: FloatValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(13).float(message.value);
@@ -214,7 +214,7 @@ function createBaseInt64Value(): Int64Value {
   return { value: 0 };
 }
 
-export const Int64Value = {
+export const Int64Value: MessageFns<Int64Value> = {
   encode(message: Int64Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).int64(message.value);
@@ -271,7 +271,7 @@ function createBaseUInt64Value(): UInt64Value {
   return { value: 0 };
 }
 
-export const UInt64Value = {
+export const UInt64Value: MessageFns<UInt64Value> = {
   encode(message: UInt64Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).uint64(message.value);
@@ -328,7 +328,7 @@ function createBaseInt32Value(): Int32Value {
   return { value: 0 };
 }
 
-export const Int32Value = {
+export const Int32Value: MessageFns<Int32Value> = {
   encode(message: Int32Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).int32(message.value);
@@ -385,7 +385,7 @@ function createBaseUInt32Value(): UInt32Value {
   return { value: 0 };
 }
 
-export const UInt32Value = {
+export const UInt32Value: MessageFns<UInt32Value> = {
   encode(message: UInt32Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).uint32(message.value);
@@ -442,7 +442,7 @@ function createBaseBoolValue(): BoolValue {
   return { value: false };
 }
 
-export const BoolValue = {
+export const BoolValue: MessageFns<BoolValue> = {
   encode(message: BoolValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== false) {
       writer.uint32(8).bool(message.value);
@@ -499,7 +499,7 @@ function createBaseStringValue(): StringValue {
   return { value: "" };
 }
 
-export const StringValue = {
+export const StringValue: MessageFns<StringValue> = {
   encode(message: StringValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== "") {
       writer.uint32(10).string(message.value);
@@ -556,7 +556,7 @@ function createBaseBytesValue(): BytesValue {
   return { value: new Uint8Array(0) };
 }
 
-export const BytesValue = {
+export const BytesValue: MessageFns<BytesValue> = {
   encode(message: BytesValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value.length !== 0) {
       writer.uint32(10).bytes(message.value);
@@ -655,4 +655,13 @@ function longToNumber(int64: { toString(): string }): number {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create(base?: DeepPartial<T>): T;
+  fromPartial(object: DeepPartial<T>): T;
 }

--- a/integration/nice-grpc/simple.ts
+++ b/integration/nice-grpc/simple.ts
@@ -29,7 +29,7 @@ function createBaseTestMessage(): TestMessage {
   return { timestamp: undefined };
 }
 
-export const TestMessage = {
+export const TestMessage: MessageFns<TestMessage> = {
   encode(message: TestMessage, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.timestamp !== undefined) {
       Timestamp.encode(toTimestamp(message.timestamp), writer.uint32(10).fork()).join();
@@ -409,3 +409,12 @@ function isSet(value: any): boolean {
 }
 
 export type ServerStreamingMethodResult<Response> = { [Symbol.asyncIterator](): AsyncIterator<Response, void> };
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create(base?: DeepPartial<T>): T;
+  fromPartial(object: DeepPartial<T>): T;
+}

--- a/integration/no-comments/simple.ts
+++ b/integration/no-comments/simple.ts
@@ -22,7 +22,7 @@ function createBaseSimple(): Simple {
   return { name: "", age: 0, child: undefined, testField: "", testNotDeprecated: "" };
 }
 
-export const Simple = {
+export const Simple: MessageFns<Simple> = {
   encode(message: Simple, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -141,7 +141,7 @@ function createBaseChild(): Child {
   return { name: "" };
 }
 
-export const Child = {
+export const Child: MessageFns<Child> = {
   encode(message: Child, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -208,4 +208,13 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/no-defaults-for-optionals-with-nulls/proto-2.ts
+++ b/integration/no-defaults-for-optionals-with-nulls/proto-2.ts
@@ -22,7 +22,7 @@ function createBaseProto2TestMessage(): Proto2TestMessage {
   return { boolValue: null, intValue: null, stringValue: null, mapValue: {} };
 }
 
-export const Proto2TestMessage = {
+export const Proto2TestMessage: MessageFns<Proto2TestMessage> = {
   encode(message: Proto2TestMessage, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.boolValue !== undefined && message.boolValue !== null) {
       writer.uint32(8).bool(message.boolValue);
@@ -145,7 +145,7 @@ function createBaseProto2TestMessage_MapValueEntry(): Proto2TestMessage_MapValue
   return { key: null, value: null };
 }
 
-export const Proto2TestMessage_MapValueEntry = {
+export const Proto2TestMessage_MapValueEntry: MessageFns<Proto2TestMessage_MapValueEntry> = {
   encode(message: Proto2TestMessage_MapValueEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== undefined && message.key !== null) {
       writer.uint32(10).string(message.key);
@@ -235,4 +235,13 @@ function isObject(value: any): boolean {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/no-defaults-for-optionals-with-nulls/proto-3.ts
+++ b/integration/no-defaults-for-optionals-with-nulls/proto-3.ts
@@ -33,7 +33,7 @@ function createBaseProto3TestMessage(): Proto3TestMessage {
   };
 }
 
-export const Proto3TestMessage = {
+export const Proto3TestMessage: MessageFns<Proto3TestMessage> = {
   encode(message: Proto3TestMessage, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.boolValue !== undefined && message.boolValue !== null) {
       writer.uint32(8).bool(message.boolValue);
@@ -201,7 +201,7 @@ function createBaseProto3TestMessage_MapValueEntry(): Proto3TestMessage_MapValue
   return { key: null, value: null };
 }
 
-export const Proto3TestMessage_MapValueEntry = {
+export const Proto3TestMessage_MapValueEntry: MessageFns<Proto3TestMessage_MapValueEntry> = {
   encode(message: Proto3TestMessage_MapValueEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== undefined && message.key !== null) {
       writer.uint32(10).string(message.key);
@@ -291,4 +291,13 @@ function isObject(value: any): boolean {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/no-defaults-for-optionals/proto-2.ts
+++ b/integration/no-defaults-for-optionals/proto-2.ts
@@ -22,7 +22,7 @@ function createBaseProto2TestMessage(): Proto2TestMessage {
   return { boolValue: undefined, intValue: undefined, stringValue: undefined, mapValue: {} };
 }
 
-export const Proto2TestMessage = {
+export const Proto2TestMessage: MessageFns<Proto2TestMessage> = {
   encode(message: Proto2TestMessage, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.boolValue !== undefined) {
       writer.uint32(8).bool(message.boolValue);
@@ -145,7 +145,7 @@ function createBaseProto2TestMessage_MapValueEntry(): Proto2TestMessage_MapValue
   return { key: undefined, value: undefined };
 }
 
-export const Proto2TestMessage_MapValueEntry = {
+export const Proto2TestMessage_MapValueEntry: MessageFns<Proto2TestMessage_MapValueEntry> = {
   encode(message: Proto2TestMessage_MapValueEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== undefined) {
       writer.uint32(10).string(message.key);
@@ -235,4 +235,13 @@ function isObject(value: any): boolean {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/no-defaults-for-optionals/proto-3.ts
+++ b/integration/no-defaults-for-optionals/proto-3.ts
@@ -33,7 +33,7 @@ function createBaseProto3TestMessage(): Proto3TestMessage {
   };
 }
 
-export const Proto3TestMessage = {
+export const Proto3TestMessage: MessageFns<Proto3TestMessage> = {
   encode(message: Proto3TestMessage, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.boolValue !== undefined) {
       writer.uint32(8).bool(message.boolValue);
@@ -203,7 +203,7 @@ function createBaseProto3TestMessage_MapValueEntry(): Proto3TestMessage_MapValue
   return { key: undefined, value: undefined };
 }
 
-export const Proto3TestMessage_MapValueEntry = {
+export const Proto3TestMessage_MapValueEntry: MessageFns<Proto3TestMessage_MapValueEntry> = {
   encode(message: Proto3TestMessage_MapValueEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== undefined) {
       writer.uint32(10).string(message.key);
@@ -293,4 +293,13 @@ function isObject(value: any): boolean {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/no-proto-package/no-proto-package.ts
+++ b/integration/no-proto-package/no-proto-package.ts
@@ -19,7 +19,7 @@ function createBaseUser(): User {
   return { name: "" };
 }
 
-export const User = {
+export const User: MessageFns<User> = {
   encode(message: User, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -76,7 +76,7 @@ function createBaseEmpty(): Empty {
   return {};
 }
 
-export const Empty = {
+export const Empty: MessageFns<Empty> = {
   encode(_: Empty, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     return writer;
   },
@@ -156,4 +156,13 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/omit-optionals/simple.ts
+++ b/integration/omit-optionals/simple.ts
@@ -15,7 +15,7 @@ function createBaseTestMessage(): TestMessage {
   return { field1: false };
 }
 
-export const TestMessage = {
+export const TestMessage: MessageFns<TestMessage> = {
   encode(message: TestMessage, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.field1 !== false) {
       writer.uint32(8).bool(message.field1);
@@ -99,4 +99,13 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/oneof-properties/oneof.ts
+++ b/integration/oneof-properties/oneof.ts
@@ -95,7 +95,7 @@ function createBasePleaseChoose(): PleaseChoose {
   };
 }
 
-export const PleaseChoose = {
+export const PleaseChoose: MessageFns<PleaseChoose> = {
   encode(message: PleaseChoose, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -306,7 +306,7 @@ function createBasePleaseChoose_Submessage(): PleaseChoose_Submessage {
   return { name: "" };
 }
 
-export const PleaseChoose_Submessage = {
+export const PleaseChoose_Submessage: MessageFns<PleaseChoose_Submessage> = {
   encode(message: PleaseChoose_Submessage, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -398,4 +398,13 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/oneof-unions-snake/google/protobuf/struct.ts
+++ b/integration/oneof-unions-snake/google/protobuf/struct.ts
@@ -93,7 +93,7 @@ function createBaseStruct(): Struct {
   return { fields: {} };
 }
 
-export const Struct = {
+export const Struct: MessageFns<Struct> & StructWrapperFns = {
   encode(message: Struct, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     Object.entries(message.fields).forEach(([key, value]) => {
       if (value !== undefined) {
@@ -197,7 +197,7 @@ function createBaseStruct_FieldsEntry(): Struct_FieldsEntry {
   return { key: "", value: undefined };
 }
 
-export const Struct_FieldsEntry = {
+export const Struct_FieldsEntry: MessageFns<Struct_FieldsEntry> = {
   encode(message: Struct_FieldsEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== "") {
       writer.uint32(10).string(message.key);
@@ -271,7 +271,7 @@ function createBaseValue(): Value {
   return { kind: undefined };
 }
 
-export const Value = {
+export const Value: MessageFns<Value> & AnyValueWrapperFns = {
   encode(message: Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     switch (message.kind?.$case) {
       case "null_value":
@@ -485,7 +485,7 @@ function createBaseListValue(): ListValue {
   return { values: [] };
 }
 
-export const ListValue = {
+export const ListValue: MessageFns<ListValue> & ListValueWrapperFns = {
   encode(message: ListValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     for (const v of message.values) {
       Value.encode(Value.wrap(v!), writer.uint32(10).fork()).join();
@@ -571,4 +571,28 @@ function isObject(value: any): boolean {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
+}
+
+export interface StructWrapperFns {
+  wrap(object: { [key: string]: any } | undefined): Struct;
+  unwrap(message: Struct): { [key: string]: any };
+}
+
+export interface AnyValueWrapperFns {
+  wrap(value: any): Value;
+  unwrap(message: any): string | number | boolean | Object | null | Array<any> | undefined;
+}
+
+export interface ListValueWrapperFns {
+  wrap(array: Array<any> | undefined): ListValue;
+  unwrap(message: ListValue): Array<any>;
 }

--- a/integration/oneof-unions-snake/simple.ts
+++ b/integration/oneof-unions-snake/simple.ts
@@ -20,7 +20,7 @@ function createBaseSimpleStruct(): SimpleStruct {
   return { simple_struct: undefined };
 }
 
-export const SimpleStruct = {
+export const SimpleStruct: MessageFns<SimpleStruct> = {
   encode(message: SimpleStruct, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.simple_struct !== undefined) {
       Struct.encode(Struct.wrap(message.simple_struct), writer.uint32(10).fork()).join();
@@ -88,4 +88,13 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isObject(value: any): boolean {
   return typeof value === "object" && value !== null;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/oneof-unions-value/google/protobuf/struct.ts
+++ b/integration/oneof-unions-value/google/protobuf/struct.ts
@@ -93,7 +93,7 @@ function createBaseStruct(): Struct {
   return { fields: {} };
 }
 
-export const Struct = {
+export const Struct: MessageFns<Struct> & StructWrapperFns = {
   encode(message: Struct, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     Object.entries(message.fields).forEach(([key, value]) => {
       if (value !== undefined) {
@@ -197,7 +197,7 @@ function createBaseStruct_FieldsEntry(): Struct_FieldsEntry {
   return { key: "", value: undefined };
 }
 
-export const Struct_FieldsEntry = {
+export const Struct_FieldsEntry: MessageFns<Struct_FieldsEntry> = {
   encode(message: Struct_FieldsEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== "") {
       writer.uint32(10).string(message.key);
@@ -271,7 +271,7 @@ function createBaseValue(): Value {
   return { kind: undefined };
 }
 
-export const Value = {
+export const Value: MessageFns<Value> & AnyValueWrapperFns = {
   encode(message: Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     switch (message.kind?.$case) {
       case "nullValue":
@@ -450,7 +450,7 @@ function createBaseListValue(): ListValue {
   return { values: [] };
 }
 
-export const ListValue = {
+export const ListValue: MessageFns<ListValue> & ListValueWrapperFns = {
   encode(message: ListValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     for (const v of message.values) {
       Value.encode(Value.wrap(v!), writer.uint32(10).fork()).join();
@@ -536,4 +536,28 @@ function isObject(value: any): boolean {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
+}
+
+export interface StructWrapperFns {
+  wrap(object: { [key: string]: any } | undefined): Struct;
+  unwrap(message: Struct): { [key: string]: any };
+}
+
+export interface AnyValueWrapperFns {
+  wrap(value: any): Value;
+  unwrap(message: any): string | number | boolean | Object | null | Array<any> | undefined;
+}
+
+export interface ListValueWrapperFns {
+  wrap(array: Array<any> | undefined): ListValue;
+  unwrap(message: ListValue): Array<any>;
 }

--- a/integration/oneof-unions-value/oneof.ts
+++ b/integration/oneof-unions-value/oneof.ts
@@ -79,7 +79,7 @@ function createBasePleaseChoose(): PleaseChoose {
   return { name: "", choice: undefined, age: 0, eitherOr: undefined, signature: new Uint8Array(0), value: undefined };
 }
 
-export const PleaseChoose = {
+export const PleaseChoose: MessageFns<PleaseChoose> = {
   encode(message: PleaseChoose, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -357,7 +357,7 @@ function createBasePleaseChoose_Submessage(): PleaseChoose_Submessage {
   return { name: "" };
 }
 
-export const PleaseChoose_Submessage = {
+export const PleaseChoose_Submessage: MessageFns<PleaseChoose_Submessage> = {
   encode(message: PleaseChoose_Submessage, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -414,7 +414,7 @@ function createBaseSimpleButOptional(): SimpleButOptional {
   return { name: undefined, age: undefined };
 }
 
-export const SimpleButOptional = {
+export const SimpleButOptional: MessageFns<SimpleButOptional> = {
   encode(message: SimpleButOptional, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
@@ -524,4 +524,13 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/oneof-unions/google/protobuf/struct.ts
+++ b/integration/oneof-unions/google/protobuf/struct.ts
@@ -93,7 +93,7 @@ function createBaseStruct(): Struct {
   return { fields: {} };
 }
 
-export const Struct = {
+export const Struct: MessageFns<Struct> & StructWrapperFns = {
   encode(message: Struct, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     Object.entries(message.fields).forEach(([key, value]) => {
       if (value !== undefined) {
@@ -197,7 +197,7 @@ function createBaseStruct_FieldsEntry(): Struct_FieldsEntry {
   return { key: "", value: undefined };
 }
 
-export const Struct_FieldsEntry = {
+export const Struct_FieldsEntry: MessageFns<Struct_FieldsEntry> = {
   encode(message: Struct_FieldsEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== "") {
       writer.uint32(10).string(message.key);
@@ -271,7 +271,7 @@ function createBaseValue(): Value {
   return { kind: undefined };
 }
 
-export const Value = {
+export const Value: MessageFns<Value> & AnyValueWrapperFns = {
   encode(message: Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     switch (message.kind?.$case) {
       case "nullValue":
@@ -476,7 +476,7 @@ function createBaseListValue(): ListValue {
   return { values: [] };
 }
 
-export const ListValue = {
+export const ListValue: MessageFns<ListValue> & ListValueWrapperFns = {
   encode(message: ListValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     for (const v of message.values) {
       Value.encode(Value.wrap(v!), writer.uint32(10).fork()).join();
@@ -562,4 +562,28 @@ function isObject(value: any): boolean {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
+}
+
+export interface StructWrapperFns {
+  wrap(object: { [key: string]: any } | undefined): Struct;
+  unwrap(message: Struct): { [key: string]: any };
+}
+
+export interface AnyValueWrapperFns {
+  wrap(value: any): Value;
+  unwrap(message: any): string | number | boolean | Object | null | Array<any> | undefined;
+}
+
+export interface ListValueWrapperFns {
+  wrap(array: Array<any> | undefined): ListValue;
+  unwrap(message: ListValue): Array<any>;
 }

--- a/integration/oneof-unions/oneof.ts
+++ b/integration/oneof-unions/oneof.ts
@@ -79,7 +79,7 @@ function createBasePleaseChoose(): PleaseChoose {
   return { name: "", choice: undefined, age: 0, eitherOr: undefined, signature: new Uint8Array(0), value: undefined };
 }
 
-export const PleaseChoose = {
+export const PleaseChoose: MessageFns<PleaseChoose> = {
   encode(message: PleaseChoose, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -363,7 +363,7 @@ function createBasePleaseChoose_Submessage(): PleaseChoose_Submessage {
   return { name: "" };
 }
 
-export const PleaseChoose_Submessage = {
+export const PleaseChoose_Submessage: MessageFns<PleaseChoose_Submessage> = {
   encode(message: PleaseChoose_Submessage, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -420,7 +420,7 @@ function createBaseSimpleButOptional(): SimpleButOptional {
   return { name: undefined, age: undefined };
 }
 
-export const SimpleButOptional = {
+export const SimpleButOptional: MessageFns<SimpleButOptional> = {
   encode(message: SimpleButOptional, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
@@ -530,4 +530,13 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/optional-long/google/protobuf/timestamp.ts
+++ b/integration/optional-long/google/protobuf/timestamp.ts
@@ -120,7 +120,7 @@ function createBaseTimestamp(): Timestamp {
   return { seconds: Long.ZERO, nanos: 0 };
 }
 
-export const Timestamp = {
+export const Timestamp: MessageFns<Timestamp> = {
   encode(message: Timestamp, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.seconds !== undefined && !message.seconds.equals(Long.ZERO)) {
       writer.uint32(8).int64(message.seconds.toString());
@@ -206,4 +206,13 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/optional-long/test.ts
+++ b/integration/optional-long/test.ts
@@ -16,7 +16,7 @@ function createBaseExample(): Example {
   return { datetime: undefined };
 }
 
-export const Example = {
+export const Example: MessageFns<Example> = {
   encode(message: Example, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.datetime !== undefined) {
       Timestamp.encode(toTimestamp(message.datetime), writer.uint32(10).fork()).join();
@@ -109,4 +109,13 @@ function numberToLong(number: number) {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/optional-type-definitions/simple.ts
+++ b/integration/optional-type-definitions/simple.ts
@@ -48,7 +48,7 @@ function createBaseSimple(): Simple {
   return { $type: "simple.Simple", name: "", age: 0, child: undefined, testField: "", testNotDeprecated: "" };
 }
 
-export const Simple = {
+export const Simple: MessageFns<Simple, "simple.Simple"> = {
   $type: "simple.Simple" as const,
 
   encode(message: Simple, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
@@ -170,7 +170,7 @@ function createBaseChild(): Child {
   return { $type: "simple.Child", name: "" };
 }
 
-export const Child = {
+export const Child: MessageFns<Child, "simple.Child"> = {
   $type: "simple.Child" as const,
 
   encode(message: Child, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
@@ -239,4 +239,14 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T, V extends string> {
+  readonly $type: V;
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/options/google/protobuf/descriptor.ts
+++ b/integration/options/google/protobuf/descriptor.ts
@@ -959,7 +959,7 @@ function createBaseFileDescriptorSet(): FileDescriptorSet {
   return { file: [] };
 }
 
-export const FileDescriptorSet = {
+export const FileDescriptorSet: MessageFns<FileDescriptorSet> = {
   encode(message: FileDescriptorSet, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     for (const v of message.file) {
       FileDescriptorProto.encode(v!, writer.uint32(10).fork()).join();
@@ -1008,7 +1008,7 @@ function createBaseFileDescriptorProto(): FileDescriptorProto {
   };
 }
 
-export const FileDescriptorProto = {
+export const FileDescriptorProto: MessageFns<FileDescriptorProto> = {
   encode(message: FileDescriptorProto, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== undefined && message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -1189,7 +1189,7 @@ function createBaseDescriptorProto(): DescriptorProto {
   };
 }
 
-export const DescriptorProto = {
+export const DescriptorProto: MessageFns<DescriptorProto> = {
   encode(message: DescriptorProto, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== undefined && message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -1315,7 +1315,7 @@ function createBaseDescriptorProto_ExtensionRange(): DescriptorProto_ExtensionRa
   return { start: 0, end: 0, options: undefined };
 }
 
-export const DescriptorProto_ExtensionRange = {
+export const DescriptorProto_ExtensionRange: MessageFns<DescriptorProto_ExtensionRange> = {
   encode(message: DescriptorProto_ExtensionRange, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.start !== undefined && message.start !== 0) {
       writer.uint32(8).int32(message.start);
@@ -1371,7 +1371,7 @@ function createBaseDescriptorProto_ReservedRange(): DescriptorProto_ReservedRang
   return { start: 0, end: 0 };
 }
 
-export const DescriptorProto_ReservedRange = {
+export const DescriptorProto_ReservedRange: MessageFns<DescriptorProto_ReservedRange> = {
   encode(message: DescriptorProto_ReservedRange, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.start !== undefined && message.start !== 0) {
       writer.uint32(8).int32(message.start);
@@ -1417,7 +1417,7 @@ function createBaseExtensionRangeOptions(): ExtensionRangeOptions {
   return { uninterpretedOption: [] };
 }
 
-export const ExtensionRangeOptions = {
+export const ExtensionRangeOptions: MessageFns<ExtensionRangeOptions> = {
   encode(message: ExtensionRangeOptions, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     for (const v of message.uninterpretedOption) {
       UninterpretedOption.encode(v!, writer.uint32(7994).fork()).join();
@@ -1465,7 +1465,7 @@ function createBaseFieldDescriptorProto(): FieldDescriptorProto {
   };
 }
 
-export const FieldDescriptorProto = {
+export const FieldDescriptorProto: MessageFns<FieldDescriptorProto> = {
   encode(message: FieldDescriptorProto, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== undefined && message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -1601,7 +1601,7 @@ function createBaseOneofDescriptorProto(): OneofDescriptorProto {
   return { name: "", options: undefined };
 }
 
-export const OneofDescriptorProto = {
+export const OneofDescriptorProto: MessageFns<OneofDescriptorProto> = {
   encode(message: OneofDescriptorProto, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== undefined && message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -1647,7 +1647,7 @@ function createBaseEnumDescriptorProto(): EnumDescriptorProto {
   return { name: "", value: [], options: undefined, reservedRange: [], reservedName: [] };
 }
 
-export const EnumDescriptorProto = {
+export const EnumDescriptorProto: MessageFns<EnumDescriptorProto> = {
   encode(message: EnumDescriptorProto, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== undefined && message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -1723,7 +1723,7 @@ function createBaseEnumDescriptorProto_EnumReservedRange(): EnumDescriptorProto_
   return { start: 0, end: 0 };
 }
 
-export const EnumDescriptorProto_EnumReservedRange = {
+export const EnumDescriptorProto_EnumReservedRange: MessageFns<EnumDescriptorProto_EnumReservedRange> = {
   encode(message: EnumDescriptorProto_EnumReservedRange, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.start !== undefined && message.start !== 0) {
       writer.uint32(8).int32(message.start);
@@ -1769,7 +1769,7 @@ function createBaseEnumValueDescriptorProto(): EnumValueDescriptorProto {
   return { name: "", number: 0, options: undefined };
 }
 
-export const EnumValueDescriptorProto = {
+export const EnumValueDescriptorProto: MessageFns<EnumValueDescriptorProto> = {
   encode(message: EnumValueDescriptorProto, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== undefined && message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -1825,7 +1825,7 @@ function createBaseServiceDescriptorProto(): ServiceDescriptorProto {
   return { name: "", method: [], options: undefined };
 }
 
-export const ServiceDescriptorProto = {
+export const ServiceDescriptorProto: MessageFns<ServiceDescriptorProto> = {
   encode(message: ServiceDescriptorProto, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== undefined && message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -1888,7 +1888,7 @@ function createBaseMethodDescriptorProto(): MethodDescriptorProto {
   };
 }
 
-export const MethodDescriptorProto = {
+export const MethodDescriptorProto: MessageFns<MethodDescriptorProto> = {
   encode(message: MethodDescriptorProto, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== undefined && message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -1996,7 +1996,7 @@ function createBaseFileOptions(): FileOptions {
   };
 }
 
-export const FileOptions = {
+export const FileOptions: MessageFns<FileOptions> = {
   encode(message: FileOptions, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.javaPackage !== undefined && message.javaPackage !== "") {
       writer.uint32(10).string(message.javaPackage);
@@ -2238,7 +2238,7 @@ function createBaseMessageOptions(): MessageOptions {
   };
 }
 
-export const MessageOptions = {
+export const MessageOptions: MessageFns<MessageOptions> = {
   encode(message: MessageOptions, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.messageSetWireFormat !== undefined && message.messageSetWireFormat !== false) {
       writer.uint32(8).bool(message.messageSetWireFormat);
@@ -2314,7 +2314,7 @@ function createBaseFieldOptions(): FieldOptions {
   return { ctype: 0, packed: false, jstype: 0, lazy: false, deprecated: false, weak: false, uninterpretedOption: [] };
 }
 
-export const FieldOptions = {
+export const FieldOptions: MessageFns<FieldOptions> = {
   encode(message: FieldOptions, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.ctype !== undefined && message.ctype !== 0) {
       writer.uint32(8).int32(message.ctype);
@@ -2410,7 +2410,7 @@ function createBaseOneofOptions(): OneofOptions {
   return { uninterpretedOption: [] };
 }
 
-export const OneofOptions = {
+export const OneofOptions: MessageFns<OneofOptions> = {
   encode(message: OneofOptions, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     for (const v of message.uninterpretedOption) {
       UninterpretedOption.encode(v!, writer.uint32(7994).fork()).join();
@@ -2446,7 +2446,7 @@ function createBaseEnumOptions(): EnumOptions {
   return { allowAlias: false, deprecated: false, uninterpretedOption: [] };
 }
 
-export const EnumOptions = {
+export const EnumOptions: MessageFns<EnumOptions> = {
   encode(message: EnumOptions, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.allowAlias !== undefined && message.allowAlias !== false) {
       writer.uint32(16).bool(message.allowAlias);
@@ -2502,7 +2502,7 @@ function createBaseEnumValueOptions(): EnumValueOptions {
   return { deprecated: false, uninterpretedOption: [] };
 }
 
-export const EnumValueOptions = {
+export const EnumValueOptions: MessageFns<EnumValueOptions> = {
   encode(message: EnumValueOptions, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.deprecated !== undefined && message.deprecated !== false) {
       writer.uint32(8).bool(message.deprecated);
@@ -2548,7 +2548,7 @@ function createBaseServiceOptions(): ServiceOptions {
   return { deprecated: false, uninterpretedOption: [] };
 }
 
-export const ServiceOptions = {
+export const ServiceOptions: MessageFns<ServiceOptions> = {
   encode(message: ServiceOptions, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.deprecated !== undefined && message.deprecated !== false) {
       writer.uint32(264).bool(message.deprecated);
@@ -2594,7 +2594,7 @@ function createBaseMethodOptions(): MethodOptions {
   return { deprecated: false, idempotencyLevel: 0, uninterpretedOption: [] };
 }
 
-export const MethodOptions = {
+export const MethodOptions: MessageFns<MethodOptions> = {
   encode(message: MethodOptions, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.deprecated !== undefined && message.deprecated !== false) {
       writer.uint32(264).bool(message.deprecated);
@@ -2658,7 +2658,7 @@ function createBaseUninterpretedOption(): UninterpretedOption {
   };
 }
 
-export const UninterpretedOption = {
+export const UninterpretedOption: MessageFns<UninterpretedOption> = {
   encode(message: UninterpretedOption, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     for (const v of message.name) {
       UninterpretedOption_NamePart.encode(v!, writer.uint32(18).fork()).join();
@@ -2754,7 +2754,7 @@ function createBaseUninterpretedOption_NamePart(): UninterpretedOption_NamePart 
   return { namePart: "", isExtension: false };
 }
 
-export const UninterpretedOption_NamePart = {
+export const UninterpretedOption_NamePart: MessageFns<UninterpretedOption_NamePart> = {
   encode(message: UninterpretedOption_NamePart, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.namePart !== "") {
       writer.uint32(10).string(message.namePart);
@@ -2800,7 +2800,7 @@ function createBaseSourceCodeInfo(): SourceCodeInfo {
   return { location: [] };
 }
 
-export const SourceCodeInfo = {
+export const SourceCodeInfo: MessageFns<SourceCodeInfo> = {
   encode(message: SourceCodeInfo, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     for (const v of message.location) {
       SourceCodeInfo_Location.encode(v!, writer.uint32(10).fork()).join();
@@ -2836,7 +2836,7 @@ function createBaseSourceCodeInfo_Location(): SourceCodeInfo_Location {
   return { path: [], span: [], leadingComments: "", trailingComments: "", leadingDetachedComments: [] };
 }
 
-export const SourceCodeInfo_Location = {
+export const SourceCodeInfo_Location: MessageFns<SourceCodeInfo_Location> = {
   encode(message: SourceCodeInfo_Location, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     writer.uint32(10).fork();
     for (const v of message.path) {
@@ -2936,7 +2936,7 @@ function createBaseGeneratedCodeInfo(): GeneratedCodeInfo {
   return { annotation: [] };
 }
 
-export const GeneratedCodeInfo = {
+export const GeneratedCodeInfo: MessageFns<GeneratedCodeInfo> = {
   encode(message: GeneratedCodeInfo, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     for (const v of message.annotation) {
       GeneratedCodeInfo_Annotation.encode(v!, writer.uint32(10).fork()).join();
@@ -2972,7 +2972,7 @@ function createBaseGeneratedCodeInfo_Annotation(): GeneratedCodeInfo_Annotation 
   return { path: [], sourceFile: "", begin: 0, end: 0 };
 }
 
-export const GeneratedCodeInfo_Annotation = {
+export const GeneratedCodeInfo_Annotation: MessageFns<GeneratedCodeInfo_Annotation> = {
   encode(message: GeneratedCodeInfo_Annotation, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     writer.uint32(10).fork();
     for (const v of message.path) {
@@ -5885,4 +5885,9 @@ function longToNumber(int64: { toString(): string }): number {
     throw new globalThis.Error("Value is smaller than Number.MIN_SAFE_INTEGER");
   }
   return num;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
 }

--- a/integration/options/options.ts
+++ b/integration/options/options.ts
@@ -32,7 +32,7 @@ function createBaseMyMessage(): MyMessage {
   return { foo: undefined, foo2: undefined, bar: undefined, quux: undefined };
 }
 
-export const MyMessage = {
+export const MyMessage: MessageFns<MyMessage> = {
   encode(message: MyMessage, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.foo !== undefined) {
       writer.uint32(8).int32(message.foo);
@@ -98,7 +98,7 @@ function createBaseRequestType(): RequestType {
   return {};
 }
 
-export const RequestType = {
+export const RequestType: MessageFns<RequestType> = {
   encode(_: RequestType, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     return writer;
   },
@@ -124,7 +124,7 @@ function createBaseResponseType(): ResponseType {
   return {};
 }
 
-export const ResponseType = {
+export const ResponseType: MessageFns<ResponseType> = {
   encode(_: ResponseType, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     return writer;
   },
@@ -486,3 +486,8 @@ export const protoMetadata: ProtoMetadata = {
     enums: { "MyEnum": { options: { "my_enum_option": true }, values: { "FOO": { "my_enum_value_option": 321 } } } },
   },
 };
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+}

--- a/integration/options/something/something.ts
+++ b/integration/options/something/something.ts
@@ -17,7 +17,7 @@ function createBaseSomething(): Something {
   return { hello: "", foo: [] };
 }
 
-export const Something = {
+export const Something: MessageFns<Something> = {
   encode(message: Something, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.hello !== "") {
       writer.uint32(10).string(message.hello);
@@ -157,3 +157,8 @@ export const protoMetadata: ProtoMetadata = {
   references: { ".something.Something": Something },
   dependencies: [protoMetadata1],
 };
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+}

--- a/integration/output-decode-only/encode.ts
+++ b/integration/output-decode-only/encode.ts
@@ -14,7 +14,7 @@ function createBaseEncode(): Encode {
   return { encode: "" };
 }
 
-export const Encode = {
+export const Encode: MessageFns<Encode> = {
   decode(input: BinaryReader | Uint8Array, length?: number): Encode {
     const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
@@ -38,3 +38,7 @@ export const Encode = {
     return message;
   },
 };
+
+export interface MessageFns<T> {
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+}

--- a/integration/output-decode-only/google/protobuf/wrappers.ts
+++ b/integration/output-decode-only/google/protobuf/wrappers.ts
@@ -100,7 +100,7 @@ function createBaseDoubleValue(): DoubleValue {
   return { value: 0 };
 }
 
-export const DoubleValue = {
+export const DoubleValue: MessageFns<DoubleValue> = {
   decode(input: BinaryReader | Uint8Array, length?: number): DoubleValue {
     const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
@@ -129,7 +129,7 @@ function createBaseFloatValue(): FloatValue {
   return { value: 0 };
 }
 
-export const FloatValue = {
+export const FloatValue: MessageFns<FloatValue> = {
   decode(input: BinaryReader | Uint8Array, length?: number): FloatValue {
     const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
@@ -158,7 +158,7 @@ function createBaseInt64Value(): Int64Value {
   return { value: 0 };
 }
 
-export const Int64Value = {
+export const Int64Value: MessageFns<Int64Value> = {
   decode(input: BinaryReader | Uint8Array, length?: number): Int64Value {
     const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
@@ -187,7 +187,7 @@ function createBaseUInt64Value(): UInt64Value {
   return { value: 0 };
 }
 
-export const UInt64Value = {
+export const UInt64Value: MessageFns<UInt64Value> = {
   decode(input: BinaryReader | Uint8Array, length?: number): UInt64Value {
     const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
@@ -216,7 +216,7 @@ function createBaseInt32Value(): Int32Value {
   return { value: 0 };
 }
 
-export const Int32Value = {
+export const Int32Value: MessageFns<Int32Value> = {
   decode(input: BinaryReader | Uint8Array, length?: number): Int32Value {
     const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
@@ -245,7 +245,7 @@ function createBaseUInt32Value(): UInt32Value {
   return { value: 0 };
 }
 
-export const UInt32Value = {
+export const UInt32Value: MessageFns<UInt32Value> = {
   decode(input: BinaryReader | Uint8Array, length?: number): UInt32Value {
     const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
@@ -274,7 +274,7 @@ function createBaseBoolValue(): BoolValue {
   return { value: false };
 }
 
-export const BoolValue = {
+export const BoolValue: MessageFns<BoolValue> = {
   decode(input: BinaryReader | Uint8Array, length?: number): BoolValue {
     const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
@@ -303,7 +303,7 @@ function createBaseStringValue(): StringValue {
   return { value: "" };
 }
 
-export const StringValue = {
+export const StringValue: MessageFns<StringValue> = {
   decode(input: BinaryReader | Uint8Array, length?: number): StringValue {
     const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
@@ -332,7 +332,7 @@ function createBaseBytesValue(): BytesValue {
   return { value: new Uint8Array(0) };
 }
 
-export const BytesValue = {
+export const BytesValue: MessageFns<BytesValue> = {
   decode(input: BinaryReader | Uint8Array, length?: number): BytesValue {
     const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
@@ -366,4 +366,8 @@ function longToNumber(int64: { toString(): string }): number {
     throw new globalThis.Error("Value is smaller than Number.MIN_SAFE_INTEGER");
   }
   return num;
+}
+
+export interface MessageFns<T> {
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
 }

--- a/integration/output-encode-no-creation-methods/encode.ts
+++ b/integration/output-encode-no-creation-methods/encode.ts
@@ -10,7 +10,7 @@ export interface Encode {
   encode: string;
 }
 
-export const Encode = {
+export const Encode: MessageFns<Encode> = {
   encode(message: Encode, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.encode !== "") {
       writer.uint32(10).string(message.encode);
@@ -18,3 +18,7 @@ export const Encode = {
     return writer;
   },
 };
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+}

--- a/integration/output-encode-no-creation-methods/google/protobuf/wrappers.ts
+++ b/integration/output-encode-no-creation-methods/google/protobuf/wrappers.ts
@@ -96,7 +96,7 @@ export interface BytesValue {
   value: Uint8Array;
 }
 
-export const DoubleValue = {
+export const DoubleValue: MessageFns<DoubleValue> = {
   encode(message: DoubleValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(9).double(message.value);
@@ -105,7 +105,7 @@ export const DoubleValue = {
   },
 };
 
-export const FloatValue = {
+export const FloatValue: MessageFns<FloatValue> = {
   encode(message: FloatValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(13).float(message.value);
@@ -114,7 +114,7 @@ export const FloatValue = {
   },
 };
 
-export const Int64Value = {
+export const Int64Value: MessageFns<Int64Value> = {
   encode(message: Int64Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).int64(message.value);
@@ -123,7 +123,7 @@ export const Int64Value = {
   },
 };
 
-export const UInt64Value = {
+export const UInt64Value: MessageFns<UInt64Value> = {
   encode(message: UInt64Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).uint64(message.value);
@@ -132,7 +132,7 @@ export const UInt64Value = {
   },
 };
 
-export const Int32Value = {
+export const Int32Value: MessageFns<Int32Value> = {
   encode(message: Int32Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).int32(message.value);
@@ -141,7 +141,7 @@ export const Int32Value = {
   },
 };
 
-export const UInt32Value = {
+export const UInt32Value: MessageFns<UInt32Value> = {
   encode(message: UInt32Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).uint32(message.value);
@@ -150,7 +150,7 @@ export const UInt32Value = {
   },
 };
 
-export const BoolValue = {
+export const BoolValue: MessageFns<BoolValue> = {
   encode(message: BoolValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== false) {
       writer.uint32(8).bool(message.value);
@@ -159,7 +159,7 @@ export const BoolValue = {
   },
 };
 
-export const StringValue = {
+export const StringValue: MessageFns<StringValue> = {
   encode(message: StringValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== "") {
       writer.uint32(10).string(message.value);
@@ -168,7 +168,7 @@ export const StringValue = {
   },
 };
 
-export const BytesValue = {
+export const BytesValue: MessageFns<BytesValue> = {
   encode(message: BytesValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value.length !== 0) {
       writer.uint32(10).bytes(message.value);
@@ -176,3 +176,7 @@ export const BytesValue = {
     return writer;
   },
 };
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+}

--- a/integration/output-encode-only/encode.ts
+++ b/integration/output-encode-only/encode.ts
@@ -14,7 +14,7 @@ function createBaseEncode(): Encode {
   return { encode: "" };
 }
 
-export const Encode = {
+export const Encode: MessageFns<Encode> = {
   encode(message: Encode, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.encode !== "") {
       writer.uint32(10).string(message.encode);
@@ -22,3 +22,7 @@ export const Encode = {
     return writer;
   },
 };
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+}

--- a/integration/output-encode-only/google/protobuf/wrappers.ts
+++ b/integration/output-encode-only/google/protobuf/wrappers.ts
@@ -100,7 +100,7 @@ function createBaseDoubleValue(): DoubleValue {
   return { value: 0 };
 }
 
-export const DoubleValue = {
+export const DoubleValue: MessageFns<DoubleValue> = {
   encode(message: DoubleValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(9).double(message.value);
@@ -113,7 +113,7 @@ function createBaseFloatValue(): FloatValue {
   return { value: 0 };
 }
 
-export const FloatValue = {
+export const FloatValue: MessageFns<FloatValue> = {
   encode(message: FloatValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(13).float(message.value);
@@ -126,7 +126,7 @@ function createBaseInt64Value(): Int64Value {
   return { value: 0 };
 }
 
-export const Int64Value = {
+export const Int64Value: MessageFns<Int64Value> = {
   encode(message: Int64Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).int64(message.value);
@@ -139,7 +139,7 @@ function createBaseUInt64Value(): UInt64Value {
   return { value: 0 };
 }
 
-export const UInt64Value = {
+export const UInt64Value: MessageFns<UInt64Value> = {
   encode(message: UInt64Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).uint64(message.value);
@@ -152,7 +152,7 @@ function createBaseInt32Value(): Int32Value {
   return { value: 0 };
 }
 
-export const Int32Value = {
+export const Int32Value: MessageFns<Int32Value> = {
   encode(message: Int32Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).int32(message.value);
@@ -165,7 +165,7 @@ function createBaseUInt32Value(): UInt32Value {
   return { value: 0 };
 }
 
-export const UInt32Value = {
+export const UInt32Value: MessageFns<UInt32Value> = {
   encode(message: UInt32Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).uint32(message.value);
@@ -178,7 +178,7 @@ function createBaseBoolValue(): BoolValue {
   return { value: false };
 }
 
-export const BoolValue = {
+export const BoolValue: MessageFns<BoolValue> = {
   encode(message: BoolValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== false) {
       writer.uint32(8).bool(message.value);
@@ -191,7 +191,7 @@ function createBaseStringValue(): StringValue {
   return { value: "" };
 }
 
-export const StringValue = {
+export const StringValue: MessageFns<StringValue> = {
   encode(message: StringValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== "") {
       writer.uint32(10).string(message.value);
@@ -204,7 +204,7 @@ function createBaseBytesValue(): BytesValue {
   return { value: new Uint8Array(0) };
 }
 
-export const BytesValue = {
+export const BytesValue: MessageFns<BytesValue> = {
   encode(message: BytesValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value.length !== 0) {
       writer.uint32(10).bytes(message.value);
@@ -212,3 +212,7 @@ export const BytesValue = {
     return writer;
   },
 };
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+}

--- a/integration/output-fromJSON-only/decode.ts
+++ b/integration/output-fromJSON-only/decode.ts
@@ -9,7 +9,7 @@ export interface Encode {
   encode: string;
 }
 
-export const Encode = {
+export const Encode: MessageFns<Encode> = {
   fromJSON(object: any): Encode {
     return { encode: isSet(object.encode) ? globalThis.String(object.encode) : "" };
   },
@@ -17,4 +17,8 @@ export const Encode = {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  fromJSON(object: any): T;
 }

--- a/integration/output-fromJSON-only/google/protobuf/wrappers.ts
+++ b/integration/output-fromJSON-only/google/protobuf/wrappers.ts
@@ -95,55 +95,55 @@ export interface BytesValue {
   value: Uint8Array;
 }
 
-export const DoubleValue = {
+export const DoubleValue: MessageFns<DoubleValue> = {
   fromJSON(object: any): DoubleValue {
     return { value: isSet(object.value) ? globalThis.Number(object.value) : 0 };
   },
 };
 
-export const FloatValue = {
+export const FloatValue: MessageFns<FloatValue> = {
   fromJSON(object: any): FloatValue {
     return { value: isSet(object.value) ? globalThis.Number(object.value) : 0 };
   },
 };
 
-export const Int64Value = {
+export const Int64Value: MessageFns<Int64Value> = {
   fromJSON(object: any): Int64Value {
     return { value: isSet(object.value) ? globalThis.Number(object.value) : 0 };
   },
 };
 
-export const UInt64Value = {
+export const UInt64Value: MessageFns<UInt64Value> = {
   fromJSON(object: any): UInt64Value {
     return { value: isSet(object.value) ? globalThis.Number(object.value) : 0 };
   },
 };
 
-export const Int32Value = {
+export const Int32Value: MessageFns<Int32Value> = {
   fromJSON(object: any): Int32Value {
     return { value: isSet(object.value) ? globalThis.Number(object.value) : 0 };
   },
 };
 
-export const UInt32Value = {
+export const UInt32Value: MessageFns<UInt32Value> = {
   fromJSON(object: any): UInt32Value {
     return { value: isSet(object.value) ? globalThis.Number(object.value) : 0 };
   },
 };
 
-export const BoolValue = {
+export const BoolValue: MessageFns<BoolValue> = {
   fromJSON(object: any): BoolValue {
     return { value: isSet(object.value) ? globalThis.Boolean(object.value) : false };
   },
 };
 
-export const StringValue = {
+export const StringValue: MessageFns<StringValue> = {
   fromJSON(object: any): StringValue {
     return { value: isSet(object.value) ? globalThis.String(object.value) : "" };
   },
 };
 
-export const BytesValue = {
+export const BytesValue: MessageFns<BytesValue> = {
   fromJSON(object: any): BytesValue {
     return { value: isSet(object.value) ? bytesFromBase64(object.value) : new Uint8Array(0) };
   },
@@ -164,4 +164,8 @@ function bytesFromBase64(b64: string): Uint8Array {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  fromJSON(object: any): T;
 }

--- a/integration/output-index/a.ts
+++ b/integration/output-index/a.ts
@@ -12,7 +12,7 @@ function createBaseA(): A {
   return { a: "" };
 }
 
-export const A = {
+export const A: MessageFns<A> = {
   encode(message: A, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.a !== "") {
       writer.uint32(10).string(message.a);
@@ -79,4 +79,13 @@ type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/output-toJSON-only/encode.ts
+++ b/integration/output-toJSON-only/encode.ts
@@ -9,7 +9,7 @@ export interface Encode {
   encode: string;
 }
 
-export const Encode = {
+export const Encode: MessageFns<Encode> = {
   toJSON(message: Encode): unknown {
     const obj: any = {};
     if (message.encode !== "") {
@@ -18,3 +18,7 @@ export const Encode = {
     return obj;
   },
 };
+
+export interface MessageFns<T> {
+  toJSON(message: T): unknown;
+}

--- a/integration/output-toJSON-only/google/protobuf/wrappers.ts
+++ b/integration/output-toJSON-only/google/protobuf/wrappers.ts
@@ -95,7 +95,7 @@ export interface BytesValue {
   value: Uint8Array;
 }
 
-export const DoubleValue = {
+export const DoubleValue: MessageFns<DoubleValue> = {
   toJSON(message: DoubleValue): unknown {
     const obj: any = {};
     if (message.value !== 0) {
@@ -105,7 +105,7 @@ export const DoubleValue = {
   },
 };
 
-export const FloatValue = {
+export const FloatValue: MessageFns<FloatValue> = {
   toJSON(message: FloatValue): unknown {
     const obj: any = {};
     if (message.value !== 0) {
@@ -115,7 +115,7 @@ export const FloatValue = {
   },
 };
 
-export const Int64Value = {
+export const Int64Value: MessageFns<Int64Value> = {
   toJSON(message: Int64Value): unknown {
     const obj: any = {};
     if (message.value !== 0) {
@@ -125,7 +125,7 @@ export const Int64Value = {
   },
 };
 
-export const UInt64Value = {
+export const UInt64Value: MessageFns<UInt64Value> = {
   toJSON(message: UInt64Value): unknown {
     const obj: any = {};
     if (message.value !== 0) {
@@ -135,7 +135,7 @@ export const UInt64Value = {
   },
 };
 
-export const Int32Value = {
+export const Int32Value: MessageFns<Int32Value> = {
   toJSON(message: Int32Value): unknown {
     const obj: any = {};
     if (message.value !== 0) {
@@ -145,7 +145,7 @@ export const Int32Value = {
   },
 };
 
-export const UInt32Value = {
+export const UInt32Value: MessageFns<UInt32Value> = {
   toJSON(message: UInt32Value): unknown {
     const obj: any = {};
     if (message.value !== 0) {
@@ -155,7 +155,7 @@ export const UInt32Value = {
   },
 };
 
-export const BoolValue = {
+export const BoolValue: MessageFns<BoolValue> = {
   toJSON(message: BoolValue): unknown {
     const obj: any = {};
     if (message.value !== false) {
@@ -165,7 +165,7 @@ export const BoolValue = {
   },
 };
 
-export const StringValue = {
+export const StringValue: MessageFns<StringValue> = {
   toJSON(message: StringValue): unknown {
     const obj: any = {};
     if (message.value !== "") {
@@ -175,7 +175,7 @@ export const StringValue = {
   },
 };
 
-export const BytesValue = {
+export const BytesValue: MessageFns<BytesValue> = {
   toJSON(message: BytesValue): unknown {
     const obj: any = {};
     if (message.value.length !== 0) {
@@ -195,4 +195,8 @@ function base64FromBytes(arr: Uint8Array): string {
     });
     return globalThis.btoa(bin.join(""));
   }
+}
+
+export interface MessageFns<T> {
+  toJSON(message: T): unknown;
 }

--- a/integration/point/point.ts
+++ b/integration/point/point.ts
@@ -20,7 +20,7 @@ function createBasePoint(): Point {
   return { lat: 0, lng: 0 };
 }
 
-export const Point = {
+export const Point: MessageFns<Point> = {
   encode(message: Point, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.lat !== 0) {
       writer.uint32(9).double(message.lat);
@@ -94,7 +94,7 @@ function createBaseArea(): Area {
   return { nw: undefined, se: undefined };
 }
 
-export const Area = {
+export const Area: MessageFns<Area> = {
   encode(message: Area, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.nw !== undefined) {
       Point.encode(message.nw, writer.uint32(10).fork()).join();
@@ -178,4 +178,13 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/proto2-long/simple.ts
+++ b/integration/proto2-long/simple.ts
@@ -140,7 +140,7 @@ function createBaseOptionalsTest(): OptionalsTest {
   };
 }
 
-export const OptionalsTest = {
+export const OptionalsTest: MessageFns<OptionalsTest> = {
   encode(message: OptionalsTest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     writer.uint32(10).fork();
     for (const v of message.repId) {
@@ -871,7 +871,7 @@ function createBaseOptionalsTest_TranslationsEntry(): OptionalsTest_Translations
   return { key: "", value: "" };
 }
 
-export const OptionalsTest_TranslationsEntry = {
+export const OptionalsTest_TranslationsEntry: MessageFns<OptionalsTest_TranslationsEntry> = {
   encode(message: OptionalsTest_TranslationsEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== "") {
       writer.uint32(10).string(message.key);
@@ -947,7 +947,7 @@ function createBaseChild(): Child {
   return {};
 }
 
-export const Child = {
+export const Child: MessageFns<Child> = {
   encode(_: Child, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     return writer;
   },
@@ -1029,4 +1029,13 @@ function isObject(value: any): boolean {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/proto2-no-default-vals/simple.ts
+++ b/integration/proto2-no-default-vals/simple.ts
@@ -139,7 +139,7 @@ function createBaseOptionalsTest(): OptionalsTest {
   };
 }
 
-export const OptionalsTest = {
+export const OptionalsTest: MessageFns<OptionalsTest> = {
   encode(message: OptionalsTest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     writer.uint32(10).fork();
     for (const v of message.repId) {
@@ -858,7 +858,7 @@ function createBaseOptionalsTest_TranslationsEntry(): OptionalsTest_Translations
   return { key: "", value: "" };
 }
 
-export const OptionalsTest_TranslationsEntry = {
+export const OptionalsTest_TranslationsEntry: MessageFns<OptionalsTest_TranslationsEntry> = {
   encode(message: OptionalsTest_TranslationsEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== "") {
       writer.uint32(10).string(message.key);
@@ -934,7 +934,7 @@ function createBaseChild(): Child {
   return {};
 }
 
-export const Child = {
+export const Child: MessageFns<Child> = {
   encode(_: Child, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     return writer;
   },
@@ -1027,4 +1027,13 @@ function isObject(value: any): boolean {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/proto2-no-optionals/simple.ts
+++ b/integration/proto2-no-optionals/simple.ts
@@ -139,7 +139,7 @@ function createBaseOptionalsTest(): OptionalsTest {
   };
 }
 
-export const OptionalsTest = {
+export const OptionalsTest: MessageFns<OptionalsTest> = {
   encode(message: OptionalsTest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     writer.uint32(10).fork();
     for (const v of message.repId) {
@@ -862,7 +862,7 @@ function createBaseOptionalsTest_TranslationsEntry(): OptionalsTest_Translations
   return { key: "", value: "" };
 }
 
-export const OptionalsTest_TranslationsEntry = {
+export const OptionalsTest_TranslationsEntry: MessageFns<OptionalsTest_TranslationsEntry> = {
   encode(message: OptionalsTest_TranslationsEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== "") {
       writer.uint32(10).string(message.key);
@@ -938,7 +938,7 @@ function createBaseChild(): Child {
   return {};
 }
 
-export const Child = {
+export const Child: MessageFns<Child> = {
   encode(_: Child, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     return writer;
   },
@@ -1031,4 +1031,13 @@ function isObject(value: any): boolean {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/proto2/simple.ts
+++ b/integration/proto2/simple.ts
@@ -139,7 +139,7 @@ function createBaseOptionalsTest(): OptionalsTest {
   };
 }
 
-export const OptionalsTest = {
+export const OptionalsTest: MessageFns<OptionalsTest> = {
   encode(message: OptionalsTest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     writer.uint32(10).fork();
     for (const v of message.repId) {
@@ -862,7 +862,7 @@ function createBaseOptionalsTest_TranslationsEntry(): OptionalsTest_Translations
   return { key: "", value: "" };
 }
 
-export const OptionalsTest_TranslationsEntry = {
+export const OptionalsTest_TranslationsEntry: MessageFns<OptionalsTest_TranslationsEntry> = {
   encode(message: OptionalsTest_TranslationsEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== "") {
       writer.uint32(10).string(message.key);
@@ -938,7 +938,7 @@ function createBaseChild(): Child {
   return {};
 }
 
-export const Child = {
+export const Child: MessageFns<Child> = {
   encode(_: Child, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     return writer;
   },
@@ -1031,4 +1031,13 @@ function isObject(value: any): boolean {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/remove-enum-prefix-string-enums/remove-enum-prefix-string-enums.ts
+++ b/integration/remove-enum-prefix-string-enums/remove-enum-prefix-string-enums.ts
@@ -214,7 +214,7 @@ function createBaseWithNestedEnum(): WithNestedEnum {
   };
 }
 
-export const WithNestedEnum = {
+export const WithNestedEnum: MessageFns<WithNestedEnum> = {
   encode(message: WithNestedEnum, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.foo !== Foo.UNSPECIFIED) {
       writer.uint32(8).int32(fooToNumber(message.foo));
@@ -328,4 +328,13 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/remove-enum-prefix-unrecognized-enum-value/remove-enum-prefix-unrecognized-enum-value.ts
+++ b/integration/remove-enum-prefix-unrecognized-enum-value/remove-enum-prefix-unrecognized-enum-value.ts
@@ -157,7 +157,7 @@ function createBaseWithNestedEnum(): WithNestedEnum {
   return { foo: 0, Bar: 0, baz: 0, qux: 0 };
 }
 
-export const WithNestedEnum = {
+export const WithNestedEnum: MessageFns<WithNestedEnum> = {
   encode(message: WithNestedEnum, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.foo !== 0) {
       writer.uint32(8).int32(message.foo);
@@ -271,4 +271,13 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/remove-enum-prefix/remove-enum-prefix.ts
+++ b/integration/remove-enum-prefix/remove-enum-prefix.ts
@@ -157,7 +157,7 @@ function createBaseWithNestedEnum(): WithNestedEnum {
   return { foo: 0, Bar: 0, baz: 0, qux: 0 };
 }
 
-export const WithNestedEnum = {
+export const WithNestedEnum: MessageFns<WithNestedEnum> = {
   encode(message: WithNestedEnum, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.foo !== 0) {
       writer.uint32(8).int32(message.foo);
@@ -271,4 +271,13 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/reserved-words/reserved-words.ts
+++ b/integration/reserved-words/reserved-words.ts
@@ -13,7 +13,7 @@ function createBaseRecord(): Record {
   return {};
 }
 
-export const Record = {
+export const Record: MessageFns<Record> = {
   encode(_: Record, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     return writer;
   },
@@ -63,3 +63,12 @@ export type DeepPartial<T> = T extends Builtin ? T
 type KeysOfUnion<T> = T extends T ? keyof T : never;
 export type Exact<P, I extends P> = P extends Builtin ? P
   : P & { [K in keyof P]: Exact<P[K], I[K]> } & { [K in Exclude<keyof I, KeysOfUnion<P>>]: never };
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
+}

--- a/integration/return-observable/observable.ts
+++ b/integration/return-observable/observable.ts
@@ -19,7 +19,7 @@ function createBaseProduceRequest(): ProduceRequest {
   return { ingredients: "" };
 }
 
-export const ProduceRequest = {
+export const ProduceRequest: MessageFns<ProduceRequest> = {
   encode(message: ProduceRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.ingredients !== "") {
       writer.uint32(10).string(message.ingredients);
@@ -76,7 +76,7 @@ function createBaseProduceReply(): ProduceReply {
   return { result: "" };
 }
 
-export const ProduceReply = {
+export const ProduceReply: MessageFns<ProduceReply> = {
   encode(message: ProduceReply, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.result !== "") {
       writer.uint32(10).string(message.result);
@@ -147,4 +147,13 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/schema-no-file-descriptor/const-enum.ts
+++ b/integration/schema-no-file-descriptor/const-enum.ts
@@ -65,7 +65,7 @@ function createBaseDividerData(): DividerData {
   return { type: 0, typeMap: {} };
 }
 
-export const DividerData = {
+export const DividerData: MessageFns<DividerData> = {
   encode(message: DividerData, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.type !== 0) {
       writer.uint32(8).int32(message.type);
@@ -161,7 +161,7 @@ function createBaseDividerData_TypeMapEntry(): DividerData_TypeMapEntry {
   return { key: "", value: 0 };
 }
 
-export const DividerData_TypeMapEntry = {
+export const DividerData_TypeMapEntry: MessageFns<DividerData_TypeMapEntry> = {
   encode(message: DividerData_TypeMapEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== "") {
       writer.uint32(10).string(message.key);
@@ -278,4 +278,13 @@ function isObject(value: any): boolean {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/simple-deprecated-fields/simple.ts
+++ b/integration/simple-deprecated-fields/simple.ts
@@ -40,7 +40,7 @@ function createBaseSimple(): Simple {
   return { name: "", age: 0, child: undefined, testField: "", testNotDeprecated: "" };
 }
 
-export const Simple = {
+export const Simple: MessageFns<Simple> = {
   encode(message: Simple, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -159,7 +159,7 @@ function createBaseChild(): Child {
   return { name: "" };
 }
 
-export const Child = {
+export const Child: MessageFns<Child> = {
   encode(message: Child, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -226,4 +226,13 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/simple-esmodule-interop/simple.ts
+++ b/integration/simple-esmodule-interop/simple.ts
@@ -30,7 +30,7 @@ function createBaseSimple(): Simple {
   return { name: "", age: 0 };
 }
 
-export const Simple = {
+export const Simple: MessageFns<Simple> = {
   encode(message: Simple, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -117,7 +117,7 @@ function createBaseNumbers(): Numbers {
   };
 }
 
-export const Numbers = {
+export const Numbers: MessageFns<Numbers> = {
   encode(message: Numbers, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.double !== 0) {
       writer.uint32(9).double(message.double);
@@ -362,4 +362,13 @@ function longToNumber(int64: { toString(): string }): number {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/simple-json-name/google/protobuf/timestamp.ts
+++ b/integration/simple-json-name/google/protobuf/timestamp.ts
@@ -117,7 +117,7 @@ function createBaseTimestamp(): Timestamp {
   return { seconds: 0, nanos: 0 };
 }
 
-export const Timestamp = {
+export const Timestamp: MessageFns<Timestamp> = {
   encode(message: Timestamp, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.seconds !== 0) {
       writer.uint32(8).int64(message.seconds);
@@ -212,4 +212,13 @@ function longToNumber(int64: { toString(): string }): number {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/simple-json-name/simple.ts
+++ b/integration/simple-json-name/simple.ts
@@ -31,7 +31,7 @@ function createBaseSimple(): Simple {
   };
 }
 
-export const Simple = {
+export const Simple: MessageFns<Simple> = {
   encode(message: Simple, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -229,4 +229,13 @@ function fromJsonTimestamp(o: any): Date {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/simple-long-bigint-noliteral/google/protobuf/timestamp.ts
+++ b/integration/simple-long-bigint-noliteral/google/protobuf/timestamp.ts
@@ -117,7 +117,7 @@ function createBaseTimestamp(): Timestamp {
   return { seconds: BigInt("0"), nanos: 0 };
 }
 
-export const Timestamp = {
+export const Timestamp: MessageFns<Timestamp> = {
   encode(message: Timestamp, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.seconds !== BigInt("0")) {
       if (BigInt.asIntN(64, message.seconds) !== message.seconds) {
@@ -204,4 +204,13 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/simple-long-bigint-noliteral/google/protobuf/wrappers.ts
+++ b/integration/simple-long-bigint-noliteral/google/protobuf/wrappers.ts
@@ -100,7 +100,7 @@ function createBaseDoubleValue(): DoubleValue {
   return { value: 0 };
 }
 
-export const DoubleValue = {
+export const DoubleValue: MessageFns<DoubleValue> = {
   encode(message: DoubleValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(9).double(message.value);
@@ -157,7 +157,7 @@ function createBaseFloatValue(): FloatValue {
   return { value: 0 };
 }
 
-export const FloatValue = {
+export const FloatValue: MessageFns<FloatValue> = {
   encode(message: FloatValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(13).float(message.value);
@@ -214,7 +214,7 @@ function createBaseInt64Value(): Int64Value {
   return { value: BigInt("0") };
 }
 
-export const Int64Value = {
+export const Int64Value: MessageFns<Int64Value> = {
   encode(message: Int64Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== BigInt("0")) {
       if (BigInt.asIntN(64, message.value) !== message.value) {
@@ -274,7 +274,7 @@ function createBaseUInt64Value(): UInt64Value {
   return { value: BigInt("0") };
 }
 
-export const UInt64Value = {
+export const UInt64Value: MessageFns<UInt64Value> = {
   encode(message: UInt64Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== BigInt("0")) {
       if (BigInt.asUintN(64, message.value) !== message.value) {
@@ -334,7 +334,7 @@ function createBaseInt32Value(): Int32Value {
   return { value: 0 };
 }
 
-export const Int32Value = {
+export const Int32Value: MessageFns<Int32Value> = {
   encode(message: Int32Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).int32(message.value);
@@ -391,7 +391,7 @@ function createBaseUInt32Value(): UInt32Value {
   return { value: 0 };
 }
 
-export const UInt32Value = {
+export const UInt32Value: MessageFns<UInt32Value> = {
   encode(message: UInt32Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).uint32(message.value);
@@ -448,7 +448,7 @@ function createBaseBoolValue(): BoolValue {
   return { value: false };
 }
 
-export const BoolValue = {
+export const BoolValue: MessageFns<BoolValue> = {
   encode(message: BoolValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== false) {
       writer.uint32(8).bool(message.value);
@@ -505,7 +505,7 @@ function createBaseStringValue(): StringValue {
   return { value: "" };
 }
 
-export const StringValue = {
+export const StringValue: MessageFns<StringValue> = {
   encode(message: StringValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== "") {
       writer.uint32(10).string(message.value);
@@ -562,7 +562,7 @@ function createBaseBytesValue(): BytesValue {
   return { value: new Uint8Array(0) };
 }
 
-export const BytesValue = {
+export const BytesValue: MessageFns<BytesValue> = {
   encode(message: BytesValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value.length !== 0) {
       writer.uint32(10).bytes(message.value);
@@ -654,4 +654,13 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/simple-long-bigint-noliteral/simple.ts
+++ b/integration/simple-long-bigint-noliteral/simple.ts
@@ -46,7 +46,7 @@ function createBaseNumbers(): Numbers {
   };
 }
 
-export const Numbers = {
+export const Numbers: MessageFns<Numbers> = {
   encode(message: Numbers, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.double !== 0) {
       writer.uint32(9).double(message.double);
@@ -377,4 +377,13 @@ function fromJsonTimestamp(o: any): Date {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/simple-long-bigint/google/protobuf/timestamp.ts
+++ b/integration/simple-long-bigint/google/protobuf/timestamp.ts
@@ -117,7 +117,7 @@ function createBaseTimestamp(): Timestamp {
   return { seconds: 0n, nanos: 0 };
 }
 
-export const Timestamp = {
+export const Timestamp: MessageFns<Timestamp> = {
   encode(message: Timestamp, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.seconds !== 0n) {
       if (BigInt.asIntN(64, message.seconds) !== message.seconds) {
@@ -204,4 +204,13 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/simple-long-bigint/google/protobuf/wrappers.ts
+++ b/integration/simple-long-bigint/google/protobuf/wrappers.ts
@@ -100,7 +100,7 @@ function createBaseDoubleValue(): DoubleValue {
   return { value: 0 };
 }
 
-export const DoubleValue = {
+export const DoubleValue: MessageFns<DoubleValue> = {
   encode(message: DoubleValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(9).double(message.value);
@@ -157,7 +157,7 @@ function createBaseFloatValue(): FloatValue {
   return { value: 0 };
 }
 
-export const FloatValue = {
+export const FloatValue: MessageFns<FloatValue> = {
   encode(message: FloatValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(13).float(message.value);
@@ -214,7 +214,7 @@ function createBaseInt64Value(): Int64Value {
   return { value: 0n };
 }
 
-export const Int64Value = {
+export const Int64Value: MessageFns<Int64Value> = {
   encode(message: Int64Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0n) {
       if (BigInt.asIntN(64, message.value) !== message.value) {
@@ -274,7 +274,7 @@ function createBaseUInt64Value(): UInt64Value {
   return { value: 0n };
 }
 
-export const UInt64Value = {
+export const UInt64Value: MessageFns<UInt64Value> = {
   encode(message: UInt64Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0n) {
       if (BigInt.asUintN(64, message.value) !== message.value) {
@@ -334,7 +334,7 @@ function createBaseInt32Value(): Int32Value {
   return { value: 0 };
 }
 
-export const Int32Value = {
+export const Int32Value: MessageFns<Int32Value> = {
   encode(message: Int32Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).int32(message.value);
@@ -391,7 +391,7 @@ function createBaseUInt32Value(): UInt32Value {
   return { value: 0 };
 }
 
-export const UInt32Value = {
+export const UInt32Value: MessageFns<UInt32Value> = {
   encode(message: UInt32Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).uint32(message.value);
@@ -448,7 +448,7 @@ function createBaseBoolValue(): BoolValue {
   return { value: false };
 }
 
-export const BoolValue = {
+export const BoolValue: MessageFns<BoolValue> = {
   encode(message: BoolValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== false) {
       writer.uint32(8).bool(message.value);
@@ -505,7 +505,7 @@ function createBaseStringValue(): StringValue {
   return { value: "" };
 }
 
-export const StringValue = {
+export const StringValue: MessageFns<StringValue> = {
   encode(message: StringValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== "") {
       writer.uint32(10).string(message.value);
@@ -562,7 +562,7 @@ function createBaseBytesValue(): BytesValue {
   return { value: new Uint8Array(0) };
 }
 
-export const BytesValue = {
+export const BytesValue: MessageFns<BytesValue> = {
   encode(message: BytesValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value.length !== 0) {
       writer.uint32(10).bytes(message.value);
@@ -654,4 +654,13 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/simple-long-bigint/simple.ts
+++ b/integration/simple-long-bigint/simple.ts
@@ -46,7 +46,7 @@ function createBaseNumbers(): Numbers {
   };
 }
 
-export const Numbers = {
+export const Numbers: MessageFns<Numbers> = {
   encode(message: Numbers, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.double !== 0) {
       writer.uint32(9).double(message.double);
@@ -377,4 +377,13 @@ function fromJsonTimestamp(o: any): Date {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/simple-long-string/google/protobuf/timestamp.ts
+++ b/integration/simple-long-string/google/protobuf/timestamp.ts
@@ -117,7 +117,7 @@ function createBaseTimestamp(): Timestamp {
   return { seconds: "0", nanos: 0 };
 }
 
-export const Timestamp = {
+export const Timestamp: MessageFns<Timestamp> = {
   encode(message: Timestamp, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.seconds !== "0") {
       writer.uint32(8).int64(message.seconds);
@@ -201,4 +201,13 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/simple-long-string/google/protobuf/wrappers.ts
+++ b/integration/simple-long-string/google/protobuf/wrappers.ts
@@ -100,7 +100,7 @@ function createBaseDoubleValue(): DoubleValue {
   return { value: 0 };
 }
 
-export const DoubleValue = {
+export const DoubleValue: MessageFns<DoubleValue> = {
   encode(message: DoubleValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(9).double(message.value);
@@ -157,7 +157,7 @@ function createBaseFloatValue(): FloatValue {
   return { value: 0 };
 }
 
-export const FloatValue = {
+export const FloatValue: MessageFns<FloatValue> = {
   encode(message: FloatValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(13).float(message.value);
@@ -214,7 +214,7 @@ function createBaseInt64Value(): Int64Value {
   return { value: "0" };
 }
 
-export const Int64Value = {
+export const Int64Value: MessageFns<Int64Value> = {
   encode(message: Int64Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== "0") {
       writer.uint32(8).int64(message.value);
@@ -271,7 +271,7 @@ function createBaseUInt64Value(): UInt64Value {
   return { value: "0" };
 }
 
-export const UInt64Value = {
+export const UInt64Value: MessageFns<UInt64Value> = {
   encode(message: UInt64Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== "0") {
       writer.uint32(8).uint64(message.value);
@@ -328,7 +328,7 @@ function createBaseInt32Value(): Int32Value {
   return { value: 0 };
 }
 
-export const Int32Value = {
+export const Int32Value: MessageFns<Int32Value> = {
   encode(message: Int32Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).int32(message.value);
@@ -385,7 +385,7 @@ function createBaseUInt32Value(): UInt32Value {
   return { value: 0 };
 }
 
-export const UInt32Value = {
+export const UInt32Value: MessageFns<UInt32Value> = {
   encode(message: UInt32Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).uint32(message.value);
@@ -442,7 +442,7 @@ function createBaseBoolValue(): BoolValue {
   return { value: false };
 }
 
-export const BoolValue = {
+export const BoolValue: MessageFns<BoolValue> = {
   encode(message: BoolValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== false) {
       writer.uint32(8).bool(message.value);
@@ -499,7 +499,7 @@ function createBaseStringValue(): StringValue {
   return { value: "" };
 }
 
-export const StringValue = {
+export const StringValue: MessageFns<StringValue> = {
   encode(message: StringValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== "") {
       writer.uint32(10).string(message.value);
@@ -556,7 +556,7 @@ function createBaseBytesValue(): BytesValue {
   return { value: new Uint8Array(0) };
 }
 
-export const BytesValue = {
+export const BytesValue: MessageFns<BytesValue> = {
   encode(message: BytesValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value.length !== 0) {
       writer.uint32(10).bytes(message.value);
@@ -648,4 +648,13 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/simple-long-string/simple.ts
+++ b/integration/simple-long-string/simple.ts
@@ -44,7 +44,7 @@ function createBaseNumbers(): Numbers {
   };
 }
 
-export const Numbers = {
+export const Numbers: MessageFns<Numbers> = {
   encode(message: Numbers, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.double !== 0) {
       writer.uint32(9).double(message.double);
@@ -330,4 +330,13 @@ function fromJsonTimestamp(o: any): Date {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/simple-long/google/protobuf/wrappers.ts
+++ b/integration/simple-long/google/protobuf/wrappers.ts
@@ -101,7 +101,7 @@ function createBaseDoubleValue(): DoubleValue {
   return { value: 0 };
 }
 
-export const DoubleValue = {
+export const DoubleValue: MessageFns<DoubleValue> = {
   encode(message: DoubleValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(9).double(message.value);
@@ -158,7 +158,7 @@ function createBaseFloatValue(): FloatValue {
   return { value: 0 };
 }
 
-export const FloatValue = {
+export const FloatValue: MessageFns<FloatValue> = {
   encode(message: FloatValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(13).float(message.value);
@@ -215,7 +215,7 @@ function createBaseInt64Value(): Int64Value {
   return { value: Long.ZERO };
 }
 
-export const Int64Value = {
+export const Int64Value: MessageFns<Int64Value> = {
   encode(message: Int64Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (!message.value.equals(Long.ZERO)) {
       writer.uint32(8).int64(message.value.toString());
@@ -272,7 +272,7 @@ function createBaseUInt64Value(): UInt64Value {
   return { value: Long.UZERO };
 }
 
-export const UInt64Value = {
+export const UInt64Value: MessageFns<UInt64Value> = {
   encode(message: UInt64Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (!message.value.equals(Long.UZERO)) {
       writer.uint32(8).uint64(message.value.toString());
@@ -329,7 +329,7 @@ function createBaseInt32Value(): Int32Value {
   return { value: 0 };
 }
 
-export const Int32Value = {
+export const Int32Value: MessageFns<Int32Value> = {
   encode(message: Int32Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).int32(message.value);
@@ -386,7 +386,7 @@ function createBaseUInt32Value(): UInt32Value {
   return { value: 0 };
 }
 
-export const UInt32Value = {
+export const UInt32Value: MessageFns<UInt32Value> = {
   encode(message: UInt32Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).uint32(message.value);
@@ -443,7 +443,7 @@ function createBaseBoolValue(): BoolValue {
   return { value: false };
 }
 
-export const BoolValue = {
+export const BoolValue: MessageFns<BoolValue> = {
   encode(message: BoolValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== false) {
       writer.uint32(8).bool(message.value);
@@ -500,7 +500,7 @@ function createBaseStringValue(): StringValue {
   return { value: "" };
 }
 
-export const StringValue = {
+export const StringValue: MessageFns<StringValue> = {
   encode(message: StringValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== "") {
       writer.uint32(10).string(message.value);
@@ -557,7 +557,7 @@ function createBaseBytesValue(): BytesValue {
   return { value: new Uint8Array(0) };
 }
 
-export const BytesValue = {
+export const BytesValue: MessageFns<BytesValue> = {
   encode(message: BytesValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value.length !== 0) {
       writer.uint32(10).bytes(message.value);
@@ -649,4 +649,13 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/simple-long/simple.ts
+++ b/integration/simple-long/simple.ts
@@ -59,7 +59,7 @@ function createBaseSimpleWithWrappers(): SimpleWithWrappers {
   return { name: undefined, age: undefined, enabled: undefined, bananas: undefined, coins: [], snacks: [] };
 }
 
-export const SimpleWithWrappers = {
+export const SimpleWithWrappers: MessageFns<SimpleWithWrappers> = {
   encode(message: SimpleWithWrappers, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== undefined) {
       StringValue.encode({ value: message.name! }, writer.uint32(10).fork()).join();
@@ -195,7 +195,7 @@ function createBaseSimpleWithMap(): SimpleWithMap {
   return { nameLookup: {}, intLookup: {}, longLookup: new Map() };
 }
 
-export const SimpleWithMap = {
+export const SimpleWithMap: MessageFns<SimpleWithMap> = {
   encode(message: SimpleWithMap, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     Object.entries(message.nameLookup).forEach(([key, value]) => {
       SimpleWithMap_NameLookupEntry.encode({ key: key as any, value }, writer.uint32(18).fork()).join();
@@ -347,7 +347,7 @@ function createBaseSimpleWithMap_NameLookupEntry(): SimpleWithMap_NameLookupEntr
   return { key: "", value: "" };
 }
 
-export const SimpleWithMap_NameLookupEntry = {
+export const SimpleWithMap_NameLookupEntry: MessageFns<SimpleWithMap_NameLookupEntry> = {
   encode(message: SimpleWithMap_NameLookupEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== "") {
       writer.uint32(10).string(message.key);
@@ -423,7 +423,7 @@ function createBaseSimpleWithMap_IntLookupEntry(): SimpleWithMap_IntLookupEntry 
   return { key: 0, value: 0 };
 }
 
-export const SimpleWithMap_IntLookupEntry = {
+export const SimpleWithMap_IntLookupEntry: MessageFns<SimpleWithMap_IntLookupEntry> = {
   encode(message: SimpleWithMap_IntLookupEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== 0) {
       writer.uint32(8).int32(message.key);
@@ -497,7 +497,7 @@ function createBaseSimpleWithMap_LongLookupEntry(): SimpleWithMap_LongLookupEntr
   return { key: Long.ZERO, value: Long.ZERO };
 }
 
-export const SimpleWithMap_LongLookupEntry = {
+export const SimpleWithMap_LongLookupEntry: MessageFns<SimpleWithMap_LongLookupEntry> = {
   encode(message: SimpleWithMap_LongLookupEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (!message.key.equals(Long.ZERO)) {
       writer.uint32(8).int64(message.key.toString());
@@ -587,7 +587,7 @@ function createBaseNumbers(): Numbers {
   };
 }
 
-export const Numbers = {
+export const Numbers: MessageFns<Numbers> = {
   encode(message: Numbers, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.double !== 0) {
       writer.uint32(9).double(message.double);
@@ -873,4 +873,13 @@ function isObject(value: any): boolean {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/simple-optionals/google/protobuf/timestamp.ts
+++ b/integration/simple-optionals/google/protobuf/timestamp.ts
@@ -117,7 +117,7 @@ function createBaseTimestamp(): Timestamp {
   return { seconds: 0, nanos: 0 };
 }
 
-export const Timestamp = {
+export const Timestamp: MessageFns<Timestamp> = {
   encode(message: Timestamp, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.seconds !== 0) {
       writer.uint32(8).int64(message.seconds);
@@ -212,4 +212,13 @@ function longToNumber(int64: { toString(): string }): number {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/simple-optionals/google/protobuf/wrappers.ts
+++ b/integration/simple-optionals/google/protobuf/wrappers.ts
@@ -100,7 +100,7 @@ function createBaseDoubleValue(): DoubleValue {
   return { value: 0 };
 }
 
-export const DoubleValue = {
+export const DoubleValue: MessageFns<DoubleValue> = {
   encode(message: DoubleValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(9).double(message.value);
@@ -157,7 +157,7 @@ function createBaseFloatValue(): FloatValue {
   return { value: 0 };
 }
 
-export const FloatValue = {
+export const FloatValue: MessageFns<FloatValue> = {
   encode(message: FloatValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(13).float(message.value);
@@ -214,7 +214,7 @@ function createBaseInt64Value(): Int64Value {
   return { value: 0 };
 }
 
-export const Int64Value = {
+export const Int64Value: MessageFns<Int64Value> = {
   encode(message: Int64Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).int64(message.value);
@@ -271,7 +271,7 @@ function createBaseUInt64Value(): UInt64Value {
   return { value: 0 };
 }
 
-export const UInt64Value = {
+export const UInt64Value: MessageFns<UInt64Value> = {
   encode(message: UInt64Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).uint64(message.value);
@@ -328,7 +328,7 @@ function createBaseInt32Value(): Int32Value {
   return { value: 0 };
 }
 
-export const Int32Value = {
+export const Int32Value: MessageFns<Int32Value> = {
   encode(message: Int32Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).int32(message.value);
@@ -385,7 +385,7 @@ function createBaseUInt32Value(): UInt32Value {
   return { value: 0 };
 }
 
-export const UInt32Value = {
+export const UInt32Value: MessageFns<UInt32Value> = {
   encode(message: UInt32Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).uint32(message.value);
@@ -442,7 +442,7 @@ function createBaseBoolValue(): BoolValue {
   return { value: false };
 }
 
-export const BoolValue = {
+export const BoolValue: MessageFns<BoolValue> = {
   encode(message: BoolValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== false) {
       writer.uint32(8).bool(message.value);
@@ -499,7 +499,7 @@ function createBaseStringValue(): StringValue {
   return { value: "" };
 }
 
-export const StringValue = {
+export const StringValue: MessageFns<StringValue> = {
   encode(message: StringValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== "") {
       writer.uint32(10).string(message.value);
@@ -556,7 +556,7 @@ function createBaseBytesValue(): BytesValue {
   return { value: new Uint8Array(0) };
 }
 
-export const BytesValue = {
+export const BytesValue: MessageFns<BytesValue> = {
   encode(message: BytesValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value.length !== 0) {
       writer.uint32(10).bytes(message.value);
@@ -659,4 +659,13 @@ function longToNumber(int64: { toString(): string }): number {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/simple-optionals/import_dir/thing.ts
+++ b/integration/simple-optionals/import_dir/thing.ts
@@ -15,7 +15,7 @@ function createBaseImportedThing(): ImportedThing {
   return { createdAt: undefined };
 }
 
-export const ImportedThing = {
+export const ImportedThing: MessageFns<ImportedThing> = {
   encode(message: ImportedThing, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.createdAt !== undefined) {
       Timestamp.encode(toTimestamp(message.createdAt), writer.uint32(10).fork()).join();
@@ -104,4 +104,13 @@ function fromJsonTimestamp(o: any): Date {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/simple-optionals/simple.ts
+++ b/integration/simple-optionals/simple.ts
@@ -255,7 +255,7 @@ function createBaseSimple(): Simple {
   };
 }
 
-export const Simple = {
+export const Simple: MessageFns<Simple> = {
   encode(message: Simple, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -479,7 +479,7 @@ function createBaseChild(): Child {
   return { name: "", type: 0 };
 }
 
-export const Child = {
+export const Child: MessageFns<Child> = {
   encode(message: Child, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -553,7 +553,7 @@ function createBaseNested(): Nested {
   return { name: "", message: undefined, state: 0 };
 }
 
-export const Nested = {
+export const Nested: MessageFns<Nested> = {
   encode(message: Nested, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -644,7 +644,7 @@ function createBaseNested_InnerMessage(): Nested_InnerMessage {
   return { name: "", deep: undefined };
 }
 
-export const Nested_InnerMessage = {
+export const Nested_InnerMessage: MessageFns<Nested_InnerMessage> = {
   encode(message: Nested_InnerMessage, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -720,7 +720,7 @@ function createBaseNested_InnerMessage_DeepMessage(): Nested_InnerMessage_DeepMe
   return { name: "" };
 }
 
-export const Nested_InnerMessage_DeepMessage = {
+export const Nested_InnerMessage_DeepMessage: MessageFns<Nested_InnerMessage_DeepMessage> = {
   encode(message: Nested_InnerMessage_DeepMessage, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -779,7 +779,7 @@ function createBaseOneOfMessage(): OneOfMessage {
   return { first: undefined, last: undefined };
 }
 
-export const OneOfMessage = {
+export const OneOfMessage: MessageFns<OneOfMessage> = {
   encode(message: OneOfMessage, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.first !== undefined) {
       writer.uint32(10).string(message.first);
@@ -853,7 +853,7 @@ function createBaseSimpleWithWrappers(): SimpleWithWrappers {
   return { name: undefined, age: undefined, enabled: undefined, coins: [], snacks: [] };
 }
 
-export const SimpleWithWrappers = {
+export const SimpleWithWrappers: MessageFns<SimpleWithWrappers> = {
   encode(message: SimpleWithWrappers, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== undefined) {
       StringValue.encode({ value: message.name! }, writer.uint32(10).fork()).join();
@@ -972,7 +972,7 @@ function createBaseEntity(): Entity {
   return { id: 0 };
 }
 
-export const Entity = {
+export const Entity: MessageFns<Entity> = {
   encode(message: Entity, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.id !== 0) {
       writer.uint32(8).int32(message.id);
@@ -1029,7 +1029,7 @@ function createBaseSimpleWithMap(): SimpleWithMap {
   return { entitiesById: {}, nameLookup: {}, intLookup: {} };
 }
 
-export const SimpleWithMap = {
+export const SimpleWithMap: MessageFns<SimpleWithMap> = {
   encode(message: SimpleWithMap, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     Object.entries(message.entitiesById).forEach(([key, value]) => {
       SimpleWithMap_EntitiesByIdEntry.encode({ key: key as any, value }, writer.uint32(10).fork()).join();
@@ -1184,7 +1184,7 @@ function createBaseSimpleWithMap_EntitiesByIdEntry(): SimpleWithMap_EntitiesById
   return { key: 0, value: undefined };
 }
 
-export const SimpleWithMap_EntitiesByIdEntry = {
+export const SimpleWithMap_EntitiesByIdEntry: MessageFns<SimpleWithMap_EntitiesByIdEntry> = {
   encode(message: SimpleWithMap_EntitiesByIdEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== 0) {
       writer.uint32(8).int32(message.key);
@@ -1262,7 +1262,7 @@ function createBaseSimpleWithMap_NameLookupEntry(): SimpleWithMap_NameLookupEntr
   return { key: "", value: "" };
 }
 
-export const SimpleWithMap_NameLookupEntry = {
+export const SimpleWithMap_NameLookupEntry: MessageFns<SimpleWithMap_NameLookupEntry> = {
   encode(message: SimpleWithMap_NameLookupEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== "") {
       writer.uint32(10).string(message.key);
@@ -1338,7 +1338,7 @@ function createBaseSimpleWithMap_IntLookupEntry(): SimpleWithMap_IntLookupEntry 
   return { key: 0, value: 0 };
 }
 
-export const SimpleWithMap_IntLookupEntry = {
+export const SimpleWithMap_IntLookupEntry: MessageFns<SimpleWithMap_IntLookupEntry> = {
   encode(message: SimpleWithMap_IntLookupEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== 0) {
       writer.uint32(8).int32(message.key);
@@ -1412,7 +1412,7 @@ function createBaseSimpleWithSnakeCaseMap(): SimpleWithSnakeCaseMap {
   return { entitiesById: {} };
 }
 
-export const SimpleWithSnakeCaseMap = {
+export const SimpleWithSnakeCaseMap: MessageFns<SimpleWithSnakeCaseMap> = {
   encode(message: SimpleWithSnakeCaseMap, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     Object.entries(message.entitiesById).forEach(([key, value]) => {
       SimpleWithSnakeCaseMap_EntitiesByIdEntry.encode({ key: key as any, value }, writer.uint32(10).fork()).join();
@@ -1493,7 +1493,7 @@ function createBaseSimpleWithSnakeCaseMap_EntitiesByIdEntry(): SimpleWithSnakeCa
   return { key: 0, value: undefined };
 }
 
-export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
+export const SimpleWithSnakeCaseMap_EntitiesByIdEntry: MessageFns<SimpleWithSnakeCaseMap_EntitiesByIdEntry> = {
   encode(message: SimpleWithSnakeCaseMap_EntitiesByIdEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== 0) {
       writer.uint32(8).int32(message.key);
@@ -1573,7 +1573,7 @@ function createBasePingRequest(): PingRequest {
   return { input: "" };
 }
 
-export const PingRequest = {
+export const PingRequest: MessageFns<PingRequest> = {
   encode(message: PingRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.input !== "") {
       writer.uint32(10).string(message.input);
@@ -1630,7 +1630,7 @@ function createBasePingResponse(): PingResponse {
   return { output: "" };
 }
 
-export const PingResponse = {
+export const PingResponse: MessageFns<PingResponse> = {
   encode(message: PingResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.output !== "") {
       writer.uint32(10).string(message.output);
@@ -1700,7 +1700,7 @@ function createBaseNumbers(): Numbers {
   };
 }
 
-export const Numbers = {
+export const Numbers: MessageFns<Numbers> = {
   encode(message: Numbers, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.double !== 0) {
       writer.uint32(9).double(message.double);
@@ -1995,4 +1995,13 @@ function isObject(value: any): boolean {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/simple-proto2/simple.ts
+++ b/integration/simple-proto2/simple.ts
@@ -47,7 +47,7 @@ function createBaseIssue56(): Issue56 {
   return { test: 1 };
 }
 
-export const Issue56 = {
+export const Issue56: MessageFns<Issue56> = {
   encode(message: Issue56, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.test !== 1) {
       writer.uint32(8).int32(message.test);
@@ -114,4 +114,13 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/simple-prototype-defaults/google/protobuf/timestamp.ts
+++ b/integration/simple-prototype-defaults/google/protobuf/timestamp.ts
@@ -117,7 +117,7 @@ function createBaseTimestamp(): Timestamp {
   return { seconds: 0, nanos: 0 };
 }
 
-export const Timestamp = {
+export const Timestamp: MessageFns<Timestamp> = {
   encode(message: Timestamp, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.seconds !== 0) {
       writer.uint32(8).int64(message.seconds);
@@ -212,4 +212,13 @@ function longToNumber(int64: { toString(): string }): number {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/simple-prototype-defaults/google/protobuf/wrappers.ts
+++ b/integration/simple-prototype-defaults/google/protobuf/wrappers.ts
@@ -100,7 +100,7 @@ function createBaseDoubleValue(): DoubleValue {
   return { value: 0 };
 }
 
-export const DoubleValue = {
+export const DoubleValue: MessageFns<DoubleValue> = {
   encode(message: DoubleValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(9).double(message.value);
@@ -157,7 +157,7 @@ function createBaseFloatValue(): FloatValue {
   return { value: 0 };
 }
 
-export const FloatValue = {
+export const FloatValue: MessageFns<FloatValue> = {
   encode(message: FloatValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(13).float(message.value);
@@ -214,7 +214,7 @@ function createBaseInt64Value(): Int64Value {
   return { value: 0 };
 }
 
-export const Int64Value = {
+export const Int64Value: MessageFns<Int64Value> = {
   encode(message: Int64Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).int64(message.value);
@@ -271,7 +271,7 @@ function createBaseUInt64Value(): UInt64Value {
   return { value: 0 };
 }
 
-export const UInt64Value = {
+export const UInt64Value: MessageFns<UInt64Value> = {
   encode(message: UInt64Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).uint64(message.value);
@@ -328,7 +328,7 @@ function createBaseInt32Value(): Int32Value {
   return { value: 0 };
 }
 
-export const Int32Value = {
+export const Int32Value: MessageFns<Int32Value> = {
   encode(message: Int32Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).int32(message.value);
@@ -385,7 +385,7 @@ function createBaseUInt32Value(): UInt32Value {
   return { value: 0 };
 }
 
-export const UInt32Value = {
+export const UInt32Value: MessageFns<UInt32Value> = {
   encode(message: UInt32Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).uint32(message.value);
@@ -442,7 +442,7 @@ function createBaseBoolValue(): BoolValue {
   return { value: false };
 }
 
-export const BoolValue = {
+export const BoolValue: MessageFns<BoolValue> = {
   encode(message: BoolValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== false) {
       writer.uint32(8).bool(message.value);
@@ -499,7 +499,7 @@ function createBaseStringValue(): StringValue {
   return { value: "" };
 }
 
-export const StringValue = {
+export const StringValue: MessageFns<StringValue> = {
   encode(message: StringValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== "") {
       writer.uint32(10).string(message.value);
@@ -556,7 +556,7 @@ function createBaseBytesValue(): BytesValue {
   return { value: new Uint8Array(0) };
 }
 
-export const BytesValue = {
+export const BytesValue: MessageFns<BytesValue> = {
   encode(message: BytesValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value.length !== 0) {
       writer.uint32(10).bytes(message.value);
@@ -659,4 +659,13 @@ function longToNumber(int64: { toString(): string }): number {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/simple-prototype-defaults/google/type/date.ts
+++ b/integration/simple-prototype-defaults/google/type/date.ts
@@ -41,7 +41,7 @@ function createBaseDateMessage(): DateMessage {
   return { year: 0, month: 0, day: 0 };
 }
 
-export const DateMessage = {
+export const DateMessage: MessageFns<DateMessage> = {
   encode(message: DateMessage, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.year !== 0) {
       writer.uint32(8).int32(message.year);
@@ -140,4 +140,13 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/simple-prototype-defaults/import_dir/thing.ts
+++ b/integration/simple-prototype-defaults/import_dir/thing.ts
@@ -15,7 +15,7 @@ function createBaseImportedThing(): ImportedThing {
   return { createdAt: undefined };
 }
 
-export const ImportedThing = {
+export const ImportedThing: MessageFns<ImportedThing> = {
   encode(message: ImportedThing, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.createdAt !== undefined) {
       Timestamp.encode(toTimestamp(message.createdAt), writer.uint32(10).fork()).join();
@@ -104,4 +104,13 @@ function fromJsonTimestamp(o: any): Date {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/simple-prototype-defaults/simple.ts
+++ b/integration/simple-prototype-defaults/simple.ts
@@ -320,7 +320,7 @@ function createBaseSimple(): Simple {
   };
 }
 
-export const Simple = {
+export const Simple: MessageFns<Simple> = {
   encode(message: Simple, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -591,7 +591,7 @@ function createBaseChild(): Child {
   return { name: "", type: 0 };
 }
 
-export const Child = {
+export const Child: MessageFns<Child> = {
   encode(message: Child, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -665,7 +665,7 @@ function createBaseNested(): Nested {
   return { name: "", message: undefined, state: 0 };
 }
 
-export const Nested = {
+export const Nested: MessageFns<Nested> = {
   encode(message: Nested, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -756,7 +756,7 @@ function createBaseNested_InnerMessage(): Nested_InnerMessage {
   return { name: "", deep: undefined };
 }
 
-export const Nested_InnerMessage = {
+export const Nested_InnerMessage: MessageFns<Nested_InnerMessage> = {
   encode(message: Nested_InnerMessage, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -832,7 +832,7 @@ function createBaseNested_InnerMessage_DeepMessage(): Nested_InnerMessage_DeepMe
   return { name: "" };
 }
 
-export const Nested_InnerMessage_DeepMessage = {
+export const Nested_InnerMessage_DeepMessage: MessageFns<Nested_InnerMessage_DeepMessage> = {
   encode(message: Nested_InnerMessage_DeepMessage, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -891,7 +891,7 @@ function createBaseOneOfMessage(): OneOfMessage {
   return { first: undefined, last: undefined };
 }
 
-export const OneOfMessage = {
+export const OneOfMessage: MessageFns<OneOfMessage> = {
   encode(message: OneOfMessage, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.first !== undefined) {
       writer.uint32(10).string(message.first);
@@ -965,7 +965,7 @@ function createBaseSimpleWithWrappers(): SimpleWithWrappers {
   return { name: undefined, age: undefined, enabled: undefined, coins: [], snacks: [], id: undefined };
 }
 
-export const SimpleWithWrappers = {
+export const SimpleWithWrappers: MessageFns<SimpleWithWrappers> = {
   encode(message: SimpleWithWrappers, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== undefined) {
       StringValue.encode({ value: message.name! }, writer.uint32(10).fork()).join();
@@ -1099,7 +1099,7 @@ function createBaseEntity(): Entity {
   return { id: 0 };
 }
 
-export const Entity = {
+export const Entity: MessageFns<Entity> = {
   encode(message: Entity, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.id !== 0) {
       writer.uint32(8).int32(message.id);
@@ -1164,7 +1164,7 @@ function createBaseSimpleWithMap(): SimpleWithMap {
   };
 }
 
-export const SimpleWithMap = {
+export const SimpleWithMap: MessageFns<SimpleWithMap> = {
   encode(message: SimpleWithMap, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     Object.entries(message.entitiesById).forEach(([key, value]) => {
       SimpleWithMap_EntitiesByIdEntry.encode({ key: key as any, value }, writer.uint32(10).fork()).join();
@@ -1471,7 +1471,7 @@ function createBaseSimpleWithMap_EntitiesByIdEntry(): SimpleWithMap_EntitiesById
   return { key: 0, value: undefined };
 }
 
-export const SimpleWithMap_EntitiesByIdEntry = {
+export const SimpleWithMap_EntitiesByIdEntry: MessageFns<SimpleWithMap_EntitiesByIdEntry> = {
   encode(message: SimpleWithMap_EntitiesByIdEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== 0) {
       writer.uint32(8).int32(message.key);
@@ -1549,7 +1549,7 @@ function createBaseSimpleWithMap_NameLookupEntry(): SimpleWithMap_NameLookupEntr
   return { key: "", value: "" };
 }
 
-export const SimpleWithMap_NameLookupEntry = {
+export const SimpleWithMap_NameLookupEntry: MessageFns<SimpleWithMap_NameLookupEntry> = {
   encode(message: SimpleWithMap_NameLookupEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== "") {
       writer.uint32(10).string(message.key);
@@ -1625,7 +1625,7 @@ function createBaseSimpleWithMap_IntLookupEntry(): SimpleWithMap_IntLookupEntry 
   return { key: 0, value: 0 };
 }
 
-export const SimpleWithMap_IntLookupEntry = {
+export const SimpleWithMap_IntLookupEntry: MessageFns<SimpleWithMap_IntLookupEntry> = {
   encode(message: SimpleWithMap_IntLookupEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== 0) {
       writer.uint32(8).int32(message.key);
@@ -1699,7 +1699,7 @@ function createBaseSimpleWithMap_MapOfTimestampsEntry(): SimpleWithMap_MapOfTime
   return { key: "", value: undefined };
 }
 
-export const SimpleWithMap_MapOfTimestampsEntry = {
+export const SimpleWithMap_MapOfTimestampsEntry: MessageFns<SimpleWithMap_MapOfTimestampsEntry> = {
   encode(message: SimpleWithMap_MapOfTimestampsEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== "") {
       writer.uint32(10).string(message.key);
@@ -1777,7 +1777,7 @@ function createBaseSimpleWithMap_MapOfBytesEntry(): SimpleWithMap_MapOfBytesEntr
   return { key: "", value: new Uint8Array(0) };
 }
 
-export const SimpleWithMap_MapOfBytesEntry = {
+export const SimpleWithMap_MapOfBytesEntry: MessageFns<SimpleWithMap_MapOfBytesEntry> = {
   encode(message: SimpleWithMap_MapOfBytesEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== "") {
       writer.uint32(10).string(message.key);
@@ -1853,7 +1853,7 @@ function createBaseSimpleWithMap_MapOfStringValuesEntry(): SimpleWithMap_MapOfSt
   return { key: "", value: undefined };
 }
 
-export const SimpleWithMap_MapOfStringValuesEntry = {
+export const SimpleWithMap_MapOfStringValuesEntry: MessageFns<SimpleWithMap_MapOfStringValuesEntry> = {
   encode(message: SimpleWithMap_MapOfStringValuesEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== "") {
       writer.uint32(10).string(message.key);
@@ -1935,7 +1935,7 @@ function createBaseSimpleWithMap_LongLookupEntry(): SimpleWithMap_LongLookupEntr
   return { key: 0, value: 0 };
 }
 
-export const SimpleWithMap_LongLookupEntry = {
+export const SimpleWithMap_LongLookupEntry: MessageFns<SimpleWithMap_LongLookupEntry> = {
   encode(message: SimpleWithMap_LongLookupEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== 0) {
       writer.uint32(8).int64(message.key);
@@ -2011,7 +2011,7 @@ function createBaseSimpleWithSnakeCaseMap(): SimpleWithSnakeCaseMap {
   return { entitiesById: {} };
 }
 
-export const SimpleWithSnakeCaseMap = {
+export const SimpleWithSnakeCaseMap: MessageFns<SimpleWithSnakeCaseMap> = {
   encode(message: SimpleWithSnakeCaseMap, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     Object.entries(message.entitiesById).forEach(([key, value]) => {
       SimpleWithSnakeCaseMap_EntitiesByIdEntry.encode({ key: key as any, value }, writer.uint32(10).fork()).join();
@@ -2092,7 +2092,7 @@ function createBaseSimpleWithSnakeCaseMap_EntitiesByIdEntry(): SimpleWithSnakeCa
   return { key: 0, value: undefined };
 }
 
-export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
+export const SimpleWithSnakeCaseMap_EntitiesByIdEntry: MessageFns<SimpleWithSnakeCaseMap_EntitiesByIdEntry> = {
   encode(message: SimpleWithSnakeCaseMap_EntitiesByIdEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== 0) {
       writer.uint32(8).int32(message.key);
@@ -2176,7 +2176,7 @@ function createBaseSimpleWithMapOfEnums(): SimpleWithMapOfEnums {
   return { enumsById: {} };
 }
 
-export const SimpleWithMapOfEnums = {
+export const SimpleWithMapOfEnums: MessageFns<SimpleWithMapOfEnums> = {
   encode(message: SimpleWithMapOfEnums, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     Object.entries(message.enumsById).forEach(([key, value]) => {
       SimpleWithMapOfEnums_EnumsByIdEntry.encode({ key: key as any, value }, writer.uint32(10).fork()).join();
@@ -2257,7 +2257,7 @@ function createBaseSimpleWithMapOfEnums_EnumsByIdEntry(): SimpleWithMapOfEnums_E
   return { key: 0, value: 0 };
 }
 
-export const SimpleWithMapOfEnums_EnumsByIdEntry = {
+export const SimpleWithMapOfEnums_EnumsByIdEntry: MessageFns<SimpleWithMapOfEnums_EnumsByIdEntry> = {
   encode(message: SimpleWithMapOfEnums_EnumsByIdEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== 0) {
       writer.uint32(8).int32(message.key);
@@ -2339,7 +2339,7 @@ function createBasePingRequest(): PingRequest {
   return { input: "" };
 }
 
-export const PingRequest = {
+export const PingRequest: MessageFns<PingRequest> = {
   encode(message: PingRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.input !== "") {
       writer.uint32(10).string(message.input);
@@ -2396,7 +2396,7 @@ function createBasePingResponse(): PingResponse {
   return { output: "" };
 }
 
-export const PingResponse = {
+export const PingResponse: MessageFns<PingResponse> = {
   encode(message: PingResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.output !== "") {
       writer.uint32(10).string(message.output);
@@ -2466,7 +2466,7 @@ function createBaseNumbers(): Numbers {
   };
 }
 
-export const Numbers = {
+export const Numbers: MessageFns<Numbers> = {
   encode(message: Numbers, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.double !== 0) {
       writer.uint32(9).double(message.double);
@@ -2698,7 +2698,7 @@ function createBaseSimpleButOptional(): SimpleButOptional {
   };
 }
 
-export const SimpleButOptional = {
+export const SimpleButOptional: MessageFns<SimpleButOptional> = {
   encode(message: SimpleButOptional, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
@@ -2851,7 +2851,7 @@ function createBaseEmpty(): Empty {
   return {};
 }
 
-export const Empty = {
+export const Empty: MessageFns<Empty> = {
   encode(_: Empty, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     return writer;
   },
@@ -2990,4 +2990,13 @@ function isObject(value: any): boolean {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/simple-snake/google/protobuf/struct.ts
+++ b/integration/simple-snake/google/protobuf/struct.ts
@@ -107,7 +107,7 @@ function createBaseStruct(): Struct {
   return { fields: {} };
 }
 
-export const Struct = {
+export const Struct: MessageFns<Struct> & StructWrapperFns = {
   encode(message: Struct, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     Object.entries(message.fields).forEach(([key, value]) => {
       if (value !== undefined) {
@@ -211,7 +211,7 @@ function createBaseStruct_FieldsEntry(): Struct_FieldsEntry {
   return { key: "", value: undefined };
 }
 
-export const Struct_FieldsEntry = {
+export const Struct_FieldsEntry: MessageFns<Struct_FieldsEntry> = {
   encode(message: Struct_FieldsEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== "") {
       writer.uint32(10).string(message.key);
@@ -292,7 +292,7 @@ function createBaseValue(): Value {
   };
 }
 
-export const Value = {
+export const Value: MessageFns<Value> & AnyValueWrapperFns = {
   encode(message: Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.null_value !== undefined) {
       writer.uint32(8).int32(message.null_value);
@@ -463,7 +463,7 @@ function createBaseListValue(): ListValue {
   return { values: [] };
 }
 
-export const ListValue = {
+export const ListValue: MessageFns<ListValue> & ListValueWrapperFns = {
   encode(message: ListValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     for (const v of message.values) {
       Value.encode(Value.wrap(v!), writer.uint32(10).fork()).join();
@@ -548,4 +548,28 @@ function isObject(value: any): boolean {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
+}
+
+export interface StructWrapperFns {
+  wrap(object: { [key: string]: any } | undefined): Struct;
+  unwrap(message: Struct): { [key: string]: any };
+}
+
+export interface AnyValueWrapperFns {
+  wrap(value: any): Value;
+  unwrap(message: any): string | number | boolean | Object | null | Array<any> | undefined;
+}
+
+export interface ListValueWrapperFns {
+  wrap(array: Array<any> | undefined): ListValue;
+  unwrap(message: ListValue): Array<any>;
 }

--- a/integration/simple-snake/google/protobuf/timestamp.ts
+++ b/integration/simple-snake/google/protobuf/timestamp.ts
@@ -117,7 +117,7 @@ function createBaseTimestamp(): Timestamp {
   return { seconds: 0, nanos: 0 };
 }
 
-export const Timestamp = {
+export const Timestamp: MessageFns<Timestamp> = {
   encode(message: Timestamp, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.seconds !== 0) {
       writer.uint32(8).int64(message.seconds);
@@ -212,4 +212,13 @@ function longToNumber(int64: { toString(): string }): number {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/simple-snake/google/protobuf/wrappers.ts
+++ b/integration/simple-snake/google/protobuf/wrappers.ts
@@ -100,7 +100,7 @@ function createBaseDoubleValue(): DoubleValue {
   return { value: 0 };
 }
 
-export const DoubleValue = {
+export const DoubleValue: MessageFns<DoubleValue> = {
   encode(message: DoubleValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(9).double(message.value);
@@ -157,7 +157,7 @@ function createBaseFloatValue(): FloatValue {
   return { value: 0 };
 }
 
-export const FloatValue = {
+export const FloatValue: MessageFns<FloatValue> = {
   encode(message: FloatValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(13).float(message.value);
@@ -214,7 +214,7 @@ function createBaseInt64Value(): Int64Value {
   return { value: 0 };
 }
 
-export const Int64Value = {
+export const Int64Value: MessageFns<Int64Value> = {
   encode(message: Int64Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).int64(message.value);
@@ -271,7 +271,7 @@ function createBaseUInt64Value(): UInt64Value {
   return { value: 0 };
 }
 
-export const UInt64Value = {
+export const UInt64Value: MessageFns<UInt64Value> = {
   encode(message: UInt64Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).uint64(message.value);
@@ -328,7 +328,7 @@ function createBaseInt32Value(): Int32Value {
   return { value: 0 };
 }
 
-export const Int32Value = {
+export const Int32Value: MessageFns<Int32Value> = {
   encode(message: Int32Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).int32(message.value);
@@ -385,7 +385,7 @@ function createBaseUInt32Value(): UInt32Value {
   return { value: 0 };
 }
 
-export const UInt32Value = {
+export const UInt32Value: MessageFns<UInt32Value> = {
   encode(message: UInt32Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).uint32(message.value);
@@ -442,7 +442,7 @@ function createBaseBoolValue(): BoolValue {
   return { value: false };
 }
 
-export const BoolValue = {
+export const BoolValue: MessageFns<BoolValue> = {
   encode(message: BoolValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== false) {
       writer.uint32(8).bool(message.value);
@@ -499,7 +499,7 @@ function createBaseStringValue(): StringValue {
   return { value: "" };
 }
 
-export const StringValue = {
+export const StringValue: MessageFns<StringValue> = {
   encode(message: StringValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== "") {
       writer.uint32(10).string(message.value);
@@ -556,7 +556,7 @@ function createBaseBytesValue(): BytesValue {
   return { value: new Uint8Array(0) };
 }
 
-export const BytesValue = {
+export const BytesValue: MessageFns<BytesValue> = {
   encode(message: BytesValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value.length !== 0) {
       writer.uint32(10).bytes(message.value);
@@ -659,4 +659,13 @@ function longToNumber(int64: { toString(): string }): number {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/simple-snake/import_dir/thing.ts
+++ b/integration/simple-snake/import_dir/thing.ts
@@ -15,7 +15,7 @@ function createBaseImportedThing(): ImportedThing {
   return { created_at: undefined };
 }
 
-export const ImportedThing = {
+export const ImportedThing: MessageFns<ImportedThing> = {
   encode(message: ImportedThing, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.created_at !== undefined) {
       Timestamp.encode(toTimestamp(message.created_at), writer.uint32(10).fork()).join();
@@ -104,4 +104,13 @@ function fromJsonTimestamp(o: any): Date {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/simple-snake/simple.ts
+++ b/integration/simple-snake/simple.ts
@@ -260,7 +260,7 @@ function createBaseSimple(): Simple {
   };
 }
 
-export const Simple = {
+export const Simple: MessageFns<Simple> = {
   encode(message: Simple, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -484,7 +484,7 @@ function createBaseChild(): Child {
   return { name: "", type: 0 };
 }
 
-export const Child = {
+export const Child: MessageFns<Child> = {
   encode(message: Child, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -558,7 +558,7 @@ function createBaseNested(): Nested {
   return { name: "", message: undefined, state: 0 };
 }
 
-export const Nested = {
+export const Nested: MessageFns<Nested> = {
   encode(message: Nested, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -649,7 +649,7 @@ function createBaseNested_InnerMessage(): Nested_InnerMessage {
   return { name: "", deep: undefined };
 }
 
-export const Nested_InnerMessage = {
+export const Nested_InnerMessage: MessageFns<Nested_InnerMessage> = {
   encode(message: Nested_InnerMessage, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -725,7 +725,7 @@ function createBaseNested_InnerMessage_DeepMessage(): Nested_InnerMessage_DeepMe
   return { name: "" };
 }
 
-export const Nested_InnerMessage_DeepMessage = {
+export const Nested_InnerMessage_DeepMessage: MessageFns<Nested_InnerMessage_DeepMessage> = {
   encode(message: Nested_InnerMessage_DeepMessage, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -784,7 +784,7 @@ function createBaseOneOfMessage(): OneOfMessage {
   return { first: undefined, last: undefined };
 }
 
-export const OneOfMessage = {
+export const OneOfMessage: MessageFns<OneOfMessage> = {
   encode(message: OneOfMessage, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.first !== undefined) {
       writer.uint32(10).string(message.first);
@@ -858,7 +858,7 @@ function createBaseSimpleWithWrappers(): SimpleWithWrappers {
   return { name: undefined, age: undefined, enabled: undefined, coins: [], snacks: [] };
 }
 
-export const SimpleWithWrappers = {
+export const SimpleWithWrappers: MessageFns<SimpleWithWrappers> = {
   encode(message: SimpleWithWrappers, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== undefined) {
       StringValue.encode({ value: message.name! }, writer.uint32(10).fork()).join();
@@ -977,7 +977,7 @@ function createBaseEntity(): Entity {
   return { id: 0 };
 }
 
-export const Entity = {
+export const Entity: MessageFns<Entity> = {
   encode(message: Entity, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.id !== 0) {
       writer.uint32(8).int32(message.id);
@@ -1034,7 +1034,7 @@ function createBaseSimpleWithMap(): SimpleWithMap {
   return { entitiesById: {}, nameLookup: {}, intLookup: {} };
 }
 
-export const SimpleWithMap = {
+export const SimpleWithMap: MessageFns<SimpleWithMap> = {
   encode(message: SimpleWithMap, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     Object.entries(message.entitiesById).forEach(([key, value]) => {
       SimpleWithMap_EntitiesByIdEntry.encode({ key: key as any, value }, writer.uint32(10).fork()).join();
@@ -1189,7 +1189,7 @@ function createBaseSimpleWithMap_EntitiesByIdEntry(): SimpleWithMap_EntitiesById
   return { key: 0, value: undefined };
 }
 
-export const SimpleWithMap_EntitiesByIdEntry = {
+export const SimpleWithMap_EntitiesByIdEntry: MessageFns<SimpleWithMap_EntitiesByIdEntry> = {
   encode(message: SimpleWithMap_EntitiesByIdEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== 0) {
       writer.uint32(8).int32(message.key);
@@ -1267,7 +1267,7 @@ function createBaseSimpleWithMap_NameLookupEntry(): SimpleWithMap_NameLookupEntr
   return { key: "", value: "" };
 }
 
-export const SimpleWithMap_NameLookupEntry = {
+export const SimpleWithMap_NameLookupEntry: MessageFns<SimpleWithMap_NameLookupEntry> = {
   encode(message: SimpleWithMap_NameLookupEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== "") {
       writer.uint32(10).string(message.key);
@@ -1343,7 +1343,7 @@ function createBaseSimpleWithMap_IntLookupEntry(): SimpleWithMap_IntLookupEntry 
   return { key: 0, value: 0 };
 }
 
-export const SimpleWithMap_IntLookupEntry = {
+export const SimpleWithMap_IntLookupEntry: MessageFns<SimpleWithMap_IntLookupEntry> = {
   encode(message: SimpleWithMap_IntLookupEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== 0) {
       writer.uint32(8).int32(message.key);
@@ -1417,7 +1417,7 @@ function createBaseSimpleWithSnakeCaseMap(): SimpleWithSnakeCaseMap {
   return { entities_by_id: {} };
 }
 
-export const SimpleWithSnakeCaseMap = {
+export const SimpleWithSnakeCaseMap: MessageFns<SimpleWithSnakeCaseMap> = {
   encode(message: SimpleWithSnakeCaseMap, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     Object.entries(message.entities_by_id).forEach(([key, value]) => {
       SimpleWithSnakeCaseMap_EntitiesByIdEntry.encode({ key: key as any, value }, writer.uint32(10).fork()).join();
@@ -1498,7 +1498,7 @@ function createBaseSimpleWithSnakeCaseMap_EntitiesByIdEntry(): SimpleWithSnakeCa
   return { key: 0, value: undefined };
 }
 
-export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
+export const SimpleWithSnakeCaseMap_EntitiesByIdEntry: MessageFns<SimpleWithSnakeCaseMap_EntitiesByIdEntry> = {
   encode(message: SimpleWithSnakeCaseMap_EntitiesByIdEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== 0) {
       writer.uint32(8).int32(message.key);
@@ -1578,7 +1578,7 @@ function createBasePingRequest(): PingRequest {
   return { input: "" };
 }
 
-export const PingRequest = {
+export const PingRequest: MessageFns<PingRequest> = {
   encode(message: PingRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.input !== "") {
       writer.uint32(10).string(message.input);
@@ -1635,7 +1635,7 @@ function createBasePingResponse(): PingResponse {
   return { output: "" };
 }
 
-export const PingResponse = {
+export const PingResponse: MessageFns<PingResponse> = {
   encode(message: PingResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.output !== "") {
       writer.uint32(10).string(message.output);
@@ -1705,7 +1705,7 @@ function createBaseNumbers(): Numbers {
   };
 }
 
-export const Numbers = {
+export const Numbers: MessageFns<Numbers> = {
   encode(message: Numbers, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.double !== 0) {
       writer.uint32(9).double(message.double);
@@ -1929,7 +1929,7 @@ function createBaseSimpleStruct(): SimpleStruct {
   return { simple_struct: undefined };
 }
 
-export const SimpleStruct = {
+export const SimpleStruct: MessageFns<SimpleStruct> = {
   encode(message: SimpleStruct, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.simple_struct !== undefined) {
       Struct.encode(Struct.wrap(message.simple_struct), writer.uint32(10).fork()).join();
@@ -2057,4 +2057,13 @@ function isObject(value: any): boolean {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/simple-string-enums/google/protobuf/struct.ts
+++ b/integration/simple-string-enums/google/protobuf/struct.ts
@@ -117,7 +117,7 @@ function createBaseStruct(): Struct {
   return { fields: {} };
 }
 
-export const Struct = {
+export const Struct: MessageFns<Struct> & StructWrapperFns = {
   encode(message: Struct, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     Object.entries(message.fields).forEach(([key, value]) => {
       if (value !== undefined) {
@@ -221,7 +221,7 @@ function createBaseStruct_FieldsEntry(): Struct_FieldsEntry {
   return { key: "", value: undefined };
 }
 
-export const Struct_FieldsEntry = {
+export const Struct_FieldsEntry: MessageFns<Struct_FieldsEntry> = {
   encode(message: Struct_FieldsEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== "") {
       writer.uint32(10).string(message.key);
@@ -302,7 +302,7 @@ function createBaseValue(): Value {
   };
 }
 
-export const Value = {
+export const Value: MessageFns<Value> & AnyValueWrapperFns = {
   encode(message: Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.nullValue !== undefined) {
       writer.uint32(8).int32(nullValueToNumber(message.nullValue));
@@ -473,7 +473,7 @@ function createBaseListValue(): ListValue {
   return { values: [] };
 }
 
-export const ListValue = {
+export const ListValue: MessageFns<ListValue> & ListValueWrapperFns = {
   encode(message: ListValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     for (const v of message.values) {
       Value.encode(Value.wrap(v!), writer.uint32(10).fork()).join();
@@ -558,4 +558,28 @@ function isObject(value: any): boolean {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
+}
+
+export interface StructWrapperFns {
+  wrap(object: { [key: string]: any } | undefined): Struct;
+  unwrap(message: Struct): { [key: string]: any };
+}
+
+export interface AnyValueWrapperFns {
+  wrap(value: any): Value;
+  unwrap(message: any): string | number | boolean | Object | null | Array<any> | undefined;
+}
+
+export interface ListValueWrapperFns {
+  wrap(array: Array<any> | undefined): ListValue;
+  unwrap(message: ListValue): Array<any>;
 }

--- a/integration/simple-string-enums/simple.ts
+++ b/integration/simple-string-enums/simple.ts
@@ -77,7 +77,7 @@ function createBaseSimple(): Simple {
   return { name: "", state: StateEnum.UNKNOWN, states: [], nullValue: NullValue.NULL_VALUE, stateMap: {} };
 }
 
-export const Simple = {
+export const Simple: MessageFns<Simple> = {
   encode(message: Simple, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -230,7 +230,7 @@ function createBaseSimple_StateMapEntry(): Simple_StateMapEntry {
   return { key: "", value: StateEnum.UNKNOWN };
 }
 
-export const Simple_StateMapEntry = {
+export const Simple_StateMapEntry: MessageFns<Simple_StateMapEntry> = {
   encode(message: Simple_StateMapEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== "") {
       writer.uint32(10).string(message.key);
@@ -318,4 +318,13 @@ function isObject(value: any): boolean {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/simple-unrecognized-enum/google/protobuf/timestamp.ts
+++ b/integration/simple-unrecognized-enum/google/protobuf/timestamp.ts
@@ -117,7 +117,7 @@ function createBaseTimestamp(): Timestamp {
   return { seconds: 0, nanos: 0 };
 }
 
-export const Timestamp = {
+export const Timestamp: MessageFns<Timestamp> = {
   encode(message: Timestamp, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.seconds !== 0) {
       writer.uint32(8).int64(message.seconds);
@@ -212,4 +212,13 @@ function longToNumber(int64: { toString(): string }): number {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/simple-unrecognized-enum/google/protobuf/wrappers.ts
+++ b/integration/simple-unrecognized-enum/google/protobuf/wrappers.ts
@@ -100,7 +100,7 @@ function createBaseDoubleValue(): DoubleValue {
   return { value: 0 };
 }
 
-export const DoubleValue = {
+export const DoubleValue: MessageFns<DoubleValue> = {
   encode(message: DoubleValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(9).double(message.value);
@@ -157,7 +157,7 @@ function createBaseFloatValue(): FloatValue {
   return { value: 0 };
 }
 
-export const FloatValue = {
+export const FloatValue: MessageFns<FloatValue> = {
   encode(message: FloatValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(13).float(message.value);
@@ -214,7 +214,7 @@ function createBaseInt64Value(): Int64Value {
   return { value: 0 };
 }
 
-export const Int64Value = {
+export const Int64Value: MessageFns<Int64Value> = {
   encode(message: Int64Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).int64(message.value);
@@ -271,7 +271,7 @@ function createBaseUInt64Value(): UInt64Value {
   return { value: 0 };
 }
 
-export const UInt64Value = {
+export const UInt64Value: MessageFns<UInt64Value> = {
   encode(message: UInt64Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).uint64(message.value);
@@ -328,7 +328,7 @@ function createBaseInt32Value(): Int32Value {
   return { value: 0 };
 }
 
-export const Int32Value = {
+export const Int32Value: MessageFns<Int32Value> = {
   encode(message: Int32Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).int32(message.value);
@@ -385,7 +385,7 @@ function createBaseUInt32Value(): UInt32Value {
   return { value: 0 };
 }
 
-export const UInt32Value = {
+export const UInt32Value: MessageFns<UInt32Value> = {
   encode(message: UInt32Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).uint32(message.value);
@@ -442,7 +442,7 @@ function createBaseBoolValue(): BoolValue {
   return { value: false };
 }
 
-export const BoolValue = {
+export const BoolValue: MessageFns<BoolValue> = {
   encode(message: BoolValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== false) {
       writer.uint32(8).bool(message.value);
@@ -499,7 +499,7 @@ function createBaseStringValue(): StringValue {
   return { value: "" };
 }
 
-export const StringValue = {
+export const StringValue: MessageFns<StringValue> = {
   encode(message: StringValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== "") {
       writer.uint32(10).string(message.value);
@@ -556,7 +556,7 @@ function createBaseBytesValue(): BytesValue {
   return { value: new Uint8Array(0) };
 }
 
-export const BytesValue = {
+export const BytesValue: MessageFns<BytesValue> = {
   encode(message: BytesValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value.length !== 0) {
       writer.uint32(10).bytes(message.value);
@@ -659,4 +659,13 @@ function longToNumber(int64: { toString(): string }): number {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/simple-unrecognized-enum/import_dir/thing.ts
+++ b/integration/simple-unrecognized-enum/import_dir/thing.ts
@@ -15,7 +15,7 @@ function createBaseImportedThing(): ImportedThing {
   return { createdAt: undefined };
 }
 
-export const ImportedThing = {
+export const ImportedThing: MessageFns<ImportedThing> = {
   encode(message: ImportedThing, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.createdAt !== undefined) {
       Timestamp.encode(toTimestamp(message.createdAt), writer.uint32(10).fork()).join();
@@ -104,4 +104,13 @@ function fromJsonTimestamp(o: any): Date {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/simple-unrecognized-enum/simple.ts
+++ b/integration/simple-unrecognized-enum/simple.ts
@@ -243,7 +243,7 @@ function createBaseSimple(): Simple {
   };
 }
 
-export const Simple = {
+export const Simple: MessageFns<Simple> = {
   encode(message: Simple, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -467,7 +467,7 @@ function createBaseChild(): Child {
   return { name: "", type: 0 };
 }
 
-export const Child = {
+export const Child: MessageFns<Child> = {
   encode(message: Child, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -541,7 +541,7 @@ function createBaseNested(): Nested {
   return { name: "", message: undefined, state: 0 };
 }
 
-export const Nested = {
+export const Nested: MessageFns<Nested> = {
   encode(message: Nested, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -632,7 +632,7 @@ function createBaseNested_InnerMessage(): Nested_InnerMessage {
   return { name: "", deep: undefined };
 }
 
-export const Nested_InnerMessage = {
+export const Nested_InnerMessage: MessageFns<Nested_InnerMessage> = {
   encode(message: Nested_InnerMessage, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -708,7 +708,7 @@ function createBaseNested_InnerMessage_DeepMessage(): Nested_InnerMessage_DeepMe
   return { name: "" };
 }
 
-export const Nested_InnerMessage_DeepMessage = {
+export const Nested_InnerMessage_DeepMessage: MessageFns<Nested_InnerMessage_DeepMessage> = {
   encode(message: Nested_InnerMessage_DeepMessage, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -767,7 +767,7 @@ function createBaseOneOfMessage(): OneOfMessage {
   return { first: undefined, last: undefined };
 }
 
-export const OneOfMessage = {
+export const OneOfMessage: MessageFns<OneOfMessage> = {
   encode(message: OneOfMessage, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.first !== undefined) {
       writer.uint32(10).string(message.first);
@@ -841,7 +841,7 @@ function createBaseSimpleWithWrappers(): SimpleWithWrappers {
   return { name: undefined, age: undefined, enabled: undefined, coins: [], snacks: [] };
 }
 
-export const SimpleWithWrappers = {
+export const SimpleWithWrappers: MessageFns<SimpleWithWrappers> = {
   encode(message: SimpleWithWrappers, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== undefined) {
       StringValue.encode({ value: message.name! }, writer.uint32(10).fork()).join();
@@ -960,7 +960,7 @@ function createBaseEntity(): Entity {
   return { id: 0 };
 }
 
-export const Entity = {
+export const Entity: MessageFns<Entity> = {
   encode(message: Entity, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.id !== 0) {
       writer.uint32(8).int32(message.id);
@@ -1017,7 +1017,7 @@ function createBaseSimpleWithMap(): SimpleWithMap {
   return { entitiesById: {}, nameLookup: {}, intLookup: {} };
 }
 
-export const SimpleWithMap = {
+export const SimpleWithMap: MessageFns<SimpleWithMap> = {
   encode(message: SimpleWithMap, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     Object.entries(message.entitiesById).forEach(([key, value]) => {
       SimpleWithMap_EntitiesByIdEntry.encode({ key: key as any, value }, writer.uint32(10).fork()).join();
@@ -1172,7 +1172,7 @@ function createBaseSimpleWithMap_EntitiesByIdEntry(): SimpleWithMap_EntitiesById
   return { key: 0, value: undefined };
 }
 
-export const SimpleWithMap_EntitiesByIdEntry = {
+export const SimpleWithMap_EntitiesByIdEntry: MessageFns<SimpleWithMap_EntitiesByIdEntry> = {
   encode(message: SimpleWithMap_EntitiesByIdEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== 0) {
       writer.uint32(8).int32(message.key);
@@ -1250,7 +1250,7 @@ function createBaseSimpleWithMap_NameLookupEntry(): SimpleWithMap_NameLookupEntr
   return { key: "", value: "" };
 }
 
-export const SimpleWithMap_NameLookupEntry = {
+export const SimpleWithMap_NameLookupEntry: MessageFns<SimpleWithMap_NameLookupEntry> = {
   encode(message: SimpleWithMap_NameLookupEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== "") {
       writer.uint32(10).string(message.key);
@@ -1326,7 +1326,7 @@ function createBaseSimpleWithMap_IntLookupEntry(): SimpleWithMap_IntLookupEntry 
   return { key: 0, value: 0 };
 }
 
-export const SimpleWithMap_IntLookupEntry = {
+export const SimpleWithMap_IntLookupEntry: MessageFns<SimpleWithMap_IntLookupEntry> = {
   encode(message: SimpleWithMap_IntLookupEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== 0) {
       writer.uint32(8).int32(message.key);
@@ -1400,7 +1400,7 @@ function createBaseSimpleWithSnakeCaseMap(): SimpleWithSnakeCaseMap {
   return { entitiesById: {} };
 }
 
-export const SimpleWithSnakeCaseMap = {
+export const SimpleWithSnakeCaseMap: MessageFns<SimpleWithSnakeCaseMap> = {
   encode(message: SimpleWithSnakeCaseMap, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     Object.entries(message.entitiesById).forEach(([key, value]) => {
       SimpleWithSnakeCaseMap_EntitiesByIdEntry.encode({ key: key as any, value }, writer.uint32(10).fork()).join();
@@ -1481,7 +1481,7 @@ function createBaseSimpleWithSnakeCaseMap_EntitiesByIdEntry(): SimpleWithSnakeCa
   return { key: 0, value: undefined };
 }
 
-export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
+export const SimpleWithSnakeCaseMap_EntitiesByIdEntry: MessageFns<SimpleWithSnakeCaseMap_EntitiesByIdEntry> = {
   encode(message: SimpleWithSnakeCaseMap_EntitiesByIdEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== 0) {
       writer.uint32(8).int32(message.key);
@@ -1561,7 +1561,7 @@ function createBasePingRequest(): PingRequest {
   return { input: "" };
 }
 
-export const PingRequest = {
+export const PingRequest: MessageFns<PingRequest> = {
   encode(message: PingRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.input !== "") {
       writer.uint32(10).string(message.input);
@@ -1618,7 +1618,7 @@ function createBasePingResponse(): PingResponse {
   return { output: "" };
 }
 
-export const PingResponse = {
+export const PingResponse: MessageFns<PingResponse> = {
   encode(message: PingResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.output !== "") {
       writer.uint32(10).string(message.output);
@@ -1688,7 +1688,7 @@ function createBaseNumbers(): Numbers {
   };
 }
 
-export const Numbers = {
+export const Numbers: MessageFns<Numbers> = {
   encode(message: Numbers, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.double !== 0) {
       writer.uint32(9).double(message.double);
@@ -1983,4 +1983,13 @@ function isObject(value: any): boolean {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/simple/google/protobuf/timestamp.ts
+++ b/integration/simple/google/protobuf/timestamp.ts
@@ -117,7 +117,7 @@ function createBaseTimestamp(): Timestamp {
   return { seconds: 0, nanos: 0 };
 }
 
-export const Timestamp = {
+export const Timestamp: MessageFns<Timestamp> = {
   encode(message: Timestamp, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.seconds !== 0) {
       writer.uint32(8).int64(message.seconds);
@@ -212,4 +212,13 @@ function longToNumber(int64: { toString(): string }): number {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/simple/google/protobuf/wrappers.ts
+++ b/integration/simple/google/protobuf/wrappers.ts
@@ -100,7 +100,7 @@ function createBaseDoubleValue(): DoubleValue {
   return { value: 0 };
 }
 
-export const DoubleValue = {
+export const DoubleValue: MessageFns<DoubleValue> = {
   encode(message: DoubleValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(9).double(message.value);
@@ -157,7 +157,7 @@ function createBaseFloatValue(): FloatValue {
   return { value: 0 };
 }
 
-export const FloatValue = {
+export const FloatValue: MessageFns<FloatValue> = {
   encode(message: FloatValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(13).float(message.value);
@@ -214,7 +214,7 @@ function createBaseInt64Value(): Int64Value {
   return { value: 0 };
 }
 
-export const Int64Value = {
+export const Int64Value: MessageFns<Int64Value> = {
   encode(message: Int64Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).int64(message.value);
@@ -271,7 +271,7 @@ function createBaseUInt64Value(): UInt64Value {
   return { value: 0 };
 }
 
-export const UInt64Value = {
+export const UInt64Value: MessageFns<UInt64Value> = {
   encode(message: UInt64Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).uint64(message.value);
@@ -328,7 +328,7 @@ function createBaseInt32Value(): Int32Value {
   return { value: 0 };
 }
 
-export const Int32Value = {
+export const Int32Value: MessageFns<Int32Value> = {
   encode(message: Int32Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).int32(message.value);
@@ -385,7 +385,7 @@ function createBaseUInt32Value(): UInt32Value {
   return { value: 0 };
 }
 
-export const UInt32Value = {
+export const UInt32Value: MessageFns<UInt32Value> = {
   encode(message: UInt32Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).uint32(message.value);
@@ -442,7 +442,7 @@ function createBaseBoolValue(): BoolValue {
   return { value: false };
 }
 
-export const BoolValue = {
+export const BoolValue: MessageFns<BoolValue> = {
   encode(message: BoolValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== false) {
       writer.uint32(8).bool(message.value);
@@ -499,7 +499,7 @@ function createBaseStringValue(): StringValue {
   return { value: "" };
 }
 
-export const StringValue = {
+export const StringValue: MessageFns<StringValue> = {
   encode(message: StringValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== "") {
       writer.uint32(10).string(message.value);
@@ -556,7 +556,7 @@ function createBaseBytesValue(): BytesValue {
   return { value: new Uint8Array(0) };
 }
 
-export const BytesValue = {
+export const BytesValue: MessageFns<BytesValue> = {
   encode(message: BytesValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value.length !== 0) {
       writer.uint32(10).bytes(message.value);
@@ -659,4 +659,13 @@ function longToNumber(int64: { toString(): string }): number {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/simple/google/type/date.ts
+++ b/integration/simple/google/type/date.ts
@@ -41,7 +41,7 @@ function createBaseDateMessage(): DateMessage {
   return { year: 0, month: 0, day: 0 };
 }
 
-export const DateMessage = {
+export const DateMessage: MessageFns<DateMessage> = {
   encode(message: DateMessage, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.year !== 0) {
       writer.uint32(8).int32(message.year);
@@ -140,4 +140,13 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/simple/import_dir/thing.ts
+++ b/integration/simple/import_dir/thing.ts
@@ -15,7 +15,7 @@ function createBaseImportedThing(): ImportedThing {
   return { createdAt: undefined };
 }
 
-export const ImportedThing = {
+export const ImportedThing: MessageFns<ImportedThing> = {
   encode(message: ImportedThing, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.createdAt !== undefined) {
       Timestamp.encode(toTimestamp(message.createdAt), writer.uint32(10).fork()).join();
@@ -104,4 +104,13 @@ function fromJsonTimestamp(o: any): Date {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/simple/simple.ts
+++ b/integration/simple/simple.ts
@@ -328,7 +328,7 @@ function createBaseSimple(): Simple {
   };
 }
 
-export const Simple = {
+export const Simple: MessageFns<Simple> = {
   encode(message: Simple, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -614,7 +614,7 @@ function createBaseChild(): Child {
   return { name: "", type: 0 };
 }
 
-export const Child = {
+export const Child: MessageFns<Child> = {
   encode(message: Child, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -688,7 +688,7 @@ function createBaseNested(): Nested {
   return { name: "", message: undefined, state: 0 };
 }
 
-export const Nested = {
+export const Nested: MessageFns<Nested> = {
   encode(message: Nested, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -779,7 +779,7 @@ function createBaseNested_InnerMessage(): Nested_InnerMessage {
   return { name: "", deep: undefined };
 }
 
-export const Nested_InnerMessage = {
+export const Nested_InnerMessage: MessageFns<Nested_InnerMessage> = {
   encode(message: Nested_InnerMessage, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -855,7 +855,7 @@ function createBaseNested_InnerMessage_DeepMessage(): Nested_InnerMessage_DeepMe
   return { name: "" };
 }
 
-export const Nested_InnerMessage_DeepMessage = {
+export const Nested_InnerMessage_DeepMessage: MessageFns<Nested_InnerMessage_DeepMessage> = {
   encode(message: Nested_InnerMessage_DeepMessage, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -914,7 +914,7 @@ function createBaseOneOfMessage(): OneOfMessage {
   return { first: undefined, last: undefined };
 }
 
-export const OneOfMessage = {
+export const OneOfMessage: MessageFns<OneOfMessage> = {
   encode(message: OneOfMessage, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.first !== undefined) {
       writer.uint32(10).string(message.first);
@@ -988,7 +988,7 @@ function createBaseSimpleWithWrappers(): SimpleWithWrappers {
   return { name: undefined, age: undefined, enabled: undefined, coins: [], snacks: [], id: undefined };
 }
 
-export const SimpleWithWrappers = {
+export const SimpleWithWrappers: MessageFns<SimpleWithWrappers> = {
   encode(message: SimpleWithWrappers, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== undefined) {
       StringValue.encode({ value: message.name! }, writer.uint32(10).fork()).join();
@@ -1122,7 +1122,7 @@ function createBaseEntity(): Entity {
   return { id: 0 };
 }
 
-export const Entity = {
+export const Entity: MessageFns<Entity> = {
   encode(message: Entity, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.id !== 0) {
       writer.uint32(8).int32(message.id);
@@ -1188,7 +1188,7 @@ function createBaseSimpleWithMap(): SimpleWithMap {
   };
 }
 
-export const SimpleWithMap = {
+export const SimpleWithMap: MessageFns<SimpleWithMap> = {
   encode(message: SimpleWithMap, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     Object.entries(message.entitiesById).forEach(([key, value]) => {
       SimpleWithMap_EntitiesByIdEntry.encode({ key: key as any, value }, writer.uint32(10).fork()).join();
@@ -1529,7 +1529,7 @@ function createBaseSimpleWithMap_EntitiesByIdEntry(): SimpleWithMap_EntitiesById
   return { key: 0, value: undefined };
 }
 
-export const SimpleWithMap_EntitiesByIdEntry = {
+export const SimpleWithMap_EntitiesByIdEntry: MessageFns<SimpleWithMap_EntitiesByIdEntry> = {
   encode(message: SimpleWithMap_EntitiesByIdEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== 0) {
       writer.uint32(8).int32(message.key);
@@ -1607,7 +1607,7 @@ function createBaseSimpleWithMap_NameLookupEntry(): SimpleWithMap_NameLookupEntr
   return { key: "", value: "" };
 }
 
-export const SimpleWithMap_NameLookupEntry = {
+export const SimpleWithMap_NameLookupEntry: MessageFns<SimpleWithMap_NameLookupEntry> = {
   encode(message: SimpleWithMap_NameLookupEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== "") {
       writer.uint32(10).string(message.key);
@@ -1683,7 +1683,7 @@ function createBaseSimpleWithMap_IntLookupEntry(): SimpleWithMap_IntLookupEntry 
   return { key: 0, value: 0 };
 }
 
-export const SimpleWithMap_IntLookupEntry = {
+export const SimpleWithMap_IntLookupEntry: MessageFns<SimpleWithMap_IntLookupEntry> = {
   encode(message: SimpleWithMap_IntLookupEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== 0) {
       writer.uint32(8).int32(message.key);
@@ -1757,7 +1757,7 @@ function createBaseSimpleWithMap_MapOfTimestampsEntry(): SimpleWithMap_MapOfTime
   return { key: "", value: undefined };
 }
 
-export const SimpleWithMap_MapOfTimestampsEntry = {
+export const SimpleWithMap_MapOfTimestampsEntry: MessageFns<SimpleWithMap_MapOfTimestampsEntry> = {
   encode(message: SimpleWithMap_MapOfTimestampsEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== "") {
       writer.uint32(10).string(message.key);
@@ -1835,7 +1835,7 @@ function createBaseSimpleWithMap_MapOfBytesEntry(): SimpleWithMap_MapOfBytesEntr
   return { key: "", value: new Uint8Array(0) };
 }
 
-export const SimpleWithMap_MapOfBytesEntry = {
+export const SimpleWithMap_MapOfBytesEntry: MessageFns<SimpleWithMap_MapOfBytesEntry> = {
   encode(message: SimpleWithMap_MapOfBytesEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== "") {
       writer.uint32(10).string(message.key);
@@ -1911,7 +1911,7 @@ function createBaseSimpleWithMap_MapOfStringValuesEntry(): SimpleWithMap_MapOfSt
   return { key: "", value: undefined };
 }
 
-export const SimpleWithMap_MapOfStringValuesEntry = {
+export const SimpleWithMap_MapOfStringValuesEntry: MessageFns<SimpleWithMap_MapOfStringValuesEntry> = {
   encode(message: SimpleWithMap_MapOfStringValuesEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== "") {
       writer.uint32(10).string(message.key);
@@ -1989,7 +1989,7 @@ function createBaseSimpleWithMap_LongLookupEntry(): SimpleWithMap_LongLookupEntr
   return { key: 0, value: 0 };
 }
 
-export const SimpleWithMap_LongLookupEntry = {
+export const SimpleWithMap_LongLookupEntry: MessageFns<SimpleWithMap_LongLookupEntry> = {
   encode(message: SimpleWithMap_LongLookupEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== 0) {
       writer.uint32(8).int64(message.key);
@@ -2065,7 +2065,7 @@ function createBaseSimpleWithMap_BoolLookupEntry(): SimpleWithMap_BoolLookupEntr
   return { key: false, value: 0 };
 }
 
-export const SimpleWithMap_BoolLookupEntry = {
+export const SimpleWithMap_BoolLookupEntry: MessageFns<SimpleWithMap_BoolLookupEntry> = {
   encode(message: SimpleWithMap_BoolLookupEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== false) {
       writer.uint32(8).bool(message.key);
@@ -2141,7 +2141,7 @@ function createBaseSimpleWithSnakeCaseMap(): SimpleWithSnakeCaseMap {
   return { entitiesById: {} };
 }
 
-export const SimpleWithSnakeCaseMap = {
+export const SimpleWithSnakeCaseMap: MessageFns<SimpleWithSnakeCaseMap> = {
   encode(message: SimpleWithSnakeCaseMap, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     Object.entries(message.entitiesById).forEach(([key, value]) => {
       SimpleWithSnakeCaseMap_EntitiesByIdEntry.encode({ key: key as any, value }, writer.uint32(10).fork()).join();
@@ -2222,7 +2222,7 @@ function createBaseSimpleWithSnakeCaseMap_EntitiesByIdEntry(): SimpleWithSnakeCa
   return { key: 0, value: undefined };
 }
 
-export const SimpleWithSnakeCaseMap_EntitiesByIdEntry = {
+export const SimpleWithSnakeCaseMap_EntitiesByIdEntry: MessageFns<SimpleWithSnakeCaseMap_EntitiesByIdEntry> = {
   encode(message: SimpleWithSnakeCaseMap_EntitiesByIdEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== 0) {
       writer.uint32(8).int32(message.key);
@@ -2302,7 +2302,7 @@ function createBaseSimpleWithMapOfEnums(): SimpleWithMapOfEnums {
   return { enumsById: {} };
 }
 
-export const SimpleWithMapOfEnums = {
+export const SimpleWithMapOfEnums: MessageFns<SimpleWithMapOfEnums> = {
   encode(message: SimpleWithMapOfEnums, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     Object.entries(message.enumsById).forEach(([key, value]) => {
       SimpleWithMapOfEnums_EnumsByIdEntry.encode({ key: key as any, value }, writer.uint32(10).fork()).join();
@@ -2383,7 +2383,7 @@ function createBaseSimpleWithMapOfEnums_EnumsByIdEntry(): SimpleWithMapOfEnums_E
   return { key: 0, value: 0 };
 }
 
-export const SimpleWithMapOfEnums_EnumsByIdEntry = {
+export const SimpleWithMapOfEnums_EnumsByIdEntry: MessageFns<SimpleWithMapOfEnums_EnumsByIdEntry> = {
   encode(message: SimpleWithMapOfEnums_EnumsByIdEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== 0) {
       writer.uint32(8).int32(message.key);
@@ -2461,7 +2461,7 @@ function createBasePingRequest(): PingRequest {
   return { input: "" };
 }
 
-export const PingRequest = {
+export const PingRequest: MessageFns<PingRequest> = {
   encode(message: PingRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.input !== "") {
       writer.uint32(10).string(message.input);
@@ -2518,7 +2518,7 @@ function createBasePingResponse(): PingResponse {
   return { output: "" };
 }
 
-export const PingResponse = {
+export const PingResponse: MessageFns<PingResponse> = {
   encode(message: PingResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.output !== "") {
       writer.uint32(10).string(message.output);
@@ -2588,7 +2588,7 @@ function createBaseNumbers(): Numbers {
   };
 }
 
-export const Numbers = {
+export const Numbers: MessageFns<Numbers> = {
   encode(message: Numbers, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.double !== 0) {
       writer.uint32(9).double(message.double);
@@ -2820,7 +2820,7 @@ function createBaseSimpleButOptional(): SimpleButOptional {
   };
 }
 
-export const SimpleButOptional = {
+export const SimpleButOptional: MessageFns<SimpleButOptional> = {
   encode(message: SimpleButOptional, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
@@ -2973,7 +2973,7 @@ function createBaseEmpty(): Empty {
   return {};
 }
 
-export const Empty = {
+export const Empty: MessageFns<Empty> = {
   encode(_: Empty, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     return writer;
   },
@@ -3112,4 +3112,13 @@ function isObject(value: any): boolean {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/static-only-type-registry/bar/bar.ts
+++ b/integration/static-only-type-registry/bar/bar.ts
@@ -16,7 +16,7 @@ function createBaseBar(): Bar {
   return { foo: undefined };
 }
 
-export const Bar = {
+export const Bar: MessageFns<Bar, "foo.bar.Bar"> = {
   $type: "foo.bar.Bar" as const,
 
   encode(message: Bar, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
@@ -87,4 +87,14 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T, V extends string> {
+  readonly $type: V;
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/static-only-type-registry/foo.ts
+++ b/integration/static-only-type-registry/foo.ts
@@ -25,7 +25,7 @@ function createBaseFoo(): Foo {
   return { timestamp: undefined };
 }
 
-export const Foo = {
+export const Foo: MessageFns<Foo, "foo.Foo"> = {
   $type: "foo.Foo" as const,
 
   encode(message: Foo, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
@@ -86,7 +86,7 @@ function createBaseFoo2(): Foo2 {
   return { timestamp: undefined };
 }
 
-export const Foo2 = {
+export const Foo2: MessageFns<Foo2, "foo.Foo2"> = {
   $type: "foo.Foo2" as const,
 
   encode(message: Foo2, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
@@ -147,7 +147,7 @@ function createBaseWithStruct(): WithStruct {
   return { struct: undefined };
 }
 
-export const WithStruct = {
+export const WithStruct: MessageFns<WithStruct, "foo.WithStruct"> = {
   $type: "foo.WithStruct" as const,
 
   encode(message: WithStruct, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
@@ -244,4 +244,14 @@ function isObject(value: any): boolean {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T, V extends string> {
+  readonly $type: V;
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/static-only-type-registry/google/protobuf/struct.ts
+++ b/integration/static-only-type-registry/google/protobuf/struct.ts
@@ -108,7 +108,7 @@ function createBaseStruct(): Struct {
   return { fields: {} };
 }
 
-export const Struct = {
+export const Struct: MessageFns<Struct, "google.protobuf.Struct"> & StructWrapperFns = {
   $type: "google.protobuf.Struct" as const,
 
   encode(message: Struct, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
@@ -216,7 +216,7 @@ function createBaseStruct_FieldsEntry(): Struct_FieldsEntry {
   return { key: "", value: undefined };
 }
 
-export const Struct_FieldsEntry = {
+export const Struct_FieldsEntry: MessageFns<Struct_FieldsEntry, "google.protobuf.Struct.FieldsEntry"> = {
   $type: "google.protobuf.Struct.FieldsEntry" as const,
 
   encode(message: Struct_FieldsEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
@@ -301,7 +301,7 @@ function createBaseValue(): Value {
   };
 }
 
-export const Value = {
+export const Value: MessageFns<Value, "google.protobuf.Value"> & AnyValueWrapperFns = {
   $type: "google.protobuf.Value" as const,
 
   encode(message: Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
@@ -476,7 +476,7 @@ function createBaseListValue(): ListValue {
   return { values: [] };
 }
 
-export const ListValue = {
+export const ListValue: MessageFns<ListValue, "google.protobuf.ListValue"> & ListValueWrapperFns = {
   $type: "google.protobuf.ListValue" as const,
 
   encode(message: ListValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
@@ -565,4 +565,29 @@ function isObject(value: any): boolean {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T, V extends string> {
+  readonly $type: V;
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
+}
+
+export interface StructWrapperFns {
+  wrap(object: { [key: string]: any } | undefined): Struct;
+  unwrap(message: Struct): { [key: string]: any };
+}
+
+export interface AnyValueWrapperFns {
+  wrap(value: any): Value;
+  unwrap(message: any): string | number | boolean | Object | null | Array<any> | undefined;
+}
+
+export interface ListValueWrapperFns {
+  wrap(array: Array<any> | undefined): ListValue;
+  unwrap(message: ListValue): Array<any>;
 }

--- a/integration/static-only-type-registry/google/protobuf/timestamp.ts
+++ b/integration/static-only-type-registry/google/protobuf/timestamp.ts
@@ -118,7 +118,7 @@ function createBaseTimestamp(): Timestamp {
   return { seconds: 0, nanos: 0 };
 }
 
-export const Timestamp = {
+export const Timestamp: MessageFns<Timestamp, "google.protobuf.Timestamp"> = {
   $type: "google.protobuf.Timestamp" as const,
 
   encode(message: Timestamp, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
@@ -217,4 +217,14 @@ function longToNumber(int64: { toString(): string }): number {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T, V extends string> {
+  readonly $type: V;
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/static-only/bar/bar.ts
+++ b/integration/static-only/bar/bar.ts
@@ -15,7 +15,7 @@ function createBaseBar(): Bar {
   return { foo: undefined };
 }
 
-export const Bar = {
+export const Bar: MessageFns<Bar, "foo.bar.Bar"> = {
   $type: "foo.bar.Bar" as const,
 
   encode(message: Bar, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
@@ -84,4 +84,14 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T, V extends string> {
+  readonly $type: V;
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/static-only/foo.ts
+++ b/integration/static-only/foo.ts
@@ -24,7 +24,7 @@ function createBaseFoo(): Foo {
   return { timestamp: undefined };
 }
 
-export const Foo = {
+export const Foo: MessageFns<Foo, "foo.Foo"> = {
   $type: "foo.Foo" as const,
 
   encode(message: Foo, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
@@ -83,7 +83,7 @@ function createBaseFoo2(): Foo2 {
   return { timestamp: undefined };
 }
 
-export const Foo2 = {
+export const Foo2: MessageFns<Foo2, "foo.Foo2"> = {
   $type: "foo.Foo2" as const,
 
   encode(message: Foo2, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
@@ -142,7 +142,7 @@ function createBaseWithStruct(): WithStruct {
   return { struct: undefined };
 }
 
-export const WithStruct = {
+export const WithStruct: MessageFns<WithStruct, "foo.WithStruct"> = {
   $type: "foo.WithStruct" as const,
 
   encode(message: WithStruct, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
@@ -237,4 +237,14 @@ function isObject(value: any): boolean {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T, V extends string> {
+  readonly $type: V;
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/static-only/google/protobuf/struct.ts
+++ b/integration/static-only/google/protobuf/struct.ts
@@ -107,7 +107,7 @@ function createBaseStruct(): Struct {
   return { fields: {} };
 }
 
-export const Struct = {
+export const Struct: MessageFns<Struct, "google.protobuf.Struct"> & StructWrapperFns = {
   $type: "google.protobuf.Struct" as const,
 
   encode(message: Struct, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
@@ -213,7 +213,7 @@ function createBaseStruct_FieldsEntry(): Struct_FieldsEntry {
   return { key: "", value: undefined };
 }
 
-export const Struct_FieldsEntry = {
+export const Struct_FieldsEntry: MessageFns<Struct_FieldsEntry, "google.protobuf.Struct.FieldsEntry"> = {
   $type: "google.protobuf.Struct.FieldsEntry" as const,
 
   encode(message: Struct_FieldsEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
@@ -296,7 +296,7 @@ function createBaseValue(): Value {
   };
 }
 
-export const Value = {
+export const Value: MessageFns<Value, "google.protobuf.Value"> & AnyValueWrapperFns = {
   $type: "google.protobuf.Value" as const,
 
   encode(message: Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
@@ -469,7 +469,7 @@ function createBaseListValue(): ListValue {
   return { values: [] };
 }
 
-export const ListValue = {
+export const ListValue: MessageFns<ListValue, "google.protobuf.ListValue"> & ListValueWrapperFns = {
   $type: "google.protobuf.ListValue" as const,
 
   encode(message: ListValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
@@ -556,4 +556,29 @@ function isObject(value: any): boolean {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T, V extends string> {
+  readonly $type: V;
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
+}
+
+export interface StructWrapperFns {
+  wrap(object: { [key: string]: any } | undefined): Struct;
+  unwrap(message: Struct): { [key: string]: any };
+}
+
+export interface AnyValueWrapperFns {
+  wrap(value: any): Value;
+  unwrap(message: any): string | number | boolean | Object | null | Array<any> | undefined;
+}
+
+export interface ListValueWrapperFns {
+  wrap(array: Array<any> | undefined): ListValue;
+  unwrap(message: ListValue): Array<any>;
 }

--- a/integration/static-only/google/protobuf/timestamp.ts
+++ b/integration/static-only/google/protobuf/timestamp.ts
@@ -117,7 +117,7 @@ function createBaseTimestamp(): Timestamp {
   return { seconds: 0, nanos: 0 };
 }
 
-export const Timestamp = {
+export const Timestamp: MessageFns<Timestamp, "google.protobuf.Timestamp"> = {
   $type: "google.protobuf.Timestamp" as const,
 
   encode(message: Timestamp, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
@@ -214,4 +214,14 @@ function longToNumber(int64: { toString(): string }): number {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T, V extends string> {
+  readonly $type: V;
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/struct/google/protobuf/struct.ts
+++ b/integration/struct/google/protobuf/struct.ts
@@ -107,7 +107,7 @@ function createBaseStruct(): Struct {
   return { fields: {} };
 }
 
-export const Struct = {
+export const Struct: MessageFns<Struct> & StructWrapperFns = {
   encode(message: Struct, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     Object.entries(message.fields).forEach(([key, value]) => {
       if (value !== undefined) {
@@ -211,7 +211,7 @@ function createBaseStruct_FieldsEntry(): Struct_FieldsEntry {
   return { key: "", value: undefined };
 }
 
-export const Struct_FieldsEntry = {
+export const Struct_FieldsEntry: MessageFns<Struct_FieldsEntry> = {
   encode(message: Struct_FieldsEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== "") {
       writer.uint32(10).string(message.key);
@@ -292,7 +292,7 @@ function createBaseValue(): Value {
   };
 }
 
-export const Value = {
+export const Value: MessageFns<Value> & AnyValueWrapperFns = {
   encode(message: Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.nullValue !== undefined) {
       writer.uint32(8).int32(message.nullValue);
@@ -463,7 +463,7 @@ function createBaseListValue(): ListValue {
   return { values: [] };
 }
 
-export const ListValue = {
+export const ListValue: MessageFns<ListValue> & ListValueWrapperFns = {
   encode(message: ListValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     for (const v of message.values) {
       Value.encode(Value.wrap(v!), writer.uint32(10).fork()).join();
@@ -548,4 +548,28 @@ function isObject(value: any): boolean {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
+}
+
+export interface StructWrapperFns {
+  wrap(object: { [key: string]: any } | undefined): Struct;
+  unwrap(message: Struct): { [key: string]: any };
+}
+
+export interface AnyValueWrapperFns {
+  wrap(value: any): Value;
+  unwrap(message: any): string | number | boolean | Object | null | Array<any> | undefined;
+}
+
+export interface ListValueWrapperFns {
+  wrap(array: Array<any> | undefined): ListValue;
+  unwrap(message: ListValue): Array<any>;
 }

--- a/integration/struct/struct.ts
+++ b/integration/struct/struct.ts
@@ -15,7 +15,7 @@ function createBaseStructMessage(): StructMessage {
   return { value: undefined };
 }
 
-export const StructMessage = {
+export const StructMessage: MessageFns<StructMessage> = {
   encode(message: StructMessage, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== undefined) {
       Struct.encode(Struct.wrap(message.value), writer.uint32(10).fork()).join();
@@ -82,4 +82,13 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isObject(value: any): boolean {
   return typeof value === "object" && value !== null;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/type-annotations/bar/bar.ts
+++ b/integration/type-annotations/bar/bar.ts
@@ -16,7 +16,7 @@ function createBaseBar(): Bar {
   return { $type: "foo.bar.Bar", foo: undefined };
 }
 
-export const Bar = {
+export const Bar: MessageFns<Bar, "foo.bar.Bar"> = {
   $type: "foo.bar.Bar" as const,
 
   encode(message: Bar, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
@@ -85,4 +85,14 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T, V extends string> {
+  readonly $type: V;
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/type-annotations/foo.ts
+++ b/integration/type-annotations/foo.ts
@@ -27,7 +27,7 @@ function createBaseFoo(): Foo {
   return { $type: "foo.Foo", timestamp: undefined };
 }
 
-export const Foo = {
+export const Foo: MessageFns<Foo, "foo.Foo"> = {
   $type: "foo.Foo" as const,
 
   encode(message: Foo, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
@@ -86,7 +86,7 @@ function createBaseFoo2(): Foo2 {
   return { $type: "foo.Foo2", timestamp: undefined };
 }
 
-export const Foo2 = {
+export const Foo2: MessageFns<Foo2, "foo.Foo2"> = {
   $type: "foo.Foo2" as const,
 
   encode(message: Foo2, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
@@ -145,7 +145,7 @@ function createBaseWithStruct(): WithStruct {
   return { $type: "foo.WithStruct", struct: undefined };
 }
 
-export const WithStruct = {
+export const WithStruct: MessageFns<WithStruct, "foo.WithStruct"> = {
   $type: "foo.WithStruct" as const,
 
   encode(message: WithStruct, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
@@ -240,4 +240,14 @@ function isObject(value: any): boolean {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T, V extends string> {
+  readonly $type: V;
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/type-annotations/google/protobuf/struct.ts
+++ b/integration/type-annotations/google/protobuf/struct.ts
@@ -111,7 +111,7 @@ function createBaseStruct(): Struct {
   return { $type: "google.protobuf.Struct", fields: {} };
 }
 
-export const Struct = {
+export const Struct: MessageFns<Struct, "google.protobuf.Struct"> & StructWrapperFns = {
   $type: "google.protobuf.Struct" as const,
 
   encode(message: Struct, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
@@ -221,7 +221,7 @@ function createBaseStruct_FieldsEntry(): Struct_FieldsEntry {
   return { $type: "google.protobuf.Struct.FieldsEntry", key: "", value: undefined };
 }
 
-export const Struct_FieldsEntry = {
+export const Struct_FieldsEntry: MessageFns<Struct_FieldsEntry, "google.protobuf.Struct.FieldsEntry"> = {
   $type: "google.protobuf.Struct.FieldsEntry" as const,
 
   encode(message: Struct_FieldsEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
@@ -306,7 +306,7 @@ function createBaseValue(): Value {
   };
 }
 
-export const Value = {
+export const Value: MessageFns<Value, "google.protobuf.Value"> & AnyValueWrapperFns = {
   $type: "google.protobuf.Value" as const,
 
   encode(message: Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
@@ -480,7 +480,7 @@ function createBaseListValue(): ListValue {
   return { $type: "google.protobuf.ListValue", values: [] };
 }
 
-export const ListValue = {
+export const ListValue: MessageFns<ListValue, "google.protobuf.ListValue"> & ListValueWrapperFns = {
   $type: "google.protobuf.ListValue" as const,
 
   encode(message: ListValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
@@ -567,4 +567,29 @@ function isObject(value: any): boolean {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T, V extends string> {
+  readonly $type: V;
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
+}
+
+export interface StructWrapperFns {
+  wrap(object: { [key: string]: any } | undefined): Struct;
+  unwrap(message: Struct): { [key: string]: any };
+}
+
+export interface AnyValueWrapperFns {
+  wrap(value: any): Value;
+  unwrap(message: any): string | number | boolean | Object | null | Array<any> | undefined;
+}
+
+export interface ListValueWrapperFns {
+  wrap(array: Array<any> | undefined): ListValue;
+  unwrap(message: ListValue): Array<any>;
 }

--- a/integration/type-annotations/google/protobuf/timestamp.ts
+++ b/integration/type-annotations/google/protobuf/timestamp.ts
@@ -118,7 +118,7 @@ function createBaseTimestamp(): Timestamp {
   return { $type: "google.protobuf.Timestamp", seconds: 0, nanos: 0 };
 }
 
-export const Timestamp = {
+export const Timestamp: MessageFns<Timestamp, "google.protobuf.Timestamp"> = {
   $type: "google.protobuf.Timestamp" as const,
 
   encode(message: Timestamp, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
@@ -216,4 +216,14 @@ function longToNumber(int64: { toString(): string }): number {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T, V extends string> {
+  readonly $type: V;
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/type-registry/bar/bar.ts
+++ b/integration/type-registry/bar/bar.ts
@@ -17,7 +17,7 @@ function createBaseBar(): Bar {
   return { $type: "foo.bar.Bar", foo: undefined };
 }
 
-export const Bar = {
+export const Bar: MessageFns<Bar, "foo.bar.Bar"> = {
   $type: "foo.bar.Bar" as const,
 
   encode(message: Bar, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
@@ -88,4 +88,14 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T, V extends string> {
+  readonly $type: V;
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/type-registry/foo.ts
+++ b/integration/type-registry/foo.ts
@@ -28,7 +28,7 @@ function createBaseFoo(): Foo {
   return { $type: "foo.Foo", timestamp: undefined };
 }
 
-export const Foo = {
+export const Foo: MessageFns<Foo, "foo.Foo"> = {
   $type: "foo.Foo" as const,
 
   encode(message: Foo, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
@@ -89,7 +89,7 @@ function createBaseFoo2(): Foo2 {
   return { $type: "foo.Foo2", timestamp: undefined };
 }
 
-export const Foo2 = {
+export const Foo2: MessageFns<Foo2, "foo.Foo2"> = {
   $type: "foo.Foo2" as const,
 
   encode(message: Foo2, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
@@ -150,7 +150,7 @@ function createBaseWithStruct(): WithStruct {
   return { $type: "foo.WithStruct", struct: undefined };
 }
 
-export const WithStruct = {
+export const WithStruct: MessageFns<WithStruct, "foo.WithStruct"> = {
   $type: "foo.WithStruct" as const,
 
   encode(message: WithStruct, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
@@ -247,4 +247,14 @@ function isObject(value: any): boolean {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T, V extends string> {
+  readonly $type: V;
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/type-registry/google/protobuf/struct.ts
+++ b/integration/type-registry/google/protobuf/struct.ts
@@ -112,7 +112,7 @@ function createBaseStruct(): Struct {
   return { $type: "google.protobuf.Struct", fields: {} };
 }
 
-export const Struct = {
+export const Struct: MessageFns<Struct, "google.protobuf.Struct"> & StructWrapperFns = {
   $type: "google.protobuf.Struct" as const,
 
   encode(message: Struct, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
@@ -224,7 +224,7 @@ function createBaseStruct_FieldsEntry(): Struct_FieldsEntry {
   return { $type: "google.protobuf.Struct.FieldsEntry", key: "", value: undefined };
 }
 
-export const Struct_FieldsEntry = {
+export const Struct_FieldsEntry: MessageFns<Struct_FieldsEntry, "google.protobuf.Struct.FieldsEntry"> = {
   $type: "google.protobuf.Struct.FieldsEntry" as const,
 
   encode(message: Struct_FieldsEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
@@ -311,7 +311,7 @@ function createBaseValue(): Value {
   };
 }
 
-export const Value = {
+export const Value: MessageFns<Value, "google.protobuf.Value"> & AnyValueWrapperFns = {
   $type: "google.protobuf.Value" as const,
 
   encode(message: Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
@@ -487,7 +487,7 @@ function createBaseListValue(): ListValue {
   return { $type: "google.protobuf.ListValue", values: [] };
 }
 
-export const ListValue = {
+export const ListValue: MessageFns<ListValue, "google.protobuf.ListValue"> & ListValueWrapperFns = {
   $type: "google.protobuf.ListValue" as const,
 
   encode(message: ListValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
@@ -576,4 +576,29 @@ function isObject(value: any): boolean {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T, V extends string> {
+  readonly $type: V;
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
+}
+
+export interface StructWrapperFns {
+  wrap(object: { [key: string]: any } | undefined): Struct;
+  unwrap(message: Struct): { [key: string]: any };
+}
+
+export interface AnyValueWrapperFns {
+  wrap(value: any): Value;
+  unwrap(message: any): string | number | boolean | Object | null | Array<any> | undefined;
+}
+
+export interface ListValueWrapperFns {
+  wrap(array: Array<any> | undefined): ListValue;
+  unwrap(message: ListValue): Array<any>;
 }

--- a/integration/type-registry/google/protobuf/timestamp.ts
+++ b/integration/type-registry/google/protobuf/timestamp.ts
@@ -119,7 +119,7 @@ function createBaseTimestamp(): Timestamp {
   return { $type: "google.protobuf.Timestamp", seconds: 0, nanos: 0 };
 }
 
-export const Timestamp = {
+export const Timestamp: MessageFns<Timestamp, "google.protobuf.Timestamp"> = {
   $type: "google.protobuf.Timestamp" as const,
 
   encode(message: Timestamp, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
@@ -219,4 +219,14 @@ function longToNumber(int64: { toString(): string }): number {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T, V extends string> {
+  readonly $type: V;
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/types-with-underscores/file.ts
+++ b/integration/types-with-underscores/file.ts
@@ -17,7 +17,7 @@ function createBaseBaz(): Baz {
   return { foo: undefined };
 }
 
-export const Baz = {
+export const Baz: MessageFns<Baz> = {
   encode(message: Baz, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.foo !== undefined) {
       FooBar.encode(message.foo, writer.uint32(10).fork()).join();
@@ -74,7 +74,7 @@ function createBaseFooBar(): FooBar {
   return {};
 }
 
-export const FooBar = {
+export const FooBar: MessageFns<FooBar> = {
   encode(_: FooBar, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     return writer;
   },
@@ -127,4 +127,13 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/unknown-fields/google/protobuf/compiler/plugin.ts
+++ b/integration/unknown-fields/google/protobuf/compiler/plugin.ts
@@ -164,7 +164,7 @@ function createBaseVersion(): Version {
   return { major: 0, minor: 0, patch: 0, suffix: "", _unknownFields: {} };
 }
 
-export const Version = {
+export const Version: MessageFns<Version> = {
   encode(message: Version, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.major !== undefined && message.major !== 0) {
       writer.uint32(8).int32(message.major);
@@ -246,7 +246,7 @@ function createBaseCodeGeneratorRequest(): CodeGeneratorRequest {
   return { fileToGenerate: [], parameter: "", protoFile: [], compilerVersion: undefined, _unknownFields: {} };
 }
 
-export const CodeGeneratorRequest = {
+export const CodeGeneratorRequest: MessageFns<CodeGeneratorRequest> = {
   encode(message: CodeGeneratorRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     for (const v of message.fileToGenerate) {
       writer.uint32(10).string(v!);
@@ -328,7 +328,7 @@ function createBaseCodeGeneratorResponse(): CodeGeneratorResponse {
   return { error: "", supportedFeatures: 0, file: [], _unknownFields: {} };
 }
 
-export const CodeGeneratorResponse = {
+export const CodeGeneratorResponse: MessageFns<CodeGeneratorResponse> = {
   encode(message: CodeGeneratorResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.error !== undefined && message.error !== "") {
       writer.uint32(10).string(message.error);
@@ -400,7 +400,7 @@ function createBaseCodeGeneratorResponse_File(): CodeGeneratorResponse_File {
   return { name: "", insertionPoint: "", content: "", generatedCodeInfo: undefined, _unknownFields: {} };
 }
 
-export const CodeGeneratorResponse_File = {
+export const CodeGeneratorResponse_File: MessageFns<CodeGeneratorResponse_File> = {
   encode(message: CodeGeneratorResponse_File, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== undefined && message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -487,4 +487,9 @@ function longToNumber(int64: { toString(): string }): number {
     throw new globalThis.Error("Value is smaller than Number.MIN_SAFE_INTEGER");
   }
   return num;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
 }

--- a/integration/unknown-fields/google/protobuf/descriptor.ts
+++ b/integration/unknown-fields/google/protobuf/descriptor.ts
@@ -985,7 +985,7 @@ function createBaseFileDescriptorSet(): FileDescriptorSet {
   return { file: [], _unknownFields: {} };
 }
 
-export const FileDescriptorSet = {
+export const FileDescriptorSet: MessageFns<FileDescriptorSet> = {
   encode(message: FileDescriptorSet, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     for (const v of message.file) {
       FileDescriptorProto.encode(v!, writer.uint32(10).fork()).join();
@@ -1051,7 +1051,7 @@ function createBaseFileDescriptorProto(): FileDescriptorProto {
   };
 }
 
-export const FileDescriptorProto = {
+export const FileDescriptorProto: MessageFns<FileDescriptorProto> = {
   encode(message: FileDescriptorProto, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== undefined && message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -1249,7 +1249,7 @@ function createBaseDescriptorProto(): DescriptorProto {
   };
 }
 
-export const DescriptorProto = {
+export const DescriptorProto: MessageFns<DescriptorProto> = {
   encode(message: DescriptorProto, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== undefined && message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -1391,7 +1391,7 @@ function createBaseDescriptorProto_ExtensionRange(): DescriptorProto_ExtensionRa
   return { start: 0, end: 0, options: undefined, _unknownFields: {} };
 }
 
-export const DescriptorProto_ExtensionRange = {
+export const DescriptorProto_ExtensionRange: MessageFns<DescriptorProto_ExtensionRange> = {
   encode(message: DescriptorProto_ExtensionRange, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.start !== undefined && message.start !== 0) {
       writer.uint32(8).int32(message.start);
@@ -1463,7 +1463,7 @@ function createBaseDescriptorProto_ReservedRange(): DescriptorProto_ReservedRang
   return { start: 0, end: 0, _unknownFields: {} };
 }
 
-export const DescriptorProto_ReservedRange = {
+export const DescriptorProto_ReservedRange: MessageFns<DescriptorProto_ReservedRange> = {
   encode(message: DescriptorProto_ReservedRange, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.start !== undefined && message.start !== 0) {
       writer.uint32(8).int32(message.start);
@@ -1525,7 +1525,7 @@ function createBaseExtensionRangeOptions(): ExtensionRangeOptions {
   return { uninterpretedOption: [], _unknownFields: {} };
 }
 
-export const ExtensionRangeOptions = {
+export const ExtensionRangeOptions: MessageFns<ExtensionRangeOptions> = {
   encode(message: ExtensionRangeOptions, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     for (const v of message.uninterpretedOption) {
       UninterpretedOption.encode(v!, writer.uint32(7994).fork()).join();
@@ -1590,7 +1590,7 @@ function createBaseFieldDescriptorProto(): FieldDescriptorProto {
   };
 }
 
-export const FieldDescriptorProto = {
+export const FieldDescriptorProto: MessageFns<FieldDescriptorProto> = {
   encode(message: FieldDescriptorProto, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== undefined && message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -1742,7 +1742,7 @@ function createBaseOneofDescriptorProto(): OneofDescriptorProto {
   return { name: "", options: undefined, _unknownFields: {} };
 }
 
-export const OneofDescriptorProto = {
+export const OneofDescriptorProto: MessageFns<OneofDescriptorProto> = {
   encode(message: OneofDescriptorProto, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== undefined && message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -1804,7 +1804,7 @@ function createBaseEnumDescriptorProto(): EnumDescriptorProto {
   return { name: "", value: [], options: undefined, reservedRange: [], reservedName: [], _unknownFields: {} };
 }
 
-export const EnumDescriptorProto = {
+export const EnumDescriptorProto: MessageFns<EnumDescriptorProto> = {
   encode(message: EnumDescriptorProto, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== undefined && message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -1896,7 +1896,7 @@ function createBaseEnumDescriptorProto_EnumReservedRange(): EnumDescriptorProto_
   return { start: 0, end: 0, _unknownFields: {} };
 }
 
-export const EnumDescriptorProto_EnumReservedRange = {
+export const EnumDescriptorProto_EnumReservedRange: MessageFns<EnumDescriptorProto_EnumReservedRange> = {
   encode(message: EnumDescriptorProto_EnumReservedRange, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.start !== undefined && message.start !== 0) {
       writer.uint32(8).int32(message.start);
@@ -1958,7 +1958,7 @@ function createBaseEnumValueDescriptorProto(): EnumValueDescriptorProto {
   return { name: "", number: 0, options: undefined, _unknownFields: {} };
 }
 
-export const EnumValueDescriptorProto = {
+export const EnumValueDescriptorProto: MessageFns<EnumValueDescriptorProto> = {
   encode(message: EnumValueDescriptorProto, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== undefined && message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -2030,7 +2030,7 @@ function createBaseServiceDescriptorProto(): ServiceDescriptorProto {
   return { name: "", method: [], options: undefined, _unknownFields: {} };
 }
 
-export const ServiceDescriptorProto = {
+export const ServiceDescriptorProto: MessageFns<ServiceDescriptorProto> = {
   encode(message: ServiceDescriptorProto, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== undefined && message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -2110,7 +2110,7 @@ function createBaseMethodDescriptorProto(): MethodDescriptorProto {
   };
 }
 
-export const MethodDescriptorProto = {
+export const MethodDescriptorProto: MessageFns<MethodDescriptorProto> = {
   encode(message: MethodDescriptorProto, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== undefined && message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -2235,7 +2235,7 @@ function createBaseFileOptions(): FileOptions {
   };
 }
 
-export const FileOptions = {
+export const FileOptions: MessageFns<FileOptions> = {
   encode(message: FileOptions, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.javaPackage !== undefined && message.javaPackage !== "") {
       writer.uint32(10).string(message.javaPackage);
@@ -2494,7 +2494,7 @@ function createBaseMessageOptions(): MessageOptions {
   };
 }
 
-export const MessageOptions = {
+export const MessageOptions: MessageFns<MessageOptions> = {
   encode(message: MessageOptions, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.messageSetWireFormat !== undefined && message.messageSetWireFormat !== false) {
       writer.uint32(8).bool(message.messageSetWireFormat);
@@ -2595,7 +2595,7 @@ function createBaseFieldOptions(): FieldOptions {
   };
 }
 
-export const FieldOptions = {
+export const FieldOptions: MessageFns<FieldOptions> = {
   encode(message: FieldOptions, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.ctype !== undefined && message.ctype !== 0) {
       writer.uint32(8).int32(message.ctype);
@@ -2707,7 +2707,7 @@ function createBaseOneofOptions(): OneofOptions {
   return { uninterpretedOption: [], _unknownFields: {} };
 }
 
-export const OneofOptions = {
+export const OneofOptions: MessageFns<OneofOptions> = {
   encode(message: OneofOptions, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     for (const v of message.uninterpretedOption) {
       UninterpretedOption.encode(v!, writer.uint32(7994).fork()).join();
@@ -2759,7 +2759,7 @@ function createBaseEnumOptions(): EnumOptions {
   return { allowAlias: false, deprecated: false, uninterpretedOption: [], _unknownFields: {} };
 }
 
-export const EnumOptions = {
+export const EnumOptions: MessageFns<EnumOptions> = {
   encode(message: EnumOptions, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.allowAlias !== undefined && message.allowAlias !== false) {
       writer.uint32(16).bool(message.allowAlias);
@@ -2831,7 +2831,7 @@ function createBaseEnumValueOptions(): EnumValueOptions {
   return { deprecated: false, uninterpretedOption: [], _unknownFields: {} };
 }
 
-export const EnumValueOptions = {
+export const EnumValueOptions: MessageFns<EnumValueOptions> = {
   encode(message: EnumValueOptions, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.deprecated !== undefined && message.deprecated !== false) {
       writer.uint32(8).bool(message.deprecated);
@@ -2893,7 +2893,7 @@ function createBaseServiceOptions(): ServiceOptions {
   return { deprecated: false, uninterpretedOption: [], _unknownFields: {} };
 }
 
-export const ServiceOptions = {
+export const ServiceOptions: MessageFns<ServiceOptions> = {
   encode(message: ServiceOptions, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.deprecated !== undefined && message.deprecated !== false) {
       writer.uint32(264).bool(message.deprecated);
@@ -2955,7 +2955,7 @@ function createBaseMethodOptions(): MethodOptions {
   return { deprecated: false, idempotencyLevel: 0, uninterpretedOption: [], _unknownFields: {} };
 }
 
-export const MethodOptions = {
+export const MethodOptions: MessageFns<MethodOptions> = {
   encode(message: MethodOptions, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.deprecated !== undefined && message.deprecated !== false) {
       writer.uint32(264).bool(message.deprecated);
@@ -3036,7 +3036,7 @@ function createBaseUninterpretedOption(): UninterpretedOption {
   };
 }
 
-export const UninterpretedOption = {
+export const UninterpretedOption: MessageFns<UninterpretedOption> = {
   encode(message: UninterpretedOption, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     for (const v of message.name) {
       UninterpretedOption_NamePart.encode(v!, writer.uint32(18).fork()).join();
@@ -3148,7 +3148,7 @@ function createBaseUninterpretedOption_NamePart(): UninterpretedOption_NamePart 
   return { namePart: "", isExtension: false, _unknownFields: {} };
 }
 
-export const UninterpretedOption_NamePart = {
+export const UninterpretedOption_NamePart: MessageFns<UninterpretedOption_NamePart> = {
   encode(message: UninterpretedOption_NamePart, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.namePart !== "") {
       writer.uint32(10).string(message.namePart);
@@ -3210,7 +3210,7 @@ function createBaseSourceCodeInfo(): SourceCodeInfo {
   return { location: [], _unknownFields: {} };
 }
 
-export const SourceCodeInfo = {
+export const SourceCodeInfo: MessageFns<SourceCodeInfo> = {
   encode(message: SourceCodeInfo, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     for (const v of message.location) {
       SourceCodeInfo_Location.encode(v!, writer.uint32(10).fork()).join();
@@ -3269,7 +3269,7 @@ function createBaseSourceCodeInfo_Location(): SourceCodeInfo_Location {
   };
 }
 
-export const SourceCodeInfo_Location = {
+export const SourceCodeInfo_Location: MessageFns<SourceCodeInfo_Location> = {
   encode(message: SourceCodeInfo_Location, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     writer.uint32(10).fork();
     for (const v of message.path) {
@@ -3385,7 +3385,7 @@ function createBaseGeneratedCodeInfo(): GeneratedCodeInfo {
   return { annotation: [], _unknownFields: {} };
 }
 
-export const GeneratedCodeInfo = {
+export const GeneratedCodeInfo: MessageFns<GeneratedCodeInfo> = {
   encode(message: GeneratedCodeInfo, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     for (const v of message.annotation) {
       GeneratedCodeInfo_Annotation.encode(v!, writer.uint32(10).fork()).join();
@@ -3437,7 +3437,7 @@ function createBaseGeneratedCodeInfo_Annotation(): GeneratedCodeInfo_Annotation 
   return { path: [], sourceFile: "", begin: 0, end: 0, _unknownFields: {} };
 }
 
-export const GeneratedCodeInfo_Annotation = {
+export const GeneratedCodeInfo_Annotation: MessageFns<GeneratedCodeInfo_Annotation> = {
   encode(message: GeneratedCodeInfo_Annotation, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     writer.uint32(10).fork();
     for (const v of message.path) {
@@ -3536,4 +3536,9 @@ function longToNumber(int64: { toString(): string }): number {
     throw new globalThis.Error("Value is smaller than Number.MIN_SAFE_INTEGER");
   }
   return num;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
 }

--- a/integration/unknown-fields/options.ts
+++ b/integration/unknown-fields/options.ts
@@ -32,7 +32,7 @@ function createBaseMyMessage(): MyMessage {
   return { foo: undefined, foo2: undefined, bar: undefined, quux: undefined, _unknownFields: {} };
 }
 
-export const MyMessage = {
+export const MyMessage: MessageFns<MyMessage> = {
   encode(message: MyMessage, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.foo !== undefined) {
       writer.uint32(8).int32(message.foo);
@@ -114,7 +114,7 @@ function createBaseRequestType(): RequestType {
   return { _unknownFields: {} };
 }
 
-export const RequestType = {
+export const RequestType: MessageFns<RequestType> = {
   encode(message: RequestType, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message._unknownFields !== undefined) {
       for (const [key, values] of Object.entries(message._unknownFields)) {
@@ -156,7 +156,7 @@ function createBaseResponseType(): ResponseType {
   return { _unknownFields: {} };
 }
 
-export const ResponseType = {
+export const ResponseType: MessageFns<ResponseType> = {
   encode(message: ResponseType, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message._unknownFields !== undefined) {
       for (const [key, values] of Object.entries(message._unknownFields)) {
@@ -216,4 +216,9 @@ export class MyServiceClientImpl implements MyService {
 
 interface Rpc {
   request(service: string, method: string, data: Uint8Array): Promise<Uint8Array>;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
 }

--- a/integration/unknown-fields/something/something.ts
+++ b/integration/unknown-fields/something/something.ts
@@ -16,7 +16,7 @@ function createBaseSomething(): Something {
   return { hello: "", foo: [], _unknownFields: {} };
 }
 
-export const Something = {
+export const Something: MessageFns<Something> = {
   encode(message: Something, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.hello !== "") {
       writer.uint32(10).string(message.hello);
@@ -85,3 +85,8 @@ export const Something = {
     return message;
   },
 };
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+}

--- a/integration/use-date-false/google/protobuf/timestamp.ts
+++ b/integration/use-date-false/google/protobuf/timestamp.ts
@@ -117,7 +117,7 @@ function createBaseTimestamp(): Timestamp {
   return { seconds: 0, nanos: 0 };
 }
 
-export const Timestamp = {
+export const Timestamp: MessageFns<Timestamp> = {
   encode(message: Timestamp, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.seconds !== 0) {
       writer.uint32(8).int64(message.seconds);
@@ -212,4 +212,13 @@ function longToNumber(int64: { toString(): string }): number {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/use-date-false/metadata.ts
+++ b/integration/use-date-false/metadata.ts
@@ -15,7 +15,7 @@ function createBaseMetadata(): Metadata {
   return { lastEdited: undefined };
 }
 
-export const Metadata = {
+export const Metadata: MessageFns<Metadata> = {
   encode(message: Metadata, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.lastEdited !== undefined) {
       Timestamp.encode(message.lastEdited, writer.uint32(10).fork()).join();
@@ -106,4 +106,13 @@ function fromJsonTimestamp(o: any): Timestamp {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/use-date-string/google/protobuf/timestamp.ts
+++ b/integration/use-date-string/google/protobuf/timestamp.ts
@@ -117,7 +117,7 @@ function createBaseTimestamp(): Timestamp {
   return { seconds: 0, nanos: 0 };
 }
 
-export const Timestamp = {
+export const Timestamp: MessageFns<Timestamp> = {
   encode(message: Timestamp, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.seconds !== 0) {
       writer.uint32(8).int64(message.seconds);
@@ -212,4 +212,13 @@ function longToNumber(int64: { toString(): string }): number {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/use-date-string/use-date-string.ts
+++ b/integration/use-date-string/use-date-string.ts
@@ -24,7 +24,7 @@ function createBaseTodo(): Todo {
   return { id: "", timestamp: undefined, repeatedTimestamp: [], optionalTimestamp: undefined, mapOfTimestamps: {} };
 }
 
-export const Todo = {
+export const Todo: MessageFns<Todo> = {
   encode(message: Todo, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.id !== "") {
       writer.uint32(10).string(message.id);
@@ -167,7 +167,7 @@ function createBaseTodo_MapOfTimestampsEntry(): Todo_MapOfTimestampsEntry {
   return { key: "", value: undefined };
 }
 
-export const Todo_MapOfTimestampsEntry = {
+export const Todo_MapOfTimestampsEntry: MessageFns<Todo_MapOfTimestampsEntry> = {
   encode(message: Todo_MapOfTimestampsEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== "") {
       writer.uint32(10).string(message.key);
@@ -268,4 +268,13 @@ function isObject(value: any): boolean {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/use-date-true/google/protobuf/empty.ts
+++ b/integration/use-date-true/google/protobuf/empty.ts
@@ -24,7 +24,7 @@ function createBaseEmpty(): Empty {
   return {};
 }
 
-export const Empty = {
+export const Empty: MessageFns<Empty> = {
   encode(_: Empty, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     return writer;
   },
@@ -74,3 +74,12 @@ export type DeepPartial<T> = T extends Builtin ? T
 type KeysOfUnion<T> = T extends T ? keyof T : never;
 export type Exact<P, I extends P> = P extends Builtin ? P
   : P & { [K in keyof P]: Exact<P[K], I[K]> } & { [K in Exclude<keyof I, KeysOfUnion<P>>]: never };
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
+}

--- a/integration/use-date-true/google/protobuf/timestamp.ts
+++ b/integration/use-date-true/google/protobuf/timestamp.ts
@@ -117,7 +117,7 @@ function createBaseTimestamp(): Timestamp {
   return { seconds: 0, nanos: 0 };
 }
 
-export const Timestamp = {
+export const Timestamp: MessageFns<Timestamp> = {
   encode(message: Timestamp, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.seconds !== 0) {
       writer.uint32(8).int64(message.seconds);
@@ -212,4 +212,13 @@ function longToNumber(int64: { toString(): string }): number {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/use-date-true/use-date-true.ts
+++ b/integration/use-date-true/use-date-true.ts
@@ -25,7 +25,7 @@ function createBaseTodo(): Todo {
   return { id: "", timestamp: undefined, repeatedTimestamp: [], optionalTimestamp: undefined, mapOfTimestamps: {} };
 }
 
-export const Todo = {
+export const Todo: MessageFns<Todo> = {
   encode(message: Todo, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.id !== "") {
       writer.uint32(10).string(message.id);
@@ -168,7 +168,7 @@ function createBaseTodo_MapOfTimestampsEntry(): Todo_MapOfTimestampsEntry {
   return { key: "", value: undefined };
 }
 
-export const Todo_MapOfTimestampsEntry = {
+export const Todo_MapOfTimestampsEntry: MessageFns<Todo_MapOfTimestampsEntry> = {
   encode(message: Todo_MapOfTimestampsEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== "") {
       writer.uint32(10).string(message.key);
@@ -318,4 +318,13 @@ function isObject(value: any): boolean {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/use-exact-types-false/foo.ts
+++ b/integration/use-exact-types-false/foo.ts
@@ -15,7 +15,7 @@ function createBaseFoo(): Foo {
   return { bar: "", baz: "" };
 }
 
-export const Foo = {
+export const Foo: MessageFns<Foo> = {
   encode(message: Foo, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.bar !== "") {
       writer.uint32(10).string(message.bar);
@@ -95,4 +95,13 @@ export type DeepPartial<T> = T extends Builtin ? T
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create(base?: DeepPartial<T>): T;
+  fromPartial(object: DeepPartial<T>): T;
 }

--- a/integration/use-json-name/google/protobuf/timestamp.ts
+++ b/integration/use-json-name/google/protobuf/timestamp.ts
@@ -117,7 +117,7 @@ function createBaseTimestamp(): Timestamp {
   return { seconds: 0, nanos: 0 };
 }
 
-export const Timestamp = {
+export const Timestamp: MessageFns<Timestamp> = {
   encode(message: Timestamp, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.seconds !== 0) {
       writer.uint32(8).int64(message.seconds);
@@ -212,4 +212,13 @@ function longToNumber(int64: { toString(): string }): number {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/use-json-name/use-json-name.ts
+++ b/integration/use-json-name/use-json-name.ts
@@ -45,7 +45,7 @@ function createBaseJsonName(): JsonName {
   };
 }
 
-export const JsonName = {
+export const JsonName: MessageFns<JsonName> = {
   encode(message: JsonName, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.other_name !== "") {
       writer.uint32(10).string(message.other_name);
@@ -286,7 +286,7 @@ function createBaseNstedOneOf(): NstedOneOf {
   return { nestedOneOfField: undefined };
 }
 
-export const NstedOneOf = {
+export const NstedOneOf: MessageFns<NstedOneOf> = {
   encode(message: NstedOneOf, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.nestedOneOfField !== undefined) {
       writer.uint32(10).string(message.nestedOneOfField);
@@ -377,4 +377,13 @@ function fromJsonTimestamp(o: any): Date {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/use-json-timestamp-raw/google/protobuf/timestamp.ts
+++ b/integration/use-json-timestamp-raw/google/protobuf/timestamp.ts
@@ -117,7 +117,7 @@ function createBaseTimestamp(): Timestamp {
   return { seconds: 0, nanos: 0 };
 }
 
-export const Timestamp = {
+export const Timestamp: MessageFns<Timestamp> = {
   encode(message: Timestamp, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.seconds !== 0) {
       writer.uint32(8).int64(message.seconds);
@@ -212,4 +212,13 @@ function longToNumber(int64: { toString(): string }): number {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/use-json-timestamp-raw/metadata.ts
+++ b/integration/use-json-timestamp-raw/metadata.ts
@@ -15,7 +15,7 @@ function createBaseMetadata(): Metadata {
   return { lastEdited: undefined };
 }
 
-export const Metadata = {
+export const Metadata: MessageFns<Metadata> = {
   encode(message: Metadata, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.lastEdited !== undefined) {
       Timestamp.encode(message.lastEdited, writer.uint32(10).fork()).join();
@@ -84,4 +84,13 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/use-map-type/google/protobuf/struct.ts
+++ b/integration/use-map-type/google/protobuf/struct.ts
@@ -107,7 +107,7 @@ function createBaseStruct(): Struct {
   return { fields: new Map() };
 }
 
-export const Struct = {
+export const Struct: MessageFns<Struct> & StructWrapperFns = {
   encode(message: Struct, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     message.fields.forEach((value, key) => {
       if (value !== undefined) {
@@ -208,7 +208,7 @@ function createBaseStruct_FieldsEntry(): Struct_FieldsEntry {
   return { key: "", value: undefined };
 }
 
-export const Struct_FieldsEntry = {
+export const Struct_FieldsEntry: MessageFns<Struct_FieldsEntry> = {
   encode(message: Struct_FieldsEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== "") {
       writer.uint32(10).string(message.key);
@@ -289,7 +289,7 @@ function createBaseValue(): Value {
   };
 }
 
-export const Value = {
+export const Value: MessageFns<Value> & AnyValueWrapperFns = {
   encode(message: Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.nullValue !== undefined) {
       writer.uint32(8).int32(message.nullValue);
@@ -460,7 +460,7 @@ function createBaseListValue(): ListValue {
   return { values: [] };
 }
 
-export const ListValue = {
+export const ListValue: MessageFns<ListValue> & ListValueWrapperFns = {
   encode(message: ListValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     for (const v of message.values) {
       Value.encode(Value.wrap(v!), writer.uint32(10).fork()).join();
@@ -545,4 +545,28 @@ function isObject(value: any): boolean {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
+}
+
+export interface StructWrapperFns {
+  wrap(object: { [key: string]: any } | undefined): Struct;
+  unwrap(message: Struct): { [key: string]: any };
+}
+
+export interface AnyValueWrapperFns {
+  wrap(value: any): Value;
+  unwrap(message: any): string | number | boolean | Object | null | Array<any> | undefined;
+}
+
+export interface ListValueWrapperFns {
+  wrap(array: Array<any> | undefined): ListValue;
+  unwrap(message: ListValue): Array<any>;
 }

--- a/integration/use-map-type/google/protobuf/timestamp.ts
+++ b/integration/use-map-type/google/protobuf/timestamp.ts
@@ -117,7 +117,7 @@ function createBaseTimestamp(): Timestamp {
   return { seconds: 0, nanos: 0 };
 }
 
-export const Timestamp = {
+export const Timestamp: MessageFns<Timestamp> = {
   encode(message: Timestamp, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.seconds !== 0) {
       writer.uint32(8).int64(message.seconds);
@@ -212,4 +212,13 @@ function longToNumber(int64: { toString(): string }): number {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/use-map-type/use-map-type.ts
+++ b/integration/use-map-type/use-map-type.ts
@@ -50,7 +50,7 @@ function createBaseEntity(): Entity {
   return { id: 0 };
 }
 
-export const Entity = {
+export const Entity: MessageFns<Entity> = {
   encode(message: Entity, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.id !== 0) {
       writer.uint32(8).int32(message.id);
@@ -114,7 +114,7 @@ function createBaseMaps(): Maps {
   };
 }
 
-export const Maps = {
+export const Maps: MessageFns<Maps> = {
   encode(message: Maps, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     message.strToEntity.forEach((value, key) => {
       Maps_StrToEntityEntry.encode({ key: key as any, value }, writer.uint32(10).fork()).join();
@@ -343,7 +343,7 @@ function createBaseMaps_StrToEntityEntry(): Maps_StrToEntityEntry {
   return { key: "", value: undefined };
 }
 
-export const Maps_StrToEntityEntry = {
+export const Maps_StrToEntityEntry: MessageFns<Maps_StrToEntityEntry> = {
   encode(message: Maps_StrToEntityEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== "") {
       writer.uint32(10).string(message.key);
@@ -419,7 +419,7 @@ function createBaseMaps_Int32ToInt32Entry(): Maps_Int32ToInt32Entry {
   return { key: 0, value: 0 };
 }
 
-export const Maps_Int32ToInt32Entry = {
+export const Maps_Int32ToInt32Entry: MessageFns<Maps_Int32ToInt32Entry> = {
   encode(message: Maps_Int32ToInt32Entry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== 0) {
       writer.uint32(8).int32(message.key);
@@ -493,7 +493,7 @@ function createBaseMaps_StringToBytesEntry(): Maps_StringToBytesEntry {
   return { key: "", value: new Uint8Array(0) };
 }
 
-export const Maps_StringToBytesEntry = {
+export const Maps_StringToBytesEntry: MessageFns<Maps_StringToBytesEntry> = {
   encode(message: Maps_StringToBytesEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== "") {
       writer.uint32(10).string(message.key);
@@ -567,7 +567,7 @@ function createBaseMaps_Int64ToInt64Entry(): Maps_Int64ToInt64Entry {
   return { key: 0, value: 0 };
 }
 
-export const Maps_Int64ToInt64Entry = {
+export const Maps_Int64ToInt64Entry: MessageFns<Maps_Int64ToInt64Entry> = {
   encode(message: Maps_Int64ToInt64Entry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== 0) {
       writer.uint32(8).int64(message.key);
@@ -641,7 +641,7 @@ function createBaseMaps_MapOfTimestampsEntry(): Maps_MapOfTimestampsEntry {
   return { key: "", value: undefined };
 }
 
-export const Maps_MapOfTimestampsEntry = {
+export const Maps_MapOfTimestampsEntry: MessageFns<Maps_MapOfTimestampsEntry> = {
   encode(message: Maps_MapOfTimestampsEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== "") {
       writer.uint32(10).string(message.key);
@@ -787,4 +787,13 @@ function isObject(value: any): boolean {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/use-null-as-optional/use-null-as-optional.ts
+++ b/integration/use-null-as-optional/use-null-as-optional.ts
@@ -26,7 +26,7 @@ function createBaseProfileInfo(): ProfileInfo {
   return { id: 0, bio: "", phone: "" };
 }
 
-export const ProfileInfo = {
+export const ProfileInfo: MessageFns<ProfileInfo> = {
   encode(message: ProfileInfo, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.id !== 0) {
       writer.uint32(8).int32(message.id);
@@ -115,7 +115,7 @@ function createBaseUser(): User {
   return { id: 0, username: "", profile: null };
 }
 
-export const User = {
+export const User: MessageFns<User> = {
   encode(message: User, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.id !== 0) {
       writer.uint32(8).int32(message.id);
@@ -206,7 +206,7 @@ function createBaseUserById(): UserById {
   return { id: 0 };
 }
 
-export const UserById = {
+export const UserById: MessageFns<UserById> = {
   encode(message: UserById, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.id !== 0) {
       writer.uint32(8).int32(message.id);
@@ -297,4 +297,13 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/use-numeric-enum-json/google/protobuf/struct.ts
+++ b/integration/use-numeric-enum-json/google/protobuf/struct.ts
@@ -107,7 +107,7 @@ function createBaseStruct(): Struct {
   return { fields: {} };
 }
 
-export const Struct = {
+export const Struct: MessageFns<Struct> & StructWrapperFns = {
   encode(message: Struct, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     Object.entries(message.fields).forEach(([key, value]) => {
       if (value !== undefined) {
@@ -211,7 +211,7 @@ function createBaseStruct_FieldsEntry(): Struct_FieldsEntry {
   return { key: "", value: undefined };
 }
 
-export const Struct_FieldsEntry = {
+export const Struct_FieldsEntry: MessageFns<Struct_FieldsEntry> = {
   encode(message: Struct_FieldsEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== "") {
       writer.uint32(10).string(message.key);
@@ -292,7 +292,7 @@ function createBaseValue(): Value {
   };
 }
 
-export const Value = {
+export const Value: MessageFns<Value> & AnyValueWrapperFns = {
   encode(message: Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.nullValue !== undefined) {
       writer.uint32(8).int32(message.nullValue);
@@ -463,7 +463,7 @@ function createBaseListValue(): ListValue {
   return { values: [] };
 }
 
-export const ListValue = {
+export const ListValue: MessageFns<ListValue> & ListValueWrapperFns = {
   encode(message: ListValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     for (const v of message.values) {
       Value.encode(Value.wrap(v!), writer.uint32(10).fork()).join();
@@ -548,4 +548,28 @@ function isObject(value: any): boolean {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
+}
+
+export interface StructWrapperFns {
+  wrap(object: { [key: string]: any } | undefined): Struct;
+  unwrap(message: Struct): { [key: string]: any };
+}
+
+export interface AnyValueWrapperFns {
+  wrap(value: any): Value;
+  unwrap(message: any): string | number | boolean | Object | null | Array<any> | undefined;
+}
+
+export interface ListValueWrapperFns {
+  wrap(array: Array<any> | undefined): ListValue;
+  unwrap(message: ListValue): Array<any>;
 }

--- a/integration/use-numeric-enum-json/simple.ts
+++ b/integration/use-numeric-enum-json/simple.ts
@@ -63,7 +63,7 @@ function createBaseSimple(): Simple {
   return { name: "", state: 0, states: [], nullValue: 0, stateMap: {} };
 }
 
-export const Simple = {
+export const Simple: MessageFns<Simple> = {
   encode(message: Simple, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.name !== "") {
       writer.uint32(10).string(message.name);
@@ -216,7 +216,7 @@ function createBaseSimple_StateMapEntry(): Simple_StateMapEntry {
   return { key: "", value: 0 };
 }
 
-export const Simple_StateMapEntry = {
+export const Simple_StateMapEntry: MessageFns<Simple_StateMapEntry> = {
   encode(message: Simple_StateMapEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== "") {
       writer.uint32(10).string(message.key);
@@ -304,4 +304,13 @@ function isObject(value: any): boolean {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/use-objectid-true-external-import/objectid/objectid.ts
+++ b/integration/use-objectid-true-external-import/objectid/objectid.ts
@@ -14,7 +14,7 @@ function createBaseObjectId(): ObjectId {
   return { value: "" };
 }
 
-export const ObjectId = {
+export const ObjectId: MessageFns<ObjectId> = {
   encode(message: ObjectId, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== "") {
       writer.uint32(10).string(message.value);
@@ -81,4 +81,13 @@ export type Exact<P, I extends P> = P extends Builtin ? P
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/use-objectid-true-external-import/use-objectid-true.ts
+++ b/integration/use-objectid-true-external-import/use-objectid-true.ts
@@ -25,7 +25,7 @@ function createBaseTodo(): Todo {
   return { id: "", oid: undefined, repeatedOid: [], optionalOid: undefined, mapOfOids: {} };
 }
 
-export const Todo = {
+export const Todo: MessageFns<Todo> = {
   encode(message: Todo, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.id !== "") {
       writer.uint32(10).string(message.id);
@@ -170,7 +170,7 @@ function createBaseTodo_MapOfOidsEntry(): Todo_MapOfOidsEntry {
   return { key: "", value: undefined };
 }
 
-export const Todo_MapOfOidsEntry = {
+export const Todo_MapOfOidsEntry: MessageFns<Todo_MapOfOidsEntry> = {
   encode(message: Todo_MapOfOidsEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== "") {
       writer.uint32(10).string(message.key);
@@ -279,4 +279,13 @@ function isObject(value: any): boolean {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/use-optionals-all/google/protobuf/struct.ts
+++ b/integration/use-optionals-all/google/protobuf/struct.ts
@@ -107,7 +107,7 @@ function createBaseStruct(): Struct {
   return { fields: {} };
 }
 
-export const Struct = {
+export const Struct: MessageFns<Struct> & StructWrapperFns = {
   encode(message: Struct, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     Object.entries(message.fields || {}).forEach(([key, value]) => {
       if (value !== undefined) {
@@ -211,7 +211,7 @@ function createBaseStruct_FieldsEntry(): Struct_FieldsEntry {
   return { key: "", value: undefined };
 }
 
-export const Struct_FieldsEntry = {
+export const Struct_FieldsEntry: MessageFns<Struct_FieldsEntry> = {
   encode(message: Struct_FieldsEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== "") {
       writer.uint32(10).string(message.key);
@@ -292,7 +292,7 @@ function createBaseValue(): Value {
   };
 }
 
-export const Value = {
+export const Value: MessageFns<Value> & AnyValueWrapperFns = {
   encode(message: Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.nullValue !== undefined) {
       writer.uint32(8).int32(message.nullValue);
@@ -463,7 +463,7 @@ function createBaseListValue(): ListValue {
   return { values: [] };
 }
 
-export const ListValue = {
+export const ListValue: MessageFns<ListValue> & ListValueWrapperFns = {
   encode(message: ListValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.values !== undefined && message.values.length !== 0) {
       for (const v of message.values) {
@@ -550,4 +550,28 @@ function isObject(value: any): boolean {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
+}
+
+export interface StructWrapperFns {
+  wrap(object: { [key: string]: any } | undefined): Struct;
+  unwrap(message: Struct): { [key: string]: any };
+}
+
+export interface AnyValueWrapperFns {
+  wrap(value: any): Value;
+  unwrap(message: any): string | number | boolean | Object | null | Array<any> | undefined;
+}
+
+export interface ListValueWrapperFns {
+  wrap(array: Array<any> | undefined): ListValue;
+  unwrap(message: ListValue): Array<any>;
 }

--- a/integration/use-optionals-all/google/protobuf/timestamp.ts
+++ b/integration/use-optionals-all/google/protobuf/timestamp.ts
@@ -119,7 +119,7 @@ function createBaseTimestamp(): Timestamp {
   return { seconds: 0, nanos: 0 };
 }
 
-export const Timestamp = {
+export const Timestamp: MessageFns<Timestamp> = {
   encode(message: Timestamp, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.seconds !== undefined && message.seconds !== 0) {
       writer.uint32(8).int64(message.seconds);
@@ -214,4 +214,13 @@ function longToNumber(int64: { toString(): string }): number {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/use-optionals-all/test.ts
+++ b/integration/use-optionals-all/test.ts
@@ -111,7 +111,7 @@ function createBaseOptionalsTest(): OptionalsTest {
   };
 }
 
-export const OptionalsTest = {
+export const OptionalsTest: MessageFns<OptionalsTest> = {
   encode(message: OptionalsTest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.id !== undefined && message.id !== 0) {
       writer.uint32(8).int32(message.id);
@@ -605,7 +605,7 @@ function createBaseOptionalsTest_TranslationsEntry(): OptionalsTest_Translations
   return { key: "", value: "" };
 }
 
-export const OptionalsTest_TranslationsEntry = {
+export const OptionalsTest_TranslationsEntry: MessageFns<OptionalsTest_TranslationsEntry> = {
   encode(message: OptionalsTest_TranslationsEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== "") {
       writer.uint32(10).string(message.key);
@@ -681,7 +681,7 @@ function createBaseChild(): Child {
   return {};
 }
 
-export const Child = {
+export const Child: MessageFns<Child> = {
   encode(_: Child, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     return writer;
   },
@@ -796,4 +796,13 @@ function isObject(value: any): boolean {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/use-optionals-deprecated-only/test.ts
+++ b/integration/use-optionals-deprecated-only/test.ts
@@ -111,7 +111,7 @@ function createBaseOptionalsTest(): OptionalsTest {
   };
 }
 
-export const OptionalsTest = {
+export const OptionalsTest: MessageFns<OptionalsTest> = {
   encode(message: OptionalsTest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.id !== 0) {
       writer.uint32(8).int32(message.id);
@@ -545,7 +545,7 @@ function createBaseOptionalsTest_TranslationsEntry(): OptionalsTest_Translations
   return { key: "", value: "" };
 }
 
-export const OptionalsTest_TranslationsEntry = {
+export const OptionalsTest_TranslationsEntry: MessageFns<OptionalsTest_TranslationsEntry> = {
   encode(message: OptionalsTest_TranslationsEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== "") {
       writer.uint32(10).string(message.key);
@@ -671,4 +671,13 @@ function isObject(value: any): boolean {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/use-optionals-no-undefined/google/protobuf/struct.ts
+++ b/integration/use-optionals-no-undefined/google/protobuf/struct.ts
@@ -107,7 +107,7 @@ function createBaseStruct(): Struct {
   return {};
 }
 
-export const Struct = {
+export const Struct: MessageFns<Struct> & StructWrapperFns = {
   encode(message: Struct, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     Object.entries(message.fields || {}).forEach(([key, value]) => {
       if (value !== undefined) {
@@ -213,7 +213,7 @@ function createBaseStruct_FieldsEntry(): Struct_FieldsEntry {
   return { key: "" };
 }
 
-export const Struct_FieldsEntry = {
+export const Struct_FieldsEntry: MessageFns<Struct_FieldsEntry> = {
   encode(message: Struct_FieldsEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== "") {
       writer.uint32(10).string(message.key);
@@ -287,7 +287,7 @@ function createBaseValue(): Value {
   return {};
 }
 
-export const Value = {
+export const Value: MessageFns<Value> & AnyValueWrapperFns = {
   encode(message: Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.nullValue !== undefined) {
       writer.uint32(8).int32(message.nullValue);
@@ -458,7 +458,7 @@ function createBaseListValue(): ListValue {
   return {};
 }
 
-export const ListValue = {
+export const ListValue: MessageFns<ListValue> & ListValueWrapperFns = {
   encode(message: ListValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.values !== undefined && message.values.length !== 0) {
       for (const v of message.values) {
@@ -548,4 +548,28 @@ function isObject(value: any): boolean {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
+}
+
+export interface StructWrapperFns {
+  wrap(object: { [key: string]: any } | undefined): Struct;
+  unwrap(message: Struct): { [key: string]: any };
+}
+
+export interface AnyValueWrapperFns {
+  wrap(value: any): Value;
+  unwrap(message: any): string | number | boolean | Object | null | Array<any> | undefined;
+}
+
+export interface ListValueWrapperFns {
+  wrap(array: Array<any> | undefined): ListValue;
+  unwrap(message: ListValue): Array<any>;
 }

--- a/integration/use-optionals-no-undefined/test.ts
+++ b/integration/use-optionals-no-undefined/test.ts
@@ -84,7 +84,7 @@ function createBaseOptionalsTest(): OptionalsTest {
   return {};
 }
 
-export const OptionalsTest = {
+export const OptionalsTest: MessageFns<OptionalsTest> = {
   encode(message: OptionalsTest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.id !== undefined && message.id !== 0) {
       writer.uint32(8).int32(message.id);
@@ -606,7 +606,7 @@ function createBaseOptionalsTest_TranslationsEntry(): OptionalsTest_Translations
   return { key: "", value: "" };
 }
 
-export const OptionalsTest_TranslationsEntry = {
+export const OptionalsTest_TranslationsEntry: MessageFns<OptionalsTest_TranslationsEntry> = {
   encode(message: OptionalsTest_TranslationsEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== "") {
       writer.uint32(10).string(message.key);
@@ -682,7 +682,7 @@ function createBaseChild(): Child {
   return {};
 }
 
-export const Child = {
+export const Child: MessageFns<Child> = {
   encode(_: Child, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     return writer;
   },
@@ -775,4 +775,13 @@ function isObject(value: any): boolean {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/use-readonly-types/google/protobuf/field_mask.ts
+++ b/integration/use-readonly-types/google/protobuf/field_mask.ts
@@ -215,7 +215,7 @@ function createBaseFieldMask(): FieldMask {
   return { paths: [] };
 }
 
-export const FieldMask = {
+export const FieldMask: MessageFns<FieldMask> & FieldMaskWrapperFns = {
   encode(message: FieldMask, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     for (const v of message.paths) {
       writer.uint32(10).string(v!);
@@ -293,3 +293,17 @@ export type DeepPartial<T> = T extends Builtin ? T
 type KeysOfUnion<T> = T extends T ? keyof T : never;
 export type Exact<P, I extends P> = P extends Builtin ? P
   : P & { [K in keyof P]: Exact<P[K], I[K]> } & { [K in Exclude<keyof I, KeysOfUnion<P>>]: never };
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
+}
+
+export interface FieldMaskWrapperFns {
+  wrap(paths: readonly string[]): FieldMask;
+  unwrap(message: any): string[];
+}

--- a/integration/use-readonly-types/google/protobuf/struct.ts
+++ b/integration/use-readonly-types/google/protobuf/struct.ts
@@ -93,7 +93,7 @@ function createBaseStruct(): Struct {
   return { fields: {} };
 }
 
-export const Struct = {
+export const Struct: MessageFns<Struct> & StructWrapperFns = {
   encode(message: Struct, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     Object.entries(message.fields).forEach(([key, value]) => {
       if (value !== undefined) {
@@ -197,7 +197,7 @@ function createBaseStruct_FieldsEntry(): Struct_FieldsEntry {
   return { key: "", value: undefined };
 }
 
-export const Struct_FieldsEntry = {
+export const Struct_FieldsEntry: MessageFns<Struct_FieldsEntry> = {
   encode(message: Struct_FieldsEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== "") {
       writer.uint32(10).string(message.key);
@@ -271,7 +271,7 @@ function createBaseValue(): Value {
   return { kind: undefined };
 }
 
-export const Value = {
+export const Value: MessageFns<Value> & AnyValueWrapperFns = {
   encode(message: Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     switch (message.kind?.$case) {
       case "nullValue":
@@ -476,7 +476,7 @@ function createBaseListValue(): ListValue {
   return { values: [] };
 }
 
-export const ListValue = {
+export const ListValue: MessageFns<ListValue> & ListValueWrapperFns = {
   encode(message: ListValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     for (const v of message.values) {
       Value.encode(Value.wrap(v!), writer.uint32(10).fork()).join();
@@ -563,4 +563,28 @@ function isObject(value: any): boolean {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
+}
+
+export interface StructWrapperFns {
+  wrap(object: { [key: string]: any } | undefined): Struct;
+  unwrap(message: Struct): { [key: string]: any };
+}
+
+export interface AnyValueWrapperFns {
+  wrap(value: any): Value;
+  unwrap(message: any): string | number | boolean | Object | null | Array<any> | undefined;
+}
+
+export interface ListValueWrapperFns {
+  wrap(array: ReadonlyArray<any> | undefined): ListValue;
+  unwrap(message: any): Array<any>;
 }

--- a/integration/use-readonly-types/use-readonly-types.ts
+++ b/integration/use-readonly-types/use-readonly-types.ts
@@ -45,7 +45,7 @@ function createBaseEntity(): Entity {
   };
 }
 
-export const Entity = {
+export const Entity: MessageFns<Entity> = {
   encode(message: Entity, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.intVal !== 0) {
       writer.uint32(8).int32(message.intVal);
@@ -304,7 +304,7 @@ function createBaseSubEntity(): SubEntity {
   return { subVal: 0 };
 }
 
-export const SubEntity = {
+export const SubEntity: MessageFns<SubEntity> = {
   encode(message: SubEntity, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.subVal !== 0) {
       writer.uint32(8).int32(message.subVal);
@@ -377,4 +377,13 @@ function isObject(value: any): boolean {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/value/google/protobuf/struct.ts
+++ b/integration/value/google/protobuf/struct.ts
@@ -107,7 +107,7 @@ function createBaseStruct(): Struct {
   return { fields: {} };
 }
 
-export const Struct = {
+export const Struct: MessageFns<Struct> & StructWrapperFns = {
   encode(message: Struct, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     Object.entries(message.fields).forEach(([key, value]) => {
       if (value !== undefined) {
@@ -211,7 +211,7 @@ function createBaseStruct_FieldsEntry(): Struct_FieldsEntry {
   return { key: "", value: undefined };
 }
 
-export const Struct_FieldsEntry = {
+export const Struct_FieldsEntry: MessageFns<Struct_FieldsEntry> = {
   encode(message: Struct_FieldsEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== "") {
       writer.uint32(10).string(message.key);
@@ -292,7 +292,7 @@ function createBaseValue(): Value {
   };
 }
 
-export const Value = {
+export const Value: MessageFns<Value> & AnyValueWrapperFns = {
   encode(message: Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.nullValue !== undefined) {
       writer.uint32(8).int32(message.nullValue);
@@ -463,7 +463,7 @@ function createBaseListValue(): ListValue {
   return { values: [] };
 }
 
-export const ListValue = {
+export const ListValue: MessageFns<ListValue> & ListValueWrapperFns = {
   encode(message: ListValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     for (const v of message.values) {
       Value.encode(Value.wrap(v!), writer.uint32(10).fork()).join();
@@ -548,4 +548,28 @@ function isObject(value: any): boolean {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
+}
+
+export interface StructWrapperFns {
+  wrap(object: { [key: string]: any } | undefined): Struct;
+  unwrap(message: Struct): { [key: string]: any };
+}
+
+export interface AnyValueWrapperFns {
+  wrap(value: any): Value;
+  unwrap(message: any): string | number | boolean | Object | null | Array<any> | undefined;
+}
+
+export interface ListValueWrapperFns {
+  wrap(array: Array<any> | undefined): ListValue;
+  unwrap(message: ListValue): Array<any>;
 }

--- a/integration/value/google/protobuf/wrappers.ts
+++ b/integration/value/google/protobuf/wrappers.ts
@@ -100,7 +100,7 @@ function createBaseDoubleValue(): DoubleValue {
   return { value: 0 };
 }
 
-export const DoubleValue = {
+export const DoubleValue: MessageFns<DoubleValue> = {
   encode(message: DoubleValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(9).double(message.value);
@@ -157,7 +157,7 @@ function createBaseFloatValue(): FloatValue {
   return { value: 0 };
 }
 
-export const FloatValue = {
+export const FloatValue: MessageFns<FloatValue> = {
   encode(message: FloatValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(13).float(message.value);
@@ -214,7 +214,7 @@ function createBaseInt64Value(): Int64Value {
   return { value: 0 };
 }
 
-export const Int64Value = {
+export const Int64Value: MessageFns<Int64Value> = {
   encode(message: Int64Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).int64(message.value);
@@ -271,7 +271,7 @@ function createBaseUInt64Value(): UInt64Value {
   return { value: 0 };
 }
 
-export const UInt64Value = {
+export const UInt64Value: MessageFns<UInt64Value> = {
   encode(message: UInt64Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).uint64(message.value);
@@ -328,7 +328,7 @@ function createBaseInt32Value(): Int32Value {
   return { value: 0 };
 }
 
-export const Int32Value = {
+export const Int32Value: MessageFns<Int32Value> = {
   encode(message: Int32Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).int32(message.value);
@@ -385,7 +385,7 @@ function createBaseUInt32Value(): UInt32Value {
   return { value: 0 };
 }
 
-export const UInt32Value = {
+export const UInt32Value: MessageFns<UInt32Value> = {
   encode(message: UInt32Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).uint32(message.value);
@@ -442,7 +442,7 @@ function createBaseBoolValue(): BoolValue {
   return { value: false };
 }
 
-export const BoolValue = {
+export const BoolValue: MessageFns<BoolValue> = {
   encode(message: BoolValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== false) {
       writer.uint32(8).bool(message.value);
@@ -499,7 +499,7 @@ function createBaseStringValue(): StringValue {
   return { value: "" };
 }
 
-export const StringValue = {
+export const StringValue: MessageFns<StringValue> = {
   encode(message: StringValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== "") {
       writer.uint32(10).string(message.value);
@@ -556,7 +556,7 @@ function createBaseBytesValue(): BytesValue {
   return { value: new Uint8Array(0) };
 }
 
-export const BytesValue = {
+export const BytesValue: MessageFns<BytesValue> = {
   encode(message: BytesValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value.length !== 0) {
       writer.uint32(10).bytes(message.value);
@@ -659,4 +659,13 @@ function longToNumber(int64: { toString(): string }): number {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/value/value.ts
+++ b/integration/value/value.ts
@@ -20,7 +20,7 @@ function createBaseValueMessage(): ValueMessage {
   return { value: undefined, anyList: undefined, repeatedAny: [], repeatedStrings: [], structValue: undefined };
 }
 
-export const ValueMessage = {
+export const ValueMessage: MessageFns<ValueMessage> = {
   encode(message: ValueMessage, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== undefined) {
       Value.encode(Value.wrap(message.value), writer.uint32(10).fork()).join();
@@ -155,4 +155,13 @@ function isObject(value: any): boolean {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/vector-tile/vector_tile.ts
+++ b/integration/vector-tile/vector_tile.ts
@@ -85,7 +85,7 @@ function createBaseTile(): Tile {
   return { layers: [] };
 }
 
-export const Tile = {
+export const Tile: MessageFns<Tile> = {
   encode(message: Tile, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     for (const v of message.layers) {
       Tile_Layer.encode(v!, writer.uint32(26).fork()).join();
@@ -144,7 +144,7 @@ function createBaseTile_Value(): Tile_Value {
   return { stringValue: "", floatValue: 0, doubleValue: 0, intValue: 0, uintValue: 0, sintValue: 0, boolValue: false };
 }
 
-export const Tile_Value = {
+export const Tile_Value: MessageFns<Tile_Value> = {
   encode(message: Tile_Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.stringValue !== undefined && message.stringValue !== "") {
       writer.uint32(10).string(message.stringValue);
@@ -293,7 +293,7 @@ function createBaseTile_Feature(): Tile_Feature {
   return { id: 0, tags: [], type: 0, geometry: [] };
 }
 
-export const Tile_Feature = {
+export const Tile_Feature: MessageFns<Tile_Feature> = {
   encode(message: Tile_Feature, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.id !== undefined && message.id !== 0) {
       writer.uint32(8).uint64(message.id);
@@ -421,7 +421,7 @@ function createBaseTile_Layer(): Tile_Layer {
   return { version: 1, name: "", features: [], keys: [], values: [], extent: 4096 };
 }
 
-export const Tile_Layer = {
+export const Tile_Layer: MessageFns<Tile_Layer> = {
   encode(message: Tile_Layer, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.version !== 1) {
       writer.uint32(120).uint32(message.version);
@@ -578,4 +578,13 @@ function longToNumber(int64: { toString(): string }): number {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/wrappers-regression/google/protobuf/empty.ts
+++ b/integration/wrappers-regression/google/protobuf/empty.ts
@@ -24,7 +24,7 @@ function createBaseEmpty(): Empty {
   return {};
 }
 
-export const Empty = {
+export const Empty: MessageFns<Empty> = {
   encode(_: Empty, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     return writer;
   },
@@ -74,3 +74,12 @@ export type DeepPartial<T> = T extends Builtin ? T
 type KeysOfUnion<T> = T extends T ? keyof T : never;
 export type Exact<P, I extends P> = P extends Builtin ? P
   : P & { [K in keyof P]: Exact<P[K], I[K]> } & { [K in Exclude<keyof I, KeysOfUnion<P>>]: never };
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
+}

--- a/integration/wrappers-regression/google/protobuf/timestamp.ts
+++ b/integration/wrappers-regression/google/protobuf/timestamp.ts
@@ -117,7 +117,7 @@ function createBaseTimestamp(): Timestamp {
   return { seconds: 0, nanos: 0 };
 }
 
-export const Timestamp = {
+export const Timestamp: MessageFns<Timestamp> = {
   encode(message: Timestamp, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.seconds !== 0) {
       writer.uint32(8).int64(message.seconds);
@@ -212,4 +212,13 @@ function longToNumber(int64: { toString(): string }): number {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }

--- a/integration/wrappers-regression/google/protobuf/wrappers.ts
+++ b/integration/wrappers-regression/google/protobuf/wrappers.ts
@@ -100,7 +100,7 @@ function createBaseDoubleValue(): DoubleValue {
   return { value: 0 };
 }
 
-export const DoubleValue = {
+export const DoubleValue: MessageFns<DoubleValue> = {
   encode(message: DoubleValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(9).double(message.value);
@@ -157,7 +157,7 @@ function createBaseFloatValue(): FloatValue {
   return { value: 0 };
 }
 
-export const FloatValue = {
+export const FloatValue: MessageFns<FloatValue> = {
   encode(message: FloatValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(13).float(message.value);
@@ -214,7 +214,7 @@ function createBaseInt64Value(): Int64Value {
   return { value: 0 };
 }
 
-export const Int64Value = {
+export const Int64Value: MessageFns<Int64Value> = {
   encode(message: Int64Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).int64(message.value);
@@ -271,7 +271,7 @@ function createBaseUInt64Value(): UInt64Value {
   return { value: 0 };
 }
 
-export const UInt64Value = {
+export const UInt64Value: MessageFns<UInt64Value> = {
   encode(message: UInt64Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).uint64(message.value);
@@ -328,7 +328,7 @@ function createBaseInt32Value(): Int32Value {
   return { value: 0 };
 }
 
-export const Int32Value = {
+export const Int32Value: MessageFns<Int32Value> = {
   encode(message: Int32Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).int32(message.value);
@@ -385,7 +385,7 @@ function createBaseUInt32Value(): UInt32Value {
   return { value: 0 };
 }
 
-export const UInt32Value = {
+export const UInt32Value: MessageFns<UInt32Value> = {
   encode(message: UInt32Value, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== 0) {
       writer.uint32(8).uint32(message.value);
@@ -442,7 +442,7 @@ function createBaseBoolValue(): BoolValue {
   return { value: false };
 }
 
-export const BoolValue = {
+export const BoolValue: MessageFns<BoolValue> = {
   encode(message: BoolValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== false) {
       writer.uint32(8).bool(message.value);
@@ -499,7 +499,7 @@ function createBaseStringValue(): StringValue {
   return { value: "" };
 }
 
-export const StringValue = {
+export const StringValue: MessageFns<StringValue> = {
   encode(message: StringValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value !== "") {
       writer.uint32(10).string(message.value);
@@ -556,7 +556,7 @@ function createBaseBytesValue(): BytesValue {
   return { value: new Uint8Array(0) };
 }
 
-export const BytesValue = {
+export const BytesValue: MessageFns<BytesValue> = {
   encode(message: BytesValue, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.value.length !== 0) {
       writer.uint32(10).bytes(message.value);
@@ -659,4 +659,13 @@ function longToNumber(int64: { toString(): string }): number {
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;
+}
+
+export interface MessageFns<T> {
+  encode(message: T, writer?: BinaryWriter): BinaryWriter;
+  decode(input: BinaryReader | Uint8Array, length?: number): T;
+  fromJSON(object: any): T;
+  toJSON(message: T): unknown;
+  create<I extends Exact<DeepPartial<T>, I>>(base?: I): T;
+  fromPartial<I extends Exact<DeepPartial<T>, I>>(object: I): T;
 }


### PR DESCRIPTION
Fixes https://github.com/stephenh/ts-proto/issues/1080

Adds an interface for the static message methods to avoid tsc errors on large messages. 

Since the set of static methods created may vary from message-to-message, multiple interfaces were created and are unioned as needed:
- `MessageFns`. The common encode/decode methods. All the message objects implement this.
- `ExtensionFns`. The get/set extension methods. Added if extensions are enabled and the message has extensions.
- `ExtensionHolder`. The individual extension properties.
- `[Struct|AnyValue|ListValue|FieldMask]WrapperFns`. The wrap/unwrap methods for the well-known types.