### PR TITLE
fix: Use globalThis.Object to avoid name collision with the message name

### DIFF
--- a/integration/batching-with-context-esModuleInterop/batching.ts
+++ b/integration/batching-with-context-esModuleInterop/batching.ts
@@ -231,7 +231,7 @@ function createBaseBatchMapQueryResponse(): BatchMapQueryResponse {
 
 export const BatchMapQueryResponse: MessageFns<BatchMapQueryResponse> = {
   encode(message: BatchMapQueryResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    Object.entries(message.entities).forEach(([key, value]) => {
+    globalThis.Object.entries(message.entities).forEach(([key, value]: [string, Entity]) => {
       BatchMapQueryResponse_EntitiesEntry.encode({ key: key as any, value }, writer.uint32(10).fork()).join();
     });
     return writer;
@@ -267,10 +267,13 @@ export const BatchMapQueryResponse: MessageFns<BatchMapQueryResponse> = {
   fromJSON(object: any): BatchMapQueryResponse {
     return {
       entities: isObject(object.entities)
-        ? Object.entries(object.entities).reduce<{ [key: string]: Entity }>((acc, [key, value]) => {
-          acc[key] = Entity.fromJSON(value);
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.entities) as [string, any][]).reduce(
+          (acc: { [key: string]: Entity }, [key, value]: [string, any]) => {
+            acc[key] = Entity.fromJSON(value);
+            return acc;
+          },
+          {},
+        )
         : {},
     };
   },
@@ -278,7 +281,7 @@ export const BatchMapQueryResponse: MessageFns<BatchMapQueryResponse> = {
   toJSON(message: BatchMapQueryResponse): unknown {
     const obj: any = {};
     if (message.entities) {
-      const entries = Object.entries(message.entities);
+      const entries = globalThis.Object.entries(message.entities) as [string, Entity][];
       if (entries.length > 0) {
         obj.entities = {};
         entries.forEach(([k, v]) => {
@@ -294,12 +297,15 @@ export const BatchMapQueryResponse: MessageFns<BatchMapQueryResponse> = {
   },
   fromPartial<I extends Exact<DeepPartial<BatchMapQueryResponse>, I>>(object: I): BatchMapQueryResponse {
     const message = createBaseBatchMapQueryResponse();
-    message.entities = Object.entries(object.entities ?? {}).reduce<{ [key: string]: Entity }>((acc, [key, value]) => {
-      if (value !== undefined) {
-        acc[key] = Entity.fromPartial(value);
-      }
-      return acc;
-    }, {});
+    message.entities = (globalThis.Object.entries(object.entities ?? {}) as [string, Entity][]).reduce(
+      (acc: { [key: string]: Entity }, [key, value]: [string, Entity]) => {
+        if (value !== undefined) {
+          acc[key] = Entity.fromPartial(value);
+        }
+        return acc;
+      },
+      {},
+    );
     return message;
   },
 };

--- a/integration/batching-with-context/batching.ts
+++ b/integration/batching-with-context/batching.ts
@@ -231,7 +231,7 @@ function createBaseBatchMapQueryResponse(): BatchMapQueryResponse {
 
 export const BatchMapQueryResponse: MessageFns<BatchMapQueryResponse> = {
   encode(message: BatchMapQueryResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    Object.entries(message.entities).forEach(([key, value]) => {
+    globalThis.Object.entries(message.entities).forEach(([key, value]: [string, Entity]) => {
       BatchMapQueryResponse_EntitiesEntry.encode({ key: key as any, value }, writer.uint32(10).fork()).join();
     });
     return writer;
@@ -267,10 +267,13 @@ export const BatchMapQueryResponse: MessageFns<BatchMapQueryResponse> = {
   fromJSON(object: any): BatchMapQueryResponse {
     return {
       entities: isObject(object.entities)
-        ? Object.entries(object.entities).reduce<{ [key: string]: Entity }>((acc, [key, value]) => {
-          acc[key] = Entity.fromJSON(value);
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.entities) as [string, any][]).reduce(
+          (acc: { [key: string]: Entity }, [key, value]: [string, any]) => {
+            acc[key] = Entity.fromJSON(value);
+            return acc;
+          },
+          {},
+        )
         : {},
     };
   },
@@ -278,7 +281,7 @@ export const BatchMapQueryResponse: MessageFns<BatchMapQueryResponse> = {
   toJSON(message: BatchMapQueryResponse): unknown {
     const obj: any = {};
     if (message.entities) {
-      const entries = Object.entries(message.entities);
+      const entries = globalThis.Object.entries(message.entities) as [string, Entity][];
       if (entries.length > 0) {
         obj.entities = {};
         entries.forEach(([k, v]) => {
@@ -294,12 +297,15 @@ export const BatchMapQueryResponse: MessageFns<BatchMapQueryResponse> = {
   },
   fromPartial<I extends Exact<DeepPartial<BatchMapQueryResponse>, I>>(object: I): BatchMapQueryResponse {
     const message = createBaseBatchMapQueryResponse();
-    message.entities = Object.entries(object.entities ?? {}).reduce<{ [key: string]: Entity }>((acc, [key, value]) => {
-      if (value !== undefined) {
-        acc[key] = Entity.fromPartial(value);
-      }
-      return acc;
-    }, {});
+    message.entities = (globalThis.Object.entries(object.entities ?? {}) as [string, Entity][]).reduce(
+      (acc: { [key: string]: Entity }, [key, value]: [string, Entity]) => {
+        if (value !== undefined) {
+          acc[key] = Entity.fromPartial(value);
+        }
+        return acc;
+      },
+      {},
+    );
     return message;
   },
 };

--- a/integration/batching/batching.ts
+++ b/integration/batching/batching.ts
@@ -229,7 +229,7 @@ function createBaseBatchMapQueryResponse(): BatchMapQueryResponse {
 
 export const BatchMapQueryResponse: MessageFns<BatchMapQueryResponse> = {
   encode(message: BatchMapQueryResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    Object.entries(message.entities).forEach(([key, value]) => {
+    globalThis.Object.entries(message.entities).forEach(([key, value]: [string, Entity]) => {
       BatchMapQueryResponse_EntitiesEntry.encode({ key: key as any, value }, writer.uint32(10).fork()).join();
     });
     return writer;
@@ -265,10 +265,13 @@ export const BatchMapQueryResponse: MessageFns<BatchMapQueryResponse> = {
   fromJSON(object: any): BatchMapQueryResponse {
     return {
       entities: isObject(object.entities)
-        ? Object.entries(object.entities).reduce<{ [key: string]: Entity }>((acc, [key, value]) => {
-          acc[key] = Entity.fromJSON(value);
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.entities) as [string, any][]).reduce(
+          (acc: { [key: string]: Entity }, [key, value]: [string, any]) => {
+            acc[key] = Entity.fromJSON(value);
+            return acc;
+          },
+          {},
+        )
         : {},
     };
   },
@@ -276,7 +279,7 @@ export const BatchMapQueryResponse: MessageFns<BatchMapQueryResponse> = {
   toJSON(message: BatchMapQueryResponse): unknown {
     const obj: any = {};
     if (message.entities) {
-      const entries = Object.entries(message.entities);
+      const entries = globalThis.Object.entries(message.entities) as [string, Entity][];
       if (entries.length > 0) {
         obj.entities = {};
         entries.forEach(([k, v]) => {
@@ -292,12 +295,15 @@ export const BatchMapQueryResponse: MessageFns<BatchMapQueryResponse> = {
   },
   fromPartial<I extends Exact<DeepPartial<BatchMapQueryResponse>, I>>(object: I): BatchMapQueryResponse {
     const message = createBaseBatchMapQueryResponse();
-    message.entities = Object.entries(object.entities ?? {}).reduce<{ [key: string]: Entity }>((acc, [key, value]) => {
-      if (value !== undefined) {
-        acc[key] = Entity.fromPartial(value);
-      }
-      return acc;
-    }, {});
+    message.entities = (globalThis.Object.entries(object.entities ?? {}) as [string, Entity][]).reduce(
+      (acc: { [key: string]: Entity }, [key, value]: [string, Entity]) => {
+        if (value !== undefined) {
+          acc[key] = Entity.fromPartial(value);
+        }
+        return acc;
+      },
+      {},
+    );
     return message;
   },
 };

--- a/integration/const-enum/const-enum.ts
+++ b/integration/const-enum/const-enum.ts
@@ -86,7 +86,7 @@ export const DividerData: MessageFns<DividerData> = {
     if (message.type !== DividerData_DividerType.DOUBLE) {
       writer.uint32(8).int32(dividerData_DividerTypeToNumber(message.type));
     }
-    Object.entries(message.typeMap).forEach(([key, value]) => {
+    globalThis.Object.entries(message.typeMap).forEach(([key, value]: [string, DividerData_DividerType]) => {
       DividerData_TypeMapEntry.encode({ key: key as any, value }, writer.uint32(18).fork()).join();
     });
     return writer;
@@ -131,10 +131,13 @@ export const DividerData: MessageFns<DividerData> = {
     return {
       type: isSet(object.type) ? dividerData_DividerTypeFromJSON(object.type) : DividerData_DividerType.DOUBLE,
       typeMap: isObject(object.typeMap)
-        ? Object.entries(object.typeMap).reduce<{ [key: string]: DividerData_DividerType }>((acc, [key, value]) => {
-          acc[key] = dividerData_DividerTypeFromJSON(value);
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.typeMap) as [string, any][]).reduce(
+          (acc: { [key: string]: DividerData_DividerType }, [key, value]: [string, any]) => {
+            acc[key] = dividerData_DividerTypeFromJSON(value);
+            return acc;
+          },
+          {},
+        )
         : {},
     };
   },
@@ -145,7 +148,7 @@ export const DividerData: MessageFns<DividerData> = {
       obj.type = dividerData_DividerTypeToJSON(message.type);
     }
     if (message.typeMap) {
-      const entries = Object.entries(message.typeMap);
+      const entries = globalThis.Object.entries(message.typeMap) as [string, DividerData_DividerType][];
       if (entries.length > 0) {
         obj.typeMap = {};
         entries.forEach(([k, v]) => {
@@ -162,8 +165,8 @@ export const DividerData: MessageFns<DividerData> = {
   fromPartial<I extends Exact<DeepPartial<DividerData>, I>>(object: I): DividerData {
     const message = createBaseDividerData();
     message.type = object.type ?? DividerData_DividerType.DOUBLE;
-    message.typeMap = Object.entries(object.typeMap ?? {}).reduce<{ [key: string]: DividerData_DividerType }>(
-      (acc, [key, value]) => {
+    message.typeMap = (globalThis.Object.entries(object.typeMap ?? {}) as [string, DividerData_DividerType][]).reduce(
+      (acc: { [key: string]: DividerData_DividerType }, [key, value]: [string, DividerData_DividerType]) => {
         if (value !== undefined) {
           acc[key] = value as DividerData_DividerType;
         }

--- a/integration/emit-default-values-json/test.ts
+++ b/integration/emit-default-values-json/test.ts
@@ -181,7 +181,7 @@ export const DefaultValuesTest: MessageFns<DefaultValuesTest> = {
     if (message.optData !== undefined) {
       writer.uint32(218).bytes(message.optData);
     }
-    Object.entries(message.translations).forEach(([key, value]) => {
+    globalThis.Object.entries(message.translations).forEach(([key, value]: [string, string]) => {
       DefaultValuesTest_TranslationsEntry.encode({ key: key as any, value }, writer.uint32(242).fork()).join();
     });
     if (message.timestamp !== undefined) {
@@ -461,10 +461,13 @@ export const DefaultValuesTest: MessageFns<DefaultValuesTest> = {
       optDescription: isSet(object.optDescription) ? globalThis.String(object.optDescription) : undefined,
       optData: isSet(object.optData) ? bytesFromBase64(object.optData) : undefined,
       translations: isObject(object.translations)
-        ? Object.entries(object.translations).reduce<{ [key: string]: string }>((acc, [key, value]) => {
-          acc[key] = String(value);
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.translations) as [string, any][]).reduce(
+          (acc: { [key: string]: string }, [key, value]: [string, any]) => {
+            acc[key] = globalThis.String(value);
+            return acc;
+          },
+          {},
+        )
         : {},
       timestamp: isSet(object.timestamp) ? fromJsonTimestamp(object.timestamp) : undefined,
     };
@@ -536,7 +539,7 @@ export const DefaultValuesTest: MessageFns<DefaultValuesTest> = {
       obj.optData = base64FromBytes(message.optData);
     }
     if (message.translations) {
-      const entries = Object.entries(message.translations);
+      const entries = globalThis.Object.entries(message.translations) as [string, string][];
       if (entries.length > 0) {
         obj.translations = {};
         entries.forEach(([k, v]) => {
@@ -578,8 +581,8 @@ export const DefaultValuesTest: MessageFns<DefaultValuesTest> = {
     message.optTruth = object.optTruth ?? undefined;
     message.optDescription = object.optDescription ?? undefined;
     message.optData = object.optData ?? undefined;
-    message.translations = Object.entries(object.translations ?? {}).reduce<{ [key: string]: string }>(
-      (acc, [key, value]) => {
+    message.translations = (globalThis.Object.entries(object.translations ?? {}) as [string, string][]).reduce(
+      (acc: { [key: string]: string }, [key, value]: [string, string]) => {
         if (value !== undefined) {
           acc[key] = globalThis.String(value);
         }

--- a/integration/extensions/test.ts
+++ b/integration/extensions/test.ts
@@ -72,7 +72,7 @@ export const Extendable: MessageFns<Extendable> & ExtensionFns<Extendable> = {
       writer.uint32(10).string(message.field);
     }
     if (message._unknownFields !== undefined) {
-      for (const [key, values] of Object.entries(message._unknownFields)) {
+      for (const [key, values] of globalThis.Object.entries(message._unknownFields)) {
         const tag = parseInt(key, 10);
         for (const value of values) {
           writer.uint32(tag).raw(value);
@@ -231,7 +231,7 @@ export const Nested: MessageFns<Nested> & ExtensionHolder<"message", Nested[]> =
       writer.uint32(10).string(message.field);
     }
     if (message._unknownFields !== undefined) {
-      for (const [key, values] of Object.entries(message._unknownFields)) {
+      for (const [key, values] of globalThis.Object.entries(message._unknownFields)) {
         const tag = parseInt(key, 10);
         for (const value of values) {
           writer.uint32(tag).raw(value);
@@ -312,7 +312,7 @@ export const Group: MessageFns<Group> = {
       writer.uint32(18).string(message.value);
     }
     if (message._unknownFields !== undefined) {
-      for (const [key, values] of Object.entries(message._unknownFields)) {
+      for (const [key, values] of globalThis.Object.entries(message._unknownFields)) {
         const tag = parseInt(key, 10);
         for (const value of values) {
           writer.uint32(tag).raw(value);

--- a/integration/from-partial-no-initialize/test.ts
+++ b/integration/from-partial-no-initialize/test.ts
@@ -95,7 +95,7 @@ export const TPartial: MessageFns<TPartial> = {
     if (message.string !== undefined && message.string !== "") {
       writer.uint32(18).string(message.string);
     }
-    Object.entries(message.map || {}).forEach(([key, value]) => {
+    globalThis.Object.entries(message.map || {}).forEach(([key, value]: [string, string]) => {
       TPartial_MapEntry.encode({ key: key as any, value }, writer.uint32(26).fork()).join();
     });
     if (message.message !== undefined) {
@@ -230,10 +230,13 @@ export const TPartial: MessageFns<TPartial> = {
       number: isSet(object.number) ? globalThis.Number(object.number) : undefined,
       string: isSet(object.string) ? globalThis.String(object.string) : undefined,
       map: isObject(object.map)
-        ? Object.entries(object.map).reduce<{ [key: string]: string }>((acc, [key, value]) => {
-          acc[key] = String(value);
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.map) as [string, any][]).reduce(
+          (acc: { [key: string]: string }, [key, value]: [string, any]) => {
+            acc[key] = globalThis.String(value);
+            return acc;
+          },
+          {},
+        )
         : undefined,
       message: isSet(object.message) ? TPartialMessage.fromJSON(object.message) : undefined,
       repeatedMessage: globalThis.Array.isArray(object?.repeatedMessage)
@@ -257,7 +260,7 @@ export const TPartial: MessageFns<TPartial> = {
       obj.string = message.string;
     }
     if (message.map) {
-      const entries = Object.entries(message.map);
+      const entries = globalThis.Object.entries(message.map) as [string, string][];
       if (entries.length > 0) {
         obj.map = {};
         entries.forEach(([k, v]) => {
@@ -289,12 +292,15 @@ export const TPartial: MessageFns<TPartial> = {
     message.string = object.string ?? undefined;
     message.map = (object.map === undefined || object.map === null)
       ? undefined
-      : Object.entries(object.map ?? {}).reduce<{ [key: string]: string }>((acc, [key, value]) => {
-        if (value !== undefined) {
-          acc[key] = globalThis.String(value);
-        }
-        return acc;
-      }, {});
+      : (globalThis.Object.entries(object.map ?? {}) as [string, string][]).reduce(
+        (acc: { [key: string]: string }, [key, value]: [string, string]) => {
+          if (value !== undefined) {
+            acc[key] = globalThis.String(value);
+          }
+          return acc;
+        },
+        {},
+      );
     message.message = (object.message !== undefined && object.message !== null)
       ? TPartialMessage.fromPartial(object.message)
       : undefined;

--- a/integration/global-this/global-this-test.ts
+++ b/integration/global-this/global-this-test.ts
@@ -9,4 +9,35 @@ describe("global-this", () => {
     Number.fromPartial({});
     Array.fromPartial({});
   });
+
+  it("handles map fields in Object message correctly", () => {
+    // Test fromPartial with map
+    const obj = Object.fromPartial({
+      name: "test",
+      metadata: { key1: "value1", key2: "value2" },
+    });
+    expect(obj.name).toBe("test");
+    expect(obj.metadata).toEqual({ key1: "value1", key2: "value2" });
+
+    // Test fromJSON with map
+    const fromJson = Object.fromJSON({
+      name: "json-test",
+      metadata: { foo: "bar" },
+    });
+    expect(fromJson.name).toBe("json-test");
+    expect(fromJson.metadata).toEqual({ foo: "bar" });
+
+    // Test toJSON with map
+    const json = Object.toJSON(obj);
+    expect(json).toEqual({
+      name: "test",
+      metadata: { key1: "value1", key2: "value2" },
+    });
+
+    // Test encode/decode roundtrip
+    const encoded = Object.encode(obj).finish();
+    const decoded = Object.decode(encoded);
+    expect(decoded.name).toBe("test");
+    expect(decoded.metadata).toEqual({ key1: "value1", key2: "value2" });
+  });
 });

--- a/integration/global-this/global-this.proto
+++ b/integration/global-this/global-this.proto
@@ -3,6 +3,7 @@ package simple;
 
 message Object {
   string name = 1;
+  map<string, string> metadata = 2;
 }
 
 message Error {

--- a/integration/groups/test.ts
+++ b/integration/groups/test.ts
@@ -70,7 +70,7 @@ export const GroupsOptionalTest: MessageFns<GroupsOptionalTest> = {
       writer.uint32(24).int32(message.int3);
     }
     if (message._unknownFields !== undefined) {
-      for (const [key, values] of Object.entries(message._unknownFields)) {
+      for (const [key, values] of globalThis.Object.entries(message._unknownFields)) {
         const tag = parseInt(key, 10);
         for (const value of values) {
           writer.uint32(tag).raw(value);
@@ -181,7 +181,7 @@ export const GroupsOptionalTest_Group: MessageFns<GroupsOptionalTest_Group> = {
       writer.uint32(18).string(message.value);
     }
     if (message._unknownFields !== undefined) {
-      for (const [key, values] of Object.entries(message._unknownFields)) {
+      for (const [key, values] of globalThis.Object.entries(message._unknownFields)) {
         const tag = parseInt(key, 10);
         for (const value of values) {
           writer.uint32(tag).raw(value);
@@ -286,7 +286,7 @@ export const GroupsRepeatedTest: MessageFns<GroupsRepeatedTest> = {
       }
     }
     if (message._unknownFields !== undefined) {
-      for (const [key, values] of Object.entries(message._unknownFields)) {
+      for (const [key, values] of globalThis.Object.entries(message._unknownFields)) {
         const tag = parseInt(key, 10);
         for (const value of values) {
           writer.uint32(tag).raw(value);
@@ -439,7 +439,7 @@ export const GroupsRepeatedTest_Group: MessageFns<GroupsRepeatedTest_Group> = {
       }
     }
     if (message._unknownFields !== undefined) {
-      for (const [key, values] of Object.entries(message._unknownFields)) {
+      for (const [key, values] of globalThis.Object.entries(message._unknownFields)) {
         const tag = parseInt(key, 10);
         for (const value of values) {
           writer.uint32(tag).raw(value);
@@ -556,7 +556,7 @@ export const GroupsNestedTest: MessageFns<GroupsNestedTest> = {
       }
     }
     if (message._unknownFields !== undefined) {
-      for (const [key, values] of Object.entries(message._unknownFields)) {
+      for (const [key, values] of globalThis.Object.entries(message._unknownFields)) {
         const tag = parseInt(key, 10);
         for (const value of values) {
           writer.uint32(tag).raw(value);
@@ -704,7 +704,7 @@ export const GroupsNestedTest_Group: MessageFns<GroupsNestedTest_Group> = {
       }
     }
     if (message._unknownFields !== undefined) {
-      for (const [key, values] of Object.entries(message._unknownFields)) {
+      for (const [key, values] of globalThis.Object.entries(message._unknownFields)) {
         const tag = parseInt(key, 10);
         for (const value of values) {
           writer.uint32(tag).raw(value);
@@ -794,7 +794,7 @@ export const GroupsNestedTest_Group_Nested: MessageFns<GroupsNestedTest_Group_Ne
       }
     }
     if (message._unknownFields !== undefined) {
-      for (const [key, values] of Object.entries(message._unknownFields)) {
+      for (const [key, values] of globalThis.Object.entries(message._unknownFields)) {
         const tag = parseInt(key, 10);
         for (const value of values) {
           writer.uint32(tag).raw(value);
@@ -884,7 +884,7 @@ export const GroupsNestedTest_Group_Nested_Nested2: MessageFns<GroupsNestedTest_
       writer.uint32(10).string(message.string1);
     }
     if (message._unknownFields !== undefined) {
-      for (const [key, values] of Object.entries(message._unknownFields)) {
+      for (const [key, values] of globalThis.Object.entries(message._unknownFields)) {
         const tag = parseInt(key, 10);
         for (const value of values) {
           writer.uint32(tag).raw(value);

--- a/integration/grpc-js/google/protobuf/struct.ts
+++ b/integration/grpc-js/google/protobuf/struct.ts
@@ -109,7 +109,7 @@ function createBaseStruct(): Struct {
 
 export const Struct: MessageFns<Struct> & StructWrapperFns = {
   encode(message: Struct, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    Object.entries(message.fields).forEach(([key, value]) => {
+    globalThis.Object.entries(message.fields).forEach(([key, value]: [string, any | undefined]) => {
       if (value !== undefined) {
         Struct_FieldsEntry.encode({ key: key as any, value }, writer.uint32(10).fork()).join();
       }
@@ -147,10 +147,13 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
   fromJSON(object: any): Struct {
     return {
       fields: isObject(object.fields)
-        ? Object.entries(object.fields).reduce<{ [key: string]: any | undefined }>((acc, [key, value]) => {
-          acc[key] = value as any | undefined;
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.fields) as [string, any][]).reduce(
+          (acc: { [key: string]: any | undefined }, [key, value]: [string, any]) => {
+            acc[key] = value as any | undefined;
+            return acc;
+          },
+          {},
+        )
         : {},
     };
   },
@@ -158,7 +161,7 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
   toJSON(message: Struct): unknown {
     const obj: any = {};
     if (message.fields) {
-      const entries = Object.entries(message.fields);
+      const entries = globalThis.Object.entries(message.fields) as [string, any | undefined][];
       if (entries.length > 0) {
         obj.fields = {};
         entries.forEach(([k, v]) => {
@@ -174,8 +177,8 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
   },
   fromPartial<I extends Exact<DeepPartial<Struct>, I>>(object: I): Struct {
     const message = createBaseStruct();
-    message.fields = Object.entries(object.fields ?? {}).reduce<{ [key: string]: any | undefined }>(
-      (acc, [key, value]) => {
+    message.fields = (globalThis.Object.entries(object.fields ?? {}) as [string, any | undefined][]).reduce(
+      (acc: { [key: string]: any | undefined }, [key, value]: [string, any | undefined]) => {
         if (value !== undefined) {
           acc[key] = value;
         }
@@ -190,7 +193,7 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
     const struct = createBaseStruct();
 
     if (object !== undefined) {
-      for (const key of Object.keys(object)) {
+      for (const key of globalThis.Object.keys(object)) {
         struct.fields[key] = object[key];
       }
     }
@@ -200,7 +203,7 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
   unwrap(message: Struct): { [key: string]: any } {
     const object: { [key: string]: any } = {};
     if (message.fields) {
-      for (const key of Object.keys(message.fields)) {
+      for (const key of globalThis.Object.keys(message.fields)) {
         object[key] = message.fields[key];
       }
     }

--- a/integration/map-bigint-optional/test.ts
+++ b/integration/map-bigint-optional/test.ts
@@ -27,7 +27,7 @@ export const MapBigInt: MessageFns<MapBigInt> = {
       MapBigInt_MapEntry.encode({ key: key as any, value }, writer.uint32(10).fork()).join();
     });
     if (message._unknownFields !== undefined) {
-      for (const [key, values] of Object.entries(message._unknownFields)) {
+      for (const [key, values] of globalThis.Object.entries(message._unknownFields)) {
         const tag = parseInt(key, 10);
         for (const value of values) {
           writer.uint32(tag).raw(value);
@@ -82,10 +82,13 @@ export const MapBigInt: MessageFns<MapBigInt> = {
   fromJSON(object: any): MapBigInt {
     return {
       map: isObject(object.map)
-        ? Object.entries(object.map).reduce<Map<bigint, bigint>>((acc, [key, value]) => {
-          acc.set(BigInt(key), BigInt(value as string | number | bigint | boolean));
-          return acc;
-        }, new Map())
+        ? (globalThis.Object.entries(object.map) as [string, any][]).reduce(
+          (acc: Map<bigint, bigint>, [key, value]: [string, any]) => {
+            acc.set(BigInt(key), BigInt(value as string | number | bigint | boolean));
+            return acc;
+          },
+          new Map(),
+        )
         : undefined,
     };
   },
@@ -138,7 +141,7 @@ export const MapBigInt_MapEntry: MessageFns<MapBigInt_MapEntry> = {
       writer.uint32(16).int64(message.value);
     }
     if (message._unknownFields !== undefined) {
-      for (const [key, values] of Object.entries(message._unknownFields)) {
+      for (const [key, values] of globalThis.Object.entries(message._unknownFields)) {
         const tag = parseInt(key, 10);
         for (const value of values) {
           writer.uint32(tag).raw(value);

--- a/integration/map-long-optional/test.ts
+++ b/integration/map-long-optional/test.ts
@@ -28,7 +28,7 @@ export const MapBigInt: MessageFns<MapBigInt> = {
       MapBigInt_MapEntry.encode({ key: key as any, value }, writer.uint32(10).fork()).join();
     });
     if (message._unknownFields !== undefined) {
-      for (const [key, values] of Object.entries(message._unknownFields)) {
+      for (const [key, values] of globalThis.Object.entries(message._unknownFields)) {
         const tag = parseInt(key, 10);
         for (const value of values) {
           writer.uint32(tag).raw(value);
@@ -83,10 +83,13 @@ export const MapBigInt: MessageFns<MapBigInt> = {
   fromJSON(object: any): MapBigInt {
     return {
       map: isObject(object.map)
-        ? Object.entries(object.map).reduce<Map<Long, Long>>((acc, [key, value]) => {
-          acc.set(Long.fromValue(key), Long.fromValue(value as Long | string));
-          return acc;
-        }, new Map())
+        ? (globalThis.Object.entries(object.map) as [string, any][]).reduce(
+          (acc: Map<Long, Long>, [key, value]: [string, any]) => {
+            acc.set(Long.fromValue(key), Long.fromValue(value as Long | string));
+            return acc;
+          },
+          new Map(),
+        )
         : undefined,
     };
   },
@@ -133,7 +136,7 @@ export const MapBigInt_MapEntry: MessageFns<MapBigInt_MapEntry> = {
       writer.uint32(16).int64(message.value.toString());
     }
     if (message._unknownFields !== undefined) {
-      for (const [key, values] of Object.entries(message._unknownFields)) {
+      for (const [key, values] of globalThis.Object.entries(message._unknownFields)) {
         const tag = parseInt(key, 10);
         for (const value of values) {
           writer.uint32(tag).raw(value);

--- a/integration/map-longstring-optional/test.ts
+++ b/integration/map-longstring-optional/test.ts
@@ -27,7 +27,7 @@ export const MapBigInt: MessageFns<MapBigInt> = {
       MapBigInt_MapEntry.encode({ key: key as any, value }, writer.uint32(10).fork()).join();
     });
     if (message._unknownFields !== undefined) {
-      for (const [key, values] of Object.entries(message._unknownFields)) {
+      for (const [key, values] of globalThis.Object.entries(message._unknownFields)) {
         const tag = parseInt(key, 10);
         for (const value of values) {
           writer.uint32(tag).raw(value);
@@ -82,10 +82,13 @@ export const MapBigInt: MessageFns<MapBigInt> = {
   fromJSON(object: any): MapBigInt {
     return {
       map: isObject(object.map)
-        ? Object.entries(object.map).reduce<Map<string, string>>((acc, [key, value]) => {
-          acc.set(key, String(value));
-          return acc;
-        }, new Map())
+        ? (globalThis.Object.entries(object.map) as [string, any][]).reduce(
+          (acc: Map<string, string>, [key, value]: [string, any]) => {
+            acc.set(key, globalThis.String(value));
+            return acc;
+          },
+          new Map(),
+        )
         : undefined,
     };
   },
@@ -132,7 +135,7 @@ export const MapBigInt_MapEntry: MessageFns<MapBigInt_MapEntry> = {
       writer.uint32(16).int64(message.value);
     }
     if (message._unknownFields !== undefined) {
-      for (const [key, values] of Object.entries(message._unknownFields)) {
+      for (const [key, values] of globalThis.Object.entries(message._unknownFields)) {
         const tag = parseInt(key, 10);
         for (const value of values) {
           writer.uint32(tag).raw(value);

--- a/integration/meta-typings/simple.ts
+++ b/integration/meta-typings/simple.ts
@@ -765,19 +765,19 @@ function createBaseSimpleWithMap(): SimpleWithMap {
 
 export const SimpleWithMap: MessageFns<SimpleWithMap> = {
   encode(message: SimpleWithMap, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    Object.entries(message.entitiesById).forEach(([key, value]) => {
+    globalThis.Object.entries(message.entitiesById).forEach(([key, value]: [string, Entity]) => {
       SimpleWithMap_EntitiesByIdEntry.encode({ key: key as any, value }, writer.uint32(10).fork()).join();
     });
-    Object.entries(message.nameLookup).forEach(([key, value]) => {
+    globalThis.Object.entries(message.nameLookup).forEach(([key, value]: [string, string]) => {
       SimpleWithMap_NameLookupEntry.encode({ key: key as any, value }, writer.uint32(18).fork()).join();
     });
-    Object.entries(message.intLookup).forEach(([key, value]) => {
+    globalThis.Object.entries(message.intLookup).forEach(([key, value]: [string, number]) => {
       SimpleWithMap_IntLookupEntry.encode({ key: key as any, value }, writer.uint32(26).fork()).join();
     });
-    Object.entries(message.mapOfTimestamps).forEach(([key, value]) => {
+    globalThis.Object.entries(message.mapOfTimestamps).forEach(([key, value]: [string, Date]) => {
       SimpleWithMap_MapOfTimestampsEntry.encode({ key: key as any, value }, writer.uint32(34).fork()).join();
     });
-    Object.entries(message.mapOfBytes).forEach(([key, value]) => {
+    globalThis.Object.entries(message.mapOfBytes).forEach(([key, value]: [string, Uint8Array]) => {
       SimpleWithMap_MapOfBytesEntry.encode({ key: key as any, value }, writer.uint32(42).fork()).join();
     });
     return writer;
@@ -1101,7 +1101,7 @@ function createBaseSimpleWithSnakeCaseMap(): SimpleWithSnakeCaseMap {
 
 export const SimpleWithSnakeCaseMap: MessageFns<SimpleWithSnakeCaseMap> = {
   encode(message: SimpleWithSnakeCaseMap, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    Object.entries(message.entitiesById).forEach(([key, value]) => {
+    globalThis.Object.entries(message.entitiesById).forEach(([key, value]: [string, Entity]) => {
       SimpleWithSnakeCaseMap_EntitiesByIdEntry.encode({ key: key as any, value }, writer.uint32(10).fork()).join();
     });
     return writer;
@@ -1189,7 +1189,7 @@ function createBaseSimpleWithMapOfEnums(): SimpleWithMapOfEnums {
 
 export const SimpleWithMapOfEnums: MessageFns<SimpleWithMapOfEnums> = {
   encode(message: SimpleWithMapOfEnums, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    Object.entries(message.enumsById).forEach(([key, value]) => {
+    globalThis.Object.entries(message.enumsById).forEach(([key, value]: [string, StateEnum]) => {
       SimpleWithMapOfEnums_EnumsByIdEntry.encode({ key: key as any, value }, writer.uint32(10).fork()).join();
     });
     return writer;

--- a/integration/nestjs-simple/google/protobuf/struct.ts
+++ b/integration/nestjs-simple/google/protobuf/struct.ts
@@ -92,7 +92,7 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
     const struct = createBaseStruct();
 
     if (object !== undefined) {
-      for (const key of Object.keys(object)) {
+      for (const key of gt.Object.keys(object)) {
         struct.fields[key] = Value.wrap(object[key]);
       }
     }
@@ -102,7 +102,7 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
   unwrap(message: Struct): { [key: string]: any } {
     const object: { [key: string]: any } = {};
     if (message.fields) {
-      for (const key of Object.keys(message.fields)) {
+      for (const key of gt.Object.keys(message.fields)) {
         object[key] = Value.unwrap(message.fields[key]);
       }
     }

--- a/integration/nice-grpc/google/protobuf/struct.ts
+++ b/integration/nice-grpc/google/protobuf/struct.ts
@@ -109,7 +109,7 @@ function createBaseStruct(): Struct {
 
 export const Struct: MessageFns<Struct> & StructWrapperFns = {
   encode(message: Struct, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    Object.entries(message.fields).forEach(([key, value]) => {
+    globalThis.Object.entries(message.fields).forEach(([key, value]: [string, any | undefined]) => {
       if (value !== undefined) {
         Struct_FieldsEntry.encode({ key: key as any, value }, writer.uint32(10).fork()).join();
       }
@@ -147,10 +147,13 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
   fromJSON(object: any): Struct {
     return {
       fields: isObject(object.fields)
-        ? Object.entries(object.fields).reduce<{ [key: string]: any | undefined }>((acc, [key, value]) => {
-          acc[key] = value as any | undefined;
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.fields) as [string, any][]).reduce(
+          (acc: { [key: string]: any | undefined }, [key, value]: [string, any]) => {
+            acc[key] = value as any | undefined;
+            return acc;
+          },
+          {},
+        )
         : {},
     };
   },
@@ -158,7 +161,7 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
   toJSON(message: Struct): unknown {
     const obj: any = {};
     if (message.fields) {
-      const entries = Object.entries(message.fields);
+      const entries = globalThis.Object.entries(message.fields) as [string, any | undefined][];
       if (entries.length > 0) {
         obj.fields = {};
         entries.forEach(([k, v]) => {
@@ -174,8 +177,8 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
   },
   fromPartial(object: DeepPartial<Struct>): Struct {
     const message = createBaseStruct();
-    message.fields = Object.entries(object.fields ?? {}).reduce<{ [key: string]: any | undefined }>(
-      (acc, [key, value]) => {
+    message.fields = (globalThis.Object.entries(object.fields ?? {}) as [string, any | undefined][]).reduce(
+      (acc: { [key: string]: any | undefined }, [key, value]: [string, any | undefined]) => {
         if (value !== undefined) {
           acc[key] = value;
         }
@@ -190,7 +193,7 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
     const struct = createBaseStruct();
 
     if (object !== undefined) {
-      for (const key of Object.keys(object)) {
+      for (const key of globalThis.Object.keys(object)) {
         struct.fields[key] = object[key];
       }
     }
@@ -200,7 +203,7 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
   unwrap(message: Struct): { [key: string]: any } {
     const object: { [key: string]: any } = {};
     if (message.fields) {
-      for (const key of Object.keys(message.fields)) {
+      for (const key of globalThis.Object.keys(message.fields)) {
         object[key] = message.fields[key];
       }
     }

--- a/integration/no-defaults-for-optionals-with-nulls/proto-2.ts
+++ b/integration/no-defaults-for-optionals-with-nulls/proto-2.ts
@@ -33,7 +33,7 @@ export const Proto2TestMessage: MessageFns<Proto2TestMessage> = {
     if (message.stringValue !== undefined && message.stringValue !== null) {
       writer.uint32(26).string(message.stringValue);
     }
-    Object.entries(message.mapValue).forEach(([key, value]) => {
+    globalThis.Object.entries(message.mapValue).forEach(([key, value]: [string, string]) => {
       Proto2TestMessage_MapValueEntry.encode({ key: key as any, value }, writer.uint32(34).fork()).join();
     });
     return writer;
@@ -96,10 +96,13 @@ export const Proto2TestMessage: MessageFns<Proto2TestMessage> = {
       intValue: isSet(object.intValue) ? globalThis.Number(object.intValue) : null,
       stringValue: isSet(object.stringValue) ? globalThis.String(object.stringValue) : null,
       mapValue: isObject(object.mapValue)
-        ? Object.entries(object.mapValue).reduce<{ [key: string]: string }>((acc, [key, value]) => {
-          acc[key] = String(value);
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.mapValue) as [string, any][]).reduce(
+          (acc: { [key: string]: string }, [key, value]: [string, any]) => {
+            acc[key] = globalThis.String(value);
+            return acc;
+          },
+          {},
+        )
         : {},
     };
   },
@@ -116,7 +119,7 @@ export const Proto2TestMessage: MessageFns<Proto2TestMessage> = {
       obj.stringValue = message.stringValue;
     }
     if (message.mapValue) {
-      const entries = Object.entries(message.mapValue);
+      const entries = globalThis.Object.entries(message.mapValue) as [string, string][];
       if (entries.length > 0) {
         obj.mapValue = {};
         entries.forEach(([k, v]) => {
@@ -135,12 +138,15 @@ export const Proto2TestMessage: MessageFns<Proto2TestMessage> = {
     message.boolValue = object.boolValue ?? null;
     message.intValue = object.intValue ?? null;
     message.stringValue = object.stringValue ?? null;
-    message.mapValue = Object.entries(object.mapValue ?? {}).reduce<{ [key: string]: string }>((acc, [key, value]) => {
-      if (value !== undefined) {
-        acc[key] = globalThis.String(value);
-      }
-      return acc;
-    }, {});
+    message.mapValue = (globalThis.Object.entries(object.mapValue ?? {}) as [string, string][]).reduce(
+      (acc: { [key: string]: string }, [key, value]: [string, string]) => {
+        if (value !== undefined) {
+          acc[key] = globalThis.String(value);
+        }
+        return acc;
+      },
+      {},
+    );
     return message;
   },
 };

--- a/integration/no-defaults-for-optionals-with-nulls/proto-3.ts
+++ b/integration/no-defaults-for-optionals-with-nulls/proto-3.ts
@@ -53,7 +53,7 @@ export const Proto3TestMessage: MessageFns<Proto3TestMessage> = {
     if (message.optionalStringValue !== undefined && message.optionalStringValue !== null) {
       writer.uint32(50).string(message.optionalStringValue);
     }
-    Object.entries(message.mapValue).forEach(([key, value]) => {
+    globalThis.Object.entries(message.mapValue).forEach(([key, value]: [string, string]) => {
       Proto3TestMessage_MapValueEntry.encode({ key: key as any, value }, writer.uint32(58).fork()).join();
     });
     return writer;
@@ -143,10 +143,13 @@ export const Proto3TestMessage: MessageFns<Proto3TestMessage> = {
       optionalIntValue: isSet(object.optionalIntValue) ? globalThis.Number(object.optionalIntValue) : null,
       optionalStringValue: isSet(object.optionalStringValue) ? globalThis.String(object.optionalStringValue) : null,
       mapValue: isObject(object.mapValue)
-        ? Object.entries(object.mapValue).reduce<{ [key: string]: string }>((acc, [key, value]) => {
-          acc[key] = String(value);
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.mapValue) as [string, any][]).reduce(
+          (acc: { [key: string]: string }, [key, value]: [string, any]) => {
+            acc[key] = globalThis.String(value);
+            return acc;
+          },
+          {},
+        )
         : {},
     };
   },
@@ -172,7 +175,7 @@ export const Proto3TestMessage: MessageFns<Proto3TestMessage> = {
       obj.optionalStringValue = message.optionalStringValue;
     }
     if (message.mapValue) {
-      const entries = Object.entries(message.mapValue);
+      const entries = globalThis.Object.entries(message.mapValue) as [string, string][];
       if (entries.length > 0) {
         obj.mapValue = {};
         entries.forEach(([k, v]) => {
@@ -194,12 +197,15 @@ export const Proto3TestMessage: MessageFns<Proto3TestMessage> = {
     message.optionalBoolValue = object.optionalBoolValue ?? undefined;
     message.optionalIntValue = object.optionalIntValue ?? undefined;
     message.optionalStringValue = object.optionalStringValue ?? undefined;
-    message.mapValue = Object.entries(object.mapValue ?? {}).reduce<{ [key: string]: string }>((acc, [key, value]) => {
-      if (value !== undefined) {
-        acc[key] = globalThis.String(value);
-      }
-      return acc;
-    }, {});
+    message.mapValue = (globalThis.Object.entries(object.mapValue ?? {}) as [string, string][]).reduce(
+      (acc: { [key: string]: string }, [key, value]: [string, string]) => {
+        if (value !== undefined) {
+          acc[key] = globalThis.String(value);
+        }
+        return acc;
+      },
+      {},
+    );
     return message;
   },
 };

--- a/integration/no-defaults-for-optionals/proto-2.ts
+++ b/integration/no-defaults-for-optionals/proto-2.ts
@@ -33,7 +33,7 @@ export const Proto2TestMessage: MessageFns<Proto2TestMessage> = {
     if (message.stringValue !== undefined) {
       writer.uint32(26).string(message.stringValue);
     }
-    Object.entries(message.mapValue).forEach(([key, value]) => {
+    globalThis.Object.entries(message.mapValue).forEach(([key, value]: [string, string]) => {
       Proto2TestMessage_MapValueEntry.encode({ key: key as any, value }, writer.uint32(34).fork()).join();
     });
     return writer;
@@ -96,10 +96,13 @@ export const Proto2TestMessage: MessageFns<Proto2TestMessage> = {
       intValue: isSet(object.intValue) ? globalThis.Number(object.intValue) : undefined,
       stringValue: isSet(object.stringValue) ? globalThis.String(object.stringValue) : undefined,
       mapValue: isObject(object.mapValue)
-        ? Object.entries(object.mapValue).reduce<{ [key: string]: string }>((acc, [key, value]) => {
-          acc[key] = String(value);
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.mapValue) as [string, any][]).reduce(
+          (acc: { [key: string]: string }, [key, value]: [string, any]) => {
+            acc[key] = globalThis.String(value);
+            return acc;
+          },
+          {},
+        )
         : {},
     };
   },
@@ -116,7 +119,7 @@ export const Proto2TestMessage: MessageFns<Proto2TestMessage> = {
       obj.stringValue = message.stringValue;
     }
     if (message.mapValue) {
-      const entries = Object.entries(message.mapValue);
+      const entries = globalThis.Object.entries(message.mapValue) as [string, string][];
       if (entries.length > 0) {
         obj.mapValue = {};
         entries.forEach(([k, v]) => {
@@ -135,12 +138,15 @@ export const Proto2TestMessage: MessageFns<Proto2TestMessage> = {
     message.boolValue = object.boolValue ?? undefined;
     message.intValue = object.intValue ?? undefined;
     message.stringValue = object.stringValue ?? undefined;
-    message.mapValue = Object.entries(object.mapValue ?? {}).reduce<{ [key: string]: string }>((acc, [key, value]) => {
-      if (value !== undefined) {
-        acc[key] = globalThis.String(value);
-      }
-      return acc;
-    }, {});
+    message.mapValue = (globalThis.Object.entries(object.mapValue ?? {}) as [string, string][]).reduce(
+      (acc: { [key: string]: string }, [key, value]: [string, string]) => {
+        if (value !== undefined) {
+          acc[key] = globalThis.String(value);
+        }
+        return acc;
+      },
+      {},
+    );
     return message;
   },
 };

--- a/integration/no-defaults-for-optionals/proto-3.ts
+++ b/integration/no-defaults-for-optionals/proto-3.ts
@@ -53,7 +53,7 @@ export const Proto3TestMessage: MessageFns<Proto3TestMessage> = {
     if (message.optionalStringValue !== undefined) {
       writer.uint32(50).string(message.optionalStringValue);
     }
-    Object.entries(message.mapValue).forEach(([key, value]) => {
+    globalThis.Object.entries(message.mapValue).forEach(([key, value]: [string, string]) => {
       Proto3TestMessage_MapValueEntry.encode({ key: key as any, value }, writer.uint32(58).fork()).join();
     });
     return writer;
@@ -145,10 +145,13 @@ export const Proto3TestMessage: MessageFns<Proto3TestMessage> = {
         ? globalThis.String(object.optionalStringValue)
         : undefined,
       mapValue: isObject(object.mapValue)
-        ? Object.entries(object.mapValue).reduce<{ [key: string]: string }>((acc, [key, value]) => {
-          acc[key] = String(value);
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.mapValue) as [string, any][]).reduce(
+          (acc: { [key: string]: string }, [key, value]: [string, any]) => {
+            acc[key] = globalThis.String(value);
+            return acc;
+          },
+          {},
+        )
         : {},
     };
   },
@@ -174,7 +177,7 @@ export const Proto3TestMessage: MessageFns<Proto3TestMessage> = {
       obj.optionalStringValue = message.optionalStringValue;
     }
     if (message.mapValue) {
-      const entries = Object.entries(message.mapValue);
+      const entries = globalThis.Object.entries(message.mapValue) as [string, string][];
       if (entries.length > 0) {
         obj.mapValue = {};
         entries.forEach(([k, v]) => {
@@ -196,12 +199,15 @@ export const Proto3TestMessage: MessageFns<Proto3TestMessage> = {
     message.optionalBoolValue = object.optionalBoolValue ?? undefined;
     message.optionalIntValue = object.optionalIntValue ?? undefined;
     message.optionalStringValue = object.optionalStringValue ?? undefined;
-    message.mapValue = Object.entries(object.mapValue ?? {}).reduce<{ [key: string]: string }>((acc, [key, value]) => {
-      if (value !== undefined) {
-        acc[key] = globalThis.String(value);
-      }
-      return acc;
-    }, {});
+    message.mapValue = (globalThis.Object.entries(object.mapValue ?? {}) as [string, string][]).reduce(
+      (acc: { [key: string]: string }, [key, value]: [string, string]) => {
+        if (value !== undefined) {
+          acc[key] = globalThis.String(value);
+        }
+        return acc;
+      },
+      {},
+    );
     return message;
   },
 };

--- a/integration/oneof-unions-snake/google/protobuf/struct.ts
+++ b/integration/oneof-unions-snake/google/protobuf/struct.ts
@@ -108,7 +108,7 @@ function createBaseStruct(): Struct {
 
 export const Struct: MessageFns<Struct> & StructWrapperFns = {
   encode(message: Struct, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    Object.entries(message.fields).forEach(([key, value]) => {
+    globalThis.Object.entries(message.fields).forEach(([key, value]: [string, any | undefined]) => {
       if (value !== undefined) {
         Struct_FieldsEntry.encode({ key: key as any, value }, writer.uint32(10).fork()).join();
       }
@@ -146,10 +146,13 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
   fromJSON(object: any): Struct {
     return {
       fields: isObject(object.fields)
-        ? Object.entries(object.fields).reduce<{ [key: string]: any | undefined }>((acc, [key, value]) => {
-          acc[key] = value as any | undefined;
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.fields) as [string, any][]).reduce(
+          (acc: { [key: string]: any | undefined }, [key, value]: [string, any]) => {
+            acc[key] = value as any | undefined;
+            return acc;
+          },
+          {},
+        )
         : {},
     };
   },
@@ -157,7 +160,7 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
   toJSON(message: Struct): unknown {
     const obj: any = {};
     if (message.fields) {
-      const entries = Object.entries(message.fields);
+      const entries = globalThis.Object.entries(message.fields) as [string, any | undefined][];
       if (entries.length > 0) {
         obj.fields = {};
         entries.forEach(([k, v]) => {
@@ -173,8 +176,8 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
   },
   fromPartial<I extends Exact<DeepPartial<Struct>, I>>(object: I): Struct {
     const message = createBaseStruct();
-    message.fields = Object.entries(object.fields ?? {}).reduce<{ [key: string]: any | undefined }>(
-      (acc, [key, value]) => {
+    message.fields = (globalThis.Object.entries(object.fields ?? {}) as [string, any | undefined][]).reduce(
+      (acc: { [key: string]: any | undefined }, [key, value]: [string, any | undefined]) => {
         if (value !== undefined) {
           acc[key] = value;
         }
@@ -189,7 +192,7 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
     const struct = createBaseStruct();
 
     if (object !== undefined) {
-      for (const key of Object.keys(object)) {
+      for (const key of globalThis.Object.keys(object)) {
         struct.fields[key] = object[key];
       }
     }
@@ -199,7 +202,7 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
   unwrap(message: Struct): { [key: string]: any } {
     const object: { [key: string]: any } = {};
     if (message.fields) {
-      for (const key of Object.keys(message.fields)) {
+      for (const key of globalThis.Object.keys(message.fields)) {
         object[key] = message.fields[key];
       }
     }

--- a/integration/oneof-unions-value/google/protobuf/struct.ts
+++ b/integration/oneof-unions-value/google/protobuf/struct.ts
@@ -108,7 +108,7 @@ function createBaseStruct(): Struct {
 
 export const Struct: MessageFns<Struct> & StructWrapperFns = {
   encode(message: Struct, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    Object.entries(message.fields).forEach(([key, value]) => {
+    globalThis.Object.entries(message.fields).forEach(([key, value]: [string, any | undefined]) => {
       if (value !== undefined) {
         Struct_FieldsEntry.encode({ key: key as any, value }, writer.uint32(10).fork()).join();
       }
@@ -146,10 +146,13 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
   fromJSON(object: any): Struct {
     return {
       fields: isObject(object.fields)
-        ? Object.entries(object.fields).reduce<{ [key: string]: any | undefined }>((acc, [key, value]) => {
-          acc[key] = value as any | undefined;
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.fields) as [string, any][]).reduce(
+          (acc: { [key: string]: any | undefined }, [key, value]: [string, any]) => {
+            acc[key] = value as any | undefined;
+            return acc;
+          },
+          {},
+        )
         : {},
     };
   },
@@ -157,7 +160,7 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
   toJSON(message: Struct): unknown {
     const obj: any = {};
     if (message.fields) {
-      const entries = Object.entries(message.fields);
+      const entries = globalThis.Object.entries(message.fields) as [string, any | undefined][];
       if (entries.length > 0) {
         obj.fields = {};
         entries.forEach(([k, v]) => {
@@ -173,8 +176,8 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
   },
   fromPartial<I extends Exact<DeepPartial<Struct>, I>>(object: I): Struct {
     const message = createBaseStruct();
-    message.fields = Object.entries(object.fields ?? {}).reduce<{ [key: string]: any | undefined }>(
-      (acc, [key, value]) => {
+    message.fields = (globalThis.Object.entries(object.fields ?? {}) as [string, any | undefined][]).reduce(
+      (acc: { [key: string]: any | undefined }, [key, value]: [string, any | undefined]) => {
         if (value !== undefined) {
           acc[key] = value;
         }
@@ -189,7 +192,7 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
     const struct = createBaseStruct();
 
     if (object !== undefined) {
-      for (const key of Object.keys(object)) {
+      for (const key of globalThis.Object.keys(object)) {
         struct.fields[key] = object[key];
       }
     }
@@ -199,7 +202,7 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
   unwrap(message: Struct): { [key: string]: any } {
     const object: { [key: string]: any } = {};
     if (message.fields) {
-      for (const key of Object.keys(message.fields)) {
+      for (const key of globalThis.Object.keys(message.fields)) {
         object[key] = message.fields[key];
       }
     }

--- a/integration/oneof-unions/google/protobuf/struct.ts
+++ b/integration/oneof-unions/google/protobuf/struct.ts
@@ -108,7 +108,7 @@ function createBaseStruct(): Struct {
 
 export const Struct: MessageFns<Struct> & StructWrapperFns = {
   encode(message: Struct, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    Object.entries(message.fields).forEach(([key, value]) => {
+    globalThis.Object.entries(message.fields).forEach(([key, value]: [string, any | undefined]) => {
       if (value !== undefined) {
         Struct_FieldsEntry.encode({ key: key as any, value }, writer.uint32(10).fork()).join();
       }
@@ -146,10 +146,13 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
   fromJSON(object: any): Struct {
     return {
       fields: isObject(object.fields)
-        ? Object.entries(object.fields).reduce<{ [key: string]: any | undefined }>((acc, [key, value]) => {
-          acc[key] = value as any | undefined;
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.fields) as [string, any][]).reduce(
+          (acc: { [key: string]: any | undefined }, [key, value]: [string, any]) => {
+            acc[key] = value as any | undefined;
+            return acc;
+          },
+          {},
+        )
         : {},
     };
   },
@@ -157,7 +160,7 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
   toJSON(message: Struct): unknown {
     const obj: any = {};
     if (message.fields) {
-      const entries = Object.entries(message.fields);
+      const entries = globalThis.Object.entries(message.fields) as [string, any | undefined][];
       if (entries.length > 0) {
         obj.fields = {};
         entries.forEach(([k, v]) => {
@@ -173,8 +176,8 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
   },
   fromPartial<I extends Exact<DeepPartial<Struct>, I>>(object: I): Struct {
     const message = createBaseStruct();
-    message.fields = Object.entries(object.fields ?? {}).reduce<{ [key: string]: any | undefined }>(
-      (acc, [key, value]) => {
+    message.fields = (globalThis.Object.entries(object.fields ?? {}) as [string, any | undefined][]).reduce(
+      (acc: { [key: string]: any | undefined }, [key, value]: [string, any | undefined]) => {
         if (value !== undefined) {
           acc[key] = value;
         }
@@ -189,7 +192,7 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
     const struct = createBaseStruct();
 
     if (object !== undefined) {
-      for (const key of Object.keys(object)) {
+      for (const key of globalThis.Object.keys(object)) {
         struct.fields[key] = object[key];
       }
     }
@@ -199,7 +202,7 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
   unwrap(message: Struct): { [key: string]: any } {
     const object: { [key: string]: any } = {};
     if (message.fields) {
-      for (const key of Object.keys(message.fields)) {
+      for (const key of globalThis.Object.keys(message.fields)) {
         object[key] = message.fields[key];
       }
     }

--- a/integration/proto2-long/simple.ts
+++ b/integration/proto2-long/simple.ts
@@ -256,7 +256,7 @@ export const OptionalsTest: MessageFns<OptionalsTest> = {
     if (message.optDefvalFloat !== undefined && message.optDefvalFloat !== 0.12354) {
       writer.uint32(389).float(message.optDefvalFloat);
     }
-    Object.entries(message.translations).forEach(([key, value]) => {
+    globalThis.Object.entries(message.translations).forEach(([key, value]: [string, string]) => {
       OptionalsTest_TranslationsEntry.encode({ key: key as any, value }, writer.uint32(402).fork()).join();
     });
     return writer;
@@ -692,10 +692,13 @@ export const OptionalsTest: MessageFns<OptionalsTest> = {
       optDefvalData: isSet(object.optDefvalData) ? bytesFromBase64(object.optDefvalData) : new Uint8Array(0),
       optDefvalFloat: isSet(object.optDefvalFloat) ? globalThis.Number(object.optDefvalFloat) : 0.12354,
       translations: isObject(object.translations)
-        ? Object.entries(object.translations).reduce<{ [key: string]: string }>((acc, [key, value]) => {
-          acc[key] = String(value);
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.translations) as [string, any][]).reduce(
+          (acc: { [key: string]: string }, [key, value]: [string, any]) => {
+            acc[key] = globalThis.String(value);
+            return acc;
+          },
+          {},
+        )
         : {},
     };
   },
@@ -817,7 +820,7 @@ export const OptionalsTest: MessageFns<OptionalsTest> = {
       obj.optDefvalFloat = message.optDefvalFloat;
     }
     if (message.translations) {
-      const entries = Object.entries(message.translations);
+      const entries = globalThis.Object.entries(message.translations) as [string, string][];
       if (entries.length > 0) {
         obj.translations = {};
         entries.forEach(([k, v]) => {
@@ -883,8 +886,8 @@ export const OptionalsTest: MessageFns<OptionalsTest> = {
     message.optDefvalDescription = object.optDefvalDescription ?? "Some description";
     message.optDefvalData = object.optDefvalData ?? new Uint8Array(0);
     message.optDefvalFloat = object.optDefvalFloat ?? 0.12354;
-    message.translations = Object.entries(object.translations ?? {}).reduce<{ [key: string]: string }>(
-      (acc, [key, value]) => {
+    message.translations = (globalThis.Object.entries(object.translations ?? {}) as [string, string][]).reduce(
+      (acc: { [key: string]: string }, [key, value]: [string, string]) => {
         if (value !== undefined) {
           acc[key] = globalThis.String(value);
         }

--- a/integration/proto2-no-default-vals/simple.ts
+++ b/integration/proto2-no-default-vals/simple.ts
@@ -255,7 +255,7 @@ export const OptionalsTest: MessageFns<OptionalsTest> = {
     if (message.optDefvalFloat !== undefined && message.optDefvalFloat !== 0) {
       writer.uint32(389).float(message.optDefvalFloat);
     }
-    Object.entries(message.translations).forEach(([key, value]) => {
+    globalThis.Object.entries(message.translations).forEach(([key, value]: [string, string]) => {
       OptionalsTest_TranslationsEntry.encode({ key: key as any, value }, writer.uint32(402).fork()).join();
     });
     return writer;
@@ -687,10 +687,13 @@ export const OptionalsTest: MessageFns<OptionalsTest> = {
       optDefvalData: isSet(object.optDefvalData) ? bytesFromBase64(object.optDefvalData) : new Uint8Array(0),
       optDefvalFloat: isSet(object.optDefvalFloat) ? globalThis.Number(object.optDefvalFloat) : 0,
       translations: isObject(object.translations)
-        ? Object.entries(object.translations).reduce<{ [key: string]: string }>((acc, [key, value]) => {
-          acc[key] = String(value);
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.translations) as [string, any][]).reduce(
+          (acc: { [key: string]: string }, [key, value]: [string, any]) => {
+            acc[key] = globalThis.String(value);
+            return acc;
+          },
+          {},
+        )
         : {},
     };
   },
@@ -812,7 +815,7 @@ export const OptionalsTest: MessageFns<OptionalsTest> = {
       obj.optDefvalFloat = message.optDefvalFloat;
     }
     if (message.translations) {
-      const entries = Object.entries(message.translations);
+      const entries = globalThis.Object.entries(message.translations) as [string, string][];
       if (entries.length > 0) {
         obj.translations = {};
         entries.forEach(([k, v]) => {
@@ -870,8 +873,8 @@ export const OptionalsTest: MessageFns<OptionalsTest> = {
     message.optDefvalDescription = object.optDefvalDescription ?? "";
     message.optDefvalData = object.optDefvalData ?? new Uint8Array(0);
     message.optDefvalFloat = object.optDefvalFloat ?? 0;
-    message.translations = Object.entries(object.translations ?? {}).reduce<{ [key: string]: string }>(
-      (acc, [key, value]) => {
+    message.translations = (globalThis.Object.entries(object.translations ?? {}) as [string, string][]).reduce(
+      (acc: { [key: string]: string }, [key, value]: [string, string]) => {
         if (value !== undefined) {
           acc[key] = globalThis.String(value);
         }

--- a/integration/proto2-no-optionals/simple.ts
+++ b/integration/proto2-no-optionals/simple.ts
@@ -255,7 +255,7 @@ export const OptionalsTest: MessageFns<OptionalsTest> = {
     if (message.optDefvalFloat !== 0.12354) {
       writer.uint32(389).float(message.optDefvalFloat);
     }
-    Object.entries(message.translations).forEach(([key, value]) => {
+    globalThis.Object.entries(message.translations).forEach(([key, value]: [string, string]) => {
       OptionalsTest_TranslationsEntry.encode({ key: key as any, value }, writer.uint32(402).fork()).join();
     });
     return writer;
@@ -691,10 +691,13 @@ export const OptionalsTest: MessageFns<OptionalsTest> = {
       optDefvalData: isSet(object.optDefvalData) ? bytesFromBase64(object.optDefvalData) : new Uint8Array(0),
       optDefvalFloat: isSet(object.optDefvalFloat) ? globalThis.Number(object.optDefvalFloat) : 0.12354,
       translations: isObject(object.translations)
-        ? Object.entries(object.translations).reduce<{ [key: string]: string }>((acc, [key, value]) => {
-          acc[key] = String(value);
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.translations) as [string, any][]).reduce(
+          (acc: { [key: string]: string }, [key, value]: [string, any]) => {
+            acc[key] = globalThis.String(value);
+            return acc;
+          },
+          {},
+        )
         : {},
     };
   },
@@ -816,7 +819,7 @@ export const OptionalsTest: MessageFns<OptionalsTest> = {
       obj.optDefvalFloat = message.optDefvalFloat;
     }
     if (message.translations) {
-      const entries = Object.entries(message.translations);
+      const entries = globalThis.Object.entries(message.translations) as [string, string][];
       if (entries.length > 0) {
         obj.translations = {};
         entries.forEach(([k, v]) => {
@@ -874,8 +877,8 @@ export const OptionalsTest: MessageFns<OptionalsTest> = {
     message.optDefvalDescription = object.optDefvalDescription ?? "Some description";
     message.optDefvalData = object.optDefvalData ?? new Uint8Array(0);
     message.optDefvalFloat = object.optDefvalFloat ?? 0.12354;
-    message.translations = Object.entries(object.translations ?? {}).reduce<{ [key: string]: string }>(
-      (acc, [key, value]) => {
+    message.translations = (globalThis.Object.entries(object.translations ?? {}) as [string, string][]).reduce(
+      (acc: { [key: string]: string }, [key, value]: [string, string]) => {
         if (value !== undefined) {
           acc[key] = globalThis.String(value);
         }

--- a/integration/proto2/simple.ts
+++ b/integration/proto2/simple.ts
@@ -255,7 +255,7 @@ export const OptionalsTest: MessageFns<OptionalsTest> = {
     if (message.optDefvalFloat !== undefined && message.optDefvalFloat !== 0.12354) {
       writer.uint32(389).float(message.optDefvalFloat);
     }
-    Object.entries(message.translations).forEach(([key, value]) => {
+    globalThis.Object.entries(message.translations).forEach(([key, value]: [string, string]) => {
       OptionalsTest_TranslationsEntry.encode({ key: key as any, value }, writer.uint32(402).fork()).join();
     });
     return writer;
@@ -691,10 +691,13 @@ export const OptionalsTest: MessageFns<OptionalsTest> = {
       optDefvalData: isSet(object.optDefvalData) ? bytesFromBase64(object.optDefvalData) : new Uint8Array(0),
       optDefvalFloat: isSet(object.optDefvalFloat) ? globalThis.Number(object.optDefvalFloat) : 0.12354,
       translations: isObject(object.translations)
-        ? Object.entries(object.translations).reduce<{ [key: string]: string }>((acc, [key, value]) => {
-          acc[key] = String(value);
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.translations) as [string, any][]).reduce(
+          (acc: { [key: string]: string }, [key, value]: [string, any]) => {
+            acc[key] = globalThis.String(value);
+            return acc;
+          },
+          {},
+        )
         : {},
     };
   },
@@ -816,7 +819,7 @@ export const OptionalsTest: MessageFns<OptionalsTest> = {
       obj.optDefvalFloat = message.optDefvalFloat;
     }
     if (message.translations) {
-      const entries = Object.entries(message.translations);
+      const entries = globalThis.Object.entries(message.translations) as [string, string][];
       if (entries.length > 0) {
         obj.translations = {};
         entries.forEach(([k, v]) => {
@@ -874,8 +877,8 @@ export const OptionalsTest: MessageFns<OptionalsTest> = {
     message.optDefvalDescription = object.optDefvalDescription ?? "Some description";
     message.optDefvalData = object.optDefvalData ?? new Uint8Array(0);
     message.optDefvalFloat = object.optDefvalFloat ?? 0.12354;
-    message.translations = Object.entries(object.translations ?? {}).reduce<{ [key: string]: string }>(
-      (acc, [key, value]) => {
+    message.translations = (globalThis.Object.entries(object.translations ?? {}) as [string, string][]).reduce(
+      (acc: { [key: string]: string }, [key, value]: [string, string]) => {
         if (value !== undefined) {
           acc[key] = globalThis.String(value);
         }

--- a/integration/schema-no-file-descriptor/const-enum.ts
+++ b/integration/schema-no-file-descriptor/const-enum.ts
@@ -70,7 +70,7 @@ export const DividerData: MessageFns<DividerData> = {
     if (message.type !== 0) {
       writer.uint32(8).int32(message.type);
     }
-    Object.entries(message.typeMap).forEach(([key, value]) => {
+    globalThis.Object.entries(message.typeMap).forEach(([key, value]: [string, DividerData_DividerType]) => {
       DividerData_TypeMapEntry.encode({ key: key as any, value }, writer.uint32(18).fork()).join();
     });
     return writer;
@@ -115,10 +115,13 @@ export const DividerData: MessageFns<DividerData> = {
     return {
       type: isSet(object.type) ? dividerData_DividerTypeFromJSON(object.type) : 0,
       typeMap: isObject(object.typeMap)
-        ? Object.entries(object.typeMap).reduce<{ [key: string]: DividerData_DividerType }>((acc, [key, value]) => {
-          acc[key] = dividerData_DividerTypeFromJSON(value);
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.typeMap) as [string, any][]).reduce(
+          (acc: { [key: string]: DividerData_DividerType }, [key, value]: [string, any]) => {
+            acc[key] = dividerData_DividerTypeFromJSON(value);
+            return acc;
+          },
+          {},
+        )
         : {},
     };
   },
@@ -129,7 +132,7 @@ export const DividerData: MessageFns<DividerData> = {
       obj.type = dividerData_DividerTypeToJSON(message.type);
     }
     if (message.typeMap) {
-      const entries = Object.entries(message.typeMap);
+      const entries = globalThis.Object.entries(message.typeMap) as [string, DividerData_DividerType][];
       if (entries.length > 0) {
         obj.typeMap = {};
         entries.forEach(([k, v]) => {
@@ -146,8 +149,8 @@ export const DividerData: MessageFns<DividerData> = {
   fromPartial<I extends Exact<DeepPartial<DividerData>, I>>(object: I): DividerData {
     const message = createBaseDividerData();
     message.type = object.type ?? 0;
-    message.typeMap = Object.entries(object.typeMap ?? {}).reduce<{ [key: string]: DividerData_DividerType }>(
-      (acc, [key, value]) => {
+    message.typeMap = (globalThis.Object.entries(object.typeMap ?? {}) as [string, DividerData_DividerType][]).reduce(
+      (acc: { [key: string]: DividerData_DividerType }, [key, value]: [string, DividerData_DividerType]) => {
         if (value !== undefined) {
           acc[key] = value as DividerData_DividerType;
         }

--- a/integration/simple-long/simple.ts
+++ b/integration/simple-long/simple.ts
@@ -203,10 +203,10 @@ function createBaseSimpleWithMap(): SimpleWithMap {
 
 export const SimpleWithMap: MessageFns<SimpleWithMap> = {
   encode(message: SimpleWithMap, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    Object.entries(message.nameLookup).forEach(([key, value]) => {
+    globalThis.Object.entries(message.nameLookup).forEach(([key, value]: [string, string]) => {
       SimpleWithMap_NameLookupEntry.encode({ key: key as any, value }, writer.uint32(18).fork()).join();
     });
-    Object.entries(message.intLookup).forEach(([key, value]) => {
+    globalThis.Object.entries(message.intLookup).forEach(([key, value]: [string, number]) => {
       SimpleWithMap_IntLookupEntry.encode({ key: key as any, value }, writer.uint32(26).fork()).join();
     });
     message.longLookup.forEach((value, key) => {
@@ -267,22 +267,31 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
   fromJSON(object: any): SimpleWithMap {
     return {
       nameLookup: isObject(object.nameLookup)
-        ? Object.entries(object.nameLookup).reduce<{ [key: string]: string }>((acc, [key, value]) => {
-          acc[key] = String(value);
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.nameLookup) as [string, any][]).reduce(
+          (acc: { [key: string]: string }, [key, value]: [string, any]) => {
+            acc[key] = globalThis.String(value);
+            return acc;
+          },
+          {},
+        )
         : {},
       intLookup: isObject(object.intLookup)
-        ? Object.entries(object.intLookup).reduce<{ [key: number]: number }>((acc, [key, value]) => {
-          acc[globalThis.Number(key)] = Number(value);
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.intLookup) as [string, any][]).reduce(
+          (acc: { [key: number]: number }, [key, value]: [string, any]) => {
+            acc[globalThis.Number(key)] = globalThis.Number(value);
+            return acc;
+          },
+          {},
+        )
         : {},
       longLookup: isObject(object.longLookup)
-        ? Object.entries(object.longLookup).reduce<Map<Long, Long>>((acc, [key, value]) => {
-          acc.set(Long.fromValue(key), Long.fromValue(value as Long | string));
-          return acc;
-        }, new Map())
+        ? (globalThis.Object.entries(object.longLookup) as [string, any][]).reduce(
+          (acc: Map<Long, Long>, [key, value]: [string, any]) => {
+            acc.set(Long.fromValue(key), Long.fromValue(value as Long | string));
+            return acc;
+          },
+          new Map(),
+        )
         : new Map(),
     };
   },
@@ -290,7 +299,7 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
   toJSON(message: SimpleWithMap): unknown {
     const obj: any = {};
     if (message.nameLookup) {
-      const entries = Object.entries(message.nameLookup);
+      const entries = globalThis.Object.entries(message.nameLookup) as [string, string][];
       if (entries.length > 0) {
         obj.nameLookup = {};
         entries.forEach(([k, v]) => {
@@ -299,7 +308,7 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
       }
     }
     if (message.intLookup) {
-      const entries = Object.entries(message.intLookup);
+      const entries = globalThis.Object.entries(message.intLookup) as [string, number][];
       if (entries.length > 0) {
         obj.intLookup = {};
         entries.forEach(([k, v]) => {
@@ -321,8 +330,8 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
   },
   fromPartial<I extends Exact<DeepPartial<SimpleWithMap>, I>>(object: I): SimpleWithMap {
     const message = createBaseSimpleWithMap();
-    message.nameLookup = Object.entries(object.nameLookup ?? {}).reduce<{ [key: string]: string }>(
-      (acc, [key, value]) => {
+    message.nameLookup = (globalThis.Object.entries(object.nameLookup ?? {}) as [string, string][]).reduce(
+      (acc: { [key: string]: string }, [key, value]: [string, string]) => {
         if (value !== undefined) {
           acc[key] = globalThis.String(value);
         }
@@ -330,8 +339,8 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
       },
       {},
     );
-    message.intLookup = Object.entries(object.intLookup ?? {}).reduce<{ [key: number]: number }>(
-      (acc, [key, value]) => {
+    message.intLookup = (globalThis.Object.entries(object.intLookup ?? {}) as [string, number][]).reduce(
+      (acc: { [key: number]: number }, [key, value]: [string, number]) => {
         if (value !== undefined) {
           acc[globalThis.Number(key)] = globalThis.Number(value);
         }

--- a/integration/simple-optionals/simple.ts
+++ b/integration/simple-optionals/simple.ts
@@ -1057,13 +1057,13 @@ function createBaseSimpleWithMap(): SimpleWithMap {
 
 export const SimpleWithMap: MessageFns<SimpleWithMap> = {
   encode(message: SimpleWithMap, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    Object.entries(message.entitiesById).forEach(([key, value]) => {
+    globalThis.Object.entries(message.entitiesById).forEach(([key, value]: [string, Entity]) => {
       SimpleWithMap_EntitiesByIdEntry.encode({ key: key as any, value }, writer.uint32(10).fork()).join();
     });
-    Object.entries(message.nameLookup).forEach(([key, value]) => {
+    globalThis.Object.entries(message.nameLookup).forEach(([key, value]: [string, string]) => {
       SimpleWithMap_NameLookupEntry.encode({ key: key as any, value }, writer.uint32(18).fork()).join();
     });
-    Object.entries(message.intLookup).forEach(([key, value]) => {
+    globalThis.Object.entries(message.intLookup).forEach(([key, value]: [string, number]) => {
       SimpleWithMap_IntLookupEntry.encode({ key: key as any, value }, writer.uint32(26).fork()).join();
     });
     return writer;
@@ -1121,22 +1121,31 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
   fromJSON(object: any): SimpleWithMap {
     return {
       entitiesById: isObject(object.entitiesById)
-        ? Object.entries(object.entitiesById).reduce<{ [key: number]: Entity }>((acc, [key, value]) => {
-          acc[globalThis.Number(key)] = Entity.fromJSON(value);
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.entitiesById) as [string, any][]).reduce(
+          (acc: { [key: number]: Entity }, [key, value]: [string, any]) => {
+            acc[globalThis.Number(key)] = Entity.fromJSON(value);
+            return acc;
+          },
+          {},
+        )
         : {},
       nameLookup: isObject(object.nameLookup)
-        ? Object.entries(object.nameLookup).reduce<{ [key: string]: string }>((acc, [key, value]) => {
-          acc[key] = String(value);
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.nameLookup) as [string, any][]).reduce(
+          (acc: { [key: string]: string }, [key, value]: [string, any]) => {
+            acc[key] = globalThis.String(value);
+            return acc;
+          },
+          {},
+        )
         : {},
       intLookup: isObject(object.intLookup)
-        ? Object.entries(object.intLookup).reduce<{ [key: number]: number }>((acc, [key, value]) => {
-          acc[globalThis.Number(key)] = Number(value);
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.intLookup) as [string, any][]).reduce(
+          (acc: { [key: number]: number }, [key, value]: [string, any]) => {
+            acc[globalThis.Number(key)] = globalThis.Number(value);
+            return acc;
+          },
+          {},
+        )
         : {},
     };
   },
@@ -1144,7 +1153,7 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
   toJSON(message: SimpleWithMap): unknown {
     const obj: any = {};
     if (message.entitiesById) {
-      const entries = Object.entries(message.entitiesById);
+      const entries = globalThis.Object.entries(message.entitiesById) as [string, Entity][];
       if (entries.length > 0) {
         obj.entitiesById = {};
         entries.forEach(([k, v]) => {
@@ -1153,7 +1162,7 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
       }
     }
     if (message.nameLookup) {
-      const entries = Object.entries(message.nameLookup);
+      const entries = globalThis.Object.entries(message.nameLookup) as [string, string][];
       if (entries.length > 0) {
         obj.nameLookup = {};
         entries.forEach(([k, v]) => {
@@ -1162,7 +1171,7 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
       }
     }
     if (message.intLookup) {
-      const entries = Object.entries(message.intLookup);
+      const entries = globalThis.Object.entries(message.intLookup) as [string, number][];
       if (entries.length > 0) {
         obj.intLookup = {};
         entries.forEach(([k, v]) => {
@@ -1178,8 +1187,8 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
   },
   fromPartial<I extends Exact<DeepPartial<SimpleWithMap>, I>>(object: I): SimpleWithMap {
     const message = createBaseSimpleWithMap();
-    message.entitiesById = Object.entries(object.entitiesById ?? {}).reduce<{ [key: number]: Entity }>(
-      (acc, [key, value]) => {
+    message.entitiesById = (globalThis.Object.entries(object.entitiesById ?? {}) as [string, Entity][]).reduce(
+      (acc: { [key: number]: Entity }, [key, value]: [string, Entity]) => {
         if (value !== undefined) {
           acc[globalThis.Number(key)] = Entity.fromPartial(value);
         }
@@ -1187,8 +1196,8 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
       },
       {},
     );
-    message.nameLookup = Object.entries(object.nameLookup ?? {}).reduce<{ [key: string]: string }>(
-      (acc, [key, value]) => {
+    message.nameLookup = (globalThis.Object.entries(object.nameLookup ?? {}) as [string, string][]).reduce(
+      (acc: { [key: string]: string }, [key, value]: [string, string]) => {
         if (value !== undefined) {
           acc[key] = globalThis.String(value);
         }
@@ -1196,8 +1205,8 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
       },
       {},
     );
-    message.intLookup = Object.entries(object.intLookup ?? {}).reduce<{ [key: number]: number }>(
-      (acc, [key, value]) => {
+    message.intLookup = (globalThis.Object.entries(object.intLookup ?? {}) as [string, number][]).reduce(
+      (acc: { [key: number]: number }, [key, value]: [string, number]) => {
         if (value !== undefined) {
           acc[globalThis.Number(key)] = globalThis.Number(value);
         }
@@ -1449,7 +1458,7 @@ function createBaseSimpleWithSnakeCaseMap(): SimpleWithSnakeCaseMap {
 
 export const SimpleWithSnakeCaseMap: MessageFns<SimpleWithSnakeCaseMap> = {
   encode(message: SimpleWithSnakeCaseMap, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    Object.entries(message.entitiesById).forEach(([key, value]) => {
+    globalThis.Object.entries(message.entitiesById).forEach(([key, value]: [string, Entity]) => {
       SimpleWithSnakeCaseMap_EntitiesByIdEntry.encode({ key: key as any, value }, writer.uint32(10).fork()).join();
     });
     return writer;
@@ -1485,10 +1494,13 @@ export const SimpleWithSnakeCaseMap: MessageFns<SimpleWithSnakeCaseMap> = {
   fromJSON(object: any): SimpleWithSnakeCaseMap {
     return {
       entitiesById: isObject(object.entitiesById)
-        ? Object.entries(object.entitiesById).reduce<{ [key: number]: Entity }>((acc, [key, value]) => {
-          acc[globalThis.Number(key)] = Entity.fromJSON(value);
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.entitiesById) as [string, any][]).reduce(
+          (acc: { [key: number]: Entity }, [key, value]: [string, any]) => {
+            acc[globalThis.Number(key)] = Entity.fromJSON(value);
+            return acc;
+          },
+          {},
+        )
         : {},
     };
   },
@@ -1496,7 +1508,7 @@ export const SimpleWithSnakeCaseMap: MessageFns<SimpleWithSnakeCaseMap> = {
   toJSON(message: SimpleWithSnakeCaseMap): unknown {
     const obj: any = {};
     if (message.entitiesById) {
-      const entries = Object.entries(message.entitiesById);
+      const entries = globalThis.Object.entries(message.entitiesById) as [string, Entity][];
       if (entries.length > 0) {
         obj.entitiesById = {};
         entries.forEach(([k, v]) => {
@@ -1512,8 +1524,8 @@ export const SimpleWithSnakeCaseMap: MessageFns<SimpleWithSnakeCaseMap> = {
   },
   fromPartial<I extends Exact<DeepPartial<SimpleWithSnakeCaseMap>, I>>(object: I): SimpleWithSnakeCaseMap {
     const message = createBaseSimpleWithSnakeCaseMap();
-    message.entitiesById = Object.entries(object.entitiesById ?? {}).reduce<{ [key: number]: Entity }>(
-      (acc, [key, value]) => {
+    message.entitiesById = (globalThis.Object.entries(object.entitiesById ?? {}) as [string, Entity][]).reduce(
+      (acc: { [key: number]: Entity }, [key, value]: [string, Entity]) => {
         if (value !== undefined) {
           acc[globalThis.Number(key)] = Entity.fromPartial(value);
         }

--- a/integration/simple-prototype-defaults/simple.ts
+++ b/integration/simple-prototype-defaults/simple.ts
@@ -1196,27 +1196,27 @@ function createBaseSimpleWithMap(): SimpleWithMap {
 
 export const SimpleWithMap: MessageFns<SimpleWithMap> = {
   encode(message: SimpleWithMap, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    Object.entries(message.entitiesById).forEach(([key, value]) => {
+    globalThis.Object.entries(message.entitiesById).forEach(([key, value]: [string, Entity]) => {
       SimpleWithMap_EntitiesByIdEntry.encode({ key: key as any, value }, writer.uint32(10).fork()).join();
     });
-    Object.entries(message.nameLookup).forEach(([key, value]) => {
+    globalThis.Object.entries(message.nameLookup).forEach(([key, value]: [string, string]) => {
       SimpleWithMap_NameLookupEntry.encode({ key: key as any, value }, writer.uint32(18).fork()).join();
     });
-    Object.entries(message.intLookup).forEach(([key, value]) => {
+    globalThis.Object.entries(message.intLookup).forEach(([key, value]: [string, number]) => {
       SimpleWithMap_IntLookupEntry.encode({ key: key as any, value }, writer.uint32(26).fork()).join();
     });
-    Object.entries(message.mapOfTimestamps).forEach(([key, value]) => {
+    globalThis.Object.entries(message.mapOfTimestamps).forEach(([key, value]: [string, Date]) => {
       SimpleWithMap_MapOfTimestampsEntry.encode({ key: key as any, value }, writer.uint32(34).fork()).join();
     });
-    Object.entries(message.mapOfBytes).forEach(([key, value]) => {
+    globalThis.Object.entries(message.mapOfBytes).forEach(([key, value]: [string, Uint8Array]) => {
       SimpleWithMap_MapOfBytesEntry.encode({ key: key as any, value }, writer.uint32(42).fork()).join();
     });
-    Object.entries(message.mapOfStringValues).forEach(([key, value]) => {
+    globalThis.Object.entries(message.mapOfStringValues).forEach(([key, value]: [string, string | undefined]) => {
       if (value !== undefined) {
         SimpleWithMap_MapOfStringValuesEntry.encode({ key: key as any, value }, writer.uint32(50).fork()).join();
       }
     });
-    Object.entries(message.longLookup).forEach(([key, value]) => {
+    globalThis.Object.entries(message.longLookup).forEach(([key, value]: [string, number]) => {
       SimpleWithMap_LongLookupEntry.encode({ key: key as any, value }, writer.uint32(58).fork()).join();
     });
     return writer;
@@ -1318,38 +1318,53 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
   fromJSON(object: any): SimpleWithMap {
     return {
       entitiesById: isObject(object.entitiesById)
-        ? Object.entries(object.entitiesById).reduce<{ [key: number]: Entity }>((acc, [key, value]) => {
-          acc[globalThis.Number(key)] = Entity.fromJSON(value);
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.entitiesById) as [string, any][]).reduce(
+          (acc: { [key: number]: Entity }, [key, value]: [string, any]) => {
+            acc[globalThis.Number(key)] = Entity.fromJSON(value);
+            return acc;
+          },
+          {},
+        )
         : {},
       nameLookup: isObject(object.nameLookup)
-        ? Object.entries(object.nameLookup).reduce<{ [key: string]: string }>((acc, [key, value]) => {
-          acc[key] = String(value);
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.nameLookup) as [string, any][]).reduce(
+          (acc: { [key: string]: string }, [key, value]: [string, any]) => {
+            acc[key] = globalThis.String(value);
+            return acc;
+          },
+          {},
+        )
         : {},
       intLookup: isObject(object.intLookup)
-        ? Object.entries(object.intLookup).reduce<{ [key: number]: number }>((acc, [key, value]) => {
-          acc[globalThis.Number(key)] = Number(value);
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.intLookup) as [string, any][]).reduce(
+          (acc: { [key: number]: number }, [key, value]: [string, any]) => {
+            acc[globalThis.Number(key)] = globalThis.Number(value);
+            return acc;
+          },
+          {},
+        )
         : {},
       mapOfTimestamps: isObject(object.mapOfTimestamps)
-        ? Object.entries(object.mapOfTimestamps).reduce<{ [key: string]: Date }>((acc, [key, value]) => {
-          acc[key] = fromJsonTimestamp(value);
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.mapOfTimestamps) as [string, any][]).reduce(
+          (acc: { [key: string]: Date }, [key, value]: [string, any]) => {
+            acc[key] = fromJsonTimestamp(value);
+            return acc;
+          },
+          {},
+        )
         : {},
       mapOfBytes: isObject(object.mapOfBytes)
-        ? Object.entries(object.mapOfBytes).reduce<{ [key: string]: Uint8Array }>((acc, [key, value]) => {
-          acc[key] = bytesFromBase64(value as string);
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.mapOfBytes) as [string, any][]).reduce(
+          (acc: { [key: string]: Uint8Array }, [key, value]: [string, any]) => {
+            acc[key] = bytesFromBase64(value as string);
+            return acc;
+          },
+          {},
+        )
         : {},
       mapOfStringValues: isObject(object.mapOfStringValues)
-        ? Object.entries(object.mapOfStringValues).reduce<{ [key: string]: string | undefined }>(
-          (acc, [key, value]) => {
+        ? (globalThis.Object.entries(object.mapOfStringValues) as [string, any][]).reduce(
+          (acc: { [key: string]: string | undefined }, [key, value]: [string, any]) => {
             acc[key] = value as string | undefined;
             return acc;
           },
@@ -1357,10 +1372,13 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
         )
         : {},
       longLookup: isObject(object.longLookup)
-        ? Object.entries(object.longLookup).reduce<{ [key: number]: number }>((acc, [key, value]) => {
-          acc[globalThis.Number(key)] = Number(value);
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.longLookup) as [string, any][]).reduce(
+          (acc: { [key: number]: number }, [key, value]: [string, any]) => {
+            acc[globalThis.Number(key)] = globalThis.Number(value);
+            return acc;
+          },
+          {},
+        )
         : {},
     };
   },
@@ -1368,7 +1386,7 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
   toJSON(message: SimpleWithMap): unknown {
     const obj: any = {};
     if (message.entitiesById) {
-      const entries = Object.entries(message.entitiesById);
+      const entries = globalThis.Object.entries(message.entitiesById) as [string, Entity][];
       if (entries.length > 0) {
         obj.entitiesById = {};
         entries.forEach(([k, v]) => {
@@ -1377,7 +1395,7 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
       }
     }
     if (message.nameLookup) {
-      const entries = Object.entries(message.nameLookup);
+      const entries = globalThis.Object.entries(message.nameLookup) as [string, string][];
       if (entries.length > 0) {
         obj.nameLookup = {};
         entries.forEach(([k, v]) => {
@@ -1386,7 +1404,7 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
       }
     }
     if (message.intLookup) {
-      const entries = Object.entries(message.intLookup);
+      const entries = globalThis.Object.entries(message.intLookup) as [string, number][];
       if (entries.length > 0) {
         obj.intLookup = {};
         entries.forEach(([k, v]) => {
@@ -1395,7 +1413,7 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
       }
     }
     if (message.mapOfTimestamps) {
-      const entries = Object.entries(message.mapOfTimestamps);
+      const entries = globalThis.Object.entries(message.mapOfTimestamps) as [string, Date][];
       if (entries.length > 0) {
         obj.mapOfTimestamps = {};
         entries.forEach(([k, v]) => {
@@ -1404,7 +1422,7 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
       }
     }
     if (message.mapOfBytes) {
-      const entries = Object.entries(message.mapOfBytes);
+      const entries = globalThis.Object.entries(message.mapOfBytes) as [string, Uint8Array][];
       if (entries.length > 0) {
         obj.mapOfBytes = {};
         entries.forEach(([k, v]) => {
@@ -1413,7 +1431,7 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
       }
     }
     if (message.mapOfStringValues) {
-      const entries = Object.entries(message.mapOfStringValues);
+      const entries = globalThis.Object.entries(message.mapOfStringValues) as [string, string | undefined][];
       if (entries.length > 0) {
         obj.mapOfStringValues = {};
         entries.forEach(([k, v]) => {
@@ -1422,7 +1440,7 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
       }
     }
     if (message.longLookup) {
-      const entries = Object.entries(message.longLookup);
+      const entries = globalThis.Object.entries(message.longLookup) as [string, number][];
       if (entries.length > 0) {
         obj.longLookup = {};
         entries.forEach(([k, v]) => {
@@ -1438,8 +1456,8 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
   },
   fromPartial<I extends Exact<DeepPartial<SimpleWithMap>, I>>(object: I): SimpleWithMap {
     const message = Object.create(createBaseSimpleWithMap()) as SimpleWithMap;
-    message.entitiesById = Object.entries(object.entitiesById ?? {}).reduce<{ [key: number]: Entity }>(
-      (acc, [key, value]) => {
+    message.entitiesById = (globalThis.Object.entries(object.entitiesById ?? {}) as [string, Entity][]).reduce(
+      (acc: { [key: number]: Entity }, [key, value]: [string, Entity]) => {
         if (value !== undefined) {
           acc[globalThis.Number(key)] = Entity.fromPartial(value);
         }
@@ -1447,8 +1465,8 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
       },
       {},
     );
-    message.nameLookup = Object.entries(object.nameLookup ?? {}).reduce<{ [key: string]: string }>(
-      (acc, [key, value]) => {
+    message.nameLookup = (globalThis.Object.entries(object.nameLookup ?? {}) as [string, string][]).reduce(
+      (acc: { [key: string]: string }, [key, value]: [string, string]) => {
         if (value !== undefined) {
           acc[key] = globalThis.String(value);
         }
@@ -1456,8 +1474,8 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
       },
       {},
     );
-    message.intLookup = Object.entries(object.intLookup ?? {}).reduce<{ [key: number]: number }>(
-      (acc, [key, value]) => {
+    message.intLookup = (globalThis.Object.entries(object.intLookup ?? {}) as [string, number][]).reduce(
+      (acc: { [key: number]: number }, [key, value]: [string, number]) => {
         if (value !== undefined) {
           acc[globalThis.Number(key)] = globalThis.Number(value);
         }
@@ -1465,8 +1483,8 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
       },
       {},
     );
-    message.mapOfTimestamps = Object.entries(object.mapOfTimestamps ?? {}).reduce<{ [key: string]: Date }>(
-      (acc, [key, value]) => {
+    message.mapOfTimestamps = (globalThis.Object.entries(object.mapOfTimestamps ?? {}) as [string, Date][]).reduce(
+      (acc: { [key: string]: Date }, [key, value]: [string, Date]) => {
         if (value !== undefined) {
           acc[key] = value;
         }
@@ -1474,8 +1492,8 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
       },
       {},
     );
-    message.mapOfBytes = Object.entries(object.mapOfBytes ?? {}).reduce<{ [key: string]: Uint8Array }>(
-      (acc, [key, value]) => {
+    message.mapOfBytes = (globalThis.Object.entries(object.mapOfBytes ?? {}) as [string, Uint8Array][]).reduce(
+      (acc: { [key: string]: Uint8Array }, [key, value]: [string, Uint8Array]) => {
         if (value !== undefined) {
           acc[key] = value;
         }
@@ -1483,16 +1501,18 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
       },
       {},
     );
-    message.mapOfStringValues = Object.entries(object.mapOfStringValues ?? {}).reduce<
-      { [key: string]: string | undefined }
-    >((acc, [key, value]) => {
-      if (value !== undefined) {
-        acc[key] = value;
-      }
-      return acc;
-    }, {});
-    message.longLookup = Object.entries(object.longLookup ?? {}).reduce<{ [key: number]: number }>(
-      (acc, [key, value]) => {
+    message.mapOfStringValues =
+      (globalThis.Object.entries(object.mapOfStringValues ?? {}) as [string, string | undefined][]).reduce(
+        (acc: { [key: string]: string | undefined }, [key, value]: [string, string | undefined]) => {
+          if (value !== undefined) {
+            acc[key] = value;
+          }
+          return acc;
+        },
+        {},
+      );
+    message.longLookup = (globalThis.Object.entries(object.longLookup ?? {}) as [string, number][]).reduce(
+      (acc: { [key: number]: number }, [key, value]: [string, number]) => {
         if (value !== undefined) {
           acc[globalThis.Number(key)] = globalThis.Number(value);
         }
@@ -2064,7 +2084,7 @@ function createBaseSimpleWithSnakeCaseMap(): SimpleWithSnakeCaseMap {
 
 export const SimpleWithSnakeCaseMap: MessageFns<SimpleWithSnakeCaseMap> = {
   encode(message: SimpleWithSnakeCaseMap, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    Object.entries(message.entitiesById).forEach(([key, value]) => {
+    globalThis.Object.entries(message.entitiesById).forEach(([key, value]: [string, Entity]) => {
       SimpleWithSnakeCaseMap_EntitiesByIdEntry.encode({ key: key as any, value }, writer.uint32(10).fork()).join();
     });
     return writer;
@@ -2100,10 +2120,13 @@ export const SimpleWithSnakeCaseMap: MessageFns<SimpleWithSnakeCaseMap> = {
   fromJSON(object: any): SimpleWithSnakeCaseMap {
     return {
       entitiesById: isObject(object.entitiesById)
-        ? Object.entries(object.entitiesById).reduce<{ [key: number]: Entity }>((acc, [key, value]) => {
-          acc[globalThis.Number(key)] = Entity.fromJSON(value);
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.entitiesById) as [string, any][]).reduce(
+          (acc: { [key: number]: Entity }, [key, value]: [string, any]) => {
+            acc[globalThis.Number(key)] = Entity.fromJSON(value);
+            return acc;
+          },
+          {},
+        )
         : {},
     };
   },
@@ -2111,7 +2134,7 @@ export const SimpleWithSnakeCaseMap: MessageFns<SimpleWithSnakeCaseMap> = {
   toJSON(message: SimpleWithSnakeCaseMap): unknown {
     const obj: any = {};
     if (message.entitiesById) {
-      const entries = Object.entries(message.entitiesById);
+      const entries = globalThis.Object.entries(message.entitiesById) as [string, Entity][];
       if (entries.length > 0) {
         obj.entitiesById = {};
         entries.forEach(([k, v]) => {
@@ -2127,8 +2150,8 @@ export const SimpleWithSnakeCaseMap: MessageFns<SimpleWithSnakeCaseMap> = {
   },
   fromPartial<I extends Exact<DeepPartial<SimpleWithSnakeCaseMap>, I>>(object: I): SimpleWithSnakeCaseMap {
     const message = Object.create(createBaseSimpleWithSnakeCaseMap()) as SimpleWithSnakeCaseMap;
-    message.entitiesById = Object.entries(object.entitiesById ?? {}).reduce<{ [key: number]: Entity }>(
-      (acc, [key, value]) => {
+    message.entitiesById = (globalThis.Object.entries(object.entitiesById ?? {}) as [string, Entity][]).reduce(
+      (acc: { [key: number]: Entity }, [key, value]: [string, Entity]) => {
         if (value !== undefined) {
           acc[globalThis.Number(key)] = Entity.fromPartial(value);
         }
@@ -2232,7 +2255,7 @@ function createBaseSimpleWithMapOfEnums(): SimpleWithMapOfEnums {
 
 export const SimpleWithMapOfEnums: MessageFns<SimpleWithMapOfEnums> = {
   encode(message: SimpleWithMapOfEnums, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    Object.entries(message.enumsById).forEach(([key, value]) => {
+    globalThis.Object.entries(message.enumsById).forEach(([key, value]: [string, StateEnum]) => {
       SimpleWithMapOfEnums_EnumsByIdEntry.encode({ key: key as any, value }, writer.uint32(10).fork()).join();
     });
     return writer;
@@ -2268,10 +2291,13 @@ export const SimpleWithMapOfEnums: MessageFns<SimpleWithMapOfEnums> = {
   fromJSON(object: any): SimpleWithMapOfEnums {
     return {
       enumsById: isObject(object.enumsById)
-        ? Object.entries(object.enumsById).reduce<{ [key: number]: StateEnum }>((acc, [key, value]) => {
-          acc[globalThis.Number(key)] = stateEnumFromJSON(value);
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.enumsById) as [string, any][]).reduce(
+          (acc: { [key: number]: StateEnum }, [key, value]: [string, any]) => {
+            acc[globalThis.Number(key)] = stateEnumFromJSON(value);
+            return acc;
+          },
+          {},
+        )
         : {},
     };
   },
@@ -2279,7 +2305,7 @@ export const SimpleWithMapOfEnums: MessageFns<SimpleWithMapOfEnums> = {
   toJSON(message: SimpleWithMapOfEnums): unknown {
     const obj: any = {};
     if (message.enumsById) {
-      const entries = Object.entries(message.enumsById);
+      const entries = globalThis.Object.entries(message.enumsById) as [string, StateEnum][];
       if (entries.length > 0) {
         obj.enumsById = {};
         entries.forEach(([k, v]) => {
@@ -2295,8 +2321,8 @@ export const SimpleWithMapOfEnums: MessageFns<SimpleWithMapOfEnums> = {
   },
   fromPartial<I extends Exact<DeepPartial<SimpleWithMapOfEnums>, I>>(object: I): SimpleWithMapOfEnums {
     const message = Object.create(createBaseSimpleWithMapOfEnums()) as SimpleWithMapOfEnums;
-    message.enumsById = Object.entries(object.enumsById ?? {}).reduce<{ [key: number]: StateEnum }>(
-      (acc, [key, value]) => {
+    message.enumsById = (globalThis.Object.entries(object.enumsById ?? {}) as [string, StateEnum][]).reduce(
+      (acc: { [key: number]: StateEnum }, [key, value]: [string, StateEnum]) => {
         if (value !== undefined) {
           acc[globalThis.Number(key)] = value as StateEnum;
         }

--- a/integration/simple-snake/google/protobuf/struct.ts
+++ b/integration/simple-snake/google/protobuf/struct.ts
@@ -109,7 +109,7 @@ function createBaseStruct(): Struct {
 
 export const Struct: MessageFns<Struct> & StructWrapperFns = {
   encode(message: Struct, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    Object.entries(message.fields).forEach(([key, value]) => {
+    globalThis.Object.entries(message.fields).forEach(([key, value]: [string, any | undefined]) => {
       if (value !== undefined) {
         Struct_FieldsEntry.encode({ key: key as any, value }, writer.uint32(10).fork()).join();
       }
@@ -147,10 +147,13 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
   fromJSON(object: any): Struct {
     return {
       fields: isObject(object.fields)
-        ? Object.entries(object.fields).reduce<{ [key: string]: any | undefined }>((acc, [key, value]) => {
-          acc[key] = value as any | undefined;
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.fields) as [string, any][]).reduce(
+          (acc: { [key: string]: any | undefined }, [key, value]: [string, any]) => {
+            acc[key] = value as any | undefined;
+            return acc;
+          },
+          {},
+        )
         : {},
     };
   },
@@ -158,7 +161,7 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
   toJSON(message: Struct): unknown {
     const obj: any = {};
     if (message.fields) {
-      const entries = Object.entries(message.fields);
+      const entries = globalThis.Object.entries(message.fields) as [string, any | undefined][];
       if (entries.length > 0) {
         obj.fields = {};
         entries.forEach(([k, v]) => {
@@ -174,8 +177,8 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
   },
   fromPartial<I extends Exact<DeepPartial<Struct>, I>>(object: I): Struct {
     const message = createBaseStruct();
-    message.fields = Object.entries(object.fields ?? {}).reduce<{ [key: string]: any | undefined }>(
-      (acc, [key, value]) => {
+    message.fields = (globalThis.Object.entries(object.fields ?? {}) as [string, any | undefined][]).reduce(
+      (acc: { [key: string]: any | undefined }, [key, value]: [string, any | undefined]) => {
         if (value !== undefined) {
           acc[key] = value;
         }
@@ -190,7 +193,7 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
     const struct = createBaseStruct();
 
     if (object !== undefined) {
-      for (const key of Object.keys(object)) {
+      for (const key of globalThis.Object.keys(object)) {
         struct.fields[key] = object[key];
       }
     }
@@ -200,7 +203,7 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
   unwrap(message: Struct): { [key: string]: any } {
     const object: { [key: string]: any } = {};
     if (message.fields) {
-      for (const key of Object.keys(message.fields)) {
+      for (const key of globalThis.Object.keys(message.fields)) {
         object[key] = message.fields[key];
       }
     }

--- a/integration/simple-snake/simple.ts
+++ b/integration/simple-snake/simple.ts
@@ -1062,13 +1062,13 @@ function createBaseSimpleWithMap(): SimpleWithMap {
 
 export const SimpleWithMap: MessageFns<SimpleWithMap> = {
   encode(message: SimpleWithMap, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    Object.entries(message.entitiesById).forEach(([key, value]) => {
+    globalThis.Object.entries(message.entitiesById).forEach(([key, value]: [string, Entity]) => {
       SimpleWithMap_EntitiesByIdEntry.encode({ key: key as any, value }, writer.uint32(10).fork()).join();
     });
-    Object.entries(message.nameLookup).forEach(([key, value]) => {
+    globalThis.Object.entries(message.nameLookup).forEach(([key, value]: [string, string]) => {
       SimpleWithMap_NameLookupEntry.encode({ key: key as any, value }, writer.uint32(18).fork()).join();
     });
-    Object.entries(message.intLookup).forEach(([key, value]) => {
+    globalThis.Object.entries(message.intLookup).forEach(([key, value]: [string, number]) => {
       SimpleWithMap_IntLookupEntry.encode({ key: key as any, value }, writer.uint32(26).fork()).join();
     });
     return writer;
@@ -1126,22 +1126,31 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
   fromJSON(object: any): SimpleWithMap {
     return {
       entitiesById: isObject(object.entitiesById)
-        ? Object.entries(object.entitiesById).reduce<{ [key: number]: Entity }>((acc, [key, value]) => {
-          acc[globalThis.Number(key)] = Entity.fromJSON(value);
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.entitiesById) as [string, any][]).reduce(
+          (acc: { [key: number]: Entity }, [key, value]: [string, any]) => {
+            acc[globalThis.Number(key)] = Entity.fromJSON(value);
+            return acc;
+          },
+          {},
+        )
         : {},
       nameLookup: isObject(object.nameLookup)
-        ? Object.entries(object.nameLookup).reduce<{ [key: string]: string }>((acc, [key, value]) => {
-          acc[key] = String(value);
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.nameLookup) as [string, any][]).reduce(
+          (acc: { [key: string]: string }, [key, value]: [string, any]) => {
+            acc[key] = globalThis.String(value);
+            return acc;
+          },
+          {},
+        )
         : {},
       intLookup: isObject(object.intLookup)
-        ? Object.entries(object.intLookup).reduce<{ [key: number]: number }>((acc, [key, value]) => {
-          acc[globalThis.Number(key)] = Number(value);
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.intLookup) as [string, any][]).reduce(
+          (acc: { [key: number]: number }, [key, value]: [string, any]) => {
+            acc[globalThis.Number(key)] = globalThis.Number(value);
+            return acc;
+          },
+          {},
+        )
         : {},
     };
   },
@@ -1149,7 +1158,7 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
   toJSON(message: SimpleWithMap): unknown {
     const obj: any = {};
     if (message.entitiesById) {
-      const entries = Object.entries(message.entitiesById);
+      const entries = globalThis.Object.entries(message.entitiesById) as [string, Entity][];
       if (entries.length > 0) {
         obj.entitiesById = {};
         entries.forEach(([k, v]) => {
@@ -1158,7 +1167,7 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
       }
     }
     if (message.nameLookup) {
-      const entries = Object.entries(message.nameLookup);
+      const entries = globalThis.Object.entries(message.nameLookup) as [string, string][];
       if (entries.length > 0) {
         obj.nameLookup = {};
         entries.forEach(([k, v]) => {
@@ -1167,7 +1176,7 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
       }
     }
     if (message.intLookup) {
-      const entries = Object.entries(message.intLookup);
+      const entries = globalThis.Object.entries(message.intLookup) as [string, number][];
       if (entries.length > 0) {
         obj.intLookup = {};
         entries.forEach(([k, v]) => {
@@ -1183,8 +1192,8 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
   },
   fromPartial<I extends Exact<DeepPartial<SimpleWithMap>, I>>(object: I): SimpleWithMap {
     const message = createBaseSimpleWithMap();
-    message.entitiesById = Object.entries(object.entitiesById ?? {}).reduce<{ [key: number]: Entity }>(
-      (acc, [key, value]) => {
+    message.entitiesById = (globalThis.Object.entries(object.entitiesById ?? {}) as [string, Entity][]).reduce(
+      (acc: { [key: number]: Entity }, [key, value]: [string, Entity]) => {
         if (value !== undefined) {
           acc[globalThis.Number(key)] = Entity.fromPartial(value);
         }
@@ -1192,8 +1201,8 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
       },
       {},
     );
-    message.nameLookup = Object.entries(object.nameLookup ?? {}).reduce<{ [key: string]: string }>(
-      (acc, [key, value]) => {
+    message.nameLookup = (globalThis.Object.entries(object.nameLookup ?? {}) as [string, string][]).reduce(
+      (acc: { [key: string]: string }, [key, value]: [string, string]) => {
         if (value !== undefined) {
           acc[key] = globalThis.String(value);
         }
@@ -1201,8 +1210,8 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
       },
       {},
     );
-    message.intLookup = Object.entries(object.intLookup ?? {}).reduce<{ [key: number]: number }>(
-      (acc, [key, value]) => {
+    message.intLookup = (globalThis.Object.entries(object.intLookup ?? {}) as [string, number][]).reduce(
+      (acc: { [key: number]: number }, [key, value]: [string, number]) => {
         if (value !== undefined) {
           acc[globalThis.Number(key)] = globalThis.Number(value);
         }
@@ -1454,7 +1463,7 @@ function createBaseSimpleWithSnakeCaseMap(): SimpleWithSnakeCaseMap {
 
 export const SimpleWithSnakeCaseMap: MessageFns<SimpleWithSnakeCaseMap> = {
   encode(message: SimpleWithSnakeCaseMap, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    Object.entries(message.entities_by_id).forEach(([key, value]) => {
+    globalThis.Object.entries(message.entities_by_id).forEach(([key, value]: [string, Entity]) => {
       SimpleWithSnakeCaseMap_EntitiesByIdEntry.encode({ key: key as any, value }, writer.uint32(10).fork()).join();
     });
     return writer;
@@ -1490,10 +1499,13 @@ export const SimpleWithSnakeCaseMap: MessageFns<SimpleWithSnakeCaseMap> = {
   fromJSON(object: any): SimpleWithSnakeCaseMap {
     return {
       entities_by_id: isObject(object.entities_by_id)
-        ? Object.entries(object.entities_by_id).reduce<{ [key: number]: Entity }>((acc, [key, value]) => {
-          acc[globalThis.Number(key)] = Entity.fromJSON(value);
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.entities_by_id) as [string, any][]).reduce(
+          (acc: { [key: number]: Entity }, [key, value]: [string, any]) => {
+            acc[globalThis.Number(key)] = Entity.fromJSON(value);
+            return acc;
+          },
+          {},
+        )
         : {},
     };
   },
@@ -1501,7 +1513,7 @@ export const SimpleWithSnakeCaseMap: MessageFns<SimpleWithSnakeCaseMap> = {
   toJSON(message: SimpleWithSnakeCaseMap): unknown {
     const obj: any = {};
     if (message.entities_by_id) {
-      const entries = Object.entries(message.entities_by_id);
+      const entries = globalThis.Object.entries(message.entities_by_id) as [string, Entity][];
       if (entries.length > 0) {
         obj.entities_by_id = {};
         entries.forEach(([k, v]) => {
@@ -1517,8 +1529,8 @@ export const SimpleWithSnakeCaseMap: MessageFns<SimpleWithSnakeCaseMap> = {
   },
   fromPartial<I extends Exact<DeepPartial<SimpleWithSnakeCaseMap>, I>>(object: I): SimpleWithSnakeCaseMap {
     const message = createBaseSimpleWithSnakeCaseMap();
-    message.entities_by_id = Object.entries(object.entities_by_id ?? {}).reduce<{ [key: number]: Entity }>(
-      (acc, [key, value]) => {
+    message.entities_by_id = (globalThis.Object.entries(object.entities_by_id ?? {}) as [string, Entity][]).reduce(
+      (acc: { [key: number]: Entity }, [key, value]: [string, Entity]) => {
         if (value !== undefined) {
           acc[globalThis.Number(key)] = Entity.fromPartial(value);
         }

--- a/integration/simple-string-enums/google/protobuf/struct.ts
+++ b/integration/simple-string-enums/google/protobuf/struct.ts
@@ -119,7 +119,7 @@ function createBaseStruct(): Struct {
 
 export const Struct: MessageFns<Struct> & StructWrapperFns = {
   encode(message: Struct, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    Object.entries(message.fields).forEach(([key, value]) => {
+    globalThis.Object.entries(message.fields).forEach(([key, value]: [string, any | undefined]) => {
       if (value !== undefined) {
         Struct_FieldsEntry.encode({ key: key as any, value }, writer.uint32(10).fork()).join();
       }
@@ -157,10 +157,13 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
   fromJSON(object: any): Struct {
     return {
       fields: isObject(object.fields)
-        ? Object.entries(object.fields).reduce<{ [key: string]: any | undefined }>((acc, [key, value]) => {
-          acc[key] = value as any | undefined;
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.fields) as [string, any][]).reduce(
+          (acc: { [key: string]: any | undefined }, [key, value]: [string, any]) => {
+            acc[key] = value as any | undefined;
+            return acc;
+          },
+          {},
+        )
         : {},
     };
   },
@@ -168,7 +171,7 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
   toJSON(message: Struct): unknown {
     const obj: any = {};
     if (message.fields) {
-      const entries = Object.entries(message.fields);
+      const entries = globalThis.Object.entries(message.fields) as [string, any | undefined][];
       if (entries.length > 0) {
         obj.fields = {};
         entries.forEach(([k, v]) => {
@@ -184,8 +187,8 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
   },
   fromPartial<I extends Exact<DeepPartial<Struct>, I>>(object: I): Struct {
     const message = createBaseStruct();
-    message.fields = Object.entries(object.fields ?? {}).reduce<{ [key: string]: any | undefined }>(
-      (acc, [key, value]) => {
+    message.fields = (globalThis.Object.entries(object.fields ?? {}) as [string, any | undefined][]).reduce(
+      (acc: { [key: string]: any | undefined }, [key, value]: [string, any | undefined]) => {
         if (value !== undefined) {
           acc[key] = value;
         }
@@ -200,7 +203,7 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
     const struct = createBaseStruct();
 
     if (object !== undefined) {
-      for (const key of Object.keys(object)) {
+      for (const key of globalThis.Object.keys(object)) {
         struct.fields[key] = object[key];
       }
     }
@@ -210,7 +213,7 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
   unwrap(message: Struct): { [key: string]: any } {
     const object: { [key: string]: any } = {};
     if (message.fields) {
-      for (const key of Object.keys(message.fields)) {
+      for (const key of globalThis.Object.keys(message.fields)) {
         object[key] = message.fields[key];
       }
     }

--- a/integration/simple-string-enums/simple.ts
+++ b/integration/simple-string-enums/simple.ts
@@ -93,7 +93,7 @@ export const Simple: MessageFns<Simple> = {
     if (message.nullValue !== NullValue.NULL_VALUE) {
       writer.uint32(48).int32(nullValueToNumber(message.nullValue));
     }
-    Object.entries(message.stateMap).forEach(([key, value]) => {
+    globalThis.Object.entries(message.stateMap).forEach(([key, value]: [string, StateEnum]) => {
       Simple_StateMapEntry.encode({ key: key as any, value }, writer.uint32(58).fork()).join();
     });
     return writer;
@@ -175,10 +175,13 @@ export const Simple: MessageFns<Simple> = {
       states: globalThis.Array.isArray(object?.states) ? object.states.map((e: any) => stateEnumFromJSON(e)) : [],
       nullValue: isSet(object.nullValue) ? nullValueFromJSON(object.nullValue) : NullValue.NULL_VALUE,
       stateMap: isObject(object.stateMap)
-        ? Object.entries(object.stateMap).reduce<{ [key: string]: StateEnum }>((acc, [key, value]) => {
-          acc[key] = stateEnumFromJSON(value);
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.stateMap) as [string, any][]).reduce(
+          (acc: { [key: string]: StateEnum }, [key, value]: [string, any]) => {
+            acc[key] = stateEnumFromJSON(value);
+            return acc;
+          },
+          {},
+        )
         : {},
     };
   },
@@ -198,7 +201,7 @@ export const Simple: MessageFns<Simple> = {
       obj.nullValue = nullValueToJSON(message.nullValue);
     }
     if (message.stateMap) {
-      const entries = Object.entries(message.stateMap);
+      const entries = globalThis.Object.entries(message.stateMap) as [string, StateEnum][];
       if (entries.length > 0) {
         obj.stateMap = {};
         entries.forEach(([k, v]) => {
@@ -218,8 +221,8 @@ export const Simple: MessageFns<Simple> = {
     message.state = object.state ?? StateEnum.UNKNOWN;
     message.states = object.states?.map((e) => e) || [];
     message.nullValue = object.nullValue ?? NullValue.NULL_VALUE;
-    message.stateMap = Object.entries(object.stateMap ?? {}).reduce<{ [key: string]: StateEnum }>(
-      (acc, [key, value]) => {
+    message.stateMap = (globalThis.Object.entries(object.stateMap ?? {}) as [string, StateEnum][]).reduce(
+      (acc: { [key: string]: StateEnum }, [key, value]: [string, StateEnum]) => {
         if (value !== undefined) {
           acc[key] = value as StateEnum;
         }

--- a/integration/simple-unrecognized-enum/simple.ts
+++ b/integration/simple-unrecognized-enum/simple.ts
@@ -1045,13 +1045,13 @@ function createBaseSimpleWithMap(): SimpleWithMap {
 
 export const SimpleWithMap: MessageFns<SimpleWithMap> = {
   encode(message: SimpleWithMap, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    Object.entries(message.entitiesById).forEach(([key, value]) => {
+    globalThis.Object.entries(message.entitiesById).forEach(([key, value]: [string, Entity]) => {
       SimpleWithMap_EntitiesByIdEntry.encode({ key: key as any, value }, writer.uint32(10).fork()).join();
     });
-    Object.entries(message.nameLookup).forEach(([key, value]) => {
+    globalThis.Object.entries(message.nameLookup).forEach(([key, value]: [string, string]) => {
       SimpleWithMap_NameLookupEntry.encode({ key: key as any, value }, writer.uint32(18).fork()).join();
     });
-    Object.entries(message.intLookup).forEach(([key, value]) => {
+    globalThis.Object.entries(message.intLookup).forEach(([key, value]: [string, number]) => {
       SimpleWithMap_IntLookupEntry.encode({ key: key as any, value }, writer.uint32(26).fork()).join();
     });
     return writer;
@@ -1109,22 +1109,31 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
   fromJSON(object: any): SimpleWithMap {
     return {
       entitiesById: isObject(object.entitiesById)
-        ? Object.entries(object.entitiesById).reduce<{ [key: number]: Entity }>((acc, [key, value]) => {
-          acc[globalThis.Number(key)] = Entity.fromJSON(value);
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.entitiesById) as [string, any][]).reduce(
+          (acc: { [key: number]: Entity }, [key, value]: [string, any]) => {
+            acc[globalThis.Number(key)] = Entity.fromJSON(value);
+            return acc;
+          },
+          {},
+        )
         : {},
       nameLookup: isObject(object.nameLookup)
-        ? Object.entries(object.nameLookup).reduce<{ [key: string]: string }>((acc, [key, value]) => {
-          acc[key] = String(value);
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.nameLookup) as [string, any][]).reduce(
+          (acc: { [key: string]: string }, [key, value]: [string, any]) => {
+            acc[key] = globalThis.String(value);
+            return acc;
+          },
+          {},
+        )
         : {},
       intLookup: isObject(object.intLookup)
-        ? Object.entries(object.intLookup).reduce<{ [key: number]: number }>((acc, [key, value]) => {
-          acc[globalThis.Number(key)] = Number(value);
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.intLookup) as [string, any][]).reduce(
+          (acc: { [key: number]: number }, [key, value]: [string, any]) => {
+            acc[globalThis.Number(key)] = globalThis.Number(value);
+            return acc;
+          },
+          {},
+        )
         : {},
     };
   },
@@ -1132,7 +1141,7 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
   toJSON(message: SimpleWithMap): unknown {
     const obj: any = {};
     if (message.entitiesById) {
-      const entries = Object.entries(message.entitiesById);
+      const entries = globalThis.Object.entries(message.entitiesById) as [string, Entity][];
       if (entries.length > 0) {
         obj.entitiesById = {};
         entries.forEach(([k, v]) => {
@@ -1141,7 +1150,7 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
       }
     }
     if (message.nameLookup) {
-      const entries = Object.entries(message.nameLookup);
+      const entries = globalThis.Object.entries(message.nameLookup) as [string, string][];
       if (entries.length > 0) {
         obj.nameLookup = {};
         entries.forEach(([k, v]) => {
@@ -1150,7 +1159,7 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
       }
     }
     if (message.intLookup) {
-      const entries = Object.entries(message.intLookup);
+      const entries = globalThis.Object.entries(message.intLookup) as [string, number][];
       if (entries.length > 0) {
         obj.intLookup = {};
         entries.forEach(([k, v]) => {
@@ -1166,8 +1175,8 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
   },
   fromPartial<I extends Exact<DeepPartial<SimpleWithMap>, I>>(object: I): SimpleWithMap {
     const message = createBaseSimpleWithMap();
-    message.entitiesById = Object.entries(object.entitiesById ?? {}).reduce<{ [key: number]: Entity }>(
-      (acc, [key, value]) => {
+    message.entitiesById = (globalThis.Object.entries(object.entitiesById ?? {}) as [string, Entity][]).reduce(
+      (acc: { [key: number]: Entity }, [key, value]: [string, Entity]) => {
         if (value !== undefined) {
           acc[globalThis.Number(key)] = Entity.fromPartial(value);
         }
@@ -1175,8 +1184,8 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
       },
       {},
     );
-    message.nameLookup = Object.entries(object.nameLookup ?? {}).reduce<{ [key: string]: string }>(
-      (acc, [key, value]) => {
+    message.nameLookup = (globalThis.Object.entries(object.nameLookup ?? {}) as [string, string][]).reduce(
+      (acc: { [key: string]: string }, [key, value]: [string, string]) => {
         if (value !== undefined) {
           acc[key] = globalThis.String(value);
         }
@@ -1184,8 +1193,8 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
       },
       {},
     );
-    message.intLookup = Object.entries(object.intLookup ?? {}).reduce<{ [key: number]: number }>(
-      (acc, [key, value]) => {
+    message.intLookup = (globalThis.Object.entries(object.intLookup ?? {}) as [string, number][]).reduce(
+      (acc: { [key: number]: number }, [key, value]: [string, number]) => {
         if (value !== undefined) {
           acc[globalThis.Number(key)] = globalThis.Number(value);
         }
@@ -1437,7 +1446,7 @@ function createBaseSimpleWithSnakeCaseMap(): SimpleWithSnakeCaseMap {
 
 export const SimpleWithSnakeCaseMap: MessageFns<SimpleWithSnakeCaseMap> = {
   encode(message: SimpleWithSnakeCaseMap, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    Object.entries(message.entitiesById).forEach(([key, value]) => {
+    globalThis.Object.entries(message.entitiesById).forEach(([key, value]: [string, Entity]) => {
       SimpleWithSnakeCaseMap_EntitiesByIdEntry.encode({ key: key as any, value }, writer.uint32(10).fork()).join();
     });
     return writer;
@@ -1473,10 +1482,13 @@ export const SimpleWithSnakeCaseMap: MessageFns<SimpleWithSnakeCaseMap> = {
   fromJSON(object: any): SimpleWithSnakeCaseMap {
     return {
       entitiesById: isObject(object.entitiesById)
-        ? Object.entries(object.entitiesById).reduce<{ [key: number]: Entity }>((acc, [key, value]) => {
-          acc[globalThis.Number(key)] = Entity.fromJSON(value);
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.entitiesById) as [string, any][]).reduce(
+          (acc: { [key: number]: Entity }, [key, value]: [string, any]) => {
+            acc[globalThis.Number(key)] = Entity.fromJSON(value);
+            return acc;
+          },
+          {},
+        )
         : {},
     };
   },
@@ -1484,7 +1496,7 @@ export const SimpleWithSnakeCaseMap: MessageFns<SimpleWithSnakeCaseMap> = {
   toJSON(message: SimpleWithSnakeCaseMap): unknown {
     const obj: any = {};
     if (message.entitiesById) {
-      const entries = Object.entries(message.entitiesById);
+      const entries = globalThis.Object.entries(message.entitiesById) as [string, Entity][];
       if (entries.length > 0) {
         obj.entitiesById = {};
         entries.forEach(([k, v]) => {
@@ -1500,8 +1512,8 @@ export const SimpleWithSnakeCaseMap: MessageFns<SimpleWithSnakeCaseMap> = {
   },
   fromPartial<I extends Exact<DeepPartial<SimpleWithSnakeCaseMap>, I>>(object: I): SimpleWithSnakeCaseMap {
     const message = createBaseSimpleWithSnakeCaseMap();
-    message.entitiesById = Object.entries(object.entitiesById ?? {}).reduce<{ [key: number]: Entity }>(
-      (acc, [key, value]) => {
+    message.entitiesById = (globalThis.Object.entries(object.entitiesById ?? {}) as [string, Entity][]).reduce(
+      (acc: { [key: number]: Entity }, [key, value]: [string, Entity]) => {
         if (value !== undefined) {
           acc[globalThis.Number(key)] = Entity.fromPartial(value);
         }

--- a/integration/simple/simple.ts
+++ b/integration/simple/simple.ts
@@ -1221,27 +1221,27 @@ function createBaseSimpleWithMap(): SimpleWithMap {
 
 export const SimpleWithMap: MessageFns<SimpleWithMap> = {
   encode(message: SimpleWithMap, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    Object.entries(message.entitiesById).forEach(([key, value]) => {
+    globalThis.Object.entries(message.entitiesById).forEach(([key, value]: [string, Entity]) => {
       SimpleWithMap_EntitiesByIdEntry.encode({ key: key as any, value }, writer.uint32(10).fork()).join();
     });
-    Object.entries(message.nameLookup).forEach(([key, value]) => {
+    globalThis.Object.entries(message.nameLookup).forEach(([key, value]: [string, string]) => {
       SimpleWithMap_NameLookupEntry.encode({ key: key as any, value }, writer.uint32(18).fork()).join();
     });
-    Object.entries(message.intLookup).forEach(([key, value]) => {
+    globalThis.Object.entries(message.intLookup).forEach(([key, value]: [string, number]) => {
       SimpleWithMap_IntLookupEntry.encode({ key: key as any, value }, writer.uint32(26).fork()).join();
     });
-    Object.entries(message.mapOfTimestamps).forEach(([key, value]) => {
+    globalThis.Object.entries(message.mapOfTimestamps).forEach(([key, value]: [string, Date]) => {
       SimpleWithMap_MapOfTimestampsEntry.encode({ key: key as any, value }, writer.uint32(34).fork()).join();
     });
-    Object.entries(message.mapOfBytes).forEach(([key, value]) => {
+    globalThis.Object.entries(message.mapOfBytes).forEach(([key, value]: [string, Uint8Array]) => {
       SimpleWithMap_MapOfBytesEntry.encode({ key: key as any, value }, writer.uint32(42).fork()).join();
     });
-    Object.entries(message.mapOfStringValues).forEach(([key, value]) => {
+    globalThis.Object.entries(message.mapOfStringValues).forEach(([key, value]: [string, string | undefined]) => {
       if (value !== undefined) {
         SimpleWithMap_MapOfStringValuesEntry.encode({ key: key as any, value }, writer.uint32(50).fork()).join();
       }
     });
-    Object.entries(message.longLookup).forEach(([key, value]) => {
+    globalThis.Object.entries(message.longLookup).forEach(([key, value]: [string, number]) => {
       SimpleWithMap_LongLookupEntry.encode({ key: key as any, value }, writer.uint32(58).fork()).join();
     });
     message.boolLookup.forEach((value, key) => {
@@ -1357,38 +1357,53 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
   fromJSON(object: any): SimpleWithMap {
     return {
       entitiesById: isObject(object.entitiesById)
-        ? Object.entries(object.entitiesById).reduce<{ [key: number]: Entity }>((acc, [key, value]) => {
-          acc[globalThis.Number(key)] = Entity.fromJSON(value);
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.entitiesById) as [string, any][]).reduce(
+          (acc: { [key: number]: Entity }, [key, value]: [string, any]) => {
+            acc[globalThis.Number(key)] = Entity.fromJSON(value);
+            return acc;
+          },
+          {},
+        )
         : {},
       nameLookup: isObject(object.nameLookup)
-        ? Object.entries(object.nameLookup).reduce<{ [key: string]: string }>((acc, [key, value]) => {
-          acc[key] = String(value);
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.nameLookup) as [string, any][]).reduce(
+          (acc: { [key: string]: string }, [key, value]: [string, any]) => {
+            acc[key] = globalThis.String(value);
+            return acc;
+          },
+          {},
+        )
         : {},
       intLookup: isObject(object.intLookup)
-        ? Object.entries(object.intLookup).reduce<{ [key: number]: number }>((acc, [key, value]) => {
-          acc[globalThis.Number(key)] = Number(value);
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.intLookup) as [string, any][]).reduce(
+          (acc: { [key: number]: number }, [key, value]: [string, any]) => {
+            acc[globalThis.Number(key)] = globalThis.Number(value);
+            return acc;
+          },
+          {},
+        )
         : {},
       mapOfTimestamps: isObject(object.mapOfTimestamps)
-        ? Object.entries(object.mapOfTimestamps).reduce<{ [key: string]: Date }>((acc, [key, value]) => {
-          acc[key] = fromJsonTimestamp(value);
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.mapOfTimestamps) as [string, any][]).reduce(
+          (acc: { [key: string]: Date }, [key, value]: [string, any]) => {
+            acc[key] = fromJsonTimestamp(value);
+            return acc;
+          },
+          {},
+        )
         : {},
       mapOfBytes: isObject(object.mapOfBytes)
-        ? Object.entries(object.mapOfBytes).reduce<{ [key: string]: Uint8Array }>((acc, [key, value]) => {
-          acc[key] = bytesFromBase64(value as string);
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.mapOfBytes) as [string, any][]).reduce(
+          (acc: { [key: string]: Uint8Array }, [key, value]: [string, any]) => {
+            acc[key] = bytesFromBase64(value as string);
+            return acc;
+          },
+          {},
+        )
         : {},
       mapOfStringValues: isObject(object.mapOfStringValues)
-        ? Object.entries(object.mapOfStringValues).reduce<{ [key: string]: string | undefined }>(
-          (acc, [key, value]) => {
+        ? (globalThis.Object.entries(object.mapOfStringValues) as [string, any][]).reduce(
+          (acc: { [key: string]: string | undefined }, [key, value]: [string, any]) => {
             acc[key] = value as string | undefined;
             return acc;
           },
@@ -1396,16 +1411,22 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
         )
         : {},
       longLookup: isObject(object.longLookup)
-        ? Object.entries(object.longLookup).reduce<{ [key: number]: number }>((acc, [key, value]) => {
-          acc[globalThis.Number(key)] = Number(value);
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.longLookup) as [string, any][]).reduce(
+          (acc: { [key: number]: number }, [key, value]: [string, any]) => {
+            acc[globalThis.Number(key)] = globalThis.Number(value);
+            return acc;
+          },
+          {},
+        )
         : {},
       boolLookup: isObject(object.boolLookup)
-        ? Object.entries(object.boolLookup).reduce<Map<boolean, number>>((acc, [key, value]) => {
-          acc.set(globalThis.Boolean(key), Number(value));
-          return acc;
-        }, new Map())
+        ? (globalThis.Object.entries(object.boolLookup) as [string, any][]).reduce(
+          (acc: Map<boolean, number>, [key, value]: [string, any]) => {
+            acc.set(globalThis.Boolean(key), globalThis.Number(value));
+            return acc;
+          },
+          new Map(),
+        )
         : new Map(),
     };
   },
@@ -1413,7 +1434,7 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
   toJSON(message: SimpleWithMap): unknown {
     const obj: any = {};
     if (message.entitiesById) {
-      const entries = Object.entries(message.entitiesById);
+      const entries = globalThis.Object.entries(message.entitiesById) as [string, Entity][];
       if (entries.length > 0) {
         obj.entitiesById = {};
         entries.forEach(([k, v]) => {
@@ -1422,7 +1443,7 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
       }
     }
     if (message.nameLookup) {
-      const entries = Object.entries(message.nameLookup);
+      const entries = globalThis.Object.entries(message.nameLookup) as [string, string][];
       if (entries.length > 0) {
         obj.nameLookup = {};
         entries.forEach(([k, v]) => {
@@ -1431,7 +1452,7 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
       }
     }
     if (message.intLookup) {
-      const entries = Object.entries(message.intLookup);
+      const entries = globalThis.Object.entries(message.intLookup) as [string, number][];
       if (entries.length > 0) {
         obj.intLookup = {};
         entries.forEach(([k, v]) => {
@@ -1440,7 +1461,7 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
       }
     }
     if (message.mapOfTimestamps) {
-      const entries = Object.entries(message.mapOfTimestamps);
+      const entries = globalThis.Object.entries(message.mapOfTimestamps) as [string, Date][];
       if (entries.length > 0) {
         obj.mapOfTimestamps = {};
         entries.forEach(([k, v]) => {
@@ -1449,7 +1470,7 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
       }
     }
     if (message.mapOfBytes) {
-      const entries = Object.entries(message.mapOfBytes);
+      const entries = globalThis.Object.entries(message.mapOfBytes) as [string, Uint8Array][];
       if (entries.length > 0) {
         obj.mapOfBytes = {};
         entries.forEach(([k, v]) => {
@@ -1458,7 +1479,7 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
       }
     }
     if (message.mapOfStringValues) {
-      const entries = Object.entries(message.mapOfStringValues);
+      const entries = globalThis.Object.entries(message.mapOfStringValues) as [string, string | undefined][];
       if (entries.length > 0) {
         obj.mapOfStringValues = {};
         entries.forEach(([k, v]) => {
@@ -1467,7 +1488,7 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
       }
     }
     if (message.longLookup) {
-      const entries = Object.entries(message.longLookup);
+      const entries = globalThis.Object.entries(message.longLookup) as [string, number][];
       if (entries.length > 0) {
         obj.longLookup = {};
         entries.forEach(([k, v]) => {
@@ -1489,8 +1510,8 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
   },
   fromPartial<I extends Exact<DeepPartial<SimpleWithMap>, I>>(object: I): SimpleWithMap {
     const message = createBaseSimpleWithMap();
-    message.entitiesById = Object.entries(object.entitiesById ?? {}).reduce<{ [key: number]: Entity }>(
-      (acc, [key, value]) => {
+    message.entitiesById = (globalThis.Object.entries(object.entitiesById ?? {}) as [string, Entity][]).reduce(
+      (acc: { [key: number]: Entity }, [key, value]: [string, Entity]) => {
         if (value !== undefined) {
           acc[globalThis.Number(key)] = Entity.fromPartial(value);
         }
@@ -1498,8 +1519,8 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
       },
       {},
     );
-    message.nameLookup = Object.entries(object.nameLookup ?? {}).reduce<{ [key: string]: string }>(
-      (acc, [key, value]) => {
+    message.nameLookup = (globalThis.Object.entries(object.nameLookup ?? {}) as [string, string][]).reduce(
+      (acc: { [key: string]: string }, [key, value]: [string, string]) => {
         if (value !== undefined) {
           acc[key] = globalThis.String(value);
         }
@@ -1507,8 +1528,8 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
       },
       {},
     );
-    message.intLookup = Object.entries(object.intLookup ?? {}).reduce<{ [key: number]: number }>(
-      (acc, [key, value]) => {
+    message.intLookup = (globalThis.Object.entries(object.intLookup ?? {}) as [string, number][]).reduce(
+      (acc: { [key: number]: number }, [key, value]: [string, number]) => {
         if (value !== undefined) {
           acc[globalThis.Number(key)] = globalThis.Number(value);
         }
@@ -1516,8 +1537,8 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
       },
       {},
     );
-    message.mapOfTimestamps = Object.entries(object.mapOfTimestamps ?? {}).reduce<{ [key: string]: Date }>(
-      (acc, [key, value]) => {
+    message.mapOfTimestamps = (globalThis.Object.entries(object.mapOfTimestamps ?? {}) as [string, Date][]).reduce(
+      (acc: { [key: string]: Date }, [key, value]: [string, Date]) => {
         if (value !== undefined) {
           acc[key] = value;
         }
@@ -1525,8 +1546,8 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
       },
       {},
     );
-    message.mapOfBytes = Object.entries(object.mapOfBytes ?? {}).reduce<{ [key: string]: Uint8Array }>(
-      (acc, [key, value]) => {
+    message.mapOfBytes = (globalThis.Object.entries(object.mapOfBytes ?? {}) as [string, Uint8Array][]).reduce(
+      (acc: { [key: string]: Uint8Array }, [key, value]: [string, Uint8Array]) => {
         if (value !== undefined) {
           acc[key] = value;
         }
@@ -1534,16 +1555,18 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
       },
       {},
     );
-    message.mapOfStringValues = Object.entries(object.mapOfStringValues ?? {}).reduce<
-      { [key: string]: string | undefined }
-    >((acc, [key, value]) => {
-      if (value !== undefined) {
-        acc[key] = value;
-      }
-      return acc;
-    }, {});
-    message.longLookup = Object.entries(object.longLookup ?? {}).reduce<{ [key: number]: number }>(
-      (acc, [key, value]) => {
+    message.mapOfStringValues =
+      (globalThis.Object.entries(object.mapOfStringValues ?? {}) as [string, string | undefined][]).reduce(
+        (acc: { [key: string]: string | undefined }, [key, value]: [string, string | undefined]) => {
+          if (value !== undefined) {
+            acc[key] = value;
+          }
+          return acc;
+        },
+        {},
+      );
+    message.longLookup = (globalThis.Object.entries(object.longLookup ?? {}) as [string, number][]).reduce(
+      (acc: { [key: number]: number }, [key, value]: [string, number]) => {
         if (value !== undefined) {
           acc[globalThis.Number(key)] = globalThis.Number(value);
         }
@@ -2198,7 +2221,7 @@ function createBaseSimpleWithSnakeCaseMap(): SimpleWithSnakeCaseMap {
 
 export const SimpleWithSnakeCaseMap: MessageFns<SimpleWithSnakeCaseMap> = {
   encode(message: SimpleWithSnakeCaseMap, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    Object.entries(message.entitiesById).forEach(([key, value]) => {
+    globalThis.Object.entries(message.entitiesById).forEach(([key, value]: [string, Entity]) => {
       SimpleWithSnakeCaseMap_EntitiesByIdEntry.encode({ key: key as any, value }, writer.uint32(10).fork()).join();
     });
     return writer;
@@ -2234,10 +2257,13 @@ export const SimpleWithSnakeCaseMap: MessageFns<SimpleWithSnakeCaseMap> = {
   fromJSON(object: any): SimpleWithSnakeCaseMap {
     return {
       entitiesById: isObject(object.entitiesById)
-        ? Object.entries(object.entitiesById).reduce<{ [key: number]: Entity }>((acc, [key, value]) => {
-          acc[globalThis.Number(key)] = Entity.fromJSON(value);
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.entitiesById) as [string, any][]).reduce(
+          (acc: { [key: number]: Entity }, [key, value]: [string, any]) => {
+            acc[globalThis.Number(key)] = Entity.fromJSON(value);
+            return acc;
+          },
+          {},
+        )
         : {},
     };
   },
@@ -2245,7 +2271,7 @@ export const SimpleWithSnakeCaseMap: MessageFns<SimpleWithSnakeCaseMap> = {
   toJSON(message: SimpleWithSnakeCaseMap): unknown {
     const obj: any = {};
     if (message.entitiesById) {
-      const entries = Object.entries(message.entitiesById);
+      const entries = globalThis.Object.entries(message.entitiesById) as [string, Entity][];
       if (entries.length > 0) {
         obj.entitiesById = {};
         entries.forEach(([k, v]) => {
@@ -2261,8 +2287,8 @@ export const SimpleWithSnakeCaseMap: MessageFns<SimpleWithSnakeCaseMap> = {
   },
   fromPartial<I extends Exact<DeepPartial<SimpleWithSnakeCaseMap>, I>>(object: I): SimpleWithSnakeCaseMap {
     const message = createBaseSimpleWithSnakeCaseMap();
-    message.entitiesById = Object.entries(object.entitiesById ?? {}).reduce<{ [key: number]: Entity }>(
-      (acc, [key, value]) => {
+    message.entitiesById = (globalThis.Object.entries(object.entitiesById ?? {}) as [string, Entity][]).reduce(
+      (acc: { [key: number]: Entity }, [key, value]: [string, Entity]) => {
         if (value !== undefined) {
           acc[globalThis.Number(key)] = Entity.fromPartial(value);
         }
@@ -2362,7 +2388,7 @@ function createBaseSimpleWithMapOfEnums(): SimpleWithMapOfEnums {
 
 export const SimpleWithMapOfEnums: MessageFns<SimpleWithMapOfEnums> = {
   encode(message: SimpleWithMapOfEnums, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    Object.entries(message.enumsById).forEach(([key, value]) => {
+    globalThis.Object.entries(message.enumsById).forEach(([key, value]: [string, StateEnum]) => {
       SimpleWithMapOfEnums_EnumsByIdEntry.encode({ key: key as any, value }, writer.uint32(10).fork()).join();
     });
     return writer;
@@ -2398,10 +2424,13 @@ export const SimpleWithMapOfEnums: MessageFns<SimpleWithMapOfEnums> = {
   fromJSON(object: any): SimpleWithMapOfEnums {
     return {
       enumsById: isObject(object.enumsById)
-        ? Object.entries(object.enumsById).reduce<{ [key: number]: StateEnum }>((acc, [key, value]) => {
-          acc[globalThis.Number(key)] = stateEnumFromJSON(value);
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.enumsById) as [string, any][]).reduce(
+          (acc: { [key: number]: StateEnum }, [key, value]: [string, any]) => {
+            acc[globalThis.Number(key)] = stateEnumFromJSON(value);
+            return acc;
+          },
+          {},
+        )
         : {},
     };
   },
@@ -2409,7 +2438,7 @@ export const SimpleWithMapOfEnums: MessageFns<SimpleWithMapOfEnums> = {
   toJSON(message: SimpleWithMapOfEnums): unknown {
     const obj: any = {};
     if (message.enumsById) {
-      const entries = Object.entries(message.enumsById);
+      const entries = globalThis.Object.entries(message.enumsById) as [string, StateEnum][];
       if (entries.length > 0) {
         obj.enumsById = {};
         entries.forEach(([k, v]) => {
@@ -2425,8 +2454,8 @@ export const SimpleWithMapOfEnums: MessageFns<SimpleWithMapOfEnums> = {
   },
   fromPartial<I extends Exact<DeepPartial<SimpleWithMapOfEnums>, I>>(object: I): SimpleWithMapOfEnums {
     const message = createBaseSimpleWithMapOfEnums();
-    message.enumsById = Object.entries(object.enumsById ?? {}).reduce<{ [key: number]: StateEnum }>(
-      (acc, [key, value]) => {
+    message.enumsById = (globalThis.Object.entries(object.enumsById ?? {}) as [string, StateEnum][]).reduce(
+      (acc: { [key: number]: StateEnum }, [key, value]: [string, StateEnum]) => {
         if (value !== undefined) {
           acc[globalThis.Number(key)] = value as StateEnum;
         }

--- a/integration/static-only-type-registry/google/protobuf/struct.ts
+++ b/integration/static-only-type-registry/google/protobuf/struct.ts
@@ -112,7 +112,7 @@ export const Struct: MessageFns<Struct, "google.protobuf.Struct"> & StructWrappe
   $type: "google.protobuf.Struct" as const,
 
   encode(message: Struct, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    Object.entries(message.fields).forEach(([key, value]) => {
+    globalThis.Object.entries(message.fields).forEach(([key, value]: [string, any | undefined]) => {
       if (value !== undefined) {
         Struct_FieldsEntry.encode({ key: key as any, value }, writer.uint32(10).fork()).join();
       }
@@ -150,10 +150,13 @@ export const Struct: MessageFns<Struct, "google.protobuf.Struct"> & StructWrappe
   fromJSON(object: any): Struct {
     return {
       fields: isObject(object.fields)
-        ? Object.entries(object.fields).reduce<{ [key: string]: any | undefined }>((acc, [key, value]) => {
-          acc[key] = value as any | undefined;
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.fields) as [string, any][]).reduce(
+          (acc: { [key: string]: any | undefined }, [key, value]: [string, any]) => {
+            acc[key] = value as any | undefined;
+            return acc;
+          },
+          {},
+        )
         : {},
     };
   },
@@ -161,7 +164,7 @@ export const Struct: MessageFns<Struct, "google.protobuf.Struct"> & StructWrappe
   toJSON(message: Struct): unknown {
     const obj: any = {};
     if (message.fields) {
-      const entries = Object.entries(message.fields);
+      const entries = globalThis.Object.entries(message.fields) as [string, any | undefined][];
       if (entries.length > 0) {
         obj.fields = {};
         entries.forEach(([k, v]) => {
@@ -177,8 +180,8 @@ export const Struct: MessageFns<Struct, "google.protobuf.Struct"> & StructWrappe
   },
   fromPartial<I extends Exact<DeepPartial<Struct>, I>>(object: I): Struct {
     const message = createBaseStruct();
-    message.fields = Object.entries(object.fields ?? {}).reduce<{ [key: string]: any | undefined }>(
-      (acc, [key, value]) => {
+    message.fields = (globalThis.Object.entries(object.fields ?? {}) as [string, any | undefined][]).reduce(
+      (acc: { [key: string]: any | undefined }, [key, value]: [string, any | undefined]) => {
         if (value !== undefined) {
           acc[key] = value;
         }
@@ -193,7 +196,7 @@ export const Struct: MessageFns<Struct, "google.protobuf.Struct"> & StructWrappe
     const struct = createBaseStruct();
 
     if (object !== undefined) {
-      for (const key of Object.keys(object)) {
+      for (const key of globalThis.Object.keys(object)) {
         struct.fields[key] = object[key];
       }
     }
@@ -203,7 +206,7 @@ export const Struct: MessageFns<Struct, "google.protobuf.Struct"> & StructWrappe
   unwrap(message: Struct): { [key: string]: any } {
     const object: { [key: string]: any } = {};
     if (message.fields) {
-      for (const key of Object.keys(message.fields)) {
+      for (const key of globalThis.Object.keys(message.fields)) {
         object[key] = message.fields[key];
       }
     }

--- a/integration/static-only/google/protobuf/struct.ts
+++ b/integration/static-only/google/protobuf/struct.ts
@@ -111,7 +111,7 @@ export const Struct: MessageFns<Struct, "google.protobuf.Struct"> & StructWrappe
   $type: "google.protobuf.Struct" as const,
 
   encode(message: Struct, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    Object.entries(message.fields).forEach(([key, value]) => {
+    globalThis.Object.entries(message.fields).forEach(([key, value]: [string, any | undefined]) => {
       if (value !== undefined) {
         Struct_FieldsEntry.encode({ key: key as any, value }, writer.uint32(10).fork()).join();
       }
@@ -149,10 +149,13 @@ export const Struct: MessageFns<Struct, "google.protobuf.Struct"> & StructWrappe
   fromJSON(object: any): Struct {
     return {
       fields: isObject(object.fields)
-        ? Object.entries(object.fields).reduce<{ [key: string]: any | undefined }>((acc, [key, value]) => {
-          acc[key] = value as any | undefined;
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.fields) as [string, any][]).reduce(
+          (acc: { [key: string]: any | undefined }, [key, value]: [string, any]) => {
+            acc[key] = value as any | undefined;
+            return acc;
+          },
+          {},
+        )
         : {},
     };
   },
@@ -160,7 +163,7 @@ export const Struct: MessageFns<Struct, "google.protobuf.Struct"> & StructWrappe
   toJSON(message: Struct): unknown {
     const obj: any = {};
     if (message.fields) {
-      const entries = Object.entries(message.fields);
+      const entries = globalThis.Object.entries(message.fields) as [string, any | undefined][];
       if (entries.length > 0) {
         obj.fields = {};
         entries.forEach(([k, v]) => {
@@ -176,8 +179,8 @@ export const Struct: MessageFns<Struct, "google.protobuf.Struct"> & StructWrappe
   },
   fromPartial<I extends Exact<DeepPartial<Struct>, I>>(object: I): Struct {
     const message = createBaseStruct();
-    message.fields = Object.entries(object.fields ?? {}).reduce<{ [key: string]: any | undefined }>(
-      (acc, [key, value]) => {
+    message.fields = (globalThis.Object.entries(object.fields ?? {}) as [string, any | undefined][]).reduce(
+      (acc: { [key: string]: any | undefined }, [key, value]: [string, any | undefined]) => {
         if (value !== undefined) {
           acc[key] = value;
         }
@@ -192,7 +195,7 @@ export const Struct: MessageFns<Struct, "google.protobuf.Struct"> & StructWrappe
     const struct = createBaseStruct();
 
     if (object !== undefined) {
-      for (const key of Object.keys(object)) {
+      for (const key of globalThis.Object.keys(object)) {
         struct.fields[key] = object[key];
       }
     }
@@ -202,7 +205,7 @@ export const Struct: MessageFns<Struct, "google.protobuf.Struct"> & StructWrappe
   unwrap(message: Struct): { [key: string]: any } {
     const object: { [key: string]: any } = {};
     if (message.fields) {
-      for (const key of Object.keys(message.fields)) {
+      for (const key of globalThis.Object.keys(message.fields)) {
         object[key] = message.fields[key];
       }
     }

--- a/integration/struct/google/protobuf/struct.ts
+++ b/integration/struct/google/protobuf/struct.ts
@@ -109,7 +109,7 @@ function createBaseStruct(): Struct {
 
 export const Struct: MessageFns<Struct> & StructWrapperFns = {
   encode(message: Struct, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    Object.entries(message.fields).forEach(([key, value]) => {
+    globalThis.Object.entries(message.fields).forEach(([key, value]: [string, any | undefined]) => {
       if (value !== undefined) {
         Struct_FieldsEntry.encode({ key: key as any, value }, writer.uint32(10).fork()).join();
       }
@@ -147,10 +147,13 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
   fromJSON(object: any): Struct {
     return {
       fields: isObject(object.fields)
-        ? Object.entries(object.fields).reduce<{ [key: string]: any | undefined }>((acc, [key, value]) => {
-          acc[key] = value as any | undefined;
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.fields) as [string, any][]).reduce(
+          (acc: { [key: string]: any | undefined }, [key, value]: [string, any]) => {
+            acc[key] = value as any | undefined;
+            return acc;
+          },
+          {},
+        )
         : {},
     };
   },
@@ -158,7 +161,7 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
   toJSON(message: Struct): unknown {
     const obj: any = {};
     if (message.fields) {
-      const entries = Object.entries(message.fields);
+      const entries = globalThis.Object.entries(message.fields) as [string, any | undefined][];
       if (entries.length > 0) {
         obj.fields = {};
         entries.forEach(([k, v]) => {
@@ -174,8 +177,8 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
   },
   fromPartial<I extends Exact<DeepPartial<Struct>, I>>(object: I): Struct {
     const message = createBaseStruct();
-    message.fields = Object.entries(object.fields ?? {}).reduce<{ [key: string]: any | undefined }>(
-      (acc, [key, value]) => {
+    message.fields = (globalThis.Object.entries(object.fields ?? {}) as [string, any | undefined][]).reduce(
+      (acc: { [key: string]: any | undefined }, [key, value]: [string, any | undefined]) => {
         if (value !== undefined) {
           acc[key] = value;
         }
@@ -190,7 +193,7 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
     const struct = createBaseStruct();
 
     if (object !== undefined) {
-      for (const key of Object.keys(object)) {
+      for (const key of globalThis.Object.keys(object)) {
         struct.fields[key] = object[key];
       }
     }
@@ -200,7 +203,7 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
   unwrap(message: Struct): { [key: string]: any } {
     const object: { [key: string]: any } = {};
     if (message.fields) {
-      for (const key of Object.keys(message.fields)) {
+      for (const key of globalThis.Object.keys(message.fields)) {
         object[key] = message.fields[key];
       }
     }

--- a/integration/suffix-type/google/protobuf/struct.ts
+++ b/integration/suffix-type/google/protobuf/struct.ts
@@ -109,7 +109,7 @@ function createBaseGRPCPStructGRPCS(): GRPCPStructGRPCS {
 
 export const GRPCPStructGRPCS: MessageFns<GRPCPStructGRPCS> & StructWrapperFns = {
   encode(message: GRPCPStructGRPCS, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    Object.entries(message.fields).forEach(([key, value]) => {
+    globalThis.Object.entries(message.fields).forEach(([key, value]: [string, any | undefined]) => {
       if (value !== undefined) {
         GRPCPStruct_FieldsEntryGRPCS.encode({ key: key as any, value }, writer.uint32(10).fork()).join();
       }
@@ -147,10 +147,13 @@ export const GRPCPStructGRPCS: MessageFns<GRPCPStructGRPCS> & StructWrapperFns =
   fromJSON(object: any): GRPCPStructGRPCS {
     return {
       fields: isObject(object.fields)
-        ? Object.entries(object.fields).reduce<{ [key: string]: any | undefined }>((acc, [key, value]) => {
-          acc[key] = value as any | undefined;
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.fields) as [string, any][]).reduce(
+          (acc: { [key: string]: any | undefined }, [key, value]: [string, any]) => {
+            acc[key] = value as any | undefined;
+            return acc;
+          },
+          {},
+        )
         : {},
     };
   },
@@ -158,7 +161,7 @@ export const GRPCPStructGRPCS: MessageFns<GRPCPStructGRPCS> & StructWrapperFns =
   toJSON(message: GRPCPStructGRPCS): unknown {
     const obj: any = {};
     if (message.fields) {
-      const entries = Object.entries(message.fields);
+      const entries = globalThis.Object.entries(message.fields) as [string, any | undefined][];
       if (entries.length > 0) {
         obj.fields = {};
         entries.forEach(([k, v]) => {
@@ -174,8 +177,8 @@ export const GRPCPStructGRPCS: MessageFns<GRPCPStructGRPCS> & StructWrapperFns =
   },
   fromPartial<I extends Exact<DeepPartial<GRPCPStructGRPCS>, I>>(object: I): GRPCPStructGRPCS {
     const message = createBaseGRPCPStructGRPCS();
-    message.fields = Object.entries(object.fields ?? {}).reduce<{ [key: string]: any | undefined }>(
-      (acc, [key, value]) => {
+    message.fields = (globalThis.Object.entries(object.fields ?? {}) as [string, any | undefined][]).reduce(
+      (acc: { [key: string]: any | undefined }, [key, value]: [string, any | undefined]) => {
         if (value !== undefined) {
           acc[key] = value;
         }
@@ -190,7 +193,7 @@ export const GRPCPStructGRPCS: MessageFns<GRPCPStructGRPCS> & StructWrapperFns =
     const struct = createBaseGRPCPStructGRPCS();
 
     if (object !== undefined) {
-      for (const key of Object.keys(object)) {
+      for (const key of globalThis.Object.keys(object)) {
         struct.fields[key] = object[key];
       }
     }
@@ -200,7 +203,7 @@ export const GRPCPStructGRPCS: MessageFns<GRPCPStructGRPCS> & StructWrapperFns =
   unwrap(message: GRPCPStructGRPCS): { [key: string]: any } {
     const object: { [key: string]: any } = {};
     if (message.fields) {
-      for (const key of Object.keys(message.fields)) {
+      for (const key of globalThis.Object.keys(message.fields)) {
         object[key] = message.fields[key];
       }
     }

--- a/integration/type-annotations/google/protobuf/struct.ts
+++ b/integration/type-annotations/google/protobuf/struct.ts
@@ -115,7 +115,7 @@ export const Struct: MessageFns<Struct, "google.protobuf.Struct"> & StructWrappe
   $type: "google.protobuf.Struct" as const,
 
   encode(message: Struct, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    Object.entries(message.fields).forEach(([key, value]) => {
+    globalThis.Object.entries(message.fields).forEach(([key, value]: [string, any | undefined]) => {
       if (value !== undefined) {
         Struct_FieldsEntry.encode(
           { $type: "google.protobuf.Struct.FieldsEntry", key: key as any, value },
@@ -157,10 +157,13 @@ export const Struct: MessageFns<Struct, "google.protobuf.Struct"> & StructWrappe
     return {
       $type: Struct.$type,
       fields: isObject(object.fields)
-        ? Object.entries(object.fields).reduce<{ [key: string]: any | undefined }>((acc, [key, value]) => {
-          acc[key] = value as any | undefined;
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.fields) as [string, any][]).reduce(
+          (acc: { [key: string]: any | undefined }, [key, value]: [string, any]) => {
+            acc[key] = value as any | undefined;
+            return acc;
+          },
+          {},
+        )
         : {},
     };
   },
@@ -168,7 +171,7 @@ export const Struct: MessageFns<Struct, "google.protobuf.Struct"> & StructWrappe
   toJSON(message: Struct): unknown {
     const obj: any = {};
     if (message.fields) {
-      const entries = Object.entries(message.fields);
+      const entries = globalThis.Object.entries(message.fields) as [string, any | undefined][];
       if (entries.length > 0) {
         obj.fields = {};
         entries.forEach(([k, v]) => {
@@ -184,8 +187,8 @@ export const Struct: MessageFns<Struct, "google.protobuf.Struct"> & StructWrappe
   },
   fromPartial<I extends Exact<DeepPartial<Struct>, I>>(object: I): Struct {
     const message = createBaseStruct();
-    message.fields = Object.entries(object.fields ?? {}).reduce<{ [key: string]: any | undefined }>(
-      (acc, [key, value]) => {
+    message.fields = (globalThis.Object.entries(object.fields ?? {}) as [string, any | undefined][]).reduce(
+      (acc: { [key: string]: any | undefined }, [key, value]: [string, any | undefined]) => {
         if (value !== undefined) {
           acc[key] = value;
         }
@@ -200,7 +203,7 @@ export const Struct: MessageFns<Struct, "google.protobuf.Struct"> & StructWrappe
     const struct = createBaseStruct();
 
     if (object !== undefined) {
-      for (const key of Object.keys(object)) {
+      for (const key of globalThis.Object.keys(object)) {
         struct.fields[key] = object[key];
       }
     }
@@ -210,7 +213,7 @@ export const Struct: MessageFns<Struct, "google.protobuf.Struct"> & StructWrappe
   unwrap(message: Struct): { [key: string]: any } {
     const object: { [key: string]: any } = {};
     if (message.fields) {
-      for (const key of Object.keys(message.fields)) {
+      for (const key of globalThis.Object.keys(message.fields)) {
         object[key] = message.fields[key];
       }
     }

--- a/integration/type-registry/google/protobuf/struct.ts
+++ b/integration/type-registry/google/protobuf/struct.ts
@@ -116,7 +116,7 @@ export const Struct: MessageFns<Struct, "google.protobuf.Struct"> & StructWrappe
   $type: "google.protobuf.Struct" as const,
 
   encode(message: Struct, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    Object.entries(message.fields).forEach(([key, value]) => {
+    globalThis.Object.entries(message.fields).forEach(([key, value]: [string, any | undefined]) => {
       if (value !== undefined) {
         Struct_FieldsEntry.encode(
           { $type: "google.protobuf.Struct.FieldsEntry", key: key as any, value },
@@ -158,10 +158,13 @@ export const Struct: MessageFns<Struct, "google.protobuf.Struct"> & StructWrappe
     return {
       $type: Struct.$type,
       fields: isObject(object.fields)
-        ? Object.entries(object.fields).reduce<{ [key: string]: any | undefined }>((acc, [key, value]) => {
-          acc[key] = value as any | undefined;
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.fields) as [string, any][]).reduce(
+          (acc: { [key: string]: any | undefined }, [key, value]: [string, any]) => {
+            acc[key] = value as any | undefined;
+            return acc;
+          },
+          {},
+        )
         : {},
     };
   },
@@ -169,7 +172,7 @@ export const Struct: MessageFns<Struct, "google.protobuf.Struct"> & StructWrappe
   toJSON(message: Struct): unknown {
     const obj: any = {};
     if (message.fields) {
-      const entries = Object.entries(message.fields);
+      const entries = globalThis.Object.entries(message.fields) as [string, any | undefined][];
       if (entries.length > 0) {
         obj.fields = {};
         entries.forEach(([k, v]) => {
@@ -185,8 +188,8 @@ export const Struct: MessageFns<Struct, "google.protobuf.Struct"> & StructWrappe
   },
   fromPartial<I extends Exact<DeepPartial<Struct>, I>>(object: I): Struct {
     const message = createBaseStruct();
-    message.fields = Object.entries(object.fields ?? {}).reduce<{ [key: string]: any | undefined }>(
-      (acc, [key, value]) => {
+    message.fields = (globalThis.Object.entries(object.fields ?? {}) as [string, any | undefined][]).reduce(
+      (acc: { [key: string]: any | undefined }, [key, value]: [string, any | undefined]) => {
         if (value !== undefined) {
           acc[key] = value;
         }
@@ -201,7 +204,7 @@ export const Struct: MessageFns<Struct, "google.protobuf.Struct"> & StructWrappe
     const struct = createBaseStruct();
 
     if (object !== undefined) {
-      for (const key of Object.keys(object)) {
+      for (const key of globalThis.Object.keys(object)) {
         struct.fields[key] = object[key];
       }
     }
@@ -211,7 +214,7 @@ export const Struct: MessageFns<Struct, "google.protobuf.Struct"> & StructWrappe
   unwrap(message: Struct): { [key: string]: any } {
     const object: { [key: string]: any } = {};
     if (message.fields) {
-      for (const key of Object.keys(message.fields)) {
+      for (const key of globalThis.Object.keys(message.fields)) {
         object[key] = message.fields[key];
       }
     }

--- a/integration/unknown-fields/google/protobuf/compiler/plugin.ts
+++ b/integration/unknown-fields/google/protobuf/compiler/plugin.ts
@@ -179,7 +179,7 @@ export const Version: MessageFns<Version> = {
       writer.uint32(34).string(message.suffix);
     }
     if (message._unknownFields !== undefined) {
-      for (const [key, values] of Object.entries(message._unknownFields)) {
+      for (const [key, values] of globalThis.Object.entries(message._unknownFields)) {
         const tag = parseInt(key, 10);
         for (const value of values) {
           writer.uint32(tag).raw(value);
@@ -265,7 +265,7 @@ export const CodeGeneratorRequest: MessageFns<CodeGeneratorRequest> = {
       Version.encode(message.compilerVersion, writer.uint32(26).fork()).join();
     }
     if (message._unknownFields !== undefined) {
-      for (const [key, values] of Object.entries(message._unknownFields)) {
+      for (const [key, values] of globalThis.Object.entries(message._unknownFields)) {
         const tag = parseInt(key, 10);
         for (const value of values) {
           writer.uint32(tag).raw(value);
@@ -348,7 +348,7 @@ export const CodeGeneratorResponse: MessageFns<CodeGeneratorResponse> = {
       CodeGeneratorResponse_File.encode(v!, writer.uint32(122).fork()).join();
     }
     if (message._unknownFields !== undefined) {
-      for (const [key, values] of Object.entries(message._unknownFields)) {
+      for (const [key, values] of globalThis.Object.entries(message._unknownFields)) {
         const tag = parseInt(key, 10);
         for (const value of values) {
           writer.uint32(tag).raw(value);
@@ -426,7 +426,7 @@ export const CodeGeneratorResponse_File: MessageFns<CodeGeneratorResponse_File> 
       GeneratedCodeInfo.encode(message.generatedCodeInfo, writer.uint32(130).fork()).join();
     }
     if (message._unknownFields !== undefined) {
-      for (const [key, values] of Object.entries(message._unknownFields)) {
+      for (const [key, values] of globalThis.Object.entries(message._unknownFields)) {
         const tag = parseInt(key, 10);
         for (const value of values) {
           writer.uint32(tag).raw(value);

--- a/integration/unknown-fields/google/protobuf/descriptor.ts
+++ b/integration/unknown-fields/google/protobuf/descriptor.ts
@@ -991,7 +991,7 @@ export const FileDescriptorSet: MessageFns<FileDescriptorSet> = {
       FileDescriptorProto.encode(v!, writer.uint32(10).fork()).join();
     }
     if (message._unknownFields !== undefined) {
-      for (const [key, values] of Object.entries(message._unknownFields)) {
+      for (const [key, values] of globalThis.Object.entries(message._unknownFields)) {
         const tag = parseInt(key, 10);
         for (const value of values) {
           writer.uint32(tag).raw(value);
@@ -1091,7 +1091,7 @@ export const FileDescriptorProto: MessageFns<FileDescriptorProto> = {
       writer.uint32(98).string(message.syntax);
     }
     if (message._unknownFields !== undefined) {
-      for (const [key, values] of Object.entries(message._unknownFields)) {
+      for (const [key, values] of globalThis.Object.entries(message._unknownFields)) {
         const tag = parseInt(key, 10);
         for (const value of values) {
           writer.uint32(tag).raw(value);
@@ -1291,7 +1291,7 @@ export const DescriptorProto: MessageFns<DescriptorProto> = {
       writer.uint32(82).string(v!);
     }
     if (message._unknownFields !== undefined) {
-      for (const [key, values] of Object.entries(message._unknownFields)) {
+      for (const [key, values] of globalThis.Object.entries(message._unknownFields)) {
         const tag = parseInt(key, 10);
         for (const value of values) {
           writer.uint32(tag).raw(value);
@@ -1422,7 +1422,7 @@ export const DescriptorProto_ExtensionRange: MessageFns<DescriptorProto_Extensio
       ExtensionRangeOptions.encode(message.options, writer.uint32(26).fork()).join();
     }
     if (message._unknownFields !== undefined) {
-      for (const [key, values] of Object.entries(message._unknownFields)) {
+      for (const [key, values] of globalThis.Object.entries(message._unknownFields)) {
         const tag = parseInt(key, 10);
         for (const value of values) {
           writer.uint32(tag).raw(value);
@@ -1494,7 +1494,7 @@ export const DescriptorProto_ReservedRange: MessageFns<DescriptorProto_ReservedR
       writer.uint32(16).int32(message.end);
     }
     if (message._unknownFields !== undefined) {
-      for (const [key, values] of Object.entries(message._unknownFields)) {
+      for (const [key, values] of globalThis.Object.entries(message._unknownFields)) {
         const tag = parseInt(key, 10);
         for (const value of values) {
           writer.uint32(tag).raw(value);
@@ -1555,7 +1555,7 @@ export const ExtensionRangeOptions: MessageFns<ExtensionRangeOptions> = {
       UninterpretedOption.encode(v!, writer.uint32(7994).fork()).join();
     }
     if (message._unknownFields !== undefined) {
-      for (const [key, values] of Object.entries(message._unknownFields)) {
+      for (const [key, values] of globalThis.Object.entries(message._unknownFields)) {
         const tag = parseInt(key, 10);
         for (const value of values) {
           writer.uint32(tag).raw(value);
@@ -1651,7 +1651,7 @@ export const FieldDescriptorProto: MessageFns<FieldDescriptorProto> = {
       writer.uint32(136).bool(message.proto3Optional);
     }
     if (message._unknownFields !== undefined) {
-      for (const [key, values] of Object.entries(message._unknownFields)) {
+      for (const [key, values] of globalThis.Object.entries(message._unknownFields)) {
         const tag = parseInt(key, 10);
         for (const value of values) {
           writer.uint32(tag).raw(value);
@@ -1787,7 +1787,7 @@ export const OneofDescriptorProto: MessageFns<OneofDescriptorProto> = {
       OneofOptions.encode(message.options, writer.uint32(18).fork()).join();
     }
     if (message._unknownFields !== undefined) {
-      for (const [key, values] of Object.entries(message._unknownFields)) {
+      for (const [key, values] of globalThis.Object.entries(message._unknownFields)) {
         const tag = parseInt(key, 10);
         for (const value of values) {
           writer.uint32(tag).raw(value);
@@ -1860,7 +1860,7 @@ export const EnumDescriptorProto: MessageFns<EnumDescriptorProto> = {
       writer.uint32(42).string(v!);
     }
     if (message._unknownFields !== undefined) {
-      for (const [key, values] of Object.entries(message._unknownFields)) {
+      for (const [key, values] of globalThis.Object.entries(message._unknownFields)) {
         const tag = parseInt(key, 10);
         for (const value of values) {
           writer.uint32(tag).raw(value);
@@ -1948,7 +1948,7 @@ export const EnumDescriptorProto_EnumReservedRange: MessageFns<EnumDescriptorPro
       writer.uint32(16).int32(message.end);
     }
     if (message._unknownFields !== undefined) {
-      for (const [key, values] of Object.entries(message._unknownFields)) {
+      for (const [key, values] of globalThis.Object.entries(message._unknownFields)) {
         const tag = parseInt(key, 10);
         for (const value of values) {
           writer.uint32(tag).raw(value);
@@ -2015,7 +2015,7 @@ export const EnumValueDescriptorProto: MessageFns<EnumValueDescriptorProto> = {
       EnumValueOptions.encode(message.options, writer.uint32(26).fork()).join();
     }
     if (message._unknownFields !== undefined) {
-      for (const [key, values] of Object.entries(message._unknownFields)) {
+      for (const [key, values] of globalThis.Object.entries(message._unknownFields)) {
         const tag = parseInt(key, 10);
         for (const value of values) {
           writer.uint32(tag).raw(value);
@@ -2090,7 +2090,7 @@ export const ServiceDescriptorProto: MessageFns<ServiceDescriptorProto> = {
       ServiceOptions.encode(message.options, writer.uint32(26).fork()).join();
     }
     if (message._unknownFields !== undefined) {
-      for (const [key, values] of Object.entries(message._unknownFields)) {
+      for (const [key, values] of globalThis.Object.entries(message._unknownFields)) {
         const tag = parseInt(key, 10);
         for (const value of values) {
           writer.uint32(tag).raw(value);
@@ -2182,7 +2182,7 @@ export const MethodDescriptorProto: MessageFns<MethodDescriptorProto> = {
       writer.uint32(48).bool(message.serverStreaming);
     }
     if (message._unknownFields !== undefined) {
-      for (const [key, values] of Object.entries(message._unknownFields)) {
+      for (const [key, values] of globalThis.Object.entries(message._unknownFields)) {
         const tag = parseInt(key, 10);
         for (const value of values) {
           writer.uint32(tag).raw(value);
@@ -2358,7 +2358,7 @@ export const FileOptions: MessageFns<FileOptions> = {
       UninterpretedOption.encode(v!, writer.uint32(7994).fork()).join();
     }
     if (message._unknownFields !== undefined) {
-      for (const [key, values] of Object.entries(message._unknownFields)) {
+      for (const [key, values] of globalThis.Object.entries(message._unknownFields)) {
         const tag = parseInt(key, 10);
         for (const value of values) {
           writer.uint32(tag).raw(value);
@@ -2590,7 +2590,7 @@ export const MessageOptions: MessageFns<MessageOptions> = {
       UninterpretedOption.encode(v!, writer.uint32(7994).fork()).join();
     }
     if (message._unknownFields !== undefined) {
-      for (const [key, values] of Object.entries(message._unknownFields)) {
+      for (const [key, values] of globalThis.Object.entries(message._unknownFields)) {
         const tag = parseInt(key, 10);
         for (const value of values) {
           writer.uint32(tag).raw(value);
@@ -2702,7 +2702,7 @@ export const FieldOptions: MessageFns<FieldOptions> = {
       UninterpretedOption.encode(v!, writer.uint32(7994).fork()).join();
     }
     if (message._unknownFields !== undefined) {
-      for (const [key, values] of Object.entries(message._unknownFields)) {
+      for (const [key, values] of globalThis.Object.entries(message._unknownFields)) {
         const tag = parseInt(key, 10);
         for (const value of values) {
           writer.uint32(tag).raw(value);
@@ -2803,7 +2803,7 @@ export const OneofOptions: MessageFns<OneofOptions> = {
       UninterpretedOption.encode(v!, writer.uint32(7994).fork()).join();
     }
     if (message._unknownFields !== undefined) {
-      for (const [key, values] of Object.entries(message._unknownFields)) {
+      for (const [key, values] of globalThis.Object.entries(message._unknownFields)) {
         const tag = parseInt(key, 10);
         for (const value of values) {
           writer.uint32(tag).raw(value);
@@ -2862,7 +2862,7 @@ export const EnumOptions: MessageFns<EnumOptions> = {
       UninterpretedOption.encode(v!, writer.uint32(7994).fork()).join();
     }
     if (message._unknownFields !== undefined) {
-      for (const [key, values] of Object.entries(message._unknownFields)) {
+      for (const [key, values] of globalThis.Object.entries(message._unknownFields)) {
         const tag = parseInt(key, 10);
         for (const value of values) {
           writer.uint32(tag).raw(value);
@@ -2934,7 +2934,7 @@ export const EnumValueOptions: MessageFns<EnumValueOptions> = {
       UninterpretedOption.encode(v!, writer.uint32(7994).fork()).join();
     }
     if (message._unknownFields !== undefined) {
-      for (const [key, values] of Object.entries(message._unknownFields)) {
+      for (const [key, values] of globalThis.Object.entries(message._unknownFields)) {
         const tag = parseInt(key, 10);
         for (const value of values) {
           writer.uint32(tag).raw(value);
@@ -2998,7 +2998,7 @@ export const ServiceOptions: MessageFns<ServiceOptions> = {
       UninterpretedOption.encode(v!, writer.uint32(7994).fork()).join();
     }
     if (message._unknownFields !== undefined) {
-      for (const [key, values] of Object.entries(message._unknownFields)) {
+      for (const [key, values] of globalThis.Object.entries(message._unknownFields)) {
         const tag = parseInt(key, 10);
         for (const value of values) {
           writer.uint32(tag).raw(value);
@@ -3065,7 +3065,7 @@ export const MethodOptions: MessageFns<MethodOptions> = {
       UninterpretedOption.encode(v!, writer.uint32(7994).fork()).join();
     }
     if (message._unknownFields !== undefined) {
-      for (const [key, values] of Object.entries(message._unknownFields)) {
+      for (const [key, values] of globalThis.Object.entries(message._unknownFields)) {
         const tag = parseInt(key, 10);
         for (const value of values) {
           writer.uint32(tag).raw(value);
@@ -3161,7 +3161,7 @@ export const UninterpretedOption: MessageFns<UninterpretedOption> = {
       writer.uint32(66).string(message.aggregateValue);
     }
     if (message._unknownFields !== undefined) {
-      for (const [key, values] of Object.entries(message._unknownFields)) {
+      for (const [key, values] of globalThis.Object.entries(message._unknownFields)) {
         const tag = parseInt(key, 10);
         for (const value of values) {
           writer.uint32(tag).raw(value);
@@ -3265,7 +3265,7 @@ export const UninterpretedOption_NamePart: MessageFns<UninterpretedOption_NamePa
       writer.uint32(16).bool(message.isExtension);
     }
     if (message._unknownFields !== undefined) {
-      for (const [key, values] of Object.entries(message._unknownFields)) {
+      for (const [key, values] of globalThis.Object.entries(message._unknownFields)) {
         const tag = parseInt(key, 10);
         for (const value of values) {
           writer.uint32(tag).raw(value);
@@ -3326,7 +3326,7 @@ export const SourceCodeInfo: MessageFns<SourceCodeInfo> = {
       SourceCodeInfo_Location.encode(v!, writer.uint32(10).fork()).join();
     }
     if (message._unknownFields !== undefined) {
-      for (const [key, values] of Object.entries(message._unknownFields)) {
+      for (const [key, values] of globalThis.Object.entries(message._unknownFields)) {
         const tag = parseInt(key, 10);
         for (const value of values) {
           writer.uint32(tag).raw(value);
@@ -3402,7 +3402,7 @@ export const SourceCodeInfo_Location: MessageFns<SourceCodeInfo_Location> = {
       writer.uint32(50).string(v!);
     }
     if (message._unknownFields !== undefined) {
-      for (const [key, values] of Object.entries(message._unknownFields)) {
+      for (const [key, values] of globalThis.Object.entries(message._unknownFields)) {
         const tag = parseInt(key, 10);
         for (const value of values) {
           writer.uint32(tag).raw(value);
@@ -3507,7 +3507,7 @@ export const GeneratedCodeInfo: MessageFns<GeneratedCodeInfo> = {
       GeneratedCodeInfo_Annotation.encode(v!, writer.uint32(10).fork()).join();
     }
     if (message._unknownFields !== undefined) {
-      for (const [key, values] of Object.entries(message._unknownFields)) {
+      for (const [key, values] of globalThis.Object.entries(message._unknownFields)) {
         const tag = parseInt(key, 10);
         for (const value of values) {
           writer.uint32(tag).raw(value);
@@ -3571,7 +3571,7 @@ export const GeneratedCodeInfo_Annotation: MessageFns<GeneratedCodeInfo_Annotati
       writer.uint32(32).int32(message.end);
     }
     if (message._unknownFields !== undefined) {
-      for (const [key, values] of Object.entries(message._unknownFields)) {
+      for (const [key, values] of globalThis.Object.entries(message._unknownFields)) {
         const tag = parseInt(key, 10);
         for (const value of values) {
           writer.uint32(tag).raw(value);

--- a/integration/unknown-fields/options.ts
+++ b/integration/unknown-fields/options.ts
@@ -47,7 +47,7 @@ export const MyMessage: MessageFns<MyMessage> = {
       writer.uint32(34).string(message.quux);
     }
     if (message._unknownFields !== undefined) {
-      for (const [key, values] of Object.entries(message._unknownFields)) {
+      for (const [key, values] of globalThis.Object.entries(message._unknownFields)) {
         const tag = parseInt(key, 10);
         for (const value of values) {
           writer.uint32(tag).raw(value);
@@ -121,7 +121,7 @@ function createBaseRequestType(): RequestType {
 export const RequestType: MessageFns<RequestType> = {
   encode(message: RequestType, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message._unknownFields !== undefined) {
-      for (const [key, values] of Object.entries(message._unknownFields)) {
+      for (const [key, values] of globalThis.Object.entries(message._unknownFields)) {
         const tag = parseInt(key, 10);
         for (const value of values) {
           writer.uint32(tag).raw(value);
@@ -163,7 +163,7 @@ function createBaseResponseType(): ResponseType {
 export const ResponseType: MessageFns<ResponseType> = {
   encode(message: ResponseType, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message._unknownFields !== undefined) {
-      for (const [key, values] of Object.entries(message._unknownFields)) {
+      for (const [key, values] of globalThis.Object.entries(message._unknownFields)) {
         const tag = parseInt(key, 10);
         for (const value of values) {
           writer.uint32(tag).raw(value);

--- a/integration/unknown-fields/something/something.ts
+++ b/integration/unknown-fields/something/something.ts
@@ -27,7 +27,7 @@ export const Something: MessageFns<Something> = {
     }
     writer.join();
     if (message._unknownFields !== undefined) {
-      for (const [key, values] of Object.entries(message._unknownFields)) {
+      for (const [key, values] of globalThis.Object.entries(message._unknownFields)) {
         const tag = parseInt(key, 10);
         for (const value of values) {
           writer.uint32(tag).raw(value);

--- a/integration/use-date-string/use-date-string.ts
+++ b/integration/use-date-string/use-date-string.ts
@@ -38,7 +38,7 @@ export const Todo: MessageFns<Todo> = {
     if (message.optionalTimestamp !== undefined) {
       Timestamp.encode(toTimestamp(message.optionalTimestamp), writer.uint32(34).fork()).join();
     }
-    Object.entries(message.mapOfTimestamps).forEach(([key, value]) => {
+    globalThis.Object.entries(message.mapOfTimestamps).forEach(([key, value]: [string, string]) => {
       Todo_MapOfTimestampsEntry.encode({ key: key as any, value }, writer.uint32(42).fork()).join();
     });
     return writer;
@@ -112,10 +112,13 @@ export const Todo: MessageFns<Todo> = {
         : [],
       optionalTimestamp: isSet(object.optionalTimestamp) ? globalThis.String(object.optionalTimestamp) : undefined,
       mapOfTimestamps: isObject(object.mapOfTimestamps)
-        ? Object.entries(object.mapOfTimestamps).reduce<{ [key: string]: string }>((acc, [key, value]) => {
-          acc[key] = globalThis.String(value);
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.mapOfTimestamps) as [string, any][]).reduce(
+          (acc: { [key: string]: string }, [key, value]: [string, any]) => {
+            acc[key] = globalThis.String(value);
+            return acc;
+          },
+          {},
+        )
         : {},
     };
   },
@@ -135,7 +138,7 @@ export const Todo: MessageFns<Todo> = {
       obj.optionalTimestamp = message.optionalTimestamp;
     }
     if (message.mapOfTimestamps) {
-      const entries = Object.entries(message.mapOfTimestamps);
+      const entries = globalThis.Object.entries(message.mapOfTimestamps) as [string, string][];
       if (entries.length > 0) {
         obj.mapOfTimestamps = {};
         entries.forEach(([k, v]) => {
@@ -155,8 +158,8 @@ export const Todo: MessageFns<Todo> = {
     message.timestamp = object.timestamp ?? undefined;
     message.repeatedTimestamp = object.repeatedTimestamp?.map((e) => e) || [];
     message.optionalTimestamp = object.optionalTimestamp ?? undefined;
-    message.mapOfTimestamps = Object.entries(object.mapOfTimestamps ?? {}).reduce<{ [key: string]: string }>(
-      (acc, [key, value]) => {
+    message.mapOfTimestamps = (globalThis.Object.entries(object.mapOfTimestamps ?? {}) as [string, string][]).reduce(
+      (acc: { [key: string]: string }, [key, value]: [string, string]) => {
         if (value !== undefined) {
           acc[key] = value;
         }

--- a/integration/use-date-true/use-date-true.ts
+++ b/integration/use-date-true/use-date-true.ts
@@ -39,7 +39,7 @@ export const Todo: MessageFns<Todo> = {
     if (message.optionalTimestamp !== undefined) {
       Timestamp.encode(toTimestamp(message.optionalTimestamp), writer.uint32(34).fork()).join();
     }
-    Object.entries(message.mapOfTimestamps).forEach(([key, value]) => {
+    globalThis.Object.entries(message.mapOfTimestamps).forEach(([key, value]: [string, Date]) => {
       Todo_MapOfTimestampsEntry.encode({ key: key as any, value }, writer.uint32(42).fork()).join();
     });
     return writer;
@@ -113,10 +113,13 @@ export const Todo: MessageFns<Todo> = {
         : [],
       optionalTimestamp: isSet(object.optionalTimestamp) ? fromJsonTimestamp(object.optionalTimestamp) : undefined,
       mapOfTimestamps: isObject(object.mapOfTimestamps)
-        ? Object.entries(object.mapOfTimestamps).reduce<{ [key: string]: Date }>((acc, [key, value]) => {
-          acc[key] = fromJsonTimestamp(value);
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.mapOfTimestamps) as [string, any][]).reduce(
+          (acc: { [key: string]: Date }, [key, value]: [string, any]) => {
+            acc[key] = fromJsonTimestamp(value);
+            return acc;
+          },
+          {},
+        )
         : {},
     };
   },
@@ -136,7 +139,7 @@ export const Todo: MessageFns<Todo> = {
       obj.optionalTimestamp = message.optionalTimestamp.toISOString();
     }
     if (message.mapOfTimestamps) {
-      const entries = Object.entries(message.mapOfTimestamps);
+      const entries = globalThis.Object.entries(message.mapOfTimestamps) as [string, Date][];
       if (entries.length > 0) {
         obj.mapOfTimestamps = {};
         entries.forEach(([k, v]) => {
@@ -156,8 +159,8 @@ export const Todo: MessageFns<Todo> = {
     message.timestamp = object.timestamp ?? undefined;
     message.repeatedTimestamp = object.repeatedTimestamp?.map((e) => e) || [];
     message.optionalTimestamp = object.optionalTimestamp ?? undefined;
-    message.mapOfTimestamps = Object.entries(object.mapOfTimestamps ?? {}).reduce<{ [key: string]: Date }>(
-      (acc, [key, value]) => {
+    message.mapOfTimestamps = (globalThis.Object.entries(object.mapOfTimestamps ?? {}) as [string, Date][]).reduce(
+      (acc: { [key: string]: Date }, [key, value]: [string, Date]) => {
         if (value !== undefined) {
           acc[key] = value;
         }

--- a/integration/use-map-type/google/protobuf/struct.ts
+++ b/integration/use-map-type/google/protobuf/struct.ts
@@ -147,10 +147,13 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
   fromJSON(object: any): Struct {
     return {
       fields: isObject(object.fields)
-        ? Object.entries(object.fields).reduce<Map<string, any | undefined>>((acc, [key, value]) => {
-          acc.set(key, value as any | undefined);
-          return acc;
-        }, new Map())
+        ? (globalThis.Object.entries(object.fields) as [string, any][]).reduce(
+          (acc: Map<string, any | undefined>, [key, value]: [string, any]) => {
+            acc.set(key, value as any | undefined);
+            return acc;
+          },
+          new Map(),
+        )
         : new Map(),
     };
   },
@@ -187,7 +190,7 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
     const struct = createBaseStruct();
 
     if (object !== undefined) {
-      for (const key of Object.keys(object)) {
+      for (const key of globalThis.Object.keys(object)) {
         struct.fields.set(key, object[key]);
       }
     }

--- a/integration/use-map-type/use-map-type.ts
+++ b/integration/use-map-type/use-map-type.ts
@@ -220,34 +220,49 @@ export const Maps: MessageFns<Maps> = {
   fromJSON(object: any): Maps {
     return {
       strToEntity: isObject(object.strToEntity)
-        ? Object.entries(object.strToEntity).reduce<Map<string, Entity>>((acc, [key, value]) => {
-          acc.set(key, Entity.fromJSON(value));
-          return acc;
-        }, new Map())
+        ? (globalThis.Object.entries(object.strToEntity) as [string, any][]).reduce(
+          (acc: Map<string, Entity>, [key, value]: [string, any]) => {
+            acc.set(key, Entity.fromJSON(value));
+            return acc;
+          },
+          new Map(),
+        )
         : new Map(),
       int32ToInt32: isObject(object.int32ToInt32)
-        ? Object.entries(object.int32ToInt32).reduce<Map<number, number>>((acc, [key, value]) => {
-          acc.set(globalThis.Number(key), Number(value));
-          return acc;
-        }, new Map())
+        ? (globalThis.Object.entries(object.int32ToInt32) as [string, any][]).reduce(
+          (acc: Map<number, number>, [key, value]: [string, any]) => {
+            acc.set(globalThis.Number(key), globalThis.Number(value));
+            return acc;
+          },
+          new Map(),
+        )
         : new Map(),
       stringToBytes: isObject(object.stringToBytes)
-        ? Object.entries(object.stringToBytes).reduce<Map<string, Uint8Array>>((acc, [key, value]) => {
-          acc.set(key, bytesFromBase64(value as string));
-          return acc;
-        }, new Map())
+        ? (globalThis.Object.entries(object.stringToBytes) as [string, any][]).reduce(
+          (acc: Map<string, Uint8Array>, [key, value]: [string, any]) => {
+            acc.set(key, bytesFromBase64(value as string));
+            return acc;
+          },
+          new Map(),
+        )
         : new Map(),
       int64ToInt64: isObject(object.int64ToInt64)
-        ? Object.entries(object.int64ToInt64).reduce<Map<number, number>>((acc, [key, value]) => {
-          acc.set(globalThis.Number(key), Number(value));
-          return acc;
-        }, new Map())
+        ? (globalThis.Object.entries(object.int64ToInt64) as [string, any][]).reduce(
+          (acc: Map<number, number>, [key, value]: [string, any]) => {
+            acc.set(globalThis.Number(key), globalThis.Number(value));
+            return acc;
+          },
+          new Map(),
+        )
         : new Map(),
       mapOfTimestamps: isObject(object.mapOfTimestamps)
-        ? Object.entries(object.mapOfTimestamps).reduce<Map<string, Date>>((acc, [key, value]) => {
-          acc.set(key, fromJsonTimestamp(value));
-          return acc;
-        }, new Map())
+        ? (globalThis.Object.entries(object.mapOfTimestamps) as [string, any][]).reduce(
+          (acc: Map<string, Date>, [key, value]: [string, any]) => {
+            acc.set(key, fromJsonTimestamp(value));
+            return acc;
+          },
+          new Map(),
+        )
         : new Map(),
       struct: isObject(object.struct) ? object.struct : undefined,
     };

--- a/integration/use-numeric-enum-json/google/protobuf/struct.ts
+++ b/integration/use-numeric-enum-json/google/protobuf/struct.ts
@@ -109,7 +109,7 @@ function createBaseStruct(): Struct {
 
 export const Struct: MessageFns<Struct> & StructWrapperFns = {
   encode(message: Struct, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    Object.entries(message.fields).forEach(([key, value]) => {
+    globalThis.Object.entries(message.fields).forEach(([key, value]: [string, any | undefined]) => {
       if (value !== undefined) {
         Struct_FieldsEntry.encode({ key: key as any, value }, writer.uint32(10).fork()).join();
       }
@@ -147,10 +147,13 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
   fromJSON(object: any): Struct {
     return {
       fields: isObject(object.fields)
-        ? Object.entries(object.fields).reduce<{ [key: string]: any | undefined }>((acc, [key, value]) => {
-          acc[key] = value as any | undefined;
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.fields) as [string, any][]).reduce(
+          (acc: { [key: string]: any | undefined }, [key, value]: [string, any]) => {
+            acc[key] = value as any | undefined;
+            return acc;
+          },
+          {},
+        )
         : {},
     };
   },
@@ -158,7 +161,7 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
   toJSON(message: Struct): unknown {
     const obj: any = {};
     if (message.fields) {
-      const entries = Object.entries(message.fields);
+      const entries = globalThis.Object.entries(message.fields) as [string, any | undefined][];
       if (entries.length > 0) {
         obj.fields = {};
         entries.forEach(([k, v]) => {
@@ -174,8 +177,8 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
   },
   fromPartial<I extends Exact<DeepPartial<Struct>, I>>(object: I): Struct {
     const message = createBaseStruct();
-    message.fields = Object.entries(object.fields ?? {}).reduce<{ [key: string]: any | undefined }>(
-      (acc, [key, value]) => {
+    message.fields = (globalThis.Object.entries(object.fields ?? {}) as [string, any | undefined][]).reduce(
+      (acc: { [key: string]: any | undefined }, [key, value]: [string, any | undefined]) => {
         if (value !== undefined) {
           acc[key] = value;
         }
@@ -190,7 +193,7 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
     const struct = createBaseStruct();
 
     if (object !== undefined) {
-      for (const key of Object.keys(object)) {
+      for (const key of globalThis.Object.keys(object)) {
         struct.fields[key] = object[key];
       }
     }
@@ -200,7 +203,7 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
   unwrap(message: Struct): { [key: string]: any } {
     const object: { [key: string]: any } = {};
     if (message.fields) {
-      for (const key of Object.keys(message.fields)) {
+      for (const key of globalThis.Object.keys(message.fields)) {
         object[key] = message.fields[key];
       }
     }

--- a/integration/use-numeric-enum-json/simple.ts
+++ b/integration/use-numeric-enum-json/simple.ts
@@ -79,7 +79,7 @@ export const Simple: MessageFns<Simple> = {
     if (message.nullValue !== 0) {
       writer.uint32(48).int32(message.nullValue);
     }
-    Object.entries(message.stateMap).forEach(([key, value]) => {
+    globalThis.Object.entries(message.stateMap).forEach(([key, value]: [string, StateEnum]) => {
       Simple_StateMapEntry.encode({ key: key as any, value }, writer.uint32(58).fork()).join();
     });
     return writer;
@@ -161,10 +161,13 @@ export const Simple: MessageFns<Simple> = {
       states: globalThis.Array.isArray(object?.states) ? object.states.map((e: any) => stateEnumFromJSON(e)) : [],
       nullValue: isSet(object.nullValue) ? nullValueFromJSON(object.nullValue) : 0,
       stateMap: isObject(object.stateMap)
-        ? Object.entries(object.stateMap).reduce<{ [key: string]: StateEnum }>((acc, [key, value]) => {
-          acc[key] = stateEnumFromJSON(value);
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.stateMap) as [string, any][]).reduce(
+          (acc: { [key: string]: StateEnum }, [key, value]: [string, any]) => {
+            acc[key] = stateEnumFromJSON(value);
+            return acc;
+          },
+          {},
+        )
         : {},
     };
   },
@@ -184,7 +187,7 @@ export const Simple: MessageFns<Simple> = {
       obj.nullValue = nullValueToJSON(message.nullValue);
     }
     if (message.stateMap) {
-      const entries = Object.entries(message.stateMap);
+      const entries = globalThis.Object.entries(message.stateMap) as [string, StateEnum][];
       if (entries.length > 0) {
         obj.stateMap = {};
         entries.forEach(([k, v]) => {
@@ -204,8 +207,8 @@ export const Simple: MessageFns<Simple> = {
     message.state = object.state ?? 0;
     message.states = object.states?.map((e) => e) || [];
     message.nullValue = object.nullValue ?? 0;
-    message.stateMap = Object.entries(object.stateMap ?? {}).reduce<{ [key: string]: StateEnum }>(
-      (acc, [key, value]) => {
+    message.stateMap = (globalThis.Object.entries(object.stateMap ?? {}) as [string, StateEnum][]).reduce(
+      (acc: { [key: string]: StateEnum }, [key, value]: [string, StateEnum]) => {
         if (value !== undefined) {
           acc[key] = value as StateEnum;
         }

--- a/integration/use-objectid-true-external-import/use-objectid-true.ts
+++ b/integration/use-objectid-true-external-import/use-objectid-true.ts
@@ -39,7 +39,7 @@ export const Todo: MessageFns<Todo> = {
     if (message.optionalOid !== undefined) {
       ObjectId.encode(toProtoObjectId(message.optionalOid), writer.uint32(34).fork()).join();
     }
-    Object.entries(message.mapOfOids).forEach(([key, value]) => {
+    globalThis.Object.entries(message.mapOfOids).forEach(([key, value]: [string, mongodb.ObjectId]) => {
       Todo_MapOfOidsEntry.encode({ key: key as any, value }, writer.uint32(42).fork()).join();
     });
     return writer;
@@ -113,10 +113,13 @@ export const Todo: MessageFns<Todo> = {
         : [],
       optionalOid: isSet(object.optionalOid) ? fromJsonObjectId(object.optionalOid) : undefined,
       mapOfOids: isObject(object.mapOfOids)
-        ? Object.entries(object.mapOfOids).reduce<{ [key: string]: mongodb.ObjectId }>((acc, [key, value]) => {
-          acc[key] = fromJsonObjectId(value);
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.mapOfOids) as [string, any][]).reduce(
+          (acc: { [key: string]: mongodb.ObjectId }, [key, value]: [string, any]) => {
+            acc[key] = fromJsonObjectId(value);
+            return acc;
+          },
+          {},
+        )
         : {},
     };
   },
@@ -136,7 +139,7 @@ export const Todo: MessageFns<Todo> = {
       obj.optionalOid = message.optionalOid.toString();
     }
     if (message.mapOfOids) {
-      const entries = Object.entries(message.mapOfOids);
+      const entries = globalThis.Object.entries(message.mapOfOids) as [string, mongodb.ObjectId][];
       if (entries.length > 0) {
         obj.mapOfOids = {};
         entries.forEach(([k, v]) => {
@@ -158,8 +161,8 @@ export const Todo: MessageFns<Todo> = {
     message.optionalOid = (object.optionalOid !== undefined && object.optionalOid !== null)
       ? object.optionalOid as mongodb.ObjectId
       : undefined;
-    message.mapOfOids = Object.entries(object.mapOfOids ?? {}).reduce<{ [key: string]: mongodb.ObjectId }>(
-      (acc, [key, value]) => {
+    message.mapOfOids = (globalThis.Object.entries(object.mapOfOids ?? {}) as [string, mongodb.ObjectId][]).reduce(
+      (acc: { [key: string]: mongodb.ObjectId }, [key, value]: [string, mongodb.ObjectId]) => {
         if (value !== undefined) {
           acc[key] = value as mongodb.ObjectId;
         }

--- a/integration/use-optionals-all/google/protobuf/struct.ts
+++ b/integration/use-optionals-all/google/protobuf/struct.ts
@@ -109,7 +109,7 @@ function createBaseStruct(): Struct {
 
 export const Struct: MessageFns<Struct> & StructWrapperFns = {
   encode(message: Struct, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    Object.entries(message.fields || {}).forEach(([key, value]) => {
+    globalThis.Object.entries(message.fields || {}).forEach(([key, value]: [string, any | undefined]) => {
       if (value !== undefined) {
         Struct_FieldsEntry.encode({ key: key as any, value }, writer.uint32(10).fork()).join();
       }
@@ -147,10 +147,13 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
   fromJSON(object: any): Struct {
     return {
       fields: isObject(object.fields)
-        ? Object.entries(object.fields).reduce<{ [key: string]: any | undefined }>((acc, [key, value]) => {
-          acc[key] = value as any | undefined;
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.fields) as [string, any][]).reduce(
+          (acc: { [key: string]: any | undefined }, [key, value]: [string, any]) => {
+            acc[key] = value as any | undefined;
+            return acc;
+          },
+          {},
+        )
         : {},
     };
   },
@@ -158,7 +161,7 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
   toJSON(message: Struct): unknown {
     const obj: any = {};
     if (message.fields) {
-      const entries = Object.entries(message.fields);
+      const entries = globalThis.Object.entries(message.fields) as [string, any | undefined][];
       if (entries.length > 0) {
         obj.fields = {};
         entries.forEach(([k, v]) => {
@@ -174,8 +177,8 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
   },
   fromPartial<I extends Exact<DeepPartial<Struct>, I>>(object: I): Struct {
     const message = createBaseStruct();
-    message.fields = Object.entries(object.fields ?? {}).reduce<{ [key: string]: any | undefined }>(
-      (acc, [key, value]) => {
+    message.fields = (globalThis.Object.entries(object.fields ?? {}) as [string, any | undefined][]).reduce(
+      (acc: { [key: string]: any | undefined }, [key, value]: [string, any | undefined]) => {
         if (value !== undefined) {
           acc[key] = value;
         }
@@ -190,7 +193,7 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
     const struct = createBaseStruct();
     struct.fields ??= {};
     if (object !== undefined) {
-      for (const key of Object.keys(object)) {
+      for (const key of globalThis.Object.keys(object)) {
         struct.fields[key] = object[key];
       }
     }
@@ -200,7 +203,7 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
   unwrap(message: Struct): { [key: string]: any } {
     const object: { [key: string]: any } = {};
     if (message.fields) {
-      for (const key of Object.keys(message.fields)) {
+      for (const key of globalThis.Object.keys(message.fields)) {
         object[key] = message.fields[key];
       }
     }

--- a/integration/use-optionals-all/test.ts
+++ b/integration/use-optionals-all/test.ts
@@ -198,7 +198,7 @@ export const OptionalsTest: MessageFns<OptionalsTest> = {
     if (message.optData !== undefined) {
       writer.uint32(218).bytes(message.optData);
     }
-    Object.entries(message.translations || {}).forEach(([key, value]) => {
+    globalThis.Object.entries(message.translations || {}).forEach(([key, value]: [string, string]) => {
       OptionalsTest_TranslationsEntry.encode({ key: key as any, value }, writer.uint32(242).fork()).join();
     });
     if (message.timestamp !== undefined) {
@@ -498,10 +498,13 @@ export const OptionalsTest: MessageFns<OptionalsTest> = {
       optDescription: isSet(object.optDescription) ? globalThis.String(object.optDescription) : undefined,
       optData: isSet(object.optData) ? bytesFromBase64(object.optData) : undefined,
       translations: isObject(object.translations)
-        ? Object.entries(object.translations).reduce<{ [key: string]: string }>((acc, [key, value]) => {
-          acc[key] = String(value);
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.translations) as [string, any][]).reduce(
+          (acc: { [key: string]: string }, [key, value]: [string, any]) => {
+            acc[key] = globalThis.String(value);
+            return acc;
+          },
+          {},
+        )
         : {},
       timestamp: isSet(object.timestamp) ? fromJsonTimestamp(object.timestamp) : undefined,
       struct: isObject(object.struct) ? object.struct : undefined,
@@ -574,7 +577,7 @@ export const OptionalsTest: MessageFns<OptionalsTest> = {
       obj.optData = base64FromBytes(message.optData);
     }
     if (message.translations) {
-      const entries = Object.entries(message.translations);
+      const entries = globalThis.Object.entries(message.translations) as [string, string][];
       if (entries.length > 0) {
         obj.translations = {};
         entries.forEach(([k, v]) => {
@@ -619,8 +622,8 @@ export const OptionalsTest: MessageFns<OptionalsTest> = {
     message.optTruth = object.optTruth ?? undefined;
     message.optDescription = object.optDescription ?? undefined;
     message.optData = object.optData ?? undefined;
-    message.translations = Object.entries(object.translations ?? {}).reduce<{ [key: string]: string }>(
-      (acc, [key, value]) => {
+    message.translations = (globalThis.Object.entries(object.translations ?? {}) as [string, string][]).reduce(
+      (acc: { [key: string]: string }, [key, value]: [string, string]) => {
         if (value !== undefined) {
           acc[key] = globalThis.String(value);
         }

--- a/integration/use-optionals-deprecated-only/test.ts
+++ b/integration/use-optionals-deprecated-only/test.ts
@@ -180,7 +180,7 @@ export const OptionalsTest: MessageFns<OptionalsTest> = {
     if (message.optData !== undefined) {
       writer.uint32(154).bytes(message.optData);
     }
-    Object.entries(message.translations).forEach(([key, value]) => {
+    globalThis.Object.entries(message.translations).forEach(([key, value]: [string, string]) => {
       OptionalsTest_TranslationsEntry.encode({ key: key as any, value }, writer.uint32(162).fork()).join();
     });
     return writer;
@@ -443,10 +443,13 @@ export const OptionalsTest: MessageFns<OptionalsTest> = {
       optDescription: isSet(object.optDescription) ? globalThis.String(object.optDescription) : undefined,
       optData: isSet(object.optData) ? bytesFromBase64(object.optData) : undefined,
       translations: isObject(object.translations)
-        ? Object.entries(object.translations).reduce<{ [key: string]: string }>((acc, [key, value]) => {
-          acc[key] = String(value);
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.translations) as [string, any][]).reduce(
+          (acc: { [key: string]: string }, [key, value]: [string, any]) => {
+            acc[key] = globalThis.String(value);
+            return acc;
+          },
+          {},
+        )
         : {},
     };
   },
@@ -511,7 +514,7 @@ export const OptionalsTest: MessageFns<OptionalsTest> = {
       obj.optData = base64FromBytes(message.optData);
     }
     if (message.translations) {
-      const entries = Object.entries(message.translations);
+      const entries = globalThis.Object.entries(message.translations) as [string, string][];
       if (entries.length > 0) {
         obj.translations = {};
         entries.forEach(([k, v]) => {
@@ -546,8 +549,8 @@ export const OptionalsTest: MessageFns<OptionalsTest> = {
     message.optTruth = object.optTruth ?? undefined;
     message.optDescription = object.optDescription ?? undefined;
     message.optData = object.optData ?? undefined;
-    message.translations = Object.entries(object.translations ?? {}).reduce<{ [key: string]: string }>(
-      (acc, [key, value]) => {
+    message.translations = (globalThis.Object.entries(object.translations ?? {}) as [string, string][]).reduce(
+      (acc: { [key: string]: string }, [key, value]: [string, string]) => {
         if (value !== undefined) {
           acc[key] = globalThis.String(value);
         }

--- a/integration/use-optionals-no-undefined/google/protobuf/struct.ts
+++ b/integration/use-optionals-no-undefined/google/protobuf/struct.ts
@@ -109,7 +109,7 @@ function createBaseStruct(): Struct {
 
 export const Struct: MessageFns<Struct> & StructWrapperFns = {
   encode(message: Struct, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    Object.entries(message.fields || {}).forEach(([key, value]) => {
+    globalThis.Object.entries(message.fields || {}).forEach(([key, value]: [string, any | undefined]) => {
       if (value !== undefined) {
         Struct_FieldsEntry.encode({ key: key as any, value }, writer.uint32(10).fork()).join();
       }
@@ -150,10 +150,13 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
   fromJSON(object: any): Struct {
     return {
       fields: isObject(object.fields)
-        ? Object.entries(object.fields).reduce<{ [key: string]: any | undefined }>((acc, [key, value]) => {
-          acc[key] = value as any | undefined;
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.fields) as [string, any][]).reduce(
+          (acc: { [key: string]: any | undefined }, [key, value]: [string, any]) => {
+            acc[key] = value as any | undefined;
+            return acc;
+          },
+          {},
+        )
         : undefined,
     };
   },
@@ -161,7 +164,7 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
   toJSON(message: Struct): unknown {
     const obj: any = {};
     if (message.fields) {
-      const entries = Object.entries(message.fields);
+      const entries = globalThis.Object.entries(message.fields) as [string, any | undefined][];
       if (entries.length > 0) {
         obj.fields = {};
         entries.forEach(([k, v]) => {
@@ -179,12 +182,15 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
     const message = createBaseStruct();
     message.fields = (object.fields === undefined || object.fields === null)
       ? undefined
-      : Object.entries(object.fields ?? {}).reduce<{ [key: string]: any | undefined }>((acc, [key, value]) => {
-        if (value !== undefined) {
-          acc[key] = value;
-        }
-        return acc;
-      }, {});
+      : (globalThis.Object.entries(object.fields ?? {}) as [string, any | undefined][]).reduce(
+        (acc: { [key: string]: any | undefined }, [key, value]: [string, any | undefined]) => {
+          if (value !== undefined) {
+            acc[key] = value;
+          }
+          return acc;
+        },
+        {},
+      );
     return message;
   },
 
@@ -192,7 +198,7 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
     const struct = createBaseStruct();
     struct.fields ??= {};
     if (object !== undefined) {
-      for (const key of Object.keys(object)) {
+      for (const key of globalThis.Object.keys(object)) {
         struct.fields[key] = object[key];
       }
     }
@@ -202,7 +208,7 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
   unwrap(message: Struct): { [key: string]: any } {
     const object: { [key: string]: any } = {};
     if (message.fields) {
-      for (const key of Object.keys(message.fields)) {
+      for (const key of globalThis.Object.keys(message.fields)) {
         object[key] = message.fields[key];
       }
     }

--- a/integration/use-optionals-no-undefined/test.ts
+++ b/integration/use-optionals-no-undefined/test.ts
@@ -171,7 +171,7 @@ export const OptionalsTest: MessageFns<OptionalsTest> = {
     if (message.optData !== undefined) {
       writer.uint32(218).bytes(message.optData);
     }
-    Object.entries(message.translations || {}).forEach(([key, value]) => {
+    globalThis.Object.entries(message.translations || {}).forEach(([key, value]: [string, string]) => {
       OptionalsTest_TranslationsEntry.encode({ key: key as any, value }, writer.uint32(242).fork()).join();
     });
     if (message.struct !== undefined) {
@@ -504,10 +504,13 @@ export const OptionalsTest: MessageFns<OptionalsTest> = {
       optDescription: isSet(object.optDescription) ? globalThis.String(object.optDescription) : undefined,
       optData: isSet(object.optData) ? bytesFromBase64(object.optData) : undefined,
       translations: isObject(object.translations)
-        ? Object.entries(object.translations).reduce<{ [key: string]: string }>((acc, [key, value]) => {
-          acc[key] = String(value);
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.translations) as [string, any][]).reduce(
+          (acc: { [key: string]: string }, [key, value]: [string, any]) => {
+            acc[key] = globalThis.String(value);
+            return acc;
+          },
+          {},
+        )
         : undefined,
       struct: isObject(object.struct) ? object.struct : undefined,
     };
@@ -579,7 +582,7 @@ export const OptionalsTest: MessageFns<OptionalsTest> = {
       obj.optData = base64FromBytes(message.optData);
     }
     if (message.translations) {
-      const entries = Object.entries(message.translations);
+      const entries = globalThis.Object.entries(message.translations) as [string, string][];
       if (entries.length > 0) {
         obj.translations = {};
         entries.forEach(([k, v]) => {
@@ -623,12 +626,15 @@ export const OptionalsTest: MessageFns<OptionalsTest> = {
     message.optData = object.optData ?? undefined;
     message.translations = (object.translations === undefined || object.translations === null)
       ? undefined
-      : Object.entries(object.translations ?? {}).reduce<{ [key: string]: string }>((acc, [key, value]) => {
-        if (value !== undefined) {
-          acc[key] = globalThis.String(value);
-        }
-        return acc;
-      }, {});
+      : (globalThis.Object.entries(object.translations ?? {}) as [string, string][]).reduce(
+        (acc: { [key: string]: string }, [key, value]: [string, string]) => {
+          if (value !== undefined) {
+            acc[key] = globalThis.String(value);
+          }
+          return acc;
+        },
+        {},
+      );
     message.struct = object.struct ?? undefined;
     return message;
   },

--- a/integration/use-readonly-types/google/protobuf/struct.ts
+++ b/integration/use-readonly-types/google/protobuf/struct.ts
@@ -108,7 +108,7 @@ function createBaseStruct(): Struct {
 
 export const Struct: MessageFns<Struct> & StructWrapperFns = {
   encode(message: Struct, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    Object.entries(message.fields).forEach(([key, value]) => {
+    globalThis.Object.entries(message.fields).forEach(([key, value]: [string, any | undefined]) => {
       if (value !== undefined) {
         Struct_FieldsEntry.encode({ key: key as any, value }, writer.uint32(10).fork()).join();
       }
@@ -146,10 +146,13 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
   fromJSON(object: any): Struct {
     return {
       fields: isObject(object.fields)
-        ? Object.entries(object.fields).reduce<{ [key: string]: any | undefined }>((acc, [key, value]) => {
-          acc[key] = value as any | undefined;
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.fields) as [string, any][]).reduce(
+          (acc: { [key: string]: any | undefined }, [key, value]: [string, any]) => {
+            acc[key] = value as any | undefined;
+            return acc;
+          },
+          {},
+        )
         : {},
     };
   },
@@ -157,7 +160,7 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
   toJSON(message: Struct): unknown {
     const obj: any = {};
     if (message.fields) {
-      const entries = Object.entries(message.fields);
+      const entries = globalThis.Object.entries(message.fields) as [string, any | undefined][];
       if (entries.length > 0) {
         obj.fields = {};
         entries.forEach(([k, v]) => {
@@ -173,8 +176,8 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
   },
   fromPartial<I extends Exact<DeepPartial<Struct>, I>>(object: I): Struct {
     const message = createBaseStruct() as any;
-    message.fields = Object.entries(object.fields ?? {}).reduce<{ [key: string]: any | undefined }>(
-      (acc, [key, value]) => {
+    message.fields = (globalThis.Object.entries(object.fields ?? {}) as [string, any | undefined][]).reduce(
+      (acc: { [key: string]: any | undefined }, [key, value]: [string, any | undefined]) => {
         if (value !== undefined) {
           acc[key] = value;
         }
@@ -189,7 +192,7 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
     const struct = createBaseStruct();
 
     if (object !== undefined) {
-      for (const key of Object.keys(object)) {
+      for (const key of globalThis.Object.keys(object)) {
         struct.fields[key] = object[key];
       }
     }
@@ -199,7 +202,7 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
   unwrap(message: Struct): { [key: string]: any } {
     const object: { [key: string]: any } = {};
     if (message.fields) {
-      for (const key of Object.keys(message.fields)) {
+      for (const key of globalThis.Object.keys(message.fields)) {
         object[key] = message.fields[key];
       }
     }

--- a/integration/value/google/protobuf/struct.ts
+++ b/integration/value/google/protobuf/struct.ts
@@ -109,7 +109,7 @@ function createBaseStruct(): Struct {
 
 export const Struct: MessageFns<Struct> & StructWrapperFns = {
   encode(message: Struct, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    Object.entries(message.fields).forEach(([key, value]) => {
+    globalThis.Object.entries(message.fields).forEach(([key, value]: [string, any | undefined]) => {
       if (value !== undefined) {
         Struct_FieldsEntry.encode({ key: key as any, value }, writer.uint32(10).fork()).join();
       }
@@ -147,10 +147,13 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
   fromJSON(object: any): Struct {
     return {
       fields: isObject(object.fields)
-        ? Object.entries(object.fields).reduce<{ [key: string]: any | undefined }>((acc, [key, value]) => {
-          acc[key] = value as any | undefined;
-          return acc;
-        }, {})
+        ? (globalThis.Object.entries(object.fields) as [string, any][]).reduce(
+          (acc: { [key: string]: any | undefined }, [key, value]: [string, any]) => {
+            acc[key] = value as any | undefined;
+            return acc;
+          },
+          {},
+        )
         : {},
     };
   },
@@ -158,7 +161,7 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
   toJSON(message: Struct): unknown {
     const obj: any = {};
     if (message.fields) {
-      const entries = Object.entries(message.fields);
+      const entries = globalThis.Object.entries(message.fields) as [string, any | undefined][];
       if (entries.length > 0) {
         obj.fields = {};
         entries.forEach(([k, v]) => {
@@ -174,8 +177,8 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
   },
   fromPartial<I extends Exact<DeepPartial<Struct>, I>>(object: I): Struct {
     const message = createBaseStruct();
-    message.fields = Object.entries(object.fields ?? {}).reduce<{ [key: string]: any | undefined }>(
-      (acc, [key, value]) => {
+    message.fields = (globalThis.Object.entries(object.fields ?? {}) as [string, any | undefined][]).reduce(
+      (acc: { [key: string]: any | undefined }, [key, value]: [string, any | undefined]) => {
         if (value !== undefined) {
           acc[key] = value;
         }
@@ -190,7 +193,7 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
     const struct = createBaseStruct();
 
     if (object !== undefined) {
-      for (const key of Object.keys(object)) {
+      for (const key of globalThis.Object.keys(object)) {
         struct.fields[key] = object[key];
       }
     }
@@ -200,7 +203,7 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
   unwrap(message: Struct): { [key: string]: any } {
     const object: { [key: string]: any } = {};
     if (message.fields) {
-      for (const key of Object.keys(message.fields)) {
+      for (const key of globalThis.Object.keys(message.fields)) {
         object[key] = message.fields[key];
       }
     }

--- a/src/generate-struct-wrappers.ts
+++ b/src/generate-struct-wrappers.ts
@@ -43,7 +43,7 @@ export function generateWrapDeep(ctx: Context, fullProtoTypeName: string, fieldN
       const struct = createBase${wrapTypeName(ctx.options, "Struct")}();
       ${defaultFields}
       if (object !== undefined) {
-        for (const key of Object.keys(object)) {
+        for (const key of ${ctx.utils.globalThis}.Object.keys(object)) {
           ${setStatement}
         }
       }
@@ -116,7 +116,7 @@ export function generateUnwrapDeep(ctx: Context, fullProtoTypeName: string, fiel
       chunks.push(code`unwrap(message: ${wrapTypeName(ctx.options, "Struct")}): {[key: string]: any} {
         const object: { [key: string]: any } = {};
         if (message.fields) {
-          for (const key of Object.keys(message.fields)) {
+          for (const key of ${ctx.utils.globalThis}.Object.keys(message.fields)) {
             object[key] = Value.unwrap(message.fields[key]);
           }
         }
@@ -190,7 +190,7 @@ export function generateWrapShallow(ctx: Context, fullProtoTypeName: string, fie
       const struct = createBase${wrapTypeName(ctx.options, "Struct")}();
       ${defaultFields}
       if (object !== undefined) {
-        for (const key of Object.keys(object)) {
+        for (const key of ${ctx.utils.globalThis}.Object.keys(object)) {
           ${setStatement}
         }
       }
@@ -307,7 +307,7 @@ export function generateUnwrapShallow(ctx: Context, fullProtoTypeName: string, f
       chunks.push(code`unwrap(message: ${wrapTypeName(ctx.options, "Struct")}): {[key: string]: any} {
         const object: { [key: string]: any } = {};
         if (message.fields) {
-          for (const key of Object.keys(message.fields)) {
+          for (const key of ${ctx.utils.globalThis}.Object.keys(message.fields)) {
             object[key] = message.fields[key];
           }
         }


### PR DESCRIPTION
This fixes issue #1239 the same way as PR #988 did. 