### PR TITLE
Export generated `Rpc` interfaces

### DIFF
--- a/src/generate-grpc-web.ts
+++ b/src/generate-grpc-web.ts
@@ -173,7 +173,7 @@ function generateGrpcWebRpcType(ctx: Context, returnObservable: boolean, hasStre
   const { options } = ctx;
   const { useAbortSignal } = options;
 
-  chunks.push(code`interface Rpc {`);
+  chunks.push(code`export interface Rpc {`);
 
   const wrapper = returnObservable ? observableType(ctx) : "Promise";
   chunks.push(code`

--- a/src/generate-services.ts
+++ b/src/generate-services.ts
@@ -456,7 +456,7 @@ export function generateRpcType(ctx: Context, hasStreamingMethods: boolean): Cod
     ]);
   }
   const chunks: Code[] = [];
-  chunks.push(code`    interface Rpc${maybeContext} {`);
+  chunks.push(code`    export interface Rpc${maybeContext} {`);
   methods.forEach((method) => {
     chunks.push(code`
       ${method[0]}(


### PR DESCRIPTION
This updates the generation of the `Rpc` interface to be publicly exported so consumers can define custom `Rpc` implementations.

Closes #1107 