### PR TITLE
fix: update basic grpc implementation

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -701,8 +701,8 @@ const sendRequest: RpcImpl = (service, method, data) => {
       return argument;
     }
 
-    // Using passThrough as the serialize and deserialize functions
-    conn.makeUnaryRequest(path, passThrough, passThrough, data, resultCallback);
+    // Using passThrough as the deserialize functions
+    conn.makeUnaryRequest(path, d => Buffer.from(d), passThrough, data, resultCallback);
   });
 };
 


### PR DESCRIPTION
In this basic grpc implementation example `serialize` callback is not correct and throws error in testing it. I have update `serialize` with `Buffer.from` which is working fine.