### PR TITLE
fix: avoid prototype pollution in generated toJSON for __proto__ json…

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -2683,6 +2683,10 @@ function generateToJson(
     const jsonName = getFieldJsonName(field, options);
     const jsonProperty = getPropertyAccessor("obj", jsonName);
     const messageProperty = getPropertyAccessor("message", fieldName);
+    const setJsonProperty = (value: Code | string): Code =>
+      jsonName === "__proto__"
+        ? code`${utils.globalThis}.Object.defineProperty(obj, "__proto__", { value: ${value}, enumerable: true });`
+        : code`${jsonProperty} = ${value};`;
 
     const readSnippet = (from: string): Code => {
       if (isEnum(field)) {
@@ -2777,7 +2781,7 @@ function generateToJson(
       if (shouldGenerateJSMapType(ctx, messageDesc, field)) {
         chunks.push(code`
           if (${messageProperty}?.size) {
-            ${jsonProperty} = {};
+            ${setJsonProperty("{}")}
             ${messageProperty}.forEach((v, k) => {
               ${jsonProperty}[${i}] = ${readSnippet("v")};
             });
@@ -2789,7 +2793,7 @@ function generateToJson(
         if (${messageProperty}) {
             const entries = ${utils.globalThis}.Object.entries(${messageProperty}) as [string, ${mapInfo.valueType}][];
             if (entries.length > 0) {
-              ${jsonProperty} = {};
+              ${setJsonProperty("{}")}
               entries.forEach(([k, v]) => {
                 ${jsonProperty}[${i}] = ${readSnippet("v")};
               });
@@ -2803,7 +2807,7 @@ function generateToJson(
       const maybeMap = needMap ? code`.map(e => ${readSnippet("e")})` : "";
       chunks.push(code`
         if (${messageProperty}?.length) {
-          ${jsonProperty} = ${messageProperty}${maybeMap};
+          ${setJsonProperty(code`${messageProperty}${maybeMap}`)}
         }
       `);
     } else if (isWithinOneOfThatShouldBeUnion(options, field)) {
@@ -2816,7 +2820,7 @@ function generateToJson(
         ${
           currentIfTarget === oneofNameWithMessage ? "else " : ""
         }if (${oneofNameWithMessage}?.$case === '${fieldName}') {
-          ${jsonProperty} = ${readSnippet(`${oneofNameWithMessage}.${valueName}`)};
+          ${setJsonProperty(readSnippet(`${oneofNameWithMessage}.${valueName}`))}
         }
       `);
       currentIfTarget = oneofNameWithMessage;
@@ -2829,7 +2833,7 @@ function generateToJson(
 
       chunks.push(code`
         if (${check}) {
-          ${jsonProperty} = ${readSnippet(`${messageProperty}`)};
+          ${setJsonProperty(readSnippet(`${messageProperty}`))}
         }
       `);
     }


### PR DESCRIPTION
…_name

When a message field's `json_name` is `__proto__`, `getPropertyAccessor` emits dot notation and `toJSON` generated `obj.__proto__ = <object>` into a plain `{}` accumulator. For an object-valued field (message, map, repeated, oneof) that assignment invokes the `__proto__` setter and replaces the returned object's prototype with attacker-influenced descriptor data.

Route the object-valued assignments through a `setJsonProperty` helper that emits `Object.defineProperty(obj, "__proto__", { value, enumerable: true })` when the json_name is exactly `__proto__`, writing an own property instead of triggering the setter. Scalar assignments are unaffected (assigning a primitive to `__proto__` is a no-op in JS).