### PR TITLE
fix: escape proto2 string field defaults in generated code

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -284,7 +284,7 @@ export function defaultValue(ctx: Context, field: FieldDescriptorProto): any {
     case FieldDescriptorProto_Type.TYPE_BOOL:
       return useDefaultValue ? field.defaultValue : false;
     case FieldDescriptorProto_Type.TYPE_STRING:
-      return useDefaultValue ? `"${field.defaultValue}"` : '""';
+      return useDefaultValue ? JSON.stringify(field.defaultValue) : '""';
     case FieldDescriptorProto_Type.TYPE_BYTES:
       // todo(proto2): need to look into all the possible default values for the bytes type, and handle each one
       if (options.env === EnvOption.NODE) {


### PR DESCRIPTION
For a proto2 string field, `defaultValue()` interpolated the attacker-controllable `field.defaultValue` straight into a double-quoted string literal (`"${field.defaultValue}"`) in the generated `createBase()` initializer. A default such as `", ...((globalThis.x = 1), {})` closes the literal and injects arbitrary JavaScript that runs whenever the generated `decode()`/`create()` path builds the base object.

Use `JSON.stringify(field.defaultValue)` so the value is emitted as a correctly escaped string literal instead of raw text.