### PR TITLE
fix: avoid prototype pollution when decoding JSON maps

### DIFF
--- a/integration/batching-with-context-esModuleInterop/batching.ts
+++ b/integration/batching-with-context-esModuleInterop/batching.ts
@@ -269,7 +269,12 @@ export const BatchMapQueryResponse: MessageFns<BatchMapQueryResponse> = {
       entities: isObject(object.entities)
         ? (globalThis.Object.entries(object.entities) as [string, any][]).reduce(
           (acc: { [key: string]: Entity }, [key, value]: [string, any]) => {
-            acc[key] = Entity.fromJSON(value);
+            globalThis.Object.defineProperty(acc, key, {
+              value: Entity.fromJSON(value),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},

--- a/integration/batching-with-context/batching.ts
+++ b/integration/batching-with-context/batching.ts
@@ -269,7 +269,12 @@ export const BatchMapQueryResponse: MessageFns<BatchMapQueryResponse> = {
       entities: isObject(object.entities)
         ? (globalThis.Object.entries(object.entities) as [string, any][]).reduce(
           (acc: { [key: string]: Entity }, [key, value]: [string, any]) => {
-            acc[key] = Entity.fromJSON(value);
+            globalThis.Object.defineProperty(acc, key, {
+              value: Entity.fromJSON(value),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},

--- a/integration/batching/batching.ts
+++ b/integration/batching/batching.ts
@@ -267,7 +267,12 @@ export const BatchMapQueryResponse: MessageFns<BatchMapQueryResponse> = {
       entities: isObject(object.entities)
         ? (globalThis.Object.entries(object.entities) as [string, any][]).reduce(
           (acc: { [key: string]: Entity }, [key, value]: [string, any]) => {
-            acc[key] = Entity.fromJSON(value);
+            globalThis.Object.defineProperty(acc, key, {
+              value: Entity.fromJSON(value),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},

--- a/integration/const-enum/const-enum.ts
+++ b/integration/const-enum/const-enum.ts
@@ -133,7 +133,12 @@ export const DividerData: MessageFns<DividerData> = {
       typeMap: isObject(object.typeMap)
         ? (globalThis.Object.entries(object.typeMap) as [string, any][]).reduce(
           (acc: { [key: string]: DividerData_DividerType }, [key, value]: [string, any]) => {
-            acc[key] = dividerData_DividerTypeFromJSON(value);
+            globalThis.Object.defineProperty(acc, key, {
+              value: dividerData_DividerTypeFromJSON(value),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},

--- a/integration/emit-default-values-json/test.ts
+++ b/integration/emit-default-values-json/test.ts
@@ -515,7 +515,12 @@ export const DefaultValuesTest: MessageFns<DefaultValuesTest> = {
       translations: isObject(object.translations)
         ? (globalThis.Object.entries(object.translations) as [string, any][]).reduce(
           (acc: { [key: string]: string }, [key, value]: [string, any]) => {
-            acc[key] = globalThis.String(value);
+            globalThis.Object.defineProperty(acc, key, {
+              value: globalThis.String(value),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},

--- a/integration/from-partial-no-initialize/test.ts
+++ b/integration/from-partial-no-initialize/test.ts
@@ -232,7 +232,12 @@ export const TPartial: MessageFns<TPartial> = {
       map: isObject(object.map)
         ? (globalThis.Object.entries(object.map) as [string, any][]).reduce(
           (acc: { [key: string]: string }, [key, value]: [string, any]) => {
-            acc[key] = globalThis.String(value);
+            globalThis.Object.defineProperty(acc, key, {
+              value: globalThis.String(value),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},

--- a/integration/global-this/global-this.ts
+++ b/integration/global-this/global-this.ts
@@ -92,7 +92,12 @@ export const Object: MessageFns<Object> = {
       metadata: isObject(object.metadata)
         ? (gt.Object.entries(object.metadata) as [string, any][]).reduce(
           (acc: { [key: string]: string }, [key, value]: [string, any]) => {
-            acc[key] = gt.String(value);
+            gt.Object.defineProperty(acc, key, {
+              value: gt.String(value),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},

--- a/integration/grpc-js/google/protobuf/struct.ts
+++ b/integration/grpc-js/google/protobuf/struct.ts
@@ -149,7 +149,12 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
       fields: isObject(object.fields)
         ? (globalThis.Object.entries(object.fields) as [string, any][]).reduce(
           (acc: { [key: string]: any | undefined }, [key, value]: [string, any]) => {
-            acc[key] = value as any | undefined;
+            globalThis.Object.defineProperty(acc, key, {
+              value: value as any | undefined,
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},

--- a/integration/nice-grpc/google/protobuf/struct.ts
+++ b/integration/nice-grpc/google/protobuf/struct.ts
@@ -149,7 +149,12 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
       fields: isObject(object.fields)
         ? (globalThis.Object.entries(object.fields) as [string, any][]).reduce(
           (acc: { [key: string]: any | undefined }, [key, value]: [string, any]) => {
-            acc[key] = value as any | undefined;
+            globalThis.Object.defineProperty(acc, key, {
+              value: value as any | undefined,
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},

--- a/integration/no-defaults-for-optionals-with-nulls/proto-2.ts
+++ b/integration/no-defaults-for-optionals-with-nulls/proto-2.ts
@@ -98,7 +98,12 @@ export const Proto2TestMessage: MessageFns<Proto2TestMessage> = {
       mapValue: isObject(object.mapValue)
         ? (globalThis.Object.entries(object.mapValue) as [string, any][]).reduce(
           (acc: { [key: string]: string }, [key, value]: [string, any]) => {
-            acc[key] = globalThis.String(value);
+            globalThis.Object.defineProperty(acc, key, {
+              value: globalThis.String(value),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},

--- a/integration/no-defaults-for-optionals-with-nulls/proto-3.ts
+++ b/integration/no-defaults-for-optionals-with-nulls/proto-3.ts
@@ -145,7 +145,12 @@ export const Proto3TestMessage: MessageFns<Proto3TestMessage> = {
       mapValue: isObject(object.mapValue)
         ? (globalThis.Object.entries(object.mapValue) as [string, any][]).reduce(
           (acc: { [key: string]: string }, [key, value]: [string, any]) => {
-            acc[key] = globalThis.String(value);
+            globalThis.Object.defineProperty(acc, key, {
+              value: globalThis.String(value),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},

--- a/integration/no-defaults-for-optionals/proto-2.ts
+++ b/integration/no-defaults-for-optionals/proto-2.ts
@@ -98,7 +98,12 @@ export const Proto2TestMessage: MessageFns<Proto2TestMessage> = {
       mapValue: isObject(object.mapValue)
         ? (globalThis.Object.entries(object.mapValue) as [string, any][]).reduce(
           (acc: { [key: string]: string }, [key, value]: [string, any]) => {
-            acc[key] = globalThis.String(value);
+            globalThis.Object.defineProperty(acc, key, {
+              value: globalThis.String(value),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},

--- a/integration/no-defaults-for-optionals/proto-3.ts
+++ b/integration/no-defaults-for-optionals/proto-3.ts
@@ -147,7 +147,12 @@ export const Proto3TestMessage: MessageFns<Proto3TestMessage> = {
       mapValue: isObject(object.mapValue)
         ? (globalThis.Object.entries(object.mapValue) as [string, any][]).reduce(
           (acc: { [key: string]: string }, [key, value]: [string, any]) => {
-            acc[key] = globalThis.String(value);
+            globalThis.Object.defineProperty(acc, key, {
+              value: globalThis.String(value),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},

--- a/integration/oneof-unions-snake/google/protobuf/struct.ts
+++ b/integration/oneof-unions-snake/google/protobuf/struct.ts
@@ -148,7 +148,12 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
       fields: isObject(object.fields)
         ? (globalThis.Object.entries(object.fields) as [string, any][]).reduce(
           (acc: { [key: string]: any | undefined }, [key, value]: [string, any]) => {
-            acc[key] = value as any | undefined;
+            globalThis.Object.defineProperty(acc, key, {
+              value: value as any | undefined,
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},

--- a/integration/oneof-unions-value/google/protobuf/struct.ts
+++ b/integration/oneof-unions-value/google/protobuf/struct.ts
@@ -148,7 +148,12 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
       fields: isObject(object.fields)
         ? (globalThis.Object.entries(object.fields) as [string, any][]).reduce(
           (acc: { [key: string]: any | undefined }, [key, value]: [string, any]) => {
-            acc[key] = value as any | undefined;
+            globalThis.Object.defineProperty(acc, key, {
+              value: value as any | undefined,
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},

--- a/integration/oneof-unions/google/protobuf/struct.ts
+++ b/integration/oneof-unions/google/protobuf/struct.ts
@@ -148,7 +148,12 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
       fields: isObject(object.fields)
         ? (globalThis.Object.entries(object.fields) as [string, any][]).reduce(
           (acc: { [key: string]: any | undefined }, [key, value]: [string, any]) => {
-            acc[key] = value as any | undefined;
+            globalThis.Object.defineProperty(acc, key, {
+              value: value as any | undefined,
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},

--- a/integration/proto2-long/simple.ts
+++ b/integration/proto2-long/simple.ts
@@ -838,7 +838,12 @@ export const OptionalsTest: MessageFns<OptionalsTest> = {
       translations: isObject(object.translations)
         ? (globalThis.Object.entries(object.translations) as [string, any][]).reduce(
           (acc: { [key: string]: string }, [key, value]: [string, any]) => {
-            acc[key] = globalThis.String(value);
+            globalThis.Object.defineProperty(acc, key, {
+              value: globalThis.String(value),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},

--- a/integration/proto2-no-default-vals/simple.ts
+++ b/integration/proto2-no-default-vals/simple.ts
@@ -837,7 +837,12 @@ export const OptionalsTest: MessageFns<OptionalsTest> = {
       translations: isObject(object.translations)
         ? (globalThis.Object.entries(object.translations) as [string, any][]).reduce(
           (acc: { [key: string]: string }, [key, value]: [string, any]) => {
-            acc[key] = globalThis.String(value);
+            globalThis.Object.defineProperty(acc, key, {
+              value: globalThis.String(value),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},

--- a/integration/proto2-no-optionals/simple.ts
+++ b/integration/proto2-no-optionals/simple.ts
@@ -837,7 +837,12 @@ export const OptionalsTest: MessageFns<OptionalsTest> = {
       translations: isObject(object.translations)
         ? (globalThis.Object.entries(object.translations) as [string, any][]).reduce(
           (acc: { [key: string]: string }, [key, value]: [string, any]) => {
-            acc[key] = globalThis.String(value);
+            globalThis.Object.defineProperty(acc, key, {
+              value: globalThis.String(value),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},

--- a/integration/proto2/simple.ts
+++ b/integration/proto2/simple.ts
@@ -837,7 +837,12 @@ export const OptionalsTest: MessageFns<OptionalsTest> = {
       translations: isObject(object.translations)
         ? (globalThis.Object.entries(object.translations) as [string, any][]).reduce(
           (acc: { [key: string]: string }, [key, value]: [string, any]) => {
-            acc[key] = globalThis.String(value);
+            globalThis.Object.defineProperty(acc, key, {
+              value: globalThis.String(value),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},

--- a/integration/schema-no-file-descriptor/const-enum.ts
+++ b/integration/schema-no-file-descriptor/const-enum.ts
@@ -117,7 +117,12 @@ export const DividerData: MessageFns<DividerData> = {
       typeMap: isObject(object.typeMap)
         ? (globalThis.Object.entries(object.typeMap) as [string, any][]).reduce(
           (acc: { [key: string]: DividerData_DividerType }, [key, value]: [string, any]) => {
-            acc[key] = dividerData_DividerTypeFromJSON(value);
+            globalThis.Object.defineProperty(acc, key, {
+              value: dividerData_DividerTypeFromJSON(value),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},

--- a/integration/simple-long/simple.ts
+++ b/integration/simple-long/simple.ts
@@ -269,7 +269,12 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
       nameLookup: isObject(object.nameLookup)
         ? (globalThis.Object.entries(object.nameLookup) as [string, any][]).reduce(
           (acc: { [key: string]: string }, [key, value]: [string, any]) => {
-            acc[key] = globalThis.String(value);
+            globalThis.Object.defineProperty(acc, key, {
+              value: globalThis.String(value),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},
@@ -278,7 +283,12 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
       intLookup: isObject(object.intLookup)
         ? (globalThis.Object.entries(object.intLookup) as [string, any][]).reduce(
           (acc: { [key: number]: number }, [key, value]: [string, any]) => {
-            acc[globalThis.Number(key)] = globalThis.Number(value);
+            globalThis.Object.defineProperty(acc, globalThis.Number(key), {
+              value: globalThis.Number(value),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},

--- a/integration/simple-optionals/simple.ts
+++ b/integration/simple-optionals/simple.ts
@@ -1131,7 +1131,12 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
       entitiesById: isObject(object.entitiesById)
         ? (globalThis.Object.entries(object.entitiesById) as [string, any][]).reduce(
           (acc: { [key: number]: Entity }, [key, value]: [string, any]) => {
-            acc[globalThis.Number(key)] = Entity.fromJSON(value);
+            globalThis.Object.defineProperty(acc, globalThis.Number(key), {
+              value: Entity.fromJSON(value),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},
@@ -1140,7 +1145,12 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
       nameLookup: isObject(object.nameLookup)
         ? (globalThis.Object.entries(object.nameLookup) as [string, any][]).reduce(
           (acc: { [key: string]: string }, [key, value]: [string, any]) => {
-            acc[key] = globalThis.String(value);
+            globalThis.Object.defineProperty(acc, key, {
+              value: globalThis.String(value),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},
@@ -1149,7 +1159,12 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
       intLookup: isObject(object.intLookup)
         ? (globalThis.Object.entries(object.intLookup) as [string, any][]).reduce(
           (acc: { [key: number]: number }, [key, value]: [string, any]) => {
-            acc[globalThis.Number(key)] = globalThis.Number(value);
+            globalThis.Object.defineProperty(acc, globalThis.Number(key), {
+              value: globalThis.Number(value),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},
@@ -1504,7 +1519,12 @@ export const SimpleWithSnakeCaseMap: MessageFns<SimpleWithSnakeCaseMap> = {
       entitiesById: isObject(object.entitiesById)
         ? (globalThis.Object.entries(object.entitiesById) as [string, any][]).reduce(
           (acc: { [key: number]: Entity }, [key, value]: [string, any]) => {
-            acc[globalThis.Number(key)] = Entity.fromJSON(value);
+            globalThis.Object.defineProperty(acc, globalThis.Number(key), {
+              value: Entity.fromJSON(value),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},
@@ -1512,7 +1532,12 @@ export const SimpleWithSnakeCaseMap: MessageFns<SimpleWithSnakeCaseMap> = {
         : isObject(object.entities_by_id)
         ? (globalThis.Object.entries(object.entities_by_id) as [string, any][]).reduce(
           (acc: { [key: number]: Entity }, [key, value]: [string, any]) => {
-            acc[globalThis.Number(key)] = Entity.fromJSON(value);
+            globalThis.Object.defineProperty(acc, globalThis.Number(key), {
+              value: Entity.fromJSON(value),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},

--- a/integration/simple-prototype-defaults/simple.ts
+++ b/integration/simple-prototype-defaults/simple.ts
@@ -1330,7 +1330,12 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
       entitiesById: isObject(object.entitiesById)
         ? (globalThis.Object.entries(object.entitiesById) as [string, any][]).reduce(
           (acc: { [key: number]: Entity }, [key, value]: [string, any]) => {
-            acc[globalThis.Number(key)] = Entity.fromJSON(value);
+            globalThis.Object.defineProperty(acc, globalThis.Number(key), {
+              value: Entity.fromJSON(value),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},
@@ -1339,7 +1344,12 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
       nameLookup: isObject(object.nameLookup)
         ? (globalThis.Object.entries(object.nameLookup) as [string, any][]).reduce(
           (acc: { [key: string]: string }, [key, value]: [string, any]) => {
-            acc[key] = globalThis.String(value);
+            globalThis.Object.defineProperty(acc, key, {
+              value: globalThis.String(value),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},
@@ -1348,7 +1358,12 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
       intLookup: isObject(object.intLookup)
         ? (globalThis.Object.entries(object.intLookup) as [string, any][]).reduce(
           (acc: { [key: number]: number }, [key, value]: [string, any]) => {
-            acc[globalThis.Number(key)] = globalThis.Number(value);
+            globalThis.Object.defineProperty(acc, globalThis.Number(key), {
+              value: globalThis.Number(value),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},
@@ -1357,7 +1372,12 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
       mapOfTimestamps: isObject(object.mapOfTimestamps)
         ? (globalThis.Object.entries(object.mapOfTimestamps) as [string, any][]).reduce(
           (acc: { [key: string]: Date }, [key, value]: [string, any]) => {
-            acc[key] = fromJsonTimestamp(value);
+            globalThis.Object.defineProperty(acc, key, {
+              value: fromJsonTimestamp(value),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},
@@ -1366,7 +1386,12 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
       mapOfBytes: isObject(object.mapOfBytes)
         ? (globalThis.Object.entries(object.mapOfBytes) as [string, any][]).reduce(
           (acc: { [key: string]: Uint8Array }, [key, value]: [string, any]) => {
-            acc[key] = bytesFromBase64(value as string);
+            globalThis.Object.defineProperty(acc, key, {
+              value: bytesFromBase64(value as string),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},
@@ -1375,7 +1400,12 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
       mapOfStringValues: isObject(object.mapOfStringValues)
         ? (globalThis.Object.entries(object.mapOfStringValues) as [string, any][]).reduce(
           (acc: { [key: string]: string | undefined }, [key, value]: [string, any]) => {
-            acc[key] = value as string | undefined;
+            globalThis.Object.defineProperty(acc, key, {
+              value: value as string | undefined,
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},
@@ -1384,7 +1414,12 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
       longLookup: isObject(object.longLookup)
         ? (globalThis.Object.entries(object.longLookup) as [string, any][]).reduce(
           (acc: { [key: number]: number }, [key, value]: [string, any]) => {
-            acc[globalThis.Number(key)] = globalThis.Number(value);
+            globalThis.Object.defineProperty(acc, globalThis.Number(key), {
+              value: globalThis.Number(value),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},
@@ -2132,7 +2167,12 @@ export const SimpleWithSnakeCaseMap: MessageFns<SimpleWithSnakeCaseMap> = {
       entitiesById: isObject(object.entitiesById)
         ? (globalThis.Object.entries(object.entitiesById) as [string, any][]).reduce(
           (acc: { [key: number]: Entity }, [key, value]: [string, any]) => {
-            acc[globalThis.Number(key)] = Entity.fromJSON(value);
+            globalThis.Object.defineProperty(acc, globalThis.Number(key), {
+              value: Entity.fromJSON(value),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},
@@ -2140,7 +2180,12 @@ export const SimpleWithSnakeCaseMap: MessageFns<SimpleWithSnakeCaseMap> = {
         : isObject(object.entities_by_id)
         ? (globalThis.Object.entries(object.entities_by_id) as [string, any][]).reduce(
           (acc: { [key: number]: Entity }, [key, value]: [string, any]) => {
-            acc[globalThis.Number(key)] = Entity.fromJSON(value);
+            globalThis.Object.defineProperty(acc, globalThis.Number(key), {
+              value: Entity.fromJSON(value),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},
@@ -2311,7 +2356,12 @@ export const SimpleWithMapOfEnums: MessageFns<SimpleWithMapOfEnums> = {
       enumsById: isObject(object.enumsById)
         ? (globalThis.Object.entries(object.enumsById) as [string, any][]).reduce(
           (acc: { [key: number]: StateEnum }, [key, value]: [string, any]) => {
-            acc[globalThis.Number(key)] = stateEnumFromJSON(value);
+            globalThis.Object.defineProperty(acc, globalThis.Number(key), {
+              value: stateEnumFromJSON(value),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},
@@ -2319,7 +2369,12 @@ export const SimpleWithMapOfEnums: MessageFns<SimpleWithMapOfEnums> = {
         : isObject(object.enums_by_id)
         ? (globalThis.Object.entries(object.enums_by_id) as [string, any][]).reduce(
           (acc: { [key: number]: StateEnum }, [key, value]: [string, any]) => {
-            acc[globalThis.Number(key)] = stateEnumFromJSON(value);
+            globalThis.Object.defineProperty(acc, globalThis.Number(key), {
+              value: stateEnumFromJSON(value),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},

--- a/integration/simple-snake/google/protobuf/struct.ts
+++ b/integration/simple-snake/google/protobuf/struct.ts
@@ -149,7 +149,12 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
       fields: isObject(object.fields)
         ? (globalThis.Object.entries(object.fields) as [string, any][]).reduce(
           (acc: { [key: string]: any | undefined }, [key, value]: [string, any]) => {
-            acc[key] = value as any | undefined;
+            globalThis.Object.defineProperty(acc, key, {
+              value: value as any | undefined,
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},

--- a/integration/simple-snake/simple.ts
+++ b/integration/simple-snake/simple.ts
@@ -1136,7 +1136,12 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
       entitiesById: isObject(object.entitiesById)
         ? (globalThis.Object.entries(object.entitiesById) as [string, any][]).reduce(
           (acc: { [key: number]: Entity }, [key, value]: [string, any]) => {
-            acc[globalThis.Number(key)] = Entity.fromJSON(value);
+            globalThis.Object.defineProperty(acc, globalThis.Number(key), {
+              value: Entity.fromJSON(value),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},
@@ -1145,7 +1150,12 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
       nameLookup: isObject(object.nameLookup)
         ? (globalThis.Object.entries(object.nameLookup) as [string, any][]).reduce(
           (acc: { [key: string]: string }, [key, value]: [string, any]) => {
-            acc[key] = globalThis.String(value);
+            globalThis.Object.defineProperty(acc, key, {
+              value: globalThis.String(value),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},
@@ -1154,7 +1164,12 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
       intLookup: isObject(object.intLookup)
         ? (globalThis.Object.entries(object.intLookup) as [string, any][]).reduce(
           (acc: { [key: number]: number }, [key, value]: [string, any]) => {
-            acc[globalThis.Number(key)] = globalThis.Number(value);
+            globalThis.Object.defineProperty(acc, globalThis.Number(key), {
+              value: globalThis.Number(value),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},
@@ -1509,7 +1524,12 @@ export const SimpleWithSnakeCaseMap: MessageFns<SimpleWithSnakeCaseMap> = {
       entities_by_id: isObject(object.entitiesById)
         ? (globalThis.Object.entries(object.entitiesById) as [string, any][]).reduce(
           (acc: { [key: number]: Entity }, [key, value]: [string, any]) => {
-            acc[globalThis.Number(key)] = Entity.fromJSON(value);
+            globalThis.Object.defineProperty(acc, globalThis.Number(key), {
+              value: Entity.fromJSON(value),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},
@@ -1517,7 +1537,12 @@ export const SimpleWithSnakeCaseMap: MessageFns<SimpleWithSnakeCaseMap> = {
         : isObject(object.entities_by_id)
         ? (globalThis.Object.entries(object.entities_by_id) as [string, any][]).reduce(
           (acc: { [key: number]: Entity }, [key, value]: [string, any]) => {
-            acc[globalThis.Number(key)] = Entity.fromJSON(value);
+            globalThis.Object.defineProperty(acc, globalThis.Number(key), {
+              value: Entity.fromJSON(value),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},

--- a/integration/simple-string-enums/google/protobuf/struct.ts
+++ b/integration/simple-string-enums/google/protobuf/struct.ts
@@ -159,7 +159,12 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
       fields: isObject(object.fields)
         ? (globalThis.Object.entries(object.fields) as [string, any][]).reduce(
           (acc: { [key: string]: any | undefined }, [key, value]: [string, any]) => {
-            acc[key] = value as any | undefined;
+            globalThis.Object.defineProperty(acc, key, {
+              value: value as any | undefined,
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},

--- a/integration/simple-string-enums/simple.ts
+++ b/integration/simple-string-enums/simple.ts
@@ -177,7 +177,12 @@ export const Simple: MessageFns<Simple> = {
       stateMap: isObject(object.stateMap)
         ? (globalThis.Object.entries(object.stateMap) as [string, any][]).reduce(
           (acc: { [key: string]: StateEnum }, [key, value]: [string, any]) => {
-            acc[key] = stateEnumFromJSON(value);
+            globalThis.Object.defineProperty(acc, key, {
+              value: stateEnumFromJSON(value),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},

--- a/integration/simple-unrecognized-enum/simple.ts
+++ b/integration/simple-unrecognized-enum/simple.ts
@@ -1119,7 +1119,12 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
       entitiesById: isObject(object.entitiesById)
         ? (globalThis.Object.entries(object.entitiesById) as [string, any][]).reduce(
           (acc: { [key: number]: Entity }, [key, value]: [string, any]) => {
-            acc[globalThis.Number(key)] = Entity.fromJSON(value);
+            globalThis.Object.defineProperty(acc, globalThis.Number(key), {
+              value: Entity.fromJSON(value),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},
@@ -1128,7 +1133,12 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
       nameLookup: isObject(object.nameLookup)
         ? (globalThis.Object.entries(object.nameLookup) as [string, any][]).reduce(
           (acc: { [key: string]: string }, [key, value]: [string, any]) => {
-            acc[key] = globalThis.String(value);
+            globalThis.Object.defineProperty(acc, key, {
+              value: globalThis.String(value),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},
@@ -1137,7 +1147,12 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
       intLookup: isObject(object.intLookup)
         ? (globalThis.Object.entries(object.intLookup) as [string, any][]).reduce(
           (acc: { [key: number]: number }, [key, value]: [string, any]) => {
-            acc[globalThis.Number(key)] = globalThis.Number(value);
+            globalThis.Object.defineProperty(acc, globalThis.Number(key), {
+              value: globalThis.Number(value),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},
@@ -1492,7 +1507,12 @@ export const SimpleWithSnakeCaseMap: MessageFns<SimpleWithSnakeCaseMap> = {
       entitiesById: isObject(object.entitiesById)
         ? (globalThis.Object.entries(object.entitiesById) as [string, any][]).reduce(
           (acc: { [key: number]: Entity }, [key, value]: [string, any]) => {
-            acc[globalThis.Number(key)] = Entity.fromJSON(value);
+            globalThis.Object.defineProperty(acc, globalThis.Number(key), {
+              value: Entity.fromJSON(value),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},
@@ -1500,7 +1520,12 @@ export const SimpleWithSnakeCaseMap: MessageFns<SimpleWithSnakeCaseMap> = {
         : isObject(object.entities_by_id)
         ? (globalThis.Object.entries(object.entities_by_id) as [string, any][]).reduce(
           (acc: { [key: number]: Entity }, [key, value]: [string, any]) => {
-            acc[globalThis.Number(key)] = Entity.fromJSON(value);
+            globalThis.Object.defineProperty(acc, globalThis.Number(key), {
+              value: Entity.fromJSON(value),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},

--- a/integration/simple/simple.ts
+++ b/integration/simple/simple.ts
@@ -1369,7 +1369,12 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
       entitiesById: isObject(object.entitiesById)
         ? (globalThis.Object.entries(object.entitiesById) as [string, any][]).reduce(
           (acc: { [key: number]: Entity }, [key, value]: [string, any]) => {
-            acc[globalThis.Number(key)] = Entity.fromJSON(value);
+            globalThis.Object.defineProperty(acc, globalThis.Number(key), {
+              value: Entity.fromJSON(value),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},
@@ -1378,7 +1383,12 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
       nameLookup: isObject(object.nameLookup)
         ? (globalThis.Object.entries(object.nameLookup) as [string, any][]).reduce(
           (acc: { [key: string]: string }, [key, value]: [string, any]) => {
-            acc[key] = globalThis.String(value);
+            globalThis.Object.defineProperty(acc, key, {
+              value: globalThis.String(value),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},
@@ -1387,7 +1397,12 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
       intLookup: isObject(object.intLookup)
         ? (globalThis.Object.entries(object.intLookup) as [string, any][]).reduce(
           (acc: { [key: number]: number }, [key, value]: [string, any]) => {
-            acc[globalThis.Number(key)] = globalThis.Number(value);
+            globalThis.Object.defineProperty(acc, globalThis.Number(key), {
+              value: globalThis.Number(value),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},
@@ -1396,7 +1411,12 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
       mapOfTimestamps: isObject(object.mapOfTimestamps)
         ? (globalThis.Object.entries(object.mapOfTimestamps) as [string, any][]).reduce(
           (acc: { [key: string]: Date }, [key, value]: [string, any]) => {
-            acc[key] = fromJsonTimestamp(value);
+            globalThis.Object.defineProperty(acc, key, {
+              value: fromJsonTimestamp(value),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},
@@ -1405,7 +1425,12 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
       mapOfBytes: isObject(object.mapOfBytes)
         ? (globalThis.Object.entries(object.mapOfBytes) as [string, any][]).reduce(
           (acc: { [key: string]: Uint8Array }, [key, value]: [string, any]) => {
-            acc[key] = bytesFromBase64(value as string);
+            globalThis.Object.defineProperty(acc, key, {
+              value: bytesFromBase64(value as string),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},
@@ -1414,7 +1439,12 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
       mapOfStringValues: isObject(object.mapOfStringValues)
         ? (globalThis.Object.entries(object.mapOfStringValues) as [string, any][]).reduce(
           (acc: { [key: string]: string | undefined }, [key, value]: [string, any]) => {
-            acc[key] = value as string | undefined;
+            globalThis.Object.defineProperty(acc, key, {
+              value: value as string | undefined,
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},
@@ -1423,7 +1453,12 @@ export const SimpleWithMap: MessageFns<SimpleWithMap> = {
       longLookup: isObject(object.longLookup)
         ? (globalThis.Object.entries(object.longLookup) as [string, any][]).reduce(
           (acc: { [key: number]: number }, [key, value]: [string, any]) => {
-            acc[globalThis.Number(key)] = globalThis.Number(value);
+            globalThis.Object.defineProperty(acc, globalThis.Number(key), {
+              value: globalThis.Number(value),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},
@@ -2269,7 +2304,12 @@ export const SimpleWithSnakeCaseMap: MessageFns<SimpleWithSnakeCaseMap> = {
       entitiesById: isObject(object.entitiesById)
         ? (globalThis.Object.entries(object.entitiesById) as [string, any][]).reduce(
           (acc: { [key: number]: Entity }, [key, value]: [string, any]) => {
-            acc[globalThis.Number(key)] = Entity.fromJSON(value);
+            globalThis.Object.defineProperty(acc, globalThis.Number(key), {
+              value: Entity.fromJSON(value),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},
@@ -2277,7 +2317,12 @@ export const SimpleWithSnakeCaseMap: MessageFns<SimpleWithSnakeCaseMap> = {
         : isObject(object.entities_by_id)
         ? (globalThis.Object.entries(object.entities_by_id) as [string, any][]).reduce(
           (acc: { [key: number]: Entity }, [key, value]: [string, any]) => {
-            acc[globalThis.Number(key)] = Entity.fromJSON(value);
+            globalThis.Object.defineProperty(acc, globalThis.Number(key), {
+              value: Entity.fromJSON(value),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},
@@ -2444,7 +2489,12 @@ export const SimpleWithMapOfEnums: MessageFns<SimpleWithMapOfEnums> = {
       enumsById: isObject(object.enumsById)
         ? (globalThis.Object.entries(object.enumsById) as [string, any][]).reduce(
           (acc: { [key: number]: StateEnum }, [key, value]: [string, any]) => {
-            acc[globalThis.Number(key)] = stateEnumFromJSON(value);
+            globalThis.Object.defineProperty(acc, globalThis.Number(key), {
+              value: stateEnumFromJSON(value),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},
@@ -2452,7 +2502,12 @@ export const SimpleWithMapOfEnums: MessageFns<SimpleWithMapOfEnums> = {
         : isObject(object.enums_by_id)
         ? (globalThis.Object.entries(object.enums_by_id) as [string, any][]).reduce(
           (acc: { [key: number]: StateEnum }, [key, value]: [string, any]) => {
-            acc[globalThis.Number(key)] = stateEnumFromJSON(value);
+            globalThis.Object.defineProperty(acc, globalThis.Number(key), {
+              value: stateEnumFromJSON(value),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},

--- a/integration/static-only-type-registry/google/protobuf/struct.ts
+++ b/integration/static-only-type-registry/google/protobuf/struct.ts
@@ -152,7 +152,12 @@ export const Struct: MessageFns<Struct, "google.protobuf.Struct"> & StructWrappe
       fields: isObject(object.fields)
         ? (globalThis.Object.entries(object.fields) as [string, any][]).reduce(
           (acc: { [key: string]: any | undefined }, [key, value]: [string, any]) => {
-            acc[key] = value as any | undefined;
+            globalThis.Object.defineProperty(acc, key, {
+              value: value as any | undefined,
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},

--- a/integration/static-only/google/protobuf/struct.ts
+++ b/integration/static-only/google/protobuf/struct.ts
@@ -151,7 +151,12 @@ export const Struct: MessageFns<Struct, "google.protobuf.Struct"> & StructWrappe
       fields: isObject(object.fields)
         ? (globalThis.Object.entries(object.fields) as [string, any][]).reduce(
           (acc: { [key: string]: any | undefined }, [key, value]: [string, any]) => {
-            acc[key] = value as any | undefined;
+            globalThis.Object.defineProperty(acc, key, {
+              value: value as any | undefined,
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},

--- a/integration/struct/google/protobuf/struct.ts
+++ b/integration/struct/google/protobuf/struct.ts
@@ -149,7 +149,12 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
       fields: isObject(object.fields)
         ? (globalThis.Object.entries(object.fields) as [string, any][]).reduce(
           (acc: { [key: string]: any | undefined }, [key, value]: [string, any]) => {
-            acc[key] = value as any | undefined;
+            globalThis.Object.defineProperty(acc, key, {
+              value: value as any | undefined,
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},

--- a/integration/suffix-type/google/protobuf/struct.ts
+++ b/integration/suffix-type/google/protobuf/struct.ts
@@ -149,7 +149,12 @@ export const GRPCPStructGRPCS: MessageFns<GRPCPStructGRPCS> & StructWrapperFns =
       fields: isObject(object.fields)
         ? (globalThis.Object.entries(object.fields) as [string, any][]).reduce(
           (acc: { [key: string]: any | undefined }, [key, value]: [string, any]) => {
-            acc[key] = value as any | undefined;
+            globalThis.Object.defineProperty(acc, key, {
+              value: value as any | undefined,
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},

--- a/integration/type-annotations/google/protobuf/struct.ts
+++ b/integration/type-annotations/google/protobuf/struct.ts
@@ -159,7 +159,12 @@ export const Struct: MessageFns<Struct, "google.protobuf.Struct"> & StructWrappe
       fields: isObject(object.fields)
         ? (globalThis.Object.entries(object.fields) as [string, any][]).reduce(
           (acc: { [key: string]: any | undefined }, [key, value]: [string, any]) => {
-            acc[key] = value as any | undefined;
+            globalThis.Object.defineProperty(acc, key, {
+              value: value as any | undefined,
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},

--- a/integration/type-registry/google/protobuf/struct.ts
+++ b/integration/type-registry/google/protobuf/struct.ts
@@ -160,7 +160,12 @@ export const Struct: MessageFns<Struct, "google.protobuf.Struct"> & StructWrappe
       fields: isObject(object.fields)
         ? (globalThis.Object.entries(object.fields) as [string, any][]).reduce(
           (acc: { [key: string]: any | undefined }, [key, value]: [string, any]) => {
-            acc[key] = value as any | undefined;
+            globalThis.Object.defineProperty(acc, key, {
+              value: value as any | undefined,
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},

--- a/integration/use-date-string/use-date-string.ts
+++ b/integration/use-date-string/use-date-string.ts
@@ -120,7 +120,12 @@ export const Todo: MessageFns<Todo> = {
       mapOfTimestamps: isObject(object.mapOfTimestamps)
         ? (globalThis.Object.entries(object.mapOfTimestamps) as [string, any][]).reduce(
           (acc: { [key: string]: string }, [key, value]: [string, any]) => {
-            acc[key] = globalThis.String(value);
+            globalThis.Object.defineProperty(acc, key, {
+              value: globalThis.String(value),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},
@@ -128,7 +133,12 @@ export const Todo: MessageFns<Todo> = {
         : isObject(object.map_of_timestamps)
         ? (globalThis.Object.entries(object.map_of_timestamps) as [string, any][]).reduce(
           (acc: { [key: string]: string }, [key, value]: [string, any]) => {
-            acc[key] = globalThis.String(value);
+            globalThis.Object.defineProperty(acc, key, {
+              value: globalThis.String(value),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},

--- a/integration/use-date-true/use-date-true.ts
+++ b/integration/use-date-true/use-date-true.ts
@@ -121,7 +121,12 @@ export const Todo: MessageFns<Todo> = {
       mapOfTimestamps: isObject(object.mapOfTimestamps)
         ? (globalThis.Object.entries(object.mapOfTimestamps) as [string, any][]).reduce(
           (acc: { [key: string]: Date }, [key, value]: [string, any]) => {
-            acc[key] = fromJsonTimestamp(value);
+            globalThis.Object.defineProperty(acc, key, {
+              value: fromJsonTimestamp(value),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},
@@ -129,7 +134,12 @@ export const Todo: MessageFns<Todo> = {
         : isObject(object.map_of_timestamps)
         ? (globalThis.Object.entries(object.map_of_timestamps) as [string, any][]).reduce(
           (acc: { [key: string]: Date }, [key, value]: [string, any]) => {
-            acc[key] = fromJsonTimestamp(value);
+            globalThis.Object.defineProperty(acc, key, {
+              value: fromJsonTimestamp(value),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},

--- a/integration/use-numeric-enum-json/google/protobuf/struct.ts
+++ b/integration/use-numeric-enum-json/google/protobuf/struct.ts
@@ -149,7 +149,12 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
       fields: isObject(object.fields)
         ? (globalThis.Object.entries(object.fields) as [string, any][]).reduce(
           (acc: { [key: string]: any | undefined }, [key, value]: [string, any]) => {
-            acc[key] = value as any | undefined;
+            globalThis.Object.defineProperty(acc, key, {
+              value: value as any | undefined,
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},

--- a/integration/use-numeric-enum-json/simple.ts
+++ b/integration/use-numeric-enum-json/simple.ts
@@ -163,7 +163,12 @@ export const Simple: MessageFns<Simple> = {
       stateMap: isObject(object.stateMap)
         ? (globalThis.Object.entries(object.stateMap) as [string, any][]).reduce(
           (acc: { [key: string]: StateEnum }, [key, value]: [string, any]) => {
-            acc[key] = stateEnumFromJSON(value);
+            globalThis.Object.defineProperty(acc, key, {
+              value: stateEnumFromJSON(value),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},

--- a/integration/use-objectid-true-external-import/use-objectid-true.ts
+++ b/integration/use-objectid-true-external-import/use-objectid-true.ts
@@ -121,7 +121,12 @@ export const Todo: MessageFns<Todo> = {
       mapOfOids: isObject(object.mapOfOids)
         ? (globalThis.Object.entries(object.mapOfOids) as [string, any][]).reduce(
           (acc: { [key: string]: mongodb.ObjectId }, [key, value]: [string, any]) => {
-            acc[key] = fromJsonObjectId(value);
+            globalThis.Object.defineProperty(acc, key, {
+              value: fromJsonObjectId(value),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},
@@ -129,7 +134,12 @@ export const Todo: MessageFns<Todo> = {
         : isObject(object.map_of_oids)
         ? (globalThis.Object.entries(object.map_of_oids) as [string, any][]).reduce(
           (acc: { [key: string]: mongodb.ObjectId }, [key, value]: [string, any]) => {
-            acc[key] = fromJsonObjectId(value);
+            globalThis.Object.defineProperty(acc, key, {
+              value: fromJsonObjectId(value),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},

--- a/integration/use-optionals-all/google/protobuf/struct.ts
+++ b/integration/use-optionals-all/google/protobuf/struct.ts
@@ -149,7 +149,12 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
       fields: isObject(object.fields)
         ? (globalThis.Object.entries(object.fields) as [string, any][]).reduce(
           (acc: { [key: string]: any | undefined }, [key, value]: [string, any]) => {
-            acc[key] = value as any | undefined;
+            globalThis.Object.defineProperty(acc, key, {
+              value: value as any | undefined,
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},

--- a/integration/use-optionals-all/test.ts
+++ b/integration/use-optionals-all/test.ts
@@ -552,7 +552,12 @@ export const OptionalsTest: MessageFns<OptionalsTest> = {
       translations: isObject(object.translations)
         ? (globalThis.Object.entries(object.translations) as [string, any][]).reduce(
           (acc: { [key: string]: string }, [key, value]: [string, any]) => {
-            acc[key] = globalThis.String(value);
+            globalThis.Object.defineProperty(acc, key, {
+              value: globalThis.String(value),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},

--- a/integration/use-optionals-deprecated-only/test.ts
+++ b/integration/use-optionals-deprecated-only/test.ts
@@ -491,7 +491,12 @@ export const OptionalsTest: MessageFns<OptionalsTest> = {
       translations: isObject(object.translations)
         ? (globalThis.Object.entries(object.translations) as [string, any][]).reduce(
           (acc: { [key: string]: string }, [key, value]: [string, any]) => {
-            acc[key] = globalThis.String(value);
+            globalThis.Object.defineProperty(acc, key, {
+              value: globalThis.String(value),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},

--- a/integration/use-optionals-no-undefined/google/protobuf/struct.ts
+++ b/integration/use-optionals-no-undefined/google/protobuf/struct.ts
@@ -152,7 +152,12 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
       fields: isObject(object.fields)
         ? (globalThis.Object.entries(object.fields) as [string, any][]).reduce(
           (acc: { [key: string]: any | undefined }, [key, value]: [string, any]) => {
-            acc[key] = value as any | undefined;
+            globalThis.Object.defineProperty(acc, key, {
+              value: value as any | undefined,
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},

--- a/integration/use-optionals-no-undefined/test.ts
+++ b/integration/use-optionals-no-undefined/test.ts
@@ -550,7 +550,12 @@ export const OptionalsTest: MessageFns<OptionalsTest> = {
       translations: isObject(object.translations)
         ? (globalThis.Object.entries(object.translations) as [string, any][]).reduce(
           (acc: { [key: string]: string }, [key, value]: [string, any]) => {
-            acc[key] = globalThis.String(value);
+            globalThis.Object.defineProperty(acc, key, {
+              value: globalThis.String(value),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},

--- a/integration/use-readonly-types/google/protobuf/struct.ts
+++ b/integration/use-readonly-types/google/protobuf/struct.ts
@@ -148,7 +148,12 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
       fields: isObject(object.fields)
         ? (globalThis.Object.entries(object.fields) as [string, any][]).reduce(
           (acc: { [key: string]: any | undefined }, [key, value]: [string, any]) => {
-            acc[key] = value as any | undefined;
+            globalThis.Object.defineProperty(acc, key, {
+              value: value as any | undefined,
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},

--- a/integration/value/google/protobuf/struct.ts
+++ b/integration/value/google/protobuf/struct.ts
@@ -149,7 +149,12 @@ export const Struct: MessageFns<Struct> & StructWrapperFns = {
       fields: isObject(object.fields)
         ? (globalThis.Object.entries(object.fields) as [string, any][]).reduce(
           (acc: { [key: string]: any | undefined }, [key, value]: [string, any]) => {
-            acc[key] = value as any | undefined;
+            globalThis.Object.defineProperty(acc, key, {
+              value: value as any | undefined,
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
             return acc;
           },
           {},

--- a/src/main.ts
+++ b/src/main.ts
@@ -2467,7 +2467,10 @@ function generateFromJson(ctx: Context, fullName: string, fullTypeName: string, 
                  ? (${
                    ctx.utils.globalThis
                  }.Object.entries(${protoJsonProperty}) as [string, any][]).reduce((acc: ${fieldType}, [key, value]: [string, any]) => {
-                     acc[${i}] = ${readSnippet("value")};
+                     ${ctx.utils.globalThis}.Object.defineProperty(acc, ${i}, {
+                       value: ${readSnippet("value")},
+                       enumerable: true, configurable: true, writable: true,
+                     });
                      return acc;
                    }, {})
                `;
@@ -2477,7 +2480,10 @@ function generateFromJson(ctx: Context, fullName: string, fullTypeName: string, 
               ? (${
                 ctx.utils.globalThis
               }.Object.entries(${jsonProperty}) as [string, any][]).reduce((acc: ${fieldType}, [key, value]: [string, any]) => {
-                  acc[${i}] = ${readSnippet("value")};
+                  ${ctx.utils.globalThis}.Object.defineProperty(acc, ${i}, {
+                    value: ${readSnippet("value")},
+                    enumerable: true, configurable: true, writable: true,
+                  });
                   return acc;
                 }, {})
               ${protoJsonComparison}


### PR DESCRIPTION
The generated `fromJSON` reducer for a `map<string, message>` field assigned each entry with `acc[key] = ...` into a plain object accumulator. A JSON body whose map contains a `__proto__` key parses that key as an own enumerable property, so `Object.entries(...)` yields it and the bracket assignment invokes the `__proto__` setter — replacing the decoded map instance's prototype with attacker-controlled data.

Emit the assignment via `Object.defineProperty(acc, key, { value, ... })` so a `__proto__` (or any other) key is written as an own data property and never triggers the prototype setter.