### PR TITLE
fix: Update js map check to include forceLong=bigInt as well

### DIFF
--- a/integration/simple-long-bigint/numbers-long-string-test.ts
+++ b/integration/simple-long-bigint/numbers-long-string-test.ts
@@ -31,11 +31,14 @@ describe("number", () => {
       guint64: BigInt("13"),
       timestamp: new Date("1970-02-03T04:05:06.0071Z"),
       uint64s: [BigInt("14"), BigInt("15"), BigInt("16")],
+      longLookup: new Map([[BigInt("1"), BigInt("2")], [BigInt("2"), BigInt("1")]]),
     };
     expect(simple.int64).toEqual(BigInt("4"));
     expect(simple.uint64).toEqual(BigInt("6"));
     expect(simple.guint64).toEqual(BigInt("13"));
     expect(simple.timestamp).toEqual(new Date("1970-02-03T04:05:06.0071Z"));
+    expect(simple.longLookup.get(BigInt("1"))).toEqual(BigInt("2"));
+    expect(simple.longLookup.get(BigInt("2"))).toEqual(BigInt("1"));
   });
 
   it("can decode", () => {
@@ -58,6 +61,7 @@ describe("number", () => {
         seconds: Long.fromNumber(1),
       }),
       uint64s: [Long.fromNumber(14), Long.fromNumber(15), Long.fromNumber(16)],
+      longLookup: { "1": Long.fromNumber(2), "2": Long.fromNumber(1) },
     };
     const expected: Numbers = {
       double: 1,
@@ -75,6 +79,7 @@ describe("number", () => {
       guint64: BigInt("13"),
       timestamp: new Date("1970-01-01T00:00:01.007000001Z"),
       uint64s: [BigInt("14"), BigInt("15"), BigInt("16")],
+      longLookup: new Map([[BigInt("1"), BigInt("2")], [BigInt("2"), BigInt("1")]]),
     };
     const s2 = Numbers.decode(new BinaryReader(PbNumbers.encode(PbNumbers.fromObject(s1)).finish()));
     expect(s2).toEqual(expected);
@@ -97,6 +102,7 @@ describe("number", () => {
       guint64: BigInt("13"),
       timestamp: new Date("1980-01-01T00:00:01.123Z"),
       uint64s: [BigInt("14"), BigInt("15"), BigInt("16")],
+      longLookup: new Map(),
     };
     const expected: INumbers = {
       double: 1,
@@ -152,6 +158,31 @@ describe("number", () => {
     expect(s2.double).toEqual(0);
   });
 
+  it("generates a Map for long-keyed maps with forceLong=bigint", () => {
+    const s1 = Numbers.fromPartial({
+      longLookup: new Map<bigint, bigint>([
+        [BigInt("1"), BigInt("2")],
+        [BigInt("2"), BigInt("1")],
+      ]),
+    });
+    expect(s1.longLookup).toBeInstanceOf(Map);
+    expect(s1.longLookup.get(BigInt("1"))).toEqual(BigInt("2"));
+    expect(s1.longLookup.get(BigInt("2"))).toEqual(BigInt("1"));
+
+    const decoded = Numbers.decode(new BinaryReader(Numbers.encode(s1).finish()));
+    expect(decoded.longLookup).toBeInstanceOf(Map);
+    expect(decoded.longLookup.get(BigInt("1"))).toEqual(BigInt("2"));
+    expect(decoded.longLookup.get(BigInt("2"))).toEqual(BigInt("1"));
+
+    const json = Numbers.toJSON(s1) as any;
+    expect(json.longLookup).toEqual({ "1": "2", "2": "1" });
+
+    const fromJson = Numbers.fromJSON(JSON.parse(JSON.stringify(json)));
+    expect(fromJson.longLookup).toBeInstanceOf(Map);
+    expect(fromJson.longLookup.get(BigInt("1"))).toEqual(BigInt("2"));
+    expect(fromJson.longLookup.get(BigInt("2"))).toEqual(BigInt("1"));
+  });
+
   it("has fromPartial", () => {
     const s1 = Numbers.fromPartial({});
     expect(s1).toMatchInlineSnapshot(`
@@ -163,6 +194,7 @@ describe("number", () => {
         "guint64": undefined,
         "int32": 0,
         "int64": 0n,
+        "longLookup": Map {},
         "sfixed32": 0,
         "sfixed64": 0n,
         "sint32": 0,

--- a/integration/simple-long-bigint/simple.proto
+++ b/integration/simple-long-bigint/simple.proto
@@ -20,4 +20,5 @@ message Numbers {
   google.protobuf.UInt64Value guint64 = 13;
   google.protobuf.Timestamp timestamp = 14;
   repeated uint64 uint64s = 15;
+  map<int64, int64> longLookup = 16;
 }

--- a/integration/simple-long-bigint/simple.ts
+++ b/integration/simple-long-bigint/simple.ts
@@ -24,6 +24,12 @@ export interface Numbers {
   guint64: bigint | undefined;
   timestamp: Date | undefined;
   uint64s: bigint[];
+  longLookup: Map<bigint, bigint>;
+}
+
+export interface Numbers_LongLookupEntry {
+  key: bigint;
+  value: bigint;
 }
 
 function createBaseNumbers(): Numbers {
@@ -43,6 +49,7 @@ function createBaseNumbers(): Numbers {
     guint64: undefined,
     timestamp: undefined,
     uint64s: [],
+    longLookup: new Map(),
   };
 }
 
@@ -113,6 +120,9 @@ export const Numbers: MessageFns<Numbers> = {
       writer.uint64(v);
     }
     writer.join();
+    message.longLookup.forEach((value, key) => {
+      Numbers_LongLookupEntry.encode({ key: key as any, value }, writer.uint32(130).fork()).join();
+    });
     return writer;
   },
 
@@ -253,6 +263,17 @@ export const Numbers: MessageFns<Numbers> = {
 
           break;
         }
+        case 16: {
+          if (tag !== 130) {
+            break;
+          }
+
+          const entry16 = Numbers_LongLookupEntry.decode(reader, reader.uint32());
+          if (entry16.value !== undefined) {
+            message.longLookup.set(entry16.key, entry16.value);
+          }
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -279,6 +300,15 @@ export const Numbers: MessageFns<Numbers> = {
       guint64: isSet(object.guint64) ? BigInt(object.guint64) : undefined,
       timestamp: isSet(object.timestamp) ? fromJsonTimestamp(object.timestamp) : undefined,
       uint64s: globalThis.Array.isArray(object?.uint64s) ? object.uint64s.map((e: any) => BigInt(e)) : [],
+      longLookup: isObject(object.longLookup)
+        ? (globalThis.Object.entries(object.longLookup) as [string, any][]).reduce(
+          (acc: Map<bigint, bigint>, [key, value]: [string, any]) => {
+            acc.set(BigInt(key), BigInt(value as string | number | bigint | boolean));
+            return acc;
+          },
+          new Map(),
+        )
+        : new Map(),
     };
   },
 
@@ -329,6 +359,12 @@ export const Numbers: MessageFns<Numbers> = {
     if (message.uint64s?.length) {
       obj.uint64s = message.uint64s.map((e) => e.toString());
     }
+    if (message.longLookup?.size) {
+      obj.longLookup = {};
+      message.longLookup.forEach((v, k) => {
+        obj.longLookup[k.toString()] = v.toString();
+      });
+    }
     return obj;
   },
 
@@ -352,6 +388,94 @@ export const Numbers: MessageFns<Numbers> = {
     message.guint64 = object.guint64 ?? undefined;
     message.timestamp = object.timestamp ?? undefined;
     message.uint64s = object.uint64s?.map((e) => e) || [];
+    message.longLookup = (() => {
+      const m = new Map();
+      (object.longLookup as Map<bigint, bigint> ?? new Map()).forEach((value, key) => {
+        if (value !== undefined) {
+          m.set(key, BigInt(value as string | number | bigint | boolean));
+        }
+      });
+      return m;
+    })();
+    return message;
+  },
+};
+
+function createBaseNumbers_LongLookupEntry(): Numbers_LongLookupEntry {
+  return { key: 0n, value: 0n };
+}
+
+export const Numbers_LongLookupEntry: MessageFns<Numbers_LongLookupEntry> = {
+  encode(message: Numbers_LongLookupEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.key !== 0n) {
+      if (BigInt.asIntN(64, message.key) !== message.key) {
+        throw new globalThis.Error("value provided for field message.key of type int64 too large");
+      }
+      writer.uint32(8).int64(message.key);
+    }
+    if (message.value !== 0n) {
+      if (BigInt.asIntN(64, message.value) !== message.value) {
+        throw new globalThis.Error("value provided for field message.value of type int64 too large");
+      }
+      writer.uint32(16).int64(message.value);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): Numbers_LongLookupEntry {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseNumbers_LongLookupEntry();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 8) {
+            break;
+          }
+
+          message.key = reader.int64() as bigint;
+          continue;
+        }
+        case 2: {
+          if (tag !== 16) {
+            break;
+          }
+
+          message.value = reader.int64() as bigint;
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): Numbers_LongLookupEntry {
+    return { key: isSet(object.key) ? BigInt(object.key) : 0n, value: isSet(object.value) ? BigInt(object.value) : 0n };
+  },
+
+  toJSON(message: Numbers_LongLookupEntry): unknown {
+    const obj: any = {};
+    if (message.key !== 0n) {
+      obj.key = message.key.toString();
+    }
+    if (message.value !== 0n) {
+      obj.value = message.value.toString();
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Numbers_LongLookupEntry>, I>>(base?: I): Numbers_LongLookupEntry {
+    return Numbers_LongLookupEntry.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<Numbers_LongLookupEntry>, I>>(object: I): Numbers_LongLookupEntry {
+    const message = createBaseNumbers_LongLookupEntry();
+    message.key = object.key ?? 0n;
+    message.value = object.value ?? 0n;
     return message;
   },
 };
@@ -388,6 +512,10 @@ function fromJsonTimestamp(o: any): Date {
   } else {
     return fromTimestamp(Timestamp.fromJSON(o));
   }
+}
+
+function isObject(value: any): boolean {
+  return typeof value === "object" && value !== null;
 }
 
 function isSet(value: any): boolean {

--- a/src/types.ts
+++ b/src/types.ts
@@ -777,7 +777,8 @@ export function shouldGenerateJSMapType(ctx: Context, message: DescriptorProto, 
   }
   return (
     mapType.keyField.type === FieldDescriptorProto_Type.TYPE_BOOL ||
-    (isLong(mapType.keyField) && ctx.options.forceLong === LongOption.LONG)
+    (isLong(mapType.keyField) &&
+      (ctx.options.forceLong === LongOption.LONG || ctx.options.forceLong === LongOption.BIGINT))
   );
 }
 


### PR DESCRIPTION
### Why
Previous fix (#905) for this only fixed forceLong=long option. This PR adds support for forceLong=bigInt as well which fixes #940 

### How
- Update `shouldGenerateJSMapType` check to include bigint option as well
- Add new map field to existing bigint test