### PR TITLE
fix: types export path

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "bin": {
     "protoc-gen-ts_proto": "./protoc-gen-ts_proto"
   },
-  "types": "build/index.d.ts",
+  "types": "build/src/index.d.ts",
   "scripts": {
     "build": "yarn tsc",
     "build:test": "yarn proto2ts && yarn proto2pbjs",


### PR DESCRIPTION
The build path was updated [here](https://github.com/stephenh/ts-proto/commit/3ecd4986063952ae06c6136fbd9ae0cfc75212d8), but the path for the types was not. This fixes the issue so you can import these types again.