### PR TITLE
fix: fix double division, fix loss of millisecond unit

### DIFF
--- a/integration/grpc-js-use-date-temporal-bigint/grpc-js-use-date-temporal-bigint-test.ts
+++ b/integration/grpc-js-use-date-temporal-bigint/grpc-js-use-date-temporal-bigint-test.ts
@@ -5,9 +5,9 @@ import 'temporal-polyfill/global';
 
 import { TestService, TimestampMessage } from "./grpc-js-use-date-temporal-bigint";
 
-const jan1 = Temporal.Instant.from("1970-01-01T14:27:59.987654321Z");
+const jan1 = Temporal.Instant.from("1973-02-01T14:27:59.987654321Z");
 
-describe("grpc-js-use-date-temporal", () => {
+describe("grpc-js-use-date-temporal-bigint", () => {
   it("compiles", () => {
     expect(TestService).not.toBeUndefined();
   });
@@ -15,13 +15,18 @@ describe("grpc-js-use-date-temporal", () => {
   it("returns simple temporal instant", async () => {
     const encoded = TestService.simpleNow.requestSerialize(jan1);
     const decoded = TestService.simpleNow.responseDeserialize(encoded);
-    expect(decoded).toStrictEqual(jan1);
+    expect(decoded.toString()).toStrictEqual(jan1.toString());
   });
 
   it("returns wrapped temporal instant", async () => {
     const data: TimestampMessage = { timestamp: jan1 };
     const encoded = TestService.wrappedNow.requestSerialize(data);
     const decoded = TestService.wrappedNow.responseDeserialize(encoded);
-    expect(decoded).toStrictEqual(data);
+
+    expect({
+      timestamp: decoded.timestamp!.toString(),
+    } satisfies Record<keyof TimestampMessage, string>).toStrictEqual({
+      timestamp: jan1.toString()
+    } satisfies Record<keyof TimestampMessage, string>);
   });
 });

--- a/integration/grpc-js-use-date-temporal-bigint/grpc-js-use-date-temporal-bigint.ts
+++ b/integration/grpc-js-use-date-temporal-bigint/grpc-js-use-date-temporal-bigint.ts
@@ -160,9 +160,9 @@ export type Exact<P, I extends P> = P extends Builtin ? P
   : P & { [K in keyof P]: Exact<P[K], I[K]> } & { [K in Exclude<keyof I, KeysOfUnion<P>>]: never };
 
 function toTimestamp(instant: Temporal.Instant): Timestamp {
-  const date = { getTime: (): number => Math.trunc(instant.epochMilliseconds / 1_000) } as const;
+  const date = { getTime: (): number => instant.epochMilliseconds } as const;
   const seconds = BigInt(Math.trunc(date.getTime() / 1_000));
-  const remainder = globalThis.Temporal.Instant.fromEpochMilliseconds(instant.epochMilliseconds).until(instant);
+  const remainder = instant.round({ smallestUnit: "seconds", roundingMode: "floor" }).until(instant);
   const nanos = (remainder.milliseconds * 1_000_000) + (remainder.microseconds * 1_000) + remainder.nanoseconds;
 
   return { seconds, nanos };

--- a/integration/grpc-js-use-date-temporal/grpc-js-use-date-temporal-test.ts
+++ b/integration/grpc-js-use-date-temporal/grpc-js-use-date-temporal-test.ts
@@ -5,7 +5,7 @@ import 'temporal-polyfill/global';
 
 import { TestService, TimestampMessage } from "./grpc-js-use-date-temporal";
 
-const jan1 = Temporal.Instant.from("1970-01-01T14:27:59.987654321Z");
+const jan1 = Temporal.Instant.from("1973-02-01T14:27:59.987654321Z");
 
 describe("grpc-js-use-date-temporal", () => {
   it("compiles", () => {
@@ -15,13 +15,18 @@ describe("grpc-js-use-date-temporal", () => {
   it("returns simple temporal instant", async () => {
     const encoded = TestService.simpleNow.requestSerialize(jan1);
     const decoded = TestService.simpleNow.responseDeserialize(encoded);
-    expect(decoded).toStrictEqual(jan1);
+    expect(decoded.toString()).toStrictEqual(jan1.toString());
   });
 
   it("returns wrapped temporal instant", async () => {
     const data: TimestampMessage = { timestamp: jan1 };
     const encoded = TestService.wrappedNow.requestSerialize(data);
     const decoded = TestService.wrappedNow.responseDeserialize(encoded);
-    expect(decoded).toStrictEqual(data);
+
+    expect({
+      timestamp: decoded.timestamp!.toString(),
+    } satisfies Record<keyof TimestampMessage, string>).toStrictEqual({
+      timestamp: jan1.toString()
+    } satisfies Record<keyof TimestampMessage, string>);
   });
 });

--- a/integration/grpc-js-use-date-temporal/grpc-js-use-date-temporal.ts
+++ b/integration/grpc-js-use-date-temporal/grpc-js-use-date-temporal.ts
@@ -160,9 +160,9 @@ export type Exact<P, I extends P> = P extends Builtin ? P
   : P & { [K in keyof P]: Exact<P[K], I[K]> } & { [K in Exclude<keyof I, KeysOfUnion<P>>]: never };
 
 function toTimestamp(instant: Temporal.Instant): Timestamp {
-  const date = { getTime: (): number => Math.trunc(instant.epochMilliseconds / 1_000) } as const;
+  const date = { getTime: (): number => instant.epochMilliseconds } as const;
   const seconds = Math.trunc(date.getTime() / 1_000);
-  const remainder = globalThis.Temporal.Instant.fromEpochMilliseconds(instant.epochMilliseconds).until(instant);
+  const remainder = instant.round({ smallestUnit: "seconds", roundingMode: "floor" }).until(instant);
   const nanos = (remainder.milliseconds * 1_000_000) + (remainder.microseconds * 1_000) + remainder.nanoseconds;
 
   return { seconds, nanos };

--- a/src/main.ts
+++ b/src/main.ts
@@ -993,12 +993,10 @@ function makeTimestampMethods(
           ? code`
             function toTimestamp(instant: Temporal.Instant): ${Timestamp} {
               const date = {
-                getTime: (): number => Math.trunc(instant.epochMilliseconds / 1_000),
+                getTime: (): number => instant.epochMilliseconds,
               } as const;
               const seconds = ${seconds};
-              const remainder = ${bytes.globalThis}.Temporal.Instant
-                .fromEpochMilliseconds(instant.epochMilliseconds)
-                .until(instant);
+              const remainder = instant.round({ smallestUnit: "seconds",  roundingMode: "floor" }).until(instant);
               const nanos = (remainder.milliseconds * 1_000_000) + (remainder.microseconds * 1_000) + remainder.nanoseconds;
             
               return { ${maybeTypeField} seconds, nanos };


### PR DESCRIPTION
This PR fixes an issue I introduced in the initial `useDate=temporal` PR [here](https://github.com/stephenh/ts-proto/pull/1219). The generated code for `toTimestamp` was dividing the `epochMilliseconds` twice, causing the date to get truncated to `1970-01-01`, so the tests would seem to work for dates.

There was _also_ a bug in how `nanos` was calculated:
```typescript
Temporal.Instant
    .fromEpochMilliseconds(instant.epochMilliseconds)
    .until(instant);
```
since we were deriving the start date from `epochMilliseconds`, so the remainder only included micro/nanoseconds (milliseconds were always `000`).

The PR addresses the first issue by ensuring we only divide once, in the generated `seconds` code. It fixes the latter by using the built-in [Temporal.Instant.prototype.round](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Instant/round) method to round to the nearest second without needing to do any explicit math.

Lastly, it also updates the tests, as the `toStrictEqual` check was succeeding even for `Instant`s whose string representations were clearly different, so now we will test against the output string.