### PR TITLE
fix: prevent code injection via string option/extension values in out…

### DIFF
--- a/src/schema.ts
+++ b/src/schema.ts
@@ -225,7 +225,7 @@ function getExtensionValue(ctx: Context, extension: FieldDescriptorProto, data: 
     const reader = new BinaryReader(data[0]);
     let value = (reader as any)[toReaderCall(extension)]();
     if (typeof value === "string") {
-      value = code`"${value}"`;
+      value = JSON.stringify(value);
     }
     return code`'${extension.name}': ${value}`;
   }


### PR DESCRIPTION
getExtensionValue() interpolated string extension values directly into generated TypeScript source via `code`"${value}"``. A string option value containing a quote and arbitrary code (e.g. `"});require('child_process')...({"`) would break out of the string literal and inject attacker-controlled code into the generated module, which executes when the output is imported or built.

Escape the value with JSON.stringify() so it is always emitted as a safe, properly-quoted string literal regardless of its contents.
