### PR TITLE
fix: Honour packed repeated fields encoding

### DIFF
--- a/integration/extensions/extensions-test.ts
+++ b/integration/extensions/extensions-test.ts
@@ -55,7 +55,7 @@ describe("extensions-test", () => {
 
     expect(extension).toEqual(extensionData);
 
-    expect(Extendable.getExtension(result, repeated)).toEqual([1, 1, 2, 3, 5]);
+    expect(Extendable.getExtension(result, repeated)).toEqual([2, 3, 5, 1, 1]);
 
     const unsetExtension = Extendable.getExtension(result, Nested.message);
 

--- a/integration/extensions/test.ts
+++ b/integration/extensions/test.ts
@@ -415,7 +415,14 @@ export const packed: Extension<number[]> = {
     const values: number[] = [];
     for (const buffer of input) {
       const reader = new BinaryReader(buffer);
-      values.push(reader.int32());
+      if (tag == 42) {
+        const end2 = reader.uint32() + reader.pos;
+        while (reader.pos < end2) {
+          values.push(reader.int32());
+        }
+      } else {
+        values.push(reader.int32());
+      }
     }
 
     return values;
@@ -442,7 +449,14 @@ export const repeated: Extension<number[]> = {
     const values: number[] = [];
     for (const buffer of input) {
       const reader = new BinaryReader(buffer);
-      values.push(reader.int32());
+      if (tag == 50) {
+        const end2 = reader.uint32() + reader.pos;
+        while (reader.pos < end2) {
+          values.push(reader.int32());
+        }
+      } else {
+        values.push(reader.int32());
+      }
     }
 
     return values;

--- a/integration/meta-typings-as-const/google/protobuf/descriptor.ts
+++ b/integration/meta-typings-as-const/google/protobuf/descriptor.ts
@@ -2953,16 +2953,12 @@ function createBaseSourceCodeInfo_Location(): SourceCodeInfo_Location {
 
 export const SourceCodeInfo_Location: MessageFns<SourceCodeInfo_Location> = {
   encode(message: SourceCodeInfo_Location, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    writer.uint32(10).fork();
     for (const v of message.path) {
-      writer.int32(v);
+      writer.uint32(8).int32(v!);
     }
-    writer.join();
-    writer.uint32(18).fork();
     for (const v of message.span) {
-      writer.int32(v);
+      writer.uint32(16).int32(v!);
     }
-    writer.join();
     if (message.leadingComments !== undefined && message.leadingComments !== "") {
       writer.uint32(26).string(message.leadingComments);
     }
@@ -3095,11 +3091,9 @@ function createBaseGeneratedCodeInfo_Annotation(): GeneratedCodeInfo_Annotation 
 
 export const GeneratedCodeInfo_Annotation: MessageFns<GeneratedCodeInfo_Annotation> = {
   encode(message: GeneratedCodeInfo_Annotation, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    writer.uint32(10).fork();
     for (const v of message.path) {
-      writer.int32(v);
+      writer.uint32(8).int32(v!);
     }
-    writer.join();
     if (message.sourceFile !== undefined && message.sourceFile !== "") {
       writer.uint32(18).string(message.sourceFile);
     }

--- a/integration/options/google/protobuf/descriptor.ts
+++ b/integration/options/google/protobuf/descriptor.ts
@@ -2953,16 +2953,12 @@ function createBaseSourceCodeInfo_Location(): SourceCodeInfo_Location {
 
 export const SourceCodeInfo_Location: MessageFns<SourceCodeInfo_Location> = {
   encode(message: SourceCodeInfo_Location, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    writer.uint32(10).fork();
     for (const v of message.path) {
-      writer.int32(v);
+      writer.uint32(8).int32(v!);
     }
-    writer.join();
-    writer.uint32(18).fork();
     for (const v of message.span) {
-      writer.int32(v);
+      writer.uint32(16).int32(v!);
     }
-    writer.join();
     if (message.leadingComments !== undefined && message.leadingComments !== "") {
       writer.uint32(26).string(message.leadingComments);
     }
@@ -3095,11 +3091,9 @@ function createBaseGeneratedCodeInfo_Annotation(): GeneratedCodeInfo_Annotation 
 
 export const GeneratedCodeInfo_Annotation: MessageFns<GeneratedCodeInfo_Annotation> = {
   encode(message: GeneratedCodeInfo_Annotation, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    writer.uint32(10).fork();
     for (const v of message.path) {
-      writer.int32(v);
+      writer.uint32(8).int32(v!);
     }
-    writer.join();
     if (message.sourceFile !== undefined && message.sourceFile !== "") {
       writer.uint32(18).string(message.sourceFile);
     }

--- a/integration/unknown-fields/google/protobuf/descriptor.ts
+++ b/integration/unknown-fields/google/protobuf/descriptor.ts
@@ -3386,16 +3386,12 @@ function createBaseSourceCodeInfo_Location(): SourceCodeInfo_Location {
 
 export const SourceCodeInfo_Location: MessageFns<SourceCodeInfo_Location> = {
   encode(message: SourceCodeInfo_Location, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    writer.uint32(10).fork();
     for (const v of message.path) {
-      writer.int32(v);
+      writer.uint32(8).int32(v!);
     }
-    writer.join();
-    writer.uint32(18).fork();
     for (const v of message.span) {
-      writer.int32(v);
+      writer.uint32(16).int32(v!);
     }
-    writer.join();
     if (message.leadingComments !== undefined && message.leadingComments !== "") {
       writer.uint32(26).string(message.leadingComments);
     }
@@ -3560,11 +3556,9 @@ function createBaseGeneratedCodeInfo_Annotation(): GeneratedCodeInfo_Annotation 
 
 export const GeneratedCodeInfo_Annotation: MessageFns<GeneratedCodeInfo_Annotation> = {
   encode(message: GeneratedCodeInfo_Annotation, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    writer.uint32(10).fork();
     for (const v of message.path) {
-      writer.int32(v);
+      writer.uint32(8).int32(v!);
     }
-    writer.join();
     if (message.sourceFile !== undefined && message.sourceFile !== "") {
       writer.uint32(18).string(message.sourceFile);
     }

--- a/integration/use-optionals-deprecated-only/test.ts
+++ b/integration/use-optionals-deprecated-only/test.ts
@@ -137,11 +137,9 @@ export const OptionalsTest: MessageFns<OptionalsTest> = {
     }
     writer.join();
     if (message.repState !== undefined && message.repState.length !== 0) {
-      writer.uint32(66).fork();
       for (const v of message.repState) {
-        writer.int32(v);
+        writer.uint32(64).int32(v!);
       }
-      writer.join();
     }
     writer.uint32(74).fork();
     for (const v of message.repStateV2) {

--- a/integration/vector-tile/vector_tile.ts
+++ b/integration/vector-tile/vector_tile.ts
@@ -306,19 +306,15 @@ export const Tile_Feature: MessageFns<Tile_Feature> = {
     if (message.id !== undefined && message.id !== 0) {
       writer.uint32(8).uint64(message.id);
     }
-    writer.uint32(18).fork();
     for (const v of message.tags) {
-      writer.uint32(v);
+      writer.uint32(16).uint32(v!);
     }
-    writer.join();
     if (message.type !== undefined && message.type !== 0) {
       writer.uint32(24).int32(message.type);
     }
-    writer.uint32(34).fork();
     for (const v of message.geometry) {
-      writer.uint32(v);
+      writer.uint32(32).uint32(v!);
     }
-    writer.join();
     return writer;
   },
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -88,6 +88,7 @@ import {
   isWithinOneOf,
   isWithinOneOfThatShouldBeUnion,
   notDefaultCheck,
+  packedField,
   packedType,
   shouldGenerateJSMapType,
   toReaderCall,
@@ -1116,6 +1117,7 @@ function makeExtensionClass(options: Options) {
         number: number;
         tag: number;
         singularTag?: number;
+        packedTag?: number;
         encode?: (message: T) => Uint8Array[];
         decode?: (tag: number, input: Uint8Array[]) => T;
         repeated: boolean;
@@ -1483,7 +1485,7 @@ function generateDecode(ctx: Context, fullName: string, messageDesc: DescriptorP
               ${messageProperty} = [];
             }`
           : "";
-        if (packedType(field) === undefined) {
+        if (packedType(field.type) === undefined) {
           if (options.useOptionals === "all") {
             chunks.push(code`
               ${tagCheck}
@@ -1541,7 +1543,7 @@ function generateDecode(ctx: Context, fullName: string, messageDesc: DescriptorP
       `);
     }
 
-    if (!isRepeated(field) || packedType(field) === undefined) {
+    if (!isRepeated(field) || packedType(field.type) === undefined) {
       chunks.push(code`continue; }`);
     }
   });
@@ -1737,7 +1739,7 @@ function generateEncode(ctx: Context, fullName: string, messageDesc: DescriptorP
             });
           `);
         }
-      } else if (packedType(field) === undefined) {
+      } else if (packedField(field, currentFile.isProto3Syntax) === undefined) {
         const listWriteSnippet = code`
           for (const v of ${messageProperty}) {
             ${writeSnippet("v!")};
@@ -1913,6 +1915,9 @@ function generateSetExtension(ctx: Context, fullName: string) {
         if (extension.singularTag !== undefined) {
           delete message._unknownFields[extension.singularTag];
         }
+        if (extension.packedTag !== undefined) {
+          delete message._unknownFields[extension.packedTag];
+        }
       }
 
       if (encoded.length !== 0) {
@@ -1941,14 +1946,17 @@ function generateGetExtension(ctx: Context, fullName: string) {
         results = extension.decode!(extension.tag, list);
       }
 
-      if (extension.singularTag === undefined) {
+      if (extension.singularTag === undefined ||
+          extension.packedTag === undefined) {
         return results;
       }
 
-      list = message._unknownFields[extension.singularTag];
+      const nonDefaultTag = (extension.singularTag === extension.tag) ?
+          extension.packedTag : extension.singularTag;
+      list = message._unknownFields[nonDefaultTag];
 
       if (list !== undefined) {
-        const results2 = extension.decode!(extension.singularTag, list);
+        const results2 = extension.decode!(nonDefaultTag, list);
 
         if (results !== undefined && (results as any).length !== 0) {
           results = (results as any).concat(results2);
@@ -1964,10 +1972,12 @@ function generateGetExtension(ctx: Context, fullName: string) {
 
 function generateExtension(ctx: Context, message: DescriptorProto | undefined, extension: FieldDescriptorProto) {
   const type = toTypeName(ctx, message, extension);
+  const { currentFile } = ctx;
   const packedTag =
-    isRepeated(extension) && packedType(extension) !== undefined ? ((extension.number << 3) | 2) >>> 0 : undefined;
+    isRepeated(extension) && packedType(extension.type) !== undefined ? ((extension.number << 3) | 2) >>> 0 : undefined;
   const singularTag = ((extension.number << 3) | basicWireType(extension.type)) >>> 0;
-  const tag = packedTag ?? singularTag;
+  const packed = isRepeated(extension) && packedField(extension, currentFile.isProto3Syntax)
+  const tag = packed ? packedTag : singularTag;
 
   const chunks: Code[] = [];
 
@@ -1976,7 +1986,10 @@ function generateExtension(ctx: Context, message: DescriptorProto | undefined, e
   chunks.push(code`number: ${extension.number},`);
   chunks.push(code`tag: ${tag},`);
 
-  if (packedTag !== undefined) chunks.push(code`singularTag: ${singularTag},`);
+  if (packedTag !== undefined) {
+    chunks.push(code`singularTag: ${singularTag},`);
+    chunks.push(code`packedTag: ${packedTag},`);
+  }
   chunks.push(code`repeated: ${extension.label == FieldDescriptorProto_Label.LABEL_REPEATED},`);
   chunks.push(code`packed: ${extension.options?.packed ? true : false},`);
 
@@ -2048,7 +2061,7 @@ function generateExtension(ctx: Context, message: DescriptorProto | undefined, e
     const writeSnippet = getEncodeSnippet(ctx, extension);
 
     if (isRepeated(extension)) {
-      if (packedTag === undefined) {
+      if (!packed) {
         chunks.push(code`
           for (const v of value) {
             const writer = new ${BinaryWriter}();
@@ -2107,7 +2120,7 @@ function generateExtension(ctx: Context, message: DescriptorProto | undefined, e
           const reader = new ${BinaryReader}(buffer);
       `);
 
-      if (packedType(extension) === undefined) {
+      if (!packed) {
         chunks.push(code`
           values.push(${readSnippet});
         `);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1483,7 +1483,7 @@ function generateDecode(ctx: Context, fullName: string, messageDesc: DescriptorP
               ${messageProperty} = [];
             }`
           : "";
-        if (packedType(field.type) === undefined) {
+        if (packedType(field) === undefined) {
           if (options.useOptionals === "all") {
             chunks.push(code`
               ${tagCheck}
@@ -1541,7 +1541,7 @@ function generateDecode(ctx: Context, fullName: string, messageDesc: DescriptorP
       `);
     }
 
-    if (!isRepeated(field) || packedType(field.type) === undefined) {
+    if (!isRepeated(field) || packedType(field) === undefined) {
       chunks.push(code`continue; }`);
     }
   });
@@ -1737,7 +1737,7 @@ function generateEncode(ctx: Context, fullName: string, messageDesc: DescriptorP
             });
           `);
         }
-      } else if (packedType(field.type) === undefined) {
+      } else if (packedType(field) === undefined) {
         const listWriteSnippet = code`
           for (const v of ${messageProperty}) {
             ${writeSnippet("v!")};
@@ -1965,7 +1965,7 @@ function generateGetExtension(ctx: Context, fullName: string) {
 function generateExtension(ctx: Context, message: DescriptorProto | undefined, extension: FieldDescriptorProto) {
   const type = toTypeName(ctx, message, extension);
   const packedTag =
-    isRepeated(extension) && packedType(extension.type) !== undefined ? ((extension.number << 3) | 2) >>> 0 : undefined;
+    isRepeated(extension) && packedType(extension) !== undefined ? ((extension.number << 3) | 2) >>> 0 : undefined;
   const singularTag = ((extension.number << 3) | basicWireType(extension.type)) >>> 0;
   const tag = packedTag ?? singularTag;
 
@@ -2107,7 +2107,7 @@ function generateExtension(ctx: Context, message: DescriptorProto | undefined, e
           const reader = new ${BinaryReader}(buffer);
       `);
 
-      if (packedType(extension.type) === undefined) {
+      if (packedType(extension) === undefined) {
         chunks.push(code`
           values.push(${readSnippet});
         `);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1976,7 +1976,7 @@ function generateExtension(ctx: Context, message: DescriptorProto | undefined, e
   const packedTag =
     isRepeated(extension) && packedType(extension.type) !== undefined ? ((extension.number << 3) | 2) >>> 0 : undefined;
   const singularTag = ((extension.number << 3) | basicWireType(extension.type)) >>> 0;
-  const packed = isRepeated(extension) && packedField(extension, currentFile.isProto3Syntax)
+  const packed = isRepeated(extension) && packedField(extension, currentFile.isProto3Syntax);
   const tag = packed ? packedTag : singularTag;
 
   const chunks: Code[] = [];
@@ -2120,7 +2120,7 @@ function generateExtension(ctx: Context, message: DescriptorProto | undefined, e
           const reader = new ${BinaryReader}(buffer);
       `);
 
-      if (!packed) {
+      if (packedTag === undefined) {
         chunks.push(code`
           values.push(${readSnippet});
         `);

--- a/src/types.ts
+++ b/src/types.ts
@@ -162,11 +162,17 @@ export function toReaderCall(field: FieldDescriptorProto): string {
   }
 }
 
-export function packedType(field: FieldDescriptorProto): number | undefined {
-  if (!field.options?.packed) {
+export function packedField(field: FieldDescriptorProto, isProto3Syntax: boolean): number | undefined {
+  if (isProto3Syntax && field.options?.packed === false) {
+    return undefined;
+  } else if (!isProto3Syntax && !!field.options?.packed) {
     return undefined;
   }
-  switch (field.type) {
+  return packedType(field.type);
+}
+
+export function packedType(type: FieldDescriptorProto_Type): number | undefined {
+  switch (type) {
     case FieldDescriptorProto_Type.TYPE_DOUBLE:
       return 1;
     case FieldDescriptorProto_Type.TYPE_FLOAT:

--- a/src/types.ts
+++ b/src/types.ts
@@ -162,8 +162,11 @@ export function toReaderCall(field: FieldDescriptorProto): string {
   }
 }
 
-export function packedType(type: FieldDescriptorProto_Type): number | undefined {
-  switch (type) {
+export function packedType(field: FieldDescriptorProto): number | undefined {
+  if (!field.options?.packed) {
+    return undefined;
+  }
+  switch (field.type) {
     case FieldDescriptorProto_Type.TYPE_DOUBLE:
       return 1;
     case FieldDescriptorProto_Type.TYPE_FLOAT:


### PR DESCRIPTION
See https://protobuf.dev/editions/features/#repeated_field_encoding

In this PR, avoid encoding fields as packed when it shouldn't.
Decoding still supports both packed/unpacked fields.

See.
https://github.com/stephenh/ts-proto/issues/1207