### PR TITLE
Mention the decode-only and encode-only options in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -406,7 +406,7 @@ Generated code will be placed in the Gradle build directory.
 
 - With `--ts_proto_opt=outputEncodeMethods=false`, the `Message.encode` and `Message.decode` methods for working with protobuf-encoded/binary data will not be output.
 
-  This is useful if you want "only types".
+  This is useful if you want "only types". Use `=decode-only` or `=encode-only` to only output decode or encode methods.
 
 - With `--ts_proto_opt=outputEncodeIncludeTypes=regex`, the `Message.encode` method will only be output for types whose name matches the provided regular expression.
 


### PR DESCRIPTION
Ref: https://github.com/stephenh/ts-proto/pull/787

This could've no doubt be phrased better, but at least it's mentioned now.